### PR TITLE
Fix zKill (R2Z2) payload decoding and add alliance/corporation lookup filters

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -455,10 +455,20 @@ include __DIR__ . '/../../src/views/partials/header.php';
             </script>
         <?php elseif ($section === 'killmail-intelligence'): ?>
             <?php
+                $trackedAllianceSelections = array_values(array_map(static fn (array $row): array => [
+                    'id' => (int) ($row['alliance_id'] ?? 0),
+                    'name' => (string) ($row['label'] ?? ('Alliance #' . (int) ($row['alliance_id'] ?? 0))),
+                    'type' => 'Alliance',
+                ], array_filter($trackedAlliances, static fn (array $row): bool => (int) ($row['alliance_id'] ?? 0) > 0)));
+                $trackedCorporationSelections = array_values(array_map(static fn (array $row): array => [
+                    'id' => (int) ($row['corporation_id'] ?? 0),
+                    'name' => (string) ($row['label'] ?? ('Corporation #' . (int) ($row['corporation_id'] ?? 0))),
+                    'type' => 'Corporation',
+                ], array_filter($trackedCorporations, static fn (array $row): bool => (int) ($row['corporation_id'] ?? 0) > 0)));
                 $alliancesText = implode("
-", array_map(static fn (array $row): string => (string) ($row['label'] ?? $row['alliance_id']), $trackedAlliances));
+", array_map(static fn (array $row): string => (string) $row['id'] . ' | ' . (string) $row['name'], $trackedAllianceSelections));
                 $corporationsText = implode("
-", array_map(static fn (array $row): string => (string) ($row['label'] ?? $row['corporation_id']), $trackedCorporations));
+", array_map(static fn (array $row): string => (string) $row['id'] . ' | ' . (string) $row['name'], $trackedCorporationSelections));
                 $statusState = is_array($killmailStatus['state'] ?? null) ? $killmailStatus['state'] : [];
             ?>
             <form class="mt-6 space-y-4" method="post">
@@ -482,20 +492,263 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     </label>
                 </div>
 
-                <label class="block space-y-2">
-                    <span class="text-sm text-muted">Tracked Alliances (one per line, by name; numeric IDs still supported)</span>
-                    <textarea name="tracked_alliance_names" rows="6" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring"><?= htmlspecialchars($alliancesText, ENT_QUOTES) ?></textarea>
-                </label>
+                <div class="grid gap-4 lg:grid-cols-2">
+                    <label class="block space-y-2" id="killmail-alliance-search-field">
+                        <span class="text-sm text-muted">Tracked Alliances</span>
+                        <textarea name="tracked_alliance_names" id="tracked_alliance_names" rows="4" class="hidden"><?= htmlspecialchars($alliancesText, ENT_QUOTES) ?></textarea>
+                        <input
+                            type="text"
+                            id="tracked_alliance_search"
+                            autocomplete="off"
+                            placeholder="Search alliances to add to the zKill filter"
+                            class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring"
+                        />
+                        <p id="tracked_alliance_status" class="text-xs text-muted">
+                            <?= htmlspecialchars($trackedAllianceSelections === []
+                                ? 'Type at least 2 characters to search alliances.'
+                                : ('Tracking ' . count($trackedAllianceSelections) . ' alliance' . (count($trackedAllianceSelections) === 1 ? '' : 's') . '.'), ENT_QUOTES) ?>
+                        </p>
+                        <ul id="tracked_alliance_results" class="hidden max-h-60 overflow-y-auto rounded-lg border border-border bg-black/40"></ul>
+                        <div id="tracked_alliance_selected" class="flex flex-wrap gap-2"></div>
+                    </label>
 
-                <label class="block space-y-2">
-                    <span class="text-sm text-muted">Tracked Corporations (one per line, by name; numeric IDs still supported)</span>
-                    <textarea name="tracked_corporation_names" rows="6" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring"><?= htmlspecialchars($corporationsText, ENT_QUOTES) ?></textarea>
-                </label>
-
-
-                <div class="rounded-lg border border-border bg-black/20 p-3 text-sm text-muted">
-                    Enter exact alliance/corporation names (for example: <span class="text-slate-100">Goonswarm Federation</span> or <span class="text-slate-100">KarmaFleet</span>). Names are resolved to IDs using ESI and stored locally.
+                    <label class="block space-y-2" id="killmail-corporation-search-field">
+                        <span class="text-sm text-muted">Tracked Corporations</span>
+                        <textarea name="tracked_corporation_names" id="tracked_corporation_names" rows="4" class="hidden"><?= htmlspecialchars($corporationsText, ENT_QUOTES) ?></textarea>
+                        <input
+                            type="text"
+                            id="tracked_corporation_search"
+                            autocomplete="off"
+                            placeholder="Search corporations to add to the zKill filter"
+                            class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring"
+                        />
+                        <p id="tracked_corporation_status" class="text-xs text-muted">
+                            <?= htmlspecialchars($trackedCorporationSelections === []
+                                ? 'Type at least 2 characters to search corporations.'
+                                : ('Tracking ' . count($trackedCorporationSelections) . ' corporation' . (count($trackedCorporationSelections) === 1 ? '' : 's') . '.'), ENT_QUOTES) ?>
+                        </p>
+                        <ul id="tracked_corporation_results" class="hidden max-h-60 overflow-y-auto rounded-lg border border-border bg-black/40"></ul>
+                        <div id="tracked_corporation_selected" class="flex flex-wrap gap-2"></div>
+                    </label>
                 </div>
+
+                <div class="rounded-lg border border-border bg-black/20 p-3 text-sm text-muted space-y-2">
+                    <p>Use the lookup fields to add the same way you pick the market hub or structure destination. Selections are stored locally as ID + name pairs for reliable zKill filtering.</p>
+                    <p>If needed, you can still paste raw numeric IDs before saving.</p>
+                </div>
+
+                <script>
+                    (() => {
+                        const createTrackedEntityPicker = ({
+                            inputId,
+                            hiddenId,
+                            resultsId,
+                            statusId,
+                            selectedId,
+                            allowedType,
+                            initialItems,
+                        }) => {
+                            const input = document.getElementById(inputId);
+                            const hidden = document.getElementById(hiddenId);
+                            const results = document.getElementById(resultsId);
+                            const status = document.getElementById(statusId);
+                            const selected = document.getElementById(selectedId);
+
+                            if (!input || !hidden || !results || !status || !selected) {
+                                return;
+                            }
+
+                            const items = new Map();
+                            let debounceTimer = null;
+
+                            const escapeHtml = (value) => {
+                                const div = document.createElement('div');
+                                div.textContent = value;
+                                return div.innerHTML;
+                            };
+
+                            const syncHiddenField = () => {
+                                hidden.value = Array.from(items.values())
+                                    .map((item) => String(item.id) + ' | ' + item.name)
+                                    .join('
+');
+                            };
+
+                            const updateStatus = (message = null) => {
+                                if (message !== null) {
+                                    status.textContent = message;
+                                    return;
+                                }
+
+                                status.textContent = items.size === 0
+                                    ? 'Type at least 2 characters to search ' + allowedType.toLowerCase() + 's.'
+                                    : 'Tracking ' + items.size + ' ' + allowedType.toLowerCase() + (items.size === 1 ? '' : 's') + '.';
+                            };
+
+                            const clearResults = () => {
+                                results.innerHTML = '';
+                                results.classList.add('hidden');
+                            };
+
+                            const renderSelected = () => {
+                                selected.innerHTML = '';
+
+                                if (items.size === 0) {
+                                    const empty = document.createElement('p');
+                                    empty.className = 'text-xs text-muted';
+                                    empty.textContent = 'No ' + allowedType.toLowerCase() + 's selected yet.';
+                                    selected.appendChild(empty);
+                                    syncHiddenField();
+                                    updateStatus();
+                                    return;
+                                }
+
+                                Array.from(items.values())
+                                    .sort((a, b) => a.name.localeCompare(b.name))
+                                    .forEach((item) => {
+                                        const chip = document.createElement('span');
+                                        chip.className = 'inline-flex items-center gap-2 rounded-full border border-border bg-black/20 px-3 py-1 text-xs text-slate-100';
+                                        chip.innerHTML = '<span>' + escapeHtml(item.name) + ' <span class="text-muted">(#' + item.id + ')</span></span>';
+
+                                        const remove = document.createElement('button');
+                                        remove.type = 'button';
+                                        remove.className = 'rounded-full px-1 text-muted hover:bg-white/10 hover:text-slate-100';
+                                        remove.setAttribute('aria-label', 'Remove ' + item.name);
+                                        remove.textContent = '×';
+                                        remove.addEventListener('click', () => {
+                                            items.delete(String(item.id));
+                                            renderSelected();
+                                        });
+
+                                        chip.appendChild(remove);
+                                        selected.appendChild(chip);
+                                    });
+
+                                syncHiddenField();
+                                updateStatus();
+                            };
+
+                            const addItem = (item) => {
+                                if (!item || String(item.type || '') !== allowedType) {
+                                    return;
+                                }
+
+                                const id = Number(item.id || 0);
+                                const name = String(item.name || '').trim();
+                                if (!Number.isFinite(id) || id <= 0 || name === '') {
+                                    return;
+                                }
+
+                                items.set(String(id), { id, name, type: allowedType });
+                                input.value = '';
+                                clearResults();
+                                renderSelected();
+                            };
+
+                            const renderResults = (rows) => {
+                                clearResults();
+
+                                const options = Array.isArray(rows)
+                                    ? rows.filter((row) => String(row.type || '') === allowedType && !items.has(String(row.id || '')))
+                                    : [];
+
+                                if (options.length === 0) {
+                                    updateStatus('No matching ' + allowedType.toLowerCase() + 's found.');
+                                    return;
+                                }
+
+                                const fragment = document.createDocumentFragment();
+                                options.forEach((item) => {
+                                    const row = document.createElement('li');
+                                    const button = document.createElement('button');
+                                    button.type = 'button';
+                                    button.className = 'flex w-full flex-col items-start gap-1 px-3 py-2 text-left text-sm hover:bg-white/5';
+                                    button.innerHTML = '<span class="text-slate-100"></span><span class="text-xs text-muted"></span>';
+                                    button.querySelector('span').textContent = item.name;
+                                    button.querySelectorAll('span')[1].textContent = item.type + ' · #' + item.id;
+                                    button.addEventListener('click', () => addItem(item));
+                                    row.appendChild(button);
+                                    fragment.appendChild(row);
+                                });
+
+                                results.appendChild(fragment);
+                                results.classList.remove('hidden');
+                                updateStatus('Select a ' + allowedType.toLowerCase() + ' from the list.');
+                            };
+
+                            input.addEventListener('input', () => {
+                                const query = input.value.trim();
+
+                                if (debounceTimer !== null) {
+                                    clearTimeout(debounceTimer);
+                                }
+
+                                if (query.length < 2) {
+                                    clearResults();
+                                    updateStatus();
+                                    return;
+                                }
+
+                                debounceTimer = window.setTimeout(async () => {
+                                    updateStatus('Searching…');
+
+                                    try {
+                                        const response = await fetch('/settings/killmail-entities.php?q=' + encodeURIComponent(query), {
+                                            headers: { 'Accept': 'application/json' },
+                                        });
+                                        const payload = await response.json();
+                                        if (!response.ok) {
+                                            throw new Error(payload.error || 'Lookup failed.');
+                                        }
+
+                                        renderResults(payload.results || []);
+                                    } catch (error) {
+                                        clearResults();
+                                        updateStatus(error instanceof Error ? error.message : 'Lookup failed.');
+                                    }
+                                }, 250);
+                            });
+
+                            document.addEventListener('click', (event) => {
+                                if (!results.contains(event.target) && event.target !== input) {
+                                    clearResults();
+                                }
+                            });
+
+                            initialItems.forEach((item) => {
+                                const id = Number(item.id || 0);
+                                const name = String(item.name || '').trim();
+                                if (!Number.isFinite(id) || id <= 0 || name === '') {
+                                    return;
+                                }
+
+                                items.set(String(id), { id, name, type: allowedType });
+                            });
+
+                            renderSelected();
+                        };
+
+                        createTrackedEntityPicker({
+                            inputId: 'tracked_alliance_search',
+                            hiddenId: 'tracked_alliance_names',
+                            resultsId: 'tracked_alliance_results',
+                            statusId: 'tracked_alliance_status',
+                            selectedId: 'tracked_alliance_selected',
+                            allowedType: 'Alliance',
+                            initialItems: <?= json_encode($trackedAllianceSelections, JSON_THROW_ON_ERROR) ?>,
+                        });
+
+                        createTrackedEntityPicker({
+                            inputId: 'tracked_corporation_search',
+                            hiddenId: 'tracked_corporation_names',
+                            resultsId: 'tracked_corporation_results',
+                            statusId: 'tracked_corporation_status',
+                            selectedId: 'tracked_corporation_selected',
+                            allowedType: 'Corporation',
+                            initialItems: <?= json_encode($trackedCorporationSelections, JSON_THROW_ON_ERROR) ?>,
+                        });
+                    })();
+                </script>
 
                 <label class="block space-y-2">
                     <span class="text-sm text-muted">Demand Prediction Mode (future-facing)</span>

--- a/public/settings/killmail-entities.php
+++ b/public/settings/killmail-entities.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$query = trim((string) ($_GET['q'] ?? ''));
+if (mb_strlen($query) < 2) {
+    http_response_code(422);
+    echo json_encode(['error' => 'Query must be at least 2 characters.', 'results' => []], JSON_THROW_ON_ERROR);
+    exit;
+}
+
+$context = esi_lookup_context();
+if (($context['ok'] ?? false) !== true) {
+    http_response_code((int) ($context['status'] ?? 403));
+    echo json_encode(['error' => $context['error'] ?? 'ESI lookup unavailable.', 'results' => []], JSON_THROW_ON_ERROR);
+    exit;
+}
+
+try {
+    $results = esi_alliance_and_corporation_search($query, $context['token']);
+    echo json_encode(['results' => $results], JSON_THROW_ON_ERROR);
+} catch (Throwable) {
+    http_response_code(502);
+    echo json_encode(['error' => 'Unable to fetch alliances/corporations from ESI at this time.', 'results' => []], JSON_THROW_ON_ERROR);
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -4178,6 +4178,15 @@ function esi_valid_access_token(int $refreshWindowSeconds = 120): string
     return $accessToken;
 }
 
+function esi_user_agent(): string
+{
+    $configured = trim((string) get_setting('app_name', 'EveMarket'));
+
+    return $configured !== ''
+        ? $configured . ' eve-market/1.0 (+https://github.com/cvweiss/evemarket)'
+        : 'EveMarket eve-market/1.0 (+https://github.com/cvweiss/evemarket)';
+}
+
 function esi_lookup_context(array $requiredScopes = []): array
 {
     $enabled = get_setting('esi_enabled', '0') === '1';
@@ -4221,6 +4230,126 @@ function esi_structure_result_shape(array $structure): array
     }
 
     return $result;
+}
+
+
+function esi_entity_result_shape(array $entity): array
+{
+    return [
+        'id' => (int) ($entity['id'] ?? 0),
+        'name' => (string) ($entity['name'] ?? ''),
+        'type' => (string) ($entity['type'] ?? ''),
+    ];
+}
+
+function esi_universe_names_lookup(array $ids): array
+{
+    $queryIds = array_values(array_unique(array_map(static fn (mixed $id): int => (int) $id, $ids)));
+    $queryIds = array_values(array_filter($queryIds, static fn (int $id): bool => $id > 0));
+    if ($queryIds === []) {
+        return [];
+    }
+
+    $ch = curl_init('https://esi.evetech.net/latest/universe/names/?datasource=tranquility');
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT => 25,
+        CURLOPT_POST => true,
+        CURLOPT_HTTPHEADER => ['Accept: application/json', 'Content-Type: application/json', 'User-Agent: ' . esi_user_agent()],
+        CURLOPT_POSTFIELDS => json_encode($queryIds, JSON_THROW_ON_ERROR),
+    ]);
+
+    $body = curl_exec($ch);
+    $status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $error = curl_error($ch);
+    curl_close($ch);
+
+    if ($body === false) {
+        throw new RuntimeException('Failed resolving entity IDs from ESI: ' . $error);
+    }
+
+    if ($status !== 200) {
+        throw new RuntimeException('Failed resolving entity IDs from ESI. HTTP status=' . $status);
+    }
+
+    $decoded = json_decode($body, true);
+
+    return is_array($decoded) ? $decoded : [];
+}
+
+function esi_alliance_and_corporation_search(string $query, array $tokenContext): array
+{
+    $term = trim($query);
+    if ($term === '') {
+        return [];
+    }
+
+    $characterId = (int) ($tokenContext['character_id'] ?? 0);
+    if ($characterId <= 0) {
+        return [];
+    }
+
+    $accessToken = esi_valid_access_token();
+    $searchResponse = http_get_json(
+        'https://esi.evetech.net/latest/characters/' . $characterId . '/search/?categories=alliance,corporation&strict=false&search=' . rawurlencode($term),
+        [
+            'Authorization: Bearer ' . $accessToken,
+            'Accept: application/json',
+            'User-Agent: ' . esi_user_agent(),
+        ]
+    );
+
+    if (($searchResponse['status'] ?? 500) >= 400) {
+        throw new RuntimeException('Failed to search alliances and corporations from ESI.');
+    }
+
+    $ids = [];
+    $entityTypesById = [];
+    foreach (['alliance' => 'Alliance', 'corporation' => 'Corporation'] as $category => $label) {
+        foreach ((array) ($searchResponse['json'][$category] ?? []) as $rawId) {
+            $id = (int) $rawId;
+            if ($id <= 0) {
+                continue;
+            }
+
+            $ids[] = $id;
+            $entityTypesById[$id] = $label;
+        }
+    }
+
+    $results = [];
+    foreach (esi_universe_names_lookup($ids) as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+
+        $id = (int) ($row['id'] ?? 0);
+        $name = trim((string) ($row['name'] ?? ''));
+        if ($id <= 0 || $name === '' || !isset($entityTypesById[$id])) {
+            continue;
+        }
+
+        if (mb_stripos($name, $term) === false) {
+            continue;
+        }
+
+        $results[$id] = esi_entity_result_shape([
+            'id' => $id,
+            'name' => $name,
+            'type' => $entityTypesById[$id],
+        ]);
+    }
+
+    usort($results, static function (array $a, array $b): int {
+        $typeCompare = strcasecmp((string) ($a['type'] ?? ''), (string) ($b['type'] ?? ''));
+        if ($typeCompare !== 0) {
+            return $typeCompare;
+        }
+
+        return strcasecmp((string) ($a['name'] ?? ''), (string) ($b['name'] ?? ''));
+    });
+
+    return array_slice(array_values($results), 0, 20);
 }
 
 
@@ -4990,10 +5119,10 @@ function killmail_parse_entity_name_lines(string $text): array
             continue;
         }
 
-        $names[$name] = true;
+        $names[(string) $name] = (string) $name;
     }
 
-    return array_keys($names);
+    return array_values($names);
 }
 
 function killmail_universe_ids_lookup(array $names): array
@@ -5008,7 +5137,7 @@ function killmail_universe_ids_lookup(array $names): array
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => 25,
         CURLOPT_POST => true,
-        CURLOPT_HTTPHEADER => ['Accept: application/json', 'Content-Type: application/json'],
+        CURLOPT_HTTPHEADER => ['Accept: application/json', 'Content-Type: application/json', 'User-Agent: ' . esi_user_agent()],
         CURLOPT_POSTFIELDS => json_encode($queryNames, JSON_UNESCAPED_SLASHES),
     ]);
 
@@ -5034,14 +5163,39 @@ function killmail_resolve_tracked_entities(string $allianceText, string $corpora
 {
     $allianceLines = killmail_parse_entity_name_lines($allianceText);
     $corporationLines = killmail_parse_entity_name_lines($corporationText);
+    $parsedAllianceRows = killmail_parse_entity_lines($allianceText);
+    $parsedCorporationRows = killmail_parse_entity_lines($corporationText);
 
     $allianceById = [];
     $corporationById = [];
     $lookupNames = [];
 
+    foreach ($parsedAllianceRows as $row) {
+        $id = (int) ($row['id'] ?? 0);
+        if ($id <= 0) {
+            continue;
+        }
+
+        $allianceById[$id] = [
+            'id' => $id,
+            'label' => isset($row['label']) && trim((string) $row['label']) !== '' ? trim((string) $row['label']) : null,
+        ];
+    }
+
+    foreach ($parsedCorporationRows as $row) {
+        $id = (int) ($row['id'] ?? 0);
+        if ($id <= 0) {
+            continue;
+        }
+
+        $corporationById[$id] = [
+            'id' => $id,
+            'label' => isset($row['label']) && trim((string) $row['label']) !== '' ? trim((string) $row['label']) : null,
+        ];
+    }
+
     foreach ($allianceLines as $line) {
-        if (preg_match('/^[1-9][0-9]{1,20}$/', $line) === 1) {
-            $allianceById[(int) $line] = ['id' => (int) $line, 'label' => null];
+        if (preg_match('/^[1-9][0-9]{1,20}(?:\s*[|,:-]\s*.+)?$/', $line) === 1) {
             continue;
         }
 
@@ -5049,8 +5203,7 @@ function killmail_resolve_tracked_entities(string $allianceText, string $corpora
     }
 
     foreach ($corporationLines as $line) {
-        if (preg_match('/^[1-9][0-9]{1,20}$/', $line) === 1) {
-            $corporationById[(int) $line] = ['id' => (int) $line, 'label' => null];
+        if (preg_match('/^[1-9][0-9]{1,20}(?:\s*[|,:-]\s*.+)?$/', $line) === 1) {
             continue;
         }
 
@@ -5060,31 +5213,35 @@ function killmail_resolve_tracked_entities(string $allianceText, string $corpora
     $unresolved = [];
 
     if ($lookupNames !== []) {
-        $resolved = killmail_universe_ids_lookup(array_keys($lookupNames));
+        try {
+            $resolved = killmail_universe_ids_lookup(array_keys($lookupNames));
 
-        foreach ((array) ($resolved['alliances'] ?? []) as $row) {
-            $name = trim((string) ($row['name'] ?? ''));
-            $id = (int) ($row['id'] ?? 0);
-            if ($id <= 0 || $name === '' || !in_array($name, $allianceLines, true)) {
-                continue;
+            foreach ((array) ($resolved['alliances'] ?? []) as $row) {
+                $name = trim((string) ($row['name'] ?? ''));
+                $id = (int) ($row['id'] ?? 0);
+                if ($id <= 0 || $name === '' || !in_array($name, $allianceLines, true)) {
+                    continue;
+                }
+
+                $allianceById[$id] = ['id' => $id, 'label' => $name];
             }
 
-            $allianceById[$id] = ['id' => $id, 'label' => $name];
-        }
+            foreach ((array) ($resolved['corporations'] ?? []) as $row) {
+                $name = trim((string) ($row['name'] ?? ''));
+                $id = (int) ($row['id'] ?? 0);
+                if ($id <= 0 || $name === '' || !in_array($name, $corporationLines, true)) {
+                    continue;
+                }
 
-        foreach ((array) ($resolved['corporations'] ?? []) as $row) {
-            $name = trim((string) ($row['name'] ?? ''));
-            $id = (int) ($row['id'] ?? 0);
-            if ($id <= 0 || $name === '' || !in_array($name, $corporationLines, true)) {
-                continue;
+                $corporationById[$id] = ['id' => $id, 'label' => $name];
             }
-
-            $corporationById[$id] = ['id' => $id, 'label' => $name];
+        } catch (Throwable $exception) {
+            $unresolved[] = 'Unable to resolve names from ESI right now; use the lookup field or numeric IDs. ' . $exception->getMessage();
         }
     }
 
     foreach ($allianceLines as $line) {
-        if (preg_match('/^[1-9][0-9]{1,20}$/', $line) === 1) {
+        if (preg_match('/^[1-9][0-9]{1,20}(?:\s*[|,:-]\s*.+)?$/', $line) === 1) {
             continue;
         }
 
@@ -5102,7 +5259,7 @@ function killmail_resolve_tracked_entities(string $allianceText, string $corpora
     }
 
     foreach ($corporationLines as $line) {
-        if (preg_match('/^[1-9][0-9]{1,20}$/', $line) === 1) {
+        if (preg_match('/^[1-9][0-9]{1,20}(?:\s*[|,:-]\s*.+)?$/', $line) === 1) {
             continue;
         }
 
@@ -5118,6 +5275,9 @@ function killmail_resolve_tracked_entities(string $allianceText, string $corpora
             $unresolved[] = 'Corporation not found: ' . $line;
         }
     }
+
+    ksort($allianceById);
+    ksort($corporationById);
 
     return [
         'alliances' => array_values($allianceById),
@@ -5242,7 +5402,9 @@ function killmail_event_matches_tracked_entities(array $event, array $attackers,
 
 function killmail_transform_r2z2_payload(array $payload): array
 {
-    $killmail = is_array($payload['killmail'] ?? null) ? $payload['killmail'] : [];
+    $killmail = is_array($payload['esi'] ?? null)
+        ? $payload['esi']
+        : (is_array($payload['killmail'] ?? null) ? $payload['killmail'] : []);
     $victim = is_array($killmail['victim'] ?? null) ? $killmail['victim'] : [];
     $zkb = is_array($payload['zkb'] ?? null) ? $payload['zkb'] : [];
     $sequenceId = (int) ($payload['sequence_id'] ?? 0);


### PR DESCRIPTION
### Motivation

- R2Z2/zKill payloads embed the actual killmail under an `esi` key so decoding must prefer that shape to correctly extract attackers, victim, items and timestamps. 
- Tracked alliance/corporation entry was a plain textarea with brittle name-resolution; the UX and lookup should behave like the existing market hub / structure pickers and store reliable `id | name` values.

### Description

- Prefer the nested `esi` killmail when transforming stream rows by updating `killmail_transform_r2z2_payload()` to read from `$payload['esi']` when present.  
- Add ESI helpers: `esi_user_agent()`, `esi_universe_names_lookup()`, `esi_alliance_and_corporation_search()` and `esi_entity_result_shape()` to perform alliance/corporation searches and name resolution with an explicit user-agent header.  
- Harden `killmail_universe_ids_lookup()` and other ESI calls to send the user-agent and avoid hard-failing when lookups temporarily fail.  
- Improve `killmail_resolve_tracked_entities()` to accept pasted `id | label` lines, parse numeric IDs up front, fall back to ESI name lookups, and accumulate unresolved messages instead of crashing.  
- Replace the two tracked-entity textareas in `public/settings/index.php` with picker-style lookup fields that mirror the market hub/structure search pattern and store selections as newline-separated `id | name` hidden values; add client-side `createTrackedEntityPicker` logic to fetch `/settings/killmail-entities.php`.  
- Add a new JSON endpoint `public/settings/killmail-entities.php` that proxies alliance/corporation searches via ESI for the picker UI.  

### Testing

- Ran PHP lint on modified files with `php -l` and there were no syntax errors. (success)  
- Validated `killmail_transform_r2z2_payload()` against a sample R2Z2 payload that contains `esi` and confirmed the returned `event`, `attackers`, and `items` counts and timestamps are parsed as expected. (success)  
- Exercised `killmail_resolve_tracked_entities()` locally with mixed `id | name` and plain-name inputs and confirmed IDs/labels are resolved or reported in `unresolved` without throwing. (success)  
- Started a local PHP server and verified the settings page renders the new lookup inputs and the new `/settings/killmail-entities.php?q=` endpoint returns structured JSON error when ESI login is disabled. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0f18e66c832fb10c057aa5fcfaeb)