### PR TITLE
Add configurable general app behavior settings

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -108,6 +108,9 @@ INSERT INTO trading_stations (station_name, station_type) VALUES
 ON DUPLICATE KEY UPDATE station_name = VALUES(station_name);
 
 INSERT INTO app_settings (setting_key, setting_value) VALUES
+    ('app_name', 'EveMarket'),
+    ('app_timezone', 'UTC'),
+    ('default_currency', 'ISK'),
     ('incremental_updates_enabled', '1'),
     ('incremental_strategy', 'watermark_upsert'),
     ('incremental_delete_policy', 'reconcile'),

--- a/public/index.php
+++ b/public/index.php
@@ -35,11 +35,12 @@ $stats = [
     ['label' => 'Trade Stations', 'value' => (string) $selectedStationsCount . '/2', 'context' => $tradeStationContext],
     ['label' => 'ESI Status', 'value' => get_setting('esi_enabled', 'disabled') === '1' ? 'Connected' : 'Pending', 'context' => 'SSO configuration health'],
     ['label' => 'Incremental SQL', 'value' => get_setting('incremental_updates_enabled', '1') === '1' ? 'Enabled' : 'Disabled', 'context' => 'Future sync/import optimizer'],
+    ['label' => 'Default Currency', 'value' => default_currency(), 'context' => 'Applied to market math defaults'],
 ];
 
 include __DIR__ . '/../src/views/partials/header.php';
 ?>
-<section class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+<section class="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
     <?php foreach ($stats as $card): ?>
         <article class="rounded-xl border border-border bg-card p-5 shadow-lg shadow-black/20">
             <p class="text-xs uppercase tracking-[0.2em] text-muted"><?= htmlspecialchars($card['label'], ENT_QUOTES) ?></p>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -21,8 +21,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     switch ($submittedSection) {
         case 'general':
             $saved = save_settings([
-                'app_timezone' => trim($_POST['app_timezone'] ?? 'UTC'),
-                'default_currency' => trim($_POST['default_currency'] ?? 'ISK'),
+                'app_name' => sanitize_app_name((string) ($_POST['app_name'] ?? app_name())),
+                'app_timezone' => sanitize_timezone((string) ($_POST['app_timezone'] ?? 'UTC')),
+                'default_currency' => sanitize_currency((string) ($_POST['default_currency'] ?? 'ISK')),
             ]);
             break;
 
@@ -54,6 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $settingValues = get_settings([
+    'app_name',
     'app_timezone',
     'default_currency',
     'market_station_id',
@@ -112,12 +114,16 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
                 <input type="hidden" name="section" value="general">
                 <label class="block space-y-2">
+                    <span class="text-sm text-muted">Application Name</span>
+                    <input name="app_name" value="<?= htmlspecialchars($settingValues['app_name'] ?? app_name(), ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                </label>
+                <label class="block space-y-2">
                     <span class="text-sm text-muted">Timezone</span>
-                    <input name="app_timezone" value="<?= htmlspecialchars($settingValues['app_timezone'] ?? 'UTC', ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                    <input name="app_timezone" value="<?= htmlspecialchars($settingValues['app_timezone'] ?? app_timezone(), ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
                 </label>
                 <label class="block space-y-2">
                     <span class="text-sm text-muted">Default Currency</span>
-                    <input name="default_currency" value="<?= htmlspecialchars($settingValues['default_currency'] ?? 'ISK', ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                    <input name="default_currency" value="<?= htmlspecialchars($settingValues['default_currency'] ?? default_currency(), ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
                 </label>
                 <button class="rounded-lg bg-accent px-4 py-2 text-sm font-medium">Save General Settings</button>
             </form>

--- a/src/functions.php
+++ b/src/functions.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/db.php';
 
-date_default_timezone_set(config('app.timezone', 'UTC'));
+date_default_timezone_set(app_timezone());
 
 function app_name(): string
 {
-    return (string) config('app.name', 'EveMarket');
+    $configured = trim((string) get_setting('app_name', config('app.name', 'EveMarket')));
+
+    return sanitize_app_name($configured);
+}
+
+function app_timezone(): string
+{
+    $timezone = trim((string) get_setting('app_timezone', config('app.timezone', 'UTC')));
+
+    return sanitize_timezone($timezone);
+}
+
+function default_currency(): string
+{
+    $currency = strtoupper(trim((string) get_setting('default_currency', 'ISK')));
+
+    return sanitize_currency($currency);
 }
 
 function current_path(): string
@@ -127,6 +143,40 @@ function sanitize_station_selection(?string $value, string $stationType): string
     return $stationType === 'alliance'
         ? sanitize_alliance_station_selection($value)
         : sanitize_market_station_selection($value);
+}
+
+
+function sanitize_app_name(string $name): string
+{
+    $name = trim($name);
+
+    if ($name === '') {
+        return 'EveMarket';
+    }
+
+    return mb_substr($name, 0, 120);
+}
+
+function sanitize_timezone(string $timezone): string
+{
+    $timezone = trim($timezone);
+
+    if ($timezone === '') {
+        return 'UTC';
+    }
+
+    return in_array($timezone, timezone_identifiers_list(), true) ? $timezone : 'UTC';
+}
+
+function sanitize_currency(string $currency): string
+{
+    $currency = strtoupper(trim($currency));
+
+    if ($currency === '' || !preg_match('/^[A-Z]{2,8}$/', $currency)) {
+        return 'ISK';
+    }
+
+    return $currency;
 }
 
 function sanitize_market_station_selection(?string $value): string


### PR DESCRIPTION
## Summary
- made general settings truly drive runtime behavior by introducing app-level helpers for app name, timezone, and default currency
- added sanitizers for general settings values to keep stored data valid and predictable
- extended General Settings UI to manage `app_name` alongside timezone/currency and save sanitized values
- surfaced configured default currency on the dashboard cards
- added schema seed defaults for `app_name`, `app_timezone`, and `default_currency`

## Details
- `src/functions.php`
  - `app_name()` now resolves from DB settings with fallback
  - added `app_timezone()` and `default_currency()` helpers
  - set `date_default_timezone_set(app_timezone())` so timezone setting affects app behavior
  - added `sanitize_app_name()`, `sanitize_timezone()`, and `sanitize_currency()`
- `public/settings/index.php`
  - General section now saves `app_name`, `app_timezone`, and `default_currency` through sanitizer helpers
  - General form now includes Application Name field
- `public/index.php`
  - added a dashboard stat card for default currency
- `database/schema.sql`
  - seeded defaults for the three general behavior settings

## Validation
- `php -l src/functions.php`
- `php -l public/settings/index.php`
- `php -l public/index.php`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b92bd96eb8832fb5eea6a7c8b7717a)