### PR TITLE
Align R2Z2 sync backoff with feed etiquette

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -5630,11 +5630,13 @@ function sync_killmail_r2z2_stream(string $runMode = 'incremental'): array
         $sequenceProbeStatus = (int) ($sequenceProbe['status'] ?? 0);
         $cursor = db_sync_cursor_get($datasetKey);
         $lastSavedSequence = $cursor !== null && preg_match('/^[0-9]+$/', $cursor) === 1 ? (int) $cursor : null;
+        $pollBackoffSeconds = killmail_poll_sleep_seconds();
 
         if ($sequenceProbeStatus === 403 || $sequenceProbeStatus === 429) {
             $cursorEnd = $cursor !== null ? $cursor : '0';
             $checksum = sync_checksum([0, 0, $cursorEnd]);
-            $warnings = ['R2Z2 sequence probe returned status ' . $sequenceProbeStatus . '; respecting feed backoff.'];
+            $warnings = ['R2Z2 sequence probe returned status ' . $sequenceProbeStatus . '; worker hit rate limiting and is backing off for ' . $pollBackoffSeconds . 's.'];
+            sleep($pollBackoffSeconds);
             $meta = [
                 'last_saved_sequence_before_run' => $lastSavedSequence,
                 'latest_remote_sequence' => null,
@@ -5693,11 +5695,14 @@ function sync_killmail_r2z2_stream(string $runMode = 'incremental'): array
 
             if ($status === 404) {
                 $sequence404s++;
+                $warnings[] = 'R2Z2 returned 404 for sequence ' . $nextSequence . '; worker reached end-of-feed and is backing off for ' . $pollBackoffSeconds . 's.';
+                sleep($pollBackoffSeconds);
                 break;
             }
 
             if ($status === 429 || $status === 403) {
-                $warnings[] = 'R2Z2 returned status ' . $status . '; respecting feed backoff.';
+                $warnings[] = 'R2Z2 returned status ' . $status . ' for sequence ' . $nextSequence . '; worker hit rate limiting and is backing off for ' . $pollBackoffSeconds . 's.';
+                sleep($pollBackoffSeconds);
                 break;
             }
 


### PR DESCRIPTION
### Motivation
- Ensure the killmail R2Z2 ingestion worker explicitly follows documented feed etiquette by using the configured `killmail_poll_sleep_seconds()` backoff when the feed signals end-of-feed or rate limiting, while preserving the existing polite 100ms pacing between successful sequence fetches.

### Description
- Cache `killmail_poll_sleep_seconds()` at the start of `sync_killmail_r2z2_stream` and use it as the explicit backoff interval when the sequence probe returns `403` or `429`, logging that the worker is backing off and sleeping before finalizing the run.
- Treat per-sequence `404` responses as an explicit end-of-feed signal by incrementing the 404 counter, adding a warning that the worker reached end-of-feed and is backing off for the configured interval, then calling `sleep()` before breaking the loop.
- Handle per-sequence `403` and `429` responses by logging a rate-limit/backoff warning and calling `sleep()` for the configured interval before exiting the loop, while leaving the existing `usleep(100000)` 100ms delay intact for successful fetches.

### Testing
- Ran `php -l src/functions.php` to verify there are no syntax errors (check passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba16dff7b0832f866be7aa7dfad6d8)