### PR TITLE
Improve readability of selected trading stations in settings and dashboard

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -18,9 +18,21 @@ if ($allianceStationName !== null) {
     $selectedStationsCount++;
 }
 
+$tradeStationContextParts = [];
+if ($marketStationName !== null) {
+    $tradeStationContextParts[] = 'Market: ' . $marketStationName;
+}
+if ($allianceStationName !== null) {
+    $tradeStationContextParts[] = 'Alliance: ' . $allianceStationName;
+}
+
+$tradeStationContext = $tradeStationContextParts === []
+    ? 'No market or alliance station selected yet'
+    : implode(' · ', $tradeStationContextParts);
+
 $stats = [
     ['label' => 'Tracked Markets', 'value' => '12', 'context' => 'Regions with active pull schedules'],
-    ['label' => 'Trade Stations', 'value' => (string) $selectedStationsCount . '/2', 'context' => 'Configured market + alliance selections'],
+    ['label' => 'Trade Stations', 'value' => (string) $selectedStationsCount . '/2', 'context' => $tradeStationContext],
     ['label' => 'ESI Status', 'value' => get_setting('esi_enabled', 'disabled') === '1' ? 'Connected' : 'Pending', 'context' => 'SSO configuration health'],
     ['label' => 'Incremental SQL', 'value' => get_setting('incremental_updates_enabled', '1') === '1' ? 'Enabled' : 'Disabled', 'context' => 'Future sync/import optimizer'],
 ];

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -133,17 +133,24 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 </label>
                 <label class="block space-y-2" id="alliance-structure-search-field">
                     <span class="text-sm text-muted">Alliance Structure Selection</span>
-                    <?php $allianceStationId = trim((string) ($settingValues['alliance_station_id'] ?? '')); ?>
+                    <?php
+                        $allianceStationId = trim((string) ($settingValues['alliance_station_id'] ?? ''));
+                        $allianceStationName = selected_station_name('alliance_station_id');
+                    ?>
                     <input type="hidden" name="alliance_station_id" id="alliance_station_id" value="<?= htmlspecialchars($allianceStationId, ENT_QUOTES) ?>">
                     <input
                         type="text"
                         id="alliance_structure_search"
                         autocomplete="off"
-                        value="<?= htmlspecialchars($allianceStationId === '' ? '' : ('Selected structure ID: ' . $allianceStationId), ENT_QUOTES) ?>"
+                        value="<?= htmlspecialchars($allianceStationName ?? '', ENT_QUOTES) ?>"
                         placeholder="Search structures by name"
                         class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring"
                     />
-                    <p id="alliance_structure_status" class="text-xs text-muted">Search is scoped to the connected ESI character token.</p>
+                    <p id="alliance_structure_status" class="text-xs text-muted">
+                        <?= htmlspecialchars($allianceStationId === ''
+                            ? 'Search is scoped to the connected ESI character token.'
+                            : ('Selected structure: ' . ($allianceStationName ?? ('Structure #' . $allianceStationId)) . ' (#' . $allianceStationId . ').'), ENT_QUOTES) ?>
+                    </p>
                     <ul id="alliance_structure_results" class="hidden max-h-60 overflow-y-auto rounded-lg border border-border bg-black/40"></ul>
                 </label>
                 <button class="rounded-lg bg-accent px-4 py-2 text-sm font-medium">Save Trading Stations</button>
@@ -198,7 +205,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             button.addEventListener('click', () => {
                                 hidden.value = String(item.id);
                                 input.value = item.name;
-                                status.textContent = 'Selected structure #' + item.id + '.';
+                                status.textContent = 'Selected structure: ' + item.name + ' (#' + item.id + ').';
                                 clearResults();
                             });
 


### PR DESCRIPTION
## Summary
- show the saved alliance structure name in the Trading Stations settings input instead of a raw ID
- update the alliance structure status text to include the selected structure name plus ID for clarity
- keep selection feedback consistent in the search result click handler
- make the Dashboard "Trade Stations" stat context human-readable by listing selected market/alliance station names when available

## Validation
- php -l public/settings/index.php
- php -l public/index.php
- captured updated settings screenshot: `browser:/tmp/codex_browser_invocations/753f5a9c4884484c/artifacts/artifacts/trading-stations-readable.png`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b928b53a0c832fb8388fff38bc187b)