### PR TITLE
Prefer local hub history for dashboard trend snippets

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -114,8 +114,9 @@ include __DIR__ . '/../src/views/partials/header.php';
         <span class="text-xs text-muted">Short-period movement from daily history</span>
     </div>
     <?php $snippets = $intel['trend_snippets'] ?? []; ?>
+    <?php $snippetMessage = trim((string) ($intel['trend_snippets_message'] ?? '')); ?>
     <?php if ($snippets === []): ?>
-        <p class="mt-4 rounded-lg border border-dashed border-border bg-black/20 p-4 text-sm text-muted">Trend snippets will appear after reference hub history is synced. Enable hub history sync in Settings → Data Sync and run at least two daily snapshots.</p>
+        <p class="mt-4 rounded-lg border border-dashed border-border bg-black/20 p-4 text-sm text-muted"><?= htmlspecialchars($snippetMessage !== '' ? $snippetMessage : 'Trend snippets will appear after reference hub history is synced. Enable hub history sync in Settings → Data Sync and run at least two daily snapshots.', ENT_QUOTES) ?></p>
     <?php else: ?>
         <div class="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             <?php foreach ($snippets as $snippet): ?>

--- a/src/functions.php
+++ b/src/functions.php
@@ -1118,6 +1118,56 @@ function dashboard_trend_snippets(array $rows): array
     return array_slice($snippets, 0, 6);
 }
 
+function market_hub_dashboard_trend_legacy_history_fallback_enabled(): bool
+{
+    return sanitize_enabled_flag(get_setting('dashboard_trend_legacy_history_fallback_enabled', '0')) === '1';
+}
+
+function dashboard_trend_history_dataset(string $marketHubRef, int $referenceSourceId): array
+{
+    $historyRows = [];
+    $message = '';
+
+    if ($marketHubRef === '' || $referenceSourceId <= 0) {
+        return [
+            'rows' => [],
+            'message' => 'Trend snippets need a reference hub. Configure Settings → General first, then run the local-history sync job for that hub.',
+        ];
+    }
+
+    try {
+        $historyRows = db_market_hub_local_history_daily_latest_points_by_type(market_hub_local_history_source(), $referenceSourceId, [], 2, 80);
+    } catch (Throwable) {
+        $historyRows = [];
+    }
+
+    if ($historyRows !== []) {
+        return [
+            'rows' => $historyRows,
+            'message' => '',
+        ];
+    }
+
+    $message = 'Trend snippets use local hub history. Run the local-history sync job for ' . market_hub_reference_name() . ' and capture at least two daily snapshots; EVE Tycoon history sync does not populate this panel.';
+
+    if (market_hub_dashboard_trend_legacy_history_fallback_enabled()) {
+        try {
+            $historyRows = db_market_history_daily_recent_window('market_hub', $referenceSourceId, 8, 80);
+        } catch (Throwable) {
+            $historyRows = [];
+        }
+
+        if ($historyRows !== []) {
+            $message = 'Trend snippets are temporarily using legacy hub history fallback. Run the local-history sync job to migrate this panel to market_hub_local_history_daily.';
+        }
+    }
+
+    return [
+        'rows' => $historyRows,
+        'message' => $message,
+    ];
+}
+
 function dashboard_intelligence_data(): array
 {
     $comparisonContext = market_comparison_context();
@@ -1139,14 +1189,8 @@ function dashboard_intelligence_data(): array
 
     $marketHubRef = market_hub_setting_reference();
     $referenceSourceId = sync_source_id_from_hub_ref($marketHubRef);
-    $historyRows = [];
-    if ($referenceSourceId > 0) {
-        try {
-            $historyRows = db_market_history_daily_recent_window('market_hub', $referenceSourceId, 8, 80);
-        } catch (Throwable) {
-            $historyRows = [];
-        }
-    }
+    $trendHistory = dashboard_trend_history_dataset($marketHubRef, $referenceSourceId);
+    $historyRows = $trendHistory['rows'] ?? [];
 
     return [
         'kpis' => [
@@ -1183,6 +1227,7 @@ function dashboard_intelligence_data(): array
             ],
         ],
         'trend_snippets' => dashboard_trend_snippets($historyRows),
+        'trend_snippets_message' => (string) ($trendHistory['message'] ?? ''),
     ];
 }
 


### PR DESCRIPTION
### Motivation

- Surface short-period trend snippets from the hub-local history store so the dashboard reflects the active hub's local snapshots rather than legacy aggregated history.
- Provide clear user guidance when local history is missing and allow a temporary, opt-in legacy fallback during migration.

### Description

- Read trend input from `market_hub_local_history_daily` using a new loader `dashboard_trend_history_dataset()` which calls `db_market_hub_local_history_daily_latest_points_by_type()` and returns `{ rows, message }`.
- Preserve the existing snippet output shape and minimum two-point requirement by keeping `dashboard_trend_snippets()` behavior and requesting 2 latest points per `type_id` from the local-history query.
- Add a small helper `market_hub_dashboard_trend_legacy_history_fallback_enabled()` to toggle an optional fallback to `db_market_history_daily_recent_window()` for migration periods.
- Expose an explicit empty-state guidance message as `trend_snippets_message` from `dashboard_intelligence_data()` and render it in `public/index.php` when no snippets are present.
- Files changed: `src/functions.php` (new loader and helper, wiring into `dashboard_intelligence_data()`), `public/index.php` (render empty-state message while preserving snippet fields `module`, `movement`, `direction`, `latest_close`, `latest_volume`).

### Testing

- `php -l src/functions.php` — syntax check passed.
- `php -l public/index.php` — syntax check passed.
- `git diff --check` — whitespace/check pass.
- Started PHP built-in server with `php -S 0.0.0.0:8000 -t public` and exercised the root page with `curl -i http://127.0.0.1:8000/ | head -n 20`, which returned HTTP output successfully.
- Attempted a Playwright page screenshot of the dashboard which failed to produce a usable capture due to a proxy/404 during the browser-tool visit (non-blocking; server and curl validated the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba08846dc4832f8dae68f377853862)