### PR TITLE
Fix stale sync health warnings and spread percent overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ README.md
    mysql -u root -p evemarket < database/schema.sql
    ```
 
+> Upgrading an existing installation? Apply schema changes before the next sync run, for example: `ALTER TABLE market_hub_local_history_daily MODIFY spread_percent DECIMAL(20,4) NULL;`.
+
 2. **Set environment variables** (example)
    ```bash
    export APP_ENV=development

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -275,7 +275,7 @@ CREATE TABLE IF NOT EXISTS market_hub_local_history_daily (
     buy_price DECIMAL(20, 2) DEFAULT NULL,
     sell_price DECIMAL(20, 2) DEFAULT NULL,
     spread_value DECIMAL(20, 2) DEFAULT NULL,
-    spread_percent DECIMAL(9, 4) DEFAULT NULL,
+    spread_percent DECIMAL(20, 4) DEFAULT NULL,
     volume BIGINT UNSIGNED NOT NULL DEFAULT 0,
     buy_order_count INT UNSIGNED NOT NULL DEFAULT 0,
     sell_order_count INT UNSIGNED NOT NULL DEFAULT 0,

--- a/src/db.php
+++ b/src/db.php
@@ -686,6 +686,15 @@ function db_market_history_daily_insert(array $historyRows, ?int $chunkSize = nu
     );
 }
 
+function db_market_hub_local_history_daily_normalize_spread_percent(mixed $value): ?float
+{
+    if ($value === null || $value === '') {
+        return null;
+    }
+
+    return round((float) $value, 4);
+}
+
 function db_market_hub_local_history_daily_normalize_row(array $row): array
 {
     $normalizeNullableFloat = static function (mixed $value): ?float {
@@ -708,7 +717,7 @@ function db_market_hub_local_history_daily_normalize_row(array $row): array
         'buy_price' => $normalizeNullableFloat($row['buy_price'] ?? null),
         'sell_price' => $normalizeNullableFloat($row['sell_price'] ?? null),
         'spread_value' => $normalizeNullableFloat($row['spread_value'] ?? null),
-        'spread_percent' => $normalizeNullableFloat($row['spread_percent'] ?? null),
+        'spread_percent' => db_market_hub_local_history_daily_normalize_spread_percent($row['spread_percent'] ?? null),
         'volume' => max(0, (int) ($row['volume'] ?? 0)),
         'buy_order_count' => max(0, (int) ($row['buy_order_count'] ?? 0)),
         'sell_order_count' => max(0, (int) ($row['sell_order_count'] ?? 0)),

--- a/src/functions.php
+++ b/src/functions.php
@@ -1088,26 +1088,50 @@ function market_format_percentage(float $value, int $precision = 1): string
     return number_format($value, $precision, '.', ',') . '%';
 }
 
+function dashboard_sync_dataset_active_error(array $states): ?string
+{
+    foreach ($states as $state) {
+        if (!is_array($state) || (string) ($state['status'] ?? '') !== 'failed') {
+            continue;
+        }
+
+        $message = trim((string) ($state['last_error_message'] ?? ''));
+        if ($message !== '') {
+            return $message;
+        }
+    }
+
+    return null;
+}
+
 function dashboard_sync_health_panel(array $dataset): array
 {
     $states = $dataset['states'] ?? [];
     $runs = $dataset['runs'] ?? [];
     $activeStateCount = count($states);
-    $failedRuns = array_values(array_filter($runs, static fn (array $run): bool => (string) ($run['run_status'] ?? '') === 'failed'));
+    $latestRun = is_array($runs[0] ?? null) ? $runs[0] : null;
+    $activeError = dashboard_sync_dataset_active_error($states);
+    $latestRunFailed = is_array($latestRun) && (string) ($latestRun['run_status'] ?? '') === 'failed';
 
     $status = 'Not synced';
     if ($activeStateCount > 0) {
-        $status = $failedRuns === [] ? 'Healthy' : 'Warning';
+        $status = ($activeError !== null || $latestRunFailed) ? 'Warning' : 'Healthy';
     }
 
     $lastSuccessAt = (string) ($dataset['last_success_at'] ?? '');
-    $lastError = trim((string) ($dataset['last_error_message'] ?? ''));
+    $lastError = $activeError;
+    if ($lastError === null && $latestRunFailed) {
+        $candidate = trim((string) ($latestRun['error_message'] ?? ''));
+        if ($candidate !== '') {
+            $lastError = $candidate;
+        }
+    }
 
     return [
         'status' => $status,
         'last_success_at' => $lastSuccessAt !== '' ? $lastSuccessAt : 'No successful sync yet',
         'recent_rows_written' => (int) ($dataset['recent_rows_written'] ?? 0),
-        'last_error' => $lastError !== '' ? $lastError : 'None',
+        'last_error' => $lastError !== null ? $lastError : 'None',
         'state_count' => $activeStateCount,
     ];
 }


### PR DESCRIPTION
### Motivation
- Sync runs were producing a SQL error `Out of range value for column 'spread_percent'` when extreme buy/sell spreads occurred, causing sync warnings and failing writes. 
- The dashboard sync health card could remain in `Warning` due to an older failed run even after newer successful runs, surfacing stale `Last error` messages. 
- Make the local-history write path and UI behavior robust to extreme numeric values and transient failures. 

### Description
- Increase `market_hub_local_history_daily.spread_percent` precision from `DECIMAL(9,4)` to `DECIMAL(20,4)` in `database/schema.sql` to avoid overflow on unusually large spreads. 
- Add `db_market_hub_local_history_daily_normalize_spread_percent()` in `src/db.php` and use it in `db_market_hub_local_history_daily_normalize_row()` to normalize nullable values and round to 4 decimals before upsert. 
- Improve dashboard sync health logic in `src/functions.php` by adding `dashboard_sync_dataset_active_error()` and changing `dashboard_sync_health_panel()` to prefer active state errors or the latest run result so the card no longer shows stale warnings after newer successes. 
- Document the required upgrade step for existing installations in `README.md` with an example `ALTER TABLE` statement. 

### Testing
- Ran PHP lints with `php -l` for `src/functions.php`, `src/db.php`, `public/index.php`, `public/settings/index.php`, and `bin/cron_tick.php`, all of which succeeded. 
- Ran `git diff --check` to ensure no whitespace or diff issues, which passed. 
- Executed a normalization sanity check with `php -r "require 'src/db.php'; var_export(db_market_hub_local_history_daily_normalize_spread_percent('123456789.123456'));"` which produced the expected rounded output. 
- Exercised the updated health panel logic via a small runtime invocation of `dashboard_sync_health_panel()` to confirm `last_error` and `status` behave as intended when an older failed run is followed by a newer success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba17737108832fbbb7d20e8c87384e)