### PR TITLE
Add local-history data sync controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ EveMarket sync pipelines depend on the `cron` daemon being present and running o
 - Cron is **timer-only**: it triggers `bin/cron_tick.php` once per minute.
 - The scheduler (`bin/cron_tick.php`) decides which jobs are due and dispatches `bin/sync_runner.php`.
 - Interval and enable/disable controls are configured in **Settings → Data Sync** (`/settings?section=data-sync`) via scheduler rows in `sync_schedules`.
-- The **Run now** button in Settings → Data Sync forces all enabled schedules due immediately and executes one scheduler tick.
+- The local-history scheduler job (`market_hub_local_history_sync`) generates `market_hub_local_history_daily` rows from the latest hub-current snapshot for the configured market hub.
+- **Trend Snippets** on the dashboard depend on that local-history generation; the external hub-history sync alone does not populate the snippet panel.
+- The **Run now** button in Settings → Data Sync includes the Local History job, forces the selected enabled schedule due immediately, and executes one scheduler tick.
 - Backfill start dates are automatic: each pipeline starts from the date sync automation was enabled (`sync_automation_enabled_since`).
 
 ### Required cron runtime environment
@@ -153,10 +155,11 @@ Cron must run with the same environment the app expects:
 - Database vars: `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD`
 - Pipeline source vars (when those pipelines are enabled):
   - `EVEMARKET_ALLIANCE_SOURCE_ID` (for `alliance-current` and `alliance-history`)
-  - `EVEMARKET_HUB_SOURCE_ID` (for `hub-current` and `hub-history`)
+  - `EVEMARKET_HUB_SOURCE_ID` (for `hub-current`, `hub-history`, and local-history generation)
 
 The canonical log path for the cron tick is `storage/logs/cron.log` (relative to app root).
 Raw order snapshots are pruned according to `raw_order_snapshot_retention_days` from Settings → Data Sync.
+Local history rows are built from those current snapshots, so keep the hub-current and Local History schedules enabled together for continuous Trend Snippet updates.
 
 ### Troubleshooting
 

--- a/public/index.php
+++ b/public/index.php
@@ -116,7 +116,7 @@ include __DIR__ . '/../src/views/partials/header.php';
     <?php $snippets = $intel['trend_snippets'] ?? []; ?>
     <?php $snippetMessage = trim((string) ($intel['trend_snippets_message'] ?? '')); ?>
     <?php if ($snippets === []): ?>
-        <p class="mt-4 rounded-lg border border-dashed border-border bg-black/20 p-4 text-sm text-muted"><?= htmlspecialchars($snippetMessage !== '' ? $snippetMessage : 'Trend snippets will appear after reference hub history is synced. Enable hub history sync in Settings → Data Sync and run at least two daily snapshots.', ENT_QUOTES) ?></p>
+        <p class="mt-4 rounded-lg border border-dashed border-border bg-black/20 p-4 text-sm text-muted"><?= htmlspecialchars($snippetMessage !== '' ? $snippetMessage : 'Trend snippets will appear after local history sync is running. Enable the local-history pipeline in Settings → Data Sync, run the Local History job, and capture at least two daily snapshots.', ENT_QUOTES) ?></p>
     <?php else: ?>
         <div class="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             <?php foreach ($snippets as $snippet): ?>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -133,6 +133,7 @@ $settingValues = get_settings([
     'alliance_current_pipeline_enabled',
     'alliance_history_pipeline_enabled',
     'hub_history_pipeline_enabled',
+    'market_hub_local_history_pipeline_enabled',
     'alliance_current_backfill_start_date',
     'alliance_history_backfill_start_date',
     'hub_history_backfill_start_date',
@@ -140,6 +141,8 @@ $settingValues = get_settings([
     'sync_automation_enabled_since',
     'static_data_source_url',
 ]);
+
+$dataSyncSettingValues = data_sync_pipeline_settings_view($settingValues);
 
 $dbStatus = db_connection_status();
 $latestEsiToken = null;
@@ -577,14 +580,14 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
                 <input type="hidden" name="section" value="data-sync">
                 <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
-                    <input type="checkbox" name="incremental_updates_enabled" value="1" <?= ($settingValues['incremental_updates_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                    <input type="checkbox" name="incremental_updates_enabled" value="1" <?= ($dataSyncSettingValues['incremental_updates_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
                     <span class="text-sm">Enable incremental database updates</span>
                 </label>
                 <label class="block space-y-2">
                     <span class="text-sm text-muted">Incremental Strategy</span>
                     <select name="incremental_strategy" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring">
                         <?php foreach (incremental_strategy_options() as $value => $label): ?>
-                            <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= ($settingValues['incremental_strategy'] ?? 'watermark_upsert') === $value ? 'selected' : '' ?>>
+                            <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= ($dataSyncSettingValues['incremental_strategy'] ?? 'watermark_upsert') === $value ? 'selected' : '' ?>>
                                 <?= htmlspecialchars($label, ENT_QUOTES) ?>
                             </option>
                         <?php endforeach; ?>
@@ -594,7 +597,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <span class="text-sm text-muted">Delete Handling Policy</span>
                     <select name="incremental_delete_policy" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring">
                         <?php foreach (incremental_delete_policy_options() as $value => $label): ?>
-                            <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= ($settingValues['incremental_delete_policy'] ?? 'reconcile') === $value ? 'selected' : '' ?>>
+                            <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= ($dataSyncSettingValues['incremental_delete_policy'] ?? 'reconcile') === $value ? 'selected' : '' ?>>
                                 <?= htmlspecialchars($label, ENT_QUOTES) ?>
                             </option>
                         <?php endforeach; ?>
@@ -602,18 +605,29 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 </label>
                 <label class="block space-y-2">
                     <span class="text-sm text-muted">Chunk Size</span>
-                    <input type="number" min="100" max="10000" step="100" name="incremental_chunk_size" value="<?= htmlspecialchars($settingValues['incremental_chunk_size'] ?? '1000', ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                    <input type="number" min="100" max="10000" step="100" name="incremental_chunk_size" value="<?= htmlspecialchars($dataSyncSettingValues['incremental_chunk_size'] ?? '1000', ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
                 </label>
 
                 <div class="space-y-3">
-                    <p class="text-sm text-muted">Per-job schedules</p>
+                    <div>
+                        <p class="text-sm text-muted">Per-job schedules</p>
+                        <p class="mt-1 text-xs text-muted">Scheduler intervals and the Run now selector are managed here, including local-history generation for dashboard trend snippets.</p>
+                    </div>
                     <?php foreach ($syncScheduleCards as $schedule): ?>
+                        <?php $isLocalHistorySchedule = ($schedule['job_key'] ?? '') === 'market_hub_local_history_sync'; ?>
                         <div class="grid gap-3 rounded-lg border border-border bg-black/20 p-3 md:grid-cols-[minmax(0,1fr)_auto_auto]">
-                            <label class="flex items-center gap-3">
-                                <input type="hidden" name="<?= htmlspecialchars($schedule['enabled_key'], ENT_QUOTES) ?>" value="0">
-                                <input type="checkbox" name="<?= htmlspecialchars($schedule['enabled_key'], ENT_QUOTES) ?>" value="1" <?= (int) $schedule['enabled'] === 1 ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
-                                <span class="text-sm">Enable <?= htmlspecialchars($schedule['label'], ENT_QUOTES) ?> job</span>
-                            </label>
+                            <div class="space-y-1">
+                                <label class="flex items-center gap-3">
+                                    <input type="hidden" name="<?= htmlspecialchars($schedule['enabled_key'], ENT_QUOTES) ?>" value="0">
+                                    <input type="checkbox" name="<?= htmlspecialchars($schedule['enabled_key'], ENT_QUOTES) ?>" value="1" <?= (int) $schedule['enabled'] === 1 ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                                    <span class="text-sm">Enable <?= htmlspecialchars($schedule['label'], ENT_QUOTES) ?> job</span>
+                                </label>
+                                <p class="pl-7 text-xs text-muted">
+                                    <?= $isLocalHistorySchedule
+                                        ? 'Generates local daily market history from your latest hub-current snapshot and powers Trend Snippets on the dashboard.'
+                                        : 'Controls how often the scheduler runs this sync job.' ?>
+                                </p>
+                            </div>
                             <input
                                 type="number"
                                 min="1"
@@ -639,31 +653,39 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
                 <label class="block space-y-2">
                     <span class="text-sm text-muted">Raw Order Snapshot Retention (days)</span>
-                    <input type="number" min="1" max="3650" step="1" name="raw_order_snapshot_retention_days" value="<?= htmlspecialchars($settingValues['raw_order_snapshot_retention_days'] ?? '30', ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                    <input type="number" min="1" max="3650" step="1" name="raw_order_snapshot_retention_days" value="<?= htmlspecialchars($dataSyncSettingValues['raw_order_snapshot_retention_days'] ?? '30', ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
                 </label>
 
                 <label class="block space-y-2">
                     <span class="text-sm text-muted">Static Data JSONL ZIP Source URL</span>
-                    <input type="url" name="static_data_source_url" value="<?= htmlspecialchars($settingValues['static_data_source_url'] ?? 'https://developers.eveonline.com/static-data/eve-online-static-data-latest-jsonl.zip', ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                    <input type="url" name="static_data_source_url" value="<?= htmlspecialchars($dataSyncSettingValues['static_data_source_url'] ?? 'https://developers.eveonline.com/static-data/eve-online-static-data-latest-jsonl.zip', ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
                     <p class="text-xs text-muted">Importer expects the official CCP JSONL ZIP payload (<span class="font-mono">.zip</span>) from developers.eveonline.com.</p>
                 </label>
 
                 <div class="space-y-3">
-                    <p class="text-sm text-muted">Pipeline toggles</p>
+                    <div>
+                        <p class="text-sm text-muted">Pipeline toggles</p>
+                        <p class="mt-1 text-xs text-muted">Use these defaults to keep related sync pipelines enabled alongside the scheduler cadence above.</p>
+                    </div>
                     <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
                         <input type="hidden" name="alliance_current_pipeline_enabled" value="0">
-                        <input type="checkbox" name="alliance_current_pipeline_enabled" value="1" <?= ($settingValues['alliance_current_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                        <input type="checkbox" name="alliance_current_pipeline_enabled" value="1" <?= ($dataSyncSettingValues['alliance_current_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
                         <span class="text-sm">Enable alliance current pipeline</span>
                     </label>
                     <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
                         <input type="hidden" name="alliance_history_pipeline_enabled" value="0">
-                        <input type="checkbox" name="alliance_history_pipeline_enabled" value="1" <?= ($settingValues['alliance_history_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                        <input type="checkbox" name="alliance_history_pipeline_enabled" value="1" <?= ($dataSyncSettingValues['alliance_history_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
                         <span class="text-sm">Enable alliance history/backfill pipeline</span>
                     </label>
                     <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
                         <input type="hidden" name="hub_history_pipeline_enabled" value="0">
-                        <input type="checkbox" name="hub_history_pipeline_enabled" value="1" <?= ($settingValues['hub_history_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                        <input type="checkbox" name="hub_history_pipeline_enabled" value="1" <?= ($dataSyncSettingValues['hub_history_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
                         <span class="text-sm">Enable market hub history pipeline</span>
+                    </label>
+                    <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
+                        <input type="hidden" name="market_hub_local_history_pipeline_enabled" value="0">
+                        <input type="checkbox" name="market_hub_local_history_pipeline_enabled" value="1" <?= ($dataSyncSettingValues['market_hub_local_history_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                        <span class="text-sm">Enable local-history pipeline for dashboard trend snippets</span>
                     </label>
                 </div>
 
@@ -679,12 +701,13 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <p class="text-sm text-muted">When enabled, future import/sync jobs will only process changed rows for better scalability.</p>
                 <div class="flex flex-wrap items-center gap-2">
                     <button name="data_sync_action" value="save" class="rounded-lg bg-accent px-4 py-2 text-sm font-medium">Save Data Sync Settings</button>
-                    <select name="run_now_job_key" class="rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring">
+                    <select name="run_now_job_key" class="rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" aria-label="Run a data sync job now">
                         <?php foreach ($runNowJobOptions as $jobOption): ?>
                             <option value="<?= htmlspecialchars($jobOption['job_key'], ENT_QUOTES) ?>"><?= htmlspecialchars($jobOption['label'], ENT_QUOTES) ?></option>
                         <?php endforeach; ?>
                     </select>
                     <button name="data_sync_action" value="run-now" class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-slate-100 hover:bg-white/5">Run selected now</button>
+                    <p class="text-xs text-muted">Local History is available in this selector and is required to populate Trend Snippets.</p>
                     <button name="data_sync_action" value="static-data-import" class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-slate-100 hover:bg-white/5">Import EVE Static Data</button>
                 </div>
             </form>

--- a/src/functions.php
+++ b/src/functions.php
@@ -567,6 +567,53 @@ function sanitize_enabled_flag(mixed $value): string
     return sanitize_pipeline_enabled($value);
 }
 
+function data_sync_pipeline_setting_defaults(): array
+{
+    return [
+        'incremental_updates_enabled' => '1',
+        'incremental_strategy' => 'watermark_upsert',
+        'incremental_delete_policy' => 'reconcile',
+        'incremental_chunk_size' => '1000',
+        'alliance_current_pipeline_enabled' => '1',
+        'alliance_history_pipeline_enabled' => '1',
+        'hub_history_pipeline_enabled' => '1',
+        'market_hub_local_history_pipeline_enabled' => '1',
+        'raw_order_snapshot_retention_days' => '30',
+        'static_data_source_url' => 'https://developers.eveonline.com/static-data/eve-online-static-data-latest-jsonl.zip',
+    ];
+}
+
+function data_sync_pipeline_setting_value(array $settings, string $key): string
+{
+    $defaults = data_sync_pipeline_setting_defaults();
+    $value = $settings[$key] ?? ($defaults[$key] ?? '');
+
+    return match ($key) {
+        'incremental_updates_enabled',
+        'alliance_current_pipeline_enabled',
+        'alliance_history_pipeline_enabled',
+        'hub_history_pipeline_enabled',
+        'market_hub_local_history_pipeline_enabled' => sanitize_pipeline_enabled($value),
+        'incremental_strategy' => sanitize_incremental_strategy((string) $value),
+        'incremental_delete_policy' => sanitize_incremental_delete_policy((string) $value),
+        'incremental_chunk_size' => sanitize_incremental_chunk_size($value),
+        'raw_order_snapshot_retention_days' => sanitize_retention_days($value),
+        'static_data_source_url' => sanitize_static_data_source_url($value),
+        default => (string) $value,
+    };
+}
+
+function data_sync_pipeline_settings_view(array $settings): array
+{
+    $resolved = [];
+
+    foreach (array_keys(data_sync_pipeline_setting_defaults()) as $key) {
+        $resolved[$key] = data_sync_pipeline_setting_value($settings, $key);
+    }
+
+    return $resolved;
+}
+
 function sanitize_backfill_start_date(mixed $value): string
 {
     $raw = trim((string) $value);
@@ -702,7 +749,7 @@ function data_sync_schedule_job_definitions(): array
             'interval_value_key' => 'market_hub_local_history_sync_interval_value',
             'interval_unit_key' => 'market_hub_local_history_sync_interval_unit',
             'default_interval_seconds' => 300,
-            'label' => 'Hub Local History',
+            'label' => 'Local History',
         ],
         'killmail_r2z2_sync' => [
             'enabled_key' => 'killmail_r2z2_sync_enabled',
@@ -794,22 +841,24 @@ function data_sync_settings_from_request(array $request): array
     $allianceCurrentEnabled = sanitize_pipeline_enabled($request['alliance_current_pipeline_enabled'] ?? null);
     $allianceHistoryEnabled = sanitize_pipeline_enabled($request['alliance_history_pipeline_enabled'] ?? null);
     $hubHistoryEnabled = sanitize_pipeline_enabled($request['hub_history_pipeline_enabled'] ?? null);
+    $localHistoryEnabled = sanitize_pipeline_enabled($request['market_hub_local_history_pipeline_enabled'] ?? null);
 
     $baselineDate = sync_automation_enabled_since_date();
 
     return [
-        'incremental_updates_enabled' => isset($request['incremental_updates_enabled']) ? '1' : '0',
+        'incremental_updates_enabled' => sanitize_pipeline_enabled($request['incremental_updates_enabled'] ?? null),
         'incremental_strategy' => sanitize_incremental_strategy($request['incremental_strategy'] ?? null),
         'incremental_delete_policy' => sanitize_incremental_delete_policy($request['incremental_delete_policy'] ?? null),
         'incremental_chunk_size' => sanitize_incremental_chunk_size($request['incremental_chunk_size'] ?? null),
         'alliance_current_pipeline_enabled' => $allianceCurrentEnabled,
         'alliance_history_pipeline_enabled' => $allianceHistoryEnabled,
         'hub_history_pipeline_enabled' => $hubHistoryEnabled,
+        'market_hub_local_history_pipeline_enabled' => $localHistoryEnabled,
         'sync_automation_enabled_since' => $baselineDate,
         'alliance_current_backfill_start_date' => data_sync_backfill_start_date('alliance_current_backfill_start_date', $allianceCurrentEnabled === '1', $baselineDate),
         'alliance_history_backfill_start_date' => data_sync_backfill_start_date('alliance_history_backfill_start_date', $allianceHistoryEnabled === '1', $baselineDate),
         'hub_history_backfill_start_date' => data_sync_backfill_start_date('hub_history_backfill_start_date', $hubHistoryEnabled === '1', $baselineDate),
-        'raw_order_snapshot_retention_days' => sanitize_retention_days($request['raw_order_snapshot_retention_days'] ?? null, 30),
+        'raw_order_snapshot_retention_days' => sanitize_retention_days($request['raw_order_snapshot_retention_days'] ?? null),
         'static_data_source_url' => sanitize_static_data_source_url($request['static_data_source_url'] ?? null),
     ];
 }


### PR DESCRIPTION
### Motivation

- Expose and sanitize a new local-history pipeline toggle and its interval/settings so the app can generate daily local hub history used by dashboard Trend Snippets.
- Make the Data Sync UI clearer about per-job intervals and surface a Run Now path for the local-history job.
- Update the dashboard copy and README so users understand Trend Snippets depend on local-history generation rather than the external hub-history provider.

### Description

- Added centralized Data Sync defaults and sanitization helpers in `src/functions.php` (`data_sync_pipeline_setting_defaults`, `data_sync_pipeline_setting_value`, `data_sync_pipeline_settings_view`) and included the `market_hub_local_history_pipeline_enabled` key and default values.
- Updated schedule metadata to label the job as `Local History` in `data_sync_schedule_job_definitions()` and added request sanitization for `market_hub_local_history_pipeline_enabled` inside `data_sync_settings_from_request()`.
- Reworked the Data Sync settings page `public/settings/index.php` to use the resolved/sanitized `dataSyncSettingValues`, show per-job interval controls with explanatory copy for the local-history job, add a checkbox for the local-history pipeline, and clarify that Local History appears in the “Run now” selector.
- Adjusted the dashboard empty-state copy in `public/index.php` to instruct users to enable and run the local-history pipeline for Trend Snippets, and updated `README.md` scheduler docs to document local-history generation and its dependency for Trend Snippets.

### Testing

- Ran PHP syntax checks: `php -l src/functions.php`, `php -l public/settings/index.php`, and `php -l public/index.php`, all succeeded.
- Ran `git diff --check` to ensure no whitespace/diff issues and it returned cleanly.
- Started the PHP dev server and captured the Data Sync settings page with an automated Playwright script to validate the new UI render; the page loaded and the screenshot was saved successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0aa5f4d4832f81a7cedd67cbcf3d)