### PR TITLE
Add local EVE static-data reference import pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,43 @@ If you previously had one cron line per pipeline/job, remove those entries and k
 - ESI OAuth flow with callback endpoint and token persistence
 - Add sync job queue + import workers
 - Split section UI blocks into dedicated templates/components as settings grow
+
+## EVE Static Data Import Pipeline
+
+EveMarket includes a local reference-data pipeline for EVE static data exports.
+
+### What it does
+
+- Checks the current upstream static-data build from `static_data_source_url`
+- Compares upstream build metadata with `static_data_import_state.imported_build_id`
+- Downloads and caches the static package in `storage/static-data/`
+- Imports selected **reference-only** datasets into MySQL tables:
+  - `ref_regions`
+  - `ref_constellations`
+  - `ref_systems`
+  - `ref_npc_stations`
+  - `ref_market_groups`
+  - `ref_item_types`
+- Tracks import status, mode, and build in `static_data_import_state`
+
+### Import modes
+
+- **Full refresh**: truncates reference tables then reloads from current build.
+- **Build-aware incremental**: compares build IDs and upserts rows when a new build is detected.
+  - If `incremental_updates_enabled=0`, imports automatically use full refresh behavior.
+
+### Run options
+
+- Web UI: **Settings → Data Sync → Import EVE Static Data**
+- CLI:
+
+```bash
+php bin/static_data_import.php --mode=auto
+php bin/static_data_import.php --mode=full --force
+php bin/static_data_import.php --mode=incremental
+```
+
+### Data-boundary policy
+
+Static data is used only for non-live, non-authenticated reference metadata.
+Do **not** use static data as a source for token-scoped character data, alliance structure auth state, live market feeds, or account-level real-time information.

--- a/bin/static_data_import.php
+++ b/bin/static_data_import.php
@@ -1,0 +1,48 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+function static_data_import_parse_options(array $argv): array
+{
+    $options = getopt('', ['mode::', 'force']);
+    $mode = trim((string) ($options['mode'] ?? 'auto'));
+    if (!in_array($mode, ['auto', 'full', 'incremental'], true)) {
+        throw new InvalidArgumentException('Argument --mode must be one of auto|full|incremental.');
+    }
+
+    return [
+        'mode' => $mode,
+        'force' => array_key_exists('force', $options),
+    ];
+}
+
+function static_data_import_log(string $event, array $payload = [], $stream = STDOUT): void
+{
+    fwrite($stream, json_encode(['event' => $event, 'ts' => gmdate(DATE_ATOM)] + $payload, JSON_UNESCAPED_SLASHES) . PHP_EOL);
+}
+
+function static_data_import_main(array $argv): int
+{
+    try {
+        $options = static_data_import_parse_options($argv);
+        $result = static_data_import_reference_data($options['mode'], $options['force']);
+
+        static_data_import_log('static_data.import.success', [
+            'mode' => $result['mode'] ?? 'auto',
+            'build_id' => $result['build_id'] ?? null,
+            'changed' => (bool) ($result['changed'] ?? false),
+            'rows_written' => (int) ($result['rows_written'] ?? 0),
+        ]);
+
+        return 0;
+    } catch (Throwable $exception) {
+        static_data_import_log('static_data.import.failed', ['error' => $exception->getMessage()], STDERR);
+
+        return 1;
+    }
+}
+
+exit(static_data_import_main($argv));

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -184,6 +184,91 @@ CREATE TABLE IF NOT EXISTS market_history_daily (
     KEY idx_market_history_daily_observed (source_type, source_id, observed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS static_data_import_state (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    source_key VARCHAR(120) NOT NULL,
+    source_url VARCHAR(500) NOT NULL,
+    remote_build_id VARCHAR(190) DEFAULT NULL,
+    imported_build_id VARCHAR(190) DEFAULT NULL,
+    imported_mode ENUM('full', 'incremental') DEFAULT NULL,
+    status ENUM('idle', 'running', 'success', 'failed') NOT NULL DEFAULT 'idle',
+    last_checked_at DATETIME DEFAULT NULL,
+    last_import_started_at DATETIME DEFAULT NULL,
+    last_import_finished_at DATETIME DEFAULT NULL,
+    last_error_message VARCHAR(500) DEFAULT NULL,
+    metadata_json JSON DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_source_key (source_key),
+    KEY idx_imported_build_id (imported_build_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ref_regions (
+    region_id INT UNSIGNED PRIMARY KEY,
+    region_name VARCHAR(120) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ref_constellations (
+    constellation_id INT UNSIGNED PRIMARY KEY,
+    region_id INT UNSIGNED NOT NULL,
+    constellation_name VARCHAR(120) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_region_id (region_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ref_systems (
+    system_id INT UNSIGNED PRIMARY KEY,
+    constellation_id INT UNSIGNED NOT NULL,
+    region_id INT UNSIGNED NOT NULL,
+    system_name VARCHAR(120) NOT NULL,
+    security DECIMAL(5,3) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_constellation_id (constellation_id),
+    KEY idx_region_id (region_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ref_npc_stations (
+    station_id INT UNSIGNED PRIMARY KEY,
+    station_name VARCHAR(190) NOT NULL,
+    system_id INT UNSIGNED NOT NULL,
+    constellation_id INT UNSIGNED NOT NULL,
+    region_id INT UNSIGNED NOT NULL,
+    station_type_id INT UNSIGNED DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_system_id (system_id),
+    KEY idx_region_id (region_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ref_market_groups (
+    market_group_id INT UNSIGNED PRIMARY KEY,
+    parent_group_id INT UNSIGNED DEFAULT NULL,
+    market_group_name VARCHAR(190) NOT NULL,
+    description TEXT DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_parent_group_id (parent_group_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ref_item_types (
+    type_id INT UNSIGNED PRIMARY KEY,
+    group_id INT UNSIGNED NOT NULL,
+    market_group_id INT UNSIGNED DEFAULT NULL,
+    type_name VARCHAR(255) NOT NULL,
+    description TEXT DEFAULT NULL,
+    published TINYINT(1) NOT NULL DEFAULT 0,
+    volume DECIMAL(20,6) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_group_id (group_id),
+    KEY idx_market_group_id (market_group_id),
+    KEY idx_published (published)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 INSERT INTO trading_stations (station_name, station_type) VALUES
     ('Jita IV - Moon 4 - Caldari Navy Assembly Plant', 'market'),
     ('Amarr VIII (Oris) - Emperor Family Academy', 'market'),
@@ -201,6 +286,7 @@ INSERT INTO app_settings (setting_key, setting_value) VALUES
     ('incremental_strategy', 'watermark_upsert'),
     ('incremental_delete_policy', 'reconcile'),
     ('incremental_chunk_size', '1000'),
+    ('static_data_source_url', 'https://www.fuzzwork.co.uk/dump/sqlite-latest.sqlite.bz2'),
     ('alliance_current_backfill_start_date', ''),
     ('alliance_history_backfill_start_date', ''),
     ('hub_history_backfill_start_date', ''),

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -56,6 +56,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 exit;
             }
 
+            if ($dataSyncAction === 'static-data-import') {
+                try {
+                    $result = static_data_import_reference_data('auto', false);
+                    $saved = (bool) ($result['ok'] ?? false);
+                    $message = $saved
+                        ? ('Static data import completed in ' . strtoupper((string) ($result['mode'] ?? 'auto')) . ' mode. Build ' . (string) ($result['build_id'] ?? '-') . '; changed=' . ((bool) ($result['changed'] ?? false) ? 'yes' : 'no') . '; rows=' . (int) ($result['rows_written'] ?? 0) . '.')
+                        : 'Static data import did not complete.';
+                    flash('success', $message);
+                } catch (Throwable $exception) {
+                    $saved = false;
+                    flash('success', 'Static data import failed: ' . $exception->getMessage());
+                }
+
+                header('Location: /settings?section=' . urlencode($submittedSection));
+                exit;
+            }
+
             $settingsSaved = save_settings(data_sync_settings_from_request($_POST));
             $schedulesSaved = save_data_sync_schedule_settings($_POST);
             $saved = $settingsSaved && $schedulesSaved;
@@ -90,6 +107,7 @@ $settingValues = get_settings([
     'hub_history_backfill_start_date',
     'raw_order_snapshot_retention_days',
     'sync_automation_enabled_since',
+    'static_data_source_url',
 ]);
 
 $stations = grouped_station_options();
@@ -101,11 +119,14 @@ $missingStructureScopes = [];
 $syncStatusCards = [];
 $syncScheduleCards = sync_schedule_settings_view_model();
 $runNowJobOptions = [];
+$staticDataState = null;
 if ($dbStatus['ok']) {
     $latestEsiToken = db_latest_esi_oauth_token();
     if ($latestEsiToken !== null) {
         $missingStructureScopes = esi_missing_scopes($latestEsiToken, $requiredStructureScopes);
     }
+
+    $staticDataState = db_static_data_import_state_get(static_data_source_key());
 
     $syncStatusCards = [
         [
@@ -472,6 +493,15 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     </label>
                 </div>
 
+                <?php if ($staticDataState !== null): ?>
+                    <div class="rounded-lg border border-border bg-black/20 p-3 text-sm text-muted space-y-1">
+                        <p><span class="text-slate-100">Static Data Source:</span> <?= htmlspecialchars((string) ($staticDataState['source_url'] ?? ''), ENT_QUOTES) ?></p>
+                        <p><span class="text-slate-100">Remote Build:</span> <?= htmlspecialchars((string) ($staticDataState['remote_build_id'] ?? '-'), ENT_QUOTES) ?></p>
+                        <p><span class="text-slate-100">Imported Build:</span> <?= htmlspecialchars((string) ($staticDataState['imported_build_id'] ?? '-'), ENT_QUOTES) ?></p>
+                        <p><span class="text-slate-100">Last Status:</span> <?= htmlspecialchars((string) ($staticDataState['status'] ?? 'idle'), ENT_QUOTES) ?> (<?= htmlspecialchars((string) ($staticDataState['imported_mode'] ?? '-'), ENT_QUOTES) ?>)</p>
+                    </div>
+                <?php endif; ?>
+
                 <p class="text-sm text-muted">When enabled, future import/sync jobs will only process changed rows for better scalability.</p>
                 <div class="flex flex-wrap items-center gap-2">
                     <button name="data_sync_action" value="save" class="rounded-lg bg-accent px-4 py-2 text-sm font-medium">Save Data Sync Settings</button>
@@ -481,6 +511,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <?php endforeach; ?>
                     </select>
                     <button name="data_sync_action" value="run-now" class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-slate-100 hover:bg-white/5">Run selected now</button>
+                    <button name="data_sync_action" value="static-data-import" class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-slate-100 hover:bg-white/5">Import EVE Static Data</button>
                 </div>
             </form>
         <?php endif; ?>

--- a/src/db.php
+++ b/src/db.php
@@ -894,3 +894,114 @@ function db_sync_schedule_force_due_by_job_keys(array $jobKeys): int
 
     return (int) $stmt->rowCount();
 }
+
+function db_static_data_import_state_get(string $sourceKey): ?array
+{
+    return db_select_one(
+        'SELECT id, source_key, source_url, remote_build_id, imported_build_id, imported_mode, status, last_checked_at, last_import_started_at, last_import_finished_at, last_error_message, metadata_json
+         FROM static_data_import_state
+         WHERE source_key = ?
+         LIMIT 1',
+        [$sourceKey]
+    );
+}
+
+function db_static_data_import_state_upsert(
+    string $sourceKey,
+    string $sourceUrl,
+    ?string $remoteBuildId,
+    ?string $importedBuildId,
+    ?string $importedMode,
+    string $status,
+    ?string $lastCheckedAt,
+    ?string $lastImportStartedAt,
+    ?string $lastImportFinishedAt,
+    ?string $lastErrorMessage,
+    ?string $metadataJson
+): bool {
+    $safeStatus = in_array($status, ['idle', 'running', 'success', 'failed'], true) ? $status : 'idle';
+    $safeMode = in_array((string) $importedMode, ['full', 'incremental'], true) ? $importedMode : null;
+
+    return db_execute(
+        'INSERT INTO static_data_import_state (
+            source_key,
+            source_url,
+            remote_build_id,
+            imported_build_id,
+            imported_mode,
+            status,
+            last_checked_at,
+            last_import_started_at,
+            last_import_finished_at,
+            last_error_message,
+            metadata_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+            source_url = VALUES(source_url),
+            remote_build_id = VALUES(remote_build_id),
+            imported_build_id = VALUES(imported_build_id),
+            imported_mode = VALUES(imported_mode),
+            status = VALUES(status),
+            last_checked_at = VALUES(last_checked_at),
+            last_import_started_at = VALUES(last_import_started_at),
+            last_import_finished_at = VALUES(last_import_finished_at),
+            last_error_message = VALUES(last_error_message),
+            metadata_json = VALUES(metadata_json),
+            updated_at = CURRENT_TIMESTAMP',
+        [
+            $sourceKey,
+            $sourceUrl,
+            $remoteBuildId,
+            $importedBuildId,
+            $safeMode,
+            $safeStatus,
+            $lastCheckedAt,
+            $lastImportStartedAt,
+            $lastImportFinishedAt,
+            $lastErrorMessage !== null ? mb_substr($lastErrorMessage, 0, 500) : null,
+            $metadataJson,
+        ]
+    );
+}
+
+function db_reference_data_truncate_all(): void
+{
+    db_transaction(static function (): void {
+        db_execute('TRUNCATE TABLE ref_item_types');
+        db_execute('TRUNCATE TABLE ref_market_groups');
+        db_execute('TRUNCATE TABLE ref_npc_stations');
+        db_execute('TRUNCATE TABLE ref_systems');
+        db_execute('TRUNCATE TABLE ref_constellations');
+        db_execute('TRUNCATE TABLE ref_regions');
+    });
+}
+
+function db_ref_regions_bulk_upsert(array $rows, ?int $chunkSize = null): int
+{
+    return db_bulk_insert_or_upsert('ref_regions', ['region_id', 'region_name'], $rows, ['region_name'], $chunkSize);
+}
+
+function db_ref_constellations_bulk_upsert(array $rows, ?int $chunkSize = null): int
+{
+    return db_bulk_insert_or_upsert('ref_constellations', ['constellation_id', 'region_id', 'constellation_name'], $rows, ['region_id', 'constellation_name'], $chunkSize);
+}
+
+function db_ref_systems_bulk_upsert(array $rows, ?int $chunkSize = null): int
+{
+    return db_bulk_insert_or_upsert('ref_systems', ['system_id', 'constellation_id', 'region_id', 'system_name', 'security'], $rows, ['constellation_id', 'region_id', 'system_name', 'security'], $chunkSize);
+}
+
+function db_ref_npc_stations_bulk_upsert(array $rows, ?int $chunkSize = null): int
+{
+    return db_bulk_insert_or_upsert('ref_npc_stations', ['station_id', 'station_name', 'system_id', 'constellation_id', 'region_id', 'station_type_id'], $rows, ['station_name', 'system_id', 'constellation_id', 'region_id', 'station_type_id'], $chunkSize);
+}
+
+function db_ref_market_groups_bulk_upsert(array $rows, ?int $chunkSize = null): int
+{
+    return db_bulk_insert_or_upsert('ref_market_groups', ['market_group_id', 'parent_group_id', 'market_group_name', 'description'], $rows, ['parent_group_id', 'market_group_name', 'description'], $chunkSize);
+}
+
+function db_ref_item_types_bulk_upsert(array $rows, ?int $chunkSize = null): int
+{
+    return db_bulk_insert_or_upsert('ref_item_types', ['type_id', 'group_id', 'market_group_id', 'type_name', 'description', 'published', 'volume'], $rows, ['group_id', 'market_group_id', 'type_name', 'description', 'published', 'volume'], $chunkSize);
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -1925,3 +1925,311 @@ function runner_lock_release(string $lockName): bool
 {
     return db_runner_lock_release($lockName);
 }
+
+function static_data_source_key(): string
+{
+    return 'fuzzwork.sqlite';
+}
+
+function static_data_source_url(): string
+{
+    $configured = trim((string) get_setting('static_data_source_url', 'https://www.fuzzwork.co.uk/dump/sqlite-latest.sqlite.bz2'));
+
+    return $configured !== '' ? $configured : 'https://www.fuzzwork.co.uk/dump/sqlite-latest.sqlite.bz2';
+}
+
+function static_data_import_mode(string $requestedMode = 'auto'): string
+{
+    $normalized = trim(mb_strtolower($requestedMode));
+    $incrementalEnabled = get_setting('incremental_updates_enabled', '1') === '1';
+
+    if ($normalized === 'full') {
+        return 'full';
+    }
+
+    if ($normalized === 'incremental') {
+        return $incrementalEnabled ? 'incremental' : 'full';
+    }
+
+    return $incrementalEnabled ? 'incremental' : 'full';
+}
+
+function static_data_fetch_remote_build_info(string $sourceUrl): array
+{
+    $headers = @get_headers($sourceUrl, true);
+    if ($headers === false) {
+        throw new RuntimeException('Unable to fetch static-data headers from source URL.');
+    }
+
+    $lastModified = '';
+    $etag = '';
+
+    if (is_array($headers['Last-Modified'] ?? null)) {
+        $lastModified = (string) end($headers['Last-Modified']);
+    } elseif (isset($headers['Last-Modified'])) {
+        $lastModified = (string) $headers['Last-Modified'];
+    }
+
+    if (is_array($headers['ETag'] ?? null)) {
+        $etag = (string) end($headers['ETag']);
+    } elseif (isset($headers['ETag'])) {
+        $etag = (string) $headers['ETag'];
+    }
+
+    $buildId = sha1($sourceUrl . '|' . trim($etag, '"') . '|' . $lastModified);
+
+    return [
+        'build_id' => $buildId,
+        'etag' => trim((string) $etag, '"'),
+        'last_modified' => $lastModified,
+    ];
+}
+
+function static_data_storage_paths(string $buildId): array
+{
+    $baseDir = dirname(__DIR__) . '/storage/static-data';
+
+    return [
+        'base_dir' => $baseDir,
+        'archive_path' => $baseDir . '/' . $buildId . '.sqlite.bz2',
+        'sqlite_path' => $baseDir . '/' . $buildId . '.sqlite',
+    ];
+}
+
+function static_data_ensure_local_sqlite(string $sourceUrl, string $buildId): string
+{
+    $paths = static_data_storage_paths($buildId);
+    if (!is_dir($paths['base_dir']) && !mkdir($paths['base_dir'], 0775, true) && !is_dir($paths['base_dir'])) {
+        throw new RuntimeException('Unable to create static-data storage directory.');
+    }
+
+    if (!is_file($paths['archive_path'])) {
+        $context = stream_context_create(['http' => ['timeout' => 120]]);
+        $payload = @file_get_contents($sourceUrl, false, $context);
+        if ($payload === false) {
+            throw new RuntimeException('Failed to download static-data package.');
+        }
+
+        if (file_put_contents($paths['archive_path'], $payload) === false) {
+            throw new RuntimeException('Failed to write static-data archive to local storage.');
+        }
+    }
+
+    if (!is_file($paths['sqlite_path'])) {
+        $input = bzopen($paths['archive_path'], 'r');
+        if ($input === false) {
+            throw new RuntimeException('Failed to open compressed static-data archive.');
+        }
+
+        $output = fopen($paths['sqlite_path'], 'wb');
+        if ($output === false) {
+            bzclose($input);
+            throw new RuntimeException('Failed to create local static-data sqlite file.');
+        }
+
+        while (!feof($input)) {
+            $chunk = bzread($input, 1024 * 1024);
+            if ($chunk === false) {
+                fclose($output);
+                bzclose($input);
+                throw new RuntimeException('Failed while decompressing static-data archive.');
+            }
+
+            if ($chunk === '') {
+                continue;
+            }
+
+            fwrite($output, $chunk);
+        }
+
+        fclose($output);
+        bzclose($input);
+    }
+
+    return $paths['sqlite_path'];
+}
+
+function static_data_sqlite_query(SQLite3 $sqlite, string $sql): array
+{
+    $result = $sqlite->query($sql);
+    if (!$result instanceof SQLite3Result) {
+        return [];
+    }
+
+    $rows = [];
+    while (($row = $result->fetchArray(SQLITE3_ASSOC)) !== false) {
+        $rows[] = $row;
+    }
+
+    return $rows;
+}
+
+function static_data_import_reference_data(string $requestedMode = 'auto', bool $force = false): array
+{
+    $sourceKey = static_data_source_key();
+    $sourceUrl = static_data_source_url();
+    $state = db_static_data_import_state_get($sourceKey);
+    $mode = static_data_import_mode($requestedMode);
+    $checkedAt = gmdate('Y-m-d H:i:s');
+
+    $remote = static_data_fetch_remote_build_info($sourceUrl);
+    $remoteBuildId = (string) $remote['build_id'];
+    $importedBuildId = (string) ($state['imported_build_id'] ?? '');
+
+    if (!$force && $remoteBuildId === $importedBuildId) {
+        db_static_data_import_state_upsert(
+            $sourceKey,
+            $sourceUrl,
+            $remoteBuildId,
+            $importedBuildId === '' ? null : $importedBuildId,
+            $state['imported_mode'] ?? null,
+            'success',
+            $checkedAt,
+            $state['last_import_started_at'] ?? null,
+            $state['last_import_finished_at'] ?? null,
+            null,
+            json_encode(['remote' => $remote, 'note' => 'Already up to date.'], JSON_THROW_ON_ERROR)
+        );
+
+        return ['ok' => true, 'changed' => false, 'build_id' => $remoteBuildId, 'rows_written' => 0, 'mode' => $mode];
+    }
+
+    $startedAt = gmdate('Y-m-d H:i:s');
+    db_static_data_import_state_upsert(
+        $sourceKey,
+        $sourceUrl,
+        $remoteBuildId,
+        $importedBuildId === '' ? null : $importedBuildId,
+        $mode,
+        'running',
+        $checkedAt,
+        $startedAt,
+        null,
+        null,
+        json_encode(['remote' => $remote], JSON_THROW_ON_ERROR)
+    );
+
+    try {
+        $sqlitePath = static_data_ensure_local_sqlite($sourceUrl, $remoteBuildId);
+        $sqlite = new SQLite3($sqlitePath, SQLITE3_OPEN_READONLY);
+
+        $regions = [];
+        foreach (static_data_sqlite_query($sqlite, 'SELECT regionID, regionName FROM mapRegions') as $row) {
+            $regions[] = ['region_id' => (int) $row['regionID'], 'region_name' => (string) ($row['regionName'] ?? '')];
+        }
+
+        $constellations = [];
+        foreach (static_data_sqlite_query($sqlite, 'SELECT constellationID, regionID, constellationName FROM mapConstellations') as $row) {
+            $constellations[] = [
+                'constellation_id' => (int) $row['constellationID'],
+                'region_id' => (int) $row['regionID'],
+                'constellation_name' => (string) ($row['constellationName'] ?? ''),
+            ];
+        }
+
+        $systems = [];
+        foreach (static_data_sqlite_query($sqlite, 'SELECT solarSystemID, constellationID, regionID, solarSystemName, security FROM mapSolarSystems') as $row) {
+            $systems[] = [
+                'system_id' => (int) $row['solarSystemID'],
+                'constellation_id' => (int) $row['constellationID'],
+                'region_id' => (int) $row['regionID'],
+                'system_name' => (string) ($row['solarSystemName'] ?? ''),
+                'security' => (float) ($row['security'] ?? 0),
+            ];
+        }
+
+        $stations = [];
+        foreach (static_data_sqlite_query($sqlite, 'SELECT stationID, stationName, solarSystemID, constellationID, regionID, stationTypeID FROM staStations') as $row) {
+            $stations[] = [
+                'station_id' => (int) $row['stationID'],
+                'station_name' => (string) ($row['stationName'] ?? ''),
+                'system_id' => (int) $row['solarSystemID'],
+                'constellation_id' => (int) $row['constellationID'],
+                'region_id' => (int) $row['regionID'],
+                'station_type_id' => isset($row['stationTypeID']) ? (int) $row['stationTypeID'] : null,
+            ];
+        }
+
+        $marketGroups = [];
+        foreach (static_data_sqlite_query($sqlite, 'SELECT marketGroupID, parentGroupID, marketGroupName, description FROM invMarketGroups') as $row) {
+            $marketGroups[] = [
+                'market_group_id' => (int) $row['marketGroupID'],
+                'parent_group_id' => isset($row['parentGroupID']) ? (int) $row['parentGroupID'] : null,
+                'market_group_name' => (string) ($row['marketGroupName'] ?? ''),
+                'description' => isset($row['description']) ? (string) $row['description'] : null,
+            ];
+        }
+
+        $types = [];
+        foreach (static_data_sqlite_query($sqlite, 'SELECT typeID, groupID, marketGroupID, typeName, description, published, volume FROM invTypes') as $row) {
+            $types[] = [
+                'type_id' => (int) $row['typeID'],
+                'group_id' => (int) $row['groupID'],
+                'market_group_id' => isset($row['marketGroupID']) ? (int) $row['marketGroupID'] : null,
+                'type_name' => (string) ($row['typeName'] ?? ''),
+                'description' => isset($row['description']) ? (string) $row['description'] : null,
+                'published' => (int) ($row['published'] ?? 0) === 1 ? 1 : 0,
+                'volume' => isset($row['volume']) ? (float) $row['volume'] : null,
+            ];
+        }
+
+        $rowsWritten = db_transaction(static function () use ($mode, $regions, $constellations, $systems, $stations, $marketGroups, $types): int {
+            if ($mode === 'full') {
+                db_reference_data_truncate_all();
+            }
+
+            $written = 0;
+            $written += db_ref_regions_bulk_upsert($regions);
+            $written += db_ref_constellations_bulk_upsert($constellations);
+            $written += db_ref_systems_bulk_upsert($systems);
+            $written += db_ref_npc_stations_bulk_upsert($stations);
+            $written += db_ref_market_groups_bulk_upsert($marketGroups);
+            $written += db_ref_item_types_bulk_upsert($types);
+
+            return $written;
+        });
+
+        $finishedAt = gmdate('Y-m-d H:i:s');
+        db_static_data_import_state_upsert(
+            $sourceKey,
+            $sourceUrl,
+            $remoteBuildId,
+            $remoteBuildId,
+            $mode,
+            'success',
+            $checkedAt,
+            $startedAt,
+            $finishedAt,
+            null,
+            json_encode([
+                'remote' => $remote,
+                'dataset_counts' => [
+                    'regions' => count($regions),
+                    'constellations' => count($constellations),
+                    'systems' => count($systems),
+                    'npc_stations' => count($stations),
+                    'market_groups' => count($marketGroups),
+                    'item_types' => count($types),
+                ],
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        return ['ok' => true, 'changed' => true, 'build_id' => $remoteBuildId, 'rows_written' => $rowsWritten, 'mode' => $mode];
+    } catch (Throwable $exception) {
+        db_static_data_import_state_upsert(
+            $sourceKey,
+            $sourceUrl,
+            $remoteBuildId,
+            $importedBuildId === '' ? null : $importedBuildId,
+            $mode,
+            'failed',
+            $checkedAt,
+            $startedAt,
+            gmdate('Y-m-d H:i:s'),
+            $exception->getMessage(),
+            json_encode(['remote' => $remote], JSON_THROW_ON_ERROR)
+        );
+
+        throw $exception;
+    }
+}


### PR DESCRIPTION
## Summary
- add schema support for static reference imports with `static_data_import_state` and normalized reference tables (`ref_regions`, `ref_constellations`, `ref_systems`, `ref_npc_stations`, `ref_market_groups`, `ref_item_types`)
- add centralized DB wrappers in `src/db.php` for import-state upserts, reference-table truncation, and bulk upsert writes
- add shared importer logic in `src/functions.php` to:
  - discover upstream build metadata
  - compare remote vs imported build
  - download/cache/decompress SQLite static-data artifacts locally
  - import selected reference datasets in full or build-aware incremental mode
  - persist import outcomes and metadata for future sync evolution
- add `bin/static_data_import.php` CLI entrypoint (`--mode=auto|full|incremental`, `--force`)
- extend Settings → Data Sync with an `Import EVE Static Data` action and current static-import status block
- document the new pipeline, modes, operational commands, and static-data boundaries in README

## Notes
- importer uses static data only for non-live metadata and explicitly avoids authenticated/live ESI concerns
- incremental/full behavior is controlled by existing `incremental_updates_enabled` setting as requested

## Validation
- `php -l src/db.php`
- `php -l src/functions.php`
- `php -l public/settings/index.php`
- `php -l bin/static_data_import.php`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b965b55f80832fbe9a075a9c362baf)