### PR TITLE
Validate trading station selections and reflect configuration on dashboard

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -8,9 +8,19 @@ $title = 'Dashboard';
 
 $dbStatus = db_connection_status();
 
+$marketStationName = selected_station_name('market_station_id');
+$allianceStationName = selected_station_name('alliance_station_id');
+$selectedStationsCount = 0;
+if ($marketStationName !== null) {
+    $selectedStationsCount++;
+}
+if ($allianceStationName !== null) {
+    $selectedStationsCount++;
+}
+
 $stats = [
     ['label' => 'Tracked Markets', 'value' => '12', 'context' => 'Regions with active pull schedules'],
-    ['label' => 'Trade Stations', 'value' => (string) count(station_options()), 'context' => 'Saved market + alliance stations'],
+    ['label' => 'Trade Stations', 'value' => (string) $selectedStationsCount . '/2', 'context' => 'Configured market + alliance selections'],
     ['label' => 'ESI Status', 'value' => get_setting('esi_enabled', 'disabled') === '1' ? 'Connected' : 'Pending', 'context' => 'SSO configuration health'],
     ['label' => 'Incremental SQL', 'value' => get_setting('incremental_updates_enabled', '1') === '1' ? 'Enabled' : 'Disabled', 'context' => 'Future sync/import optimizer'],
 ];
@@ -36,7 +46,8 @@ include __DIR__ . '/../src/views/partials/header.php';
                 <p class="text-sm font-medium">Setup checklist</p>
                 <ul class="mt-2 space-y-2 text-sm text-muted">
                     <li>• Configure general app behavior</li>
-                    <li>• Select market + alliance stations</li>
+                    <li>• Market station: <?= htmlspecialchars($marketStationName ?? 'Not selected', ENT_QUOTES) ?></li>
+                    <li>• Alliance station: <?= htmlspecialchars($allianceStationName ?? 'Not selected', ENT_QUOTES) ?></li>
                     <li>• Add ESI SSO credentials</li>
                     <li>• Choose incremental SQL strategy</li>
                 </ul>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -28,8 +28,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         case 'trading-stations':
             $saved = save_settings([
-                'market_station_id' => (string) ($_POST['market_station_id'] ?? ''),
-                'alliance_station_id' => (string) ($_POST['alliance_station_id'] ?? ''),
+                'market_station_id' => sanitize_station_selection($_POST['market_station_id'] ?? null, 'market'),
+                'alliance_station_id' => sanitize_station_selection($_POST['alliance_station_id'] ?? null, 'alliance'),
             ]);
             break;
 

--- a/src/db.php
+++ b/src/db.php
@@ -270,3 +270,16 @@ function db_sync_run_finish(
         [$runStatus, $sourceRows, $writtenRows, $cursorEnd, $errorMessage, $runId]
     );
 }
+
+function db_trading_station_options(): array
+{
+    return db_select('SELECT id, station_name, station_type FROM trading_stations ORDER BY station_name ASC');
+}
+
+function db_trading_station_by_id(int $stationId, string $stationType): ?array
+{
+    return db_select_one(
+        'SELECT id, station_name, station_type FROM trading_stations WHERE id = ? AND station_type = ? LIMIT 1',
+        [$stationId, $stationType]
+    );
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -111,7 +111,7 @@ function save_settings(array $settings): bool
 function station_options(): array
 {
     try {
-        return db_select('SELECT id, station_name, station_type FROM trading_stations ORDER BY station_name ASC');
+        return db_trading_station_options();
     } catch (Throwable) {
         return [
             ['id' => 1, 'station_name' => 'Jita IV - Moon 4 - Caldari Navy Assembly Plant', 'station_type' => 'market'],
@@ -120,6 +120,41 @@ function station_options(): array
             ['id' => 4, 'station_name' => 'T5ZI-S Fortizar', 'station_type' => 'alliance'],
         ];
     }
+}
+
+function sanitize_station_selection(?string $value, string $stationType): string
+{
+    $stationId = (int) trim((string) $value);
+
+    if ($stationId <= 0) {
+        return '';
+    }
+
+    try {
+        $station = db_trading_station_by_id($stationId, $stationType);
+    } catch (Throwable) {
+        return '';
+    }
+
+    return $station === null ? '' : (string) $station['id'];
+}
+
+function selected_station_name(string $settingKey): ?string
+{
+    $stationType = $settingKey === 'alliance_station_id' ? 'alliance' : 'market';
+    $stationId = (int) get_setting($settingKey, '');
+
+    if ($stationId <= 0) {
+        return null;
+    }
+
+    try {
+        $station = db_trading_station_by_id($stationId, $stationType);
+    } catch (Throwable) {
+        return null;
+    }
+
+    return $station['station_name'] ?? null;
 }
 
 function grouped_station_options(): array


### PR DESCRIPTION
## Summary
- moved trading-station queries into new DB-layer wrappers (`db_trading_station_options`, `db_trading_station_by_id`) to keep SQL centralized in `src/db.php`
- added shared helper logic to validate submitted market/alliance station IDs against the expected station type before persisting settings
- updated Trading Stations settings save flow to use sanitized station selection values
- updated dashboard cards/checklist to show configured station progress (`x/2`) and selected station names (or `Not selected`)

## Why
This ensures users can only persist valid market/alliance station choices and gives immediate visibility on dashboard state after selection changes.

## Validation
- `php -l src/db.php`
- `php -l src/functions.php`
- `php -l public/settings/index.php`
- `php -l public/index.php`
- opened dashboard and captured screenshot after changes

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b922fe5d18832f801c0e6de4e1c76c)