### PR TITLE
Add Killmail Intelligence overview UI

### DIFF
--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Killmail Overview';
+$data = killmail_overview_data();
+$summary = $data['summary'] ?? [];
+$status = $data['status'] ?? [];
+$rows = $data['rows'] ?? [];
+$filters = $data['filters'] ?? [];
+$pagination = $data['pagination'] ?? [];
+$error = $data['error'] ?? null;
+$emptyMessage = (string) ($data['empty_message'] ?? 'No killmails available yet.');
+
+$queryParams = $_GET;
+$buildPageUrl = static function (int $targetPage) use ($queryParams): string {
+    $params = $queryParams;
+    $params['page'] = max(1, $targetPage);
+
+    return current_path() . '?' . http_build_query($params);
+};
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<?php if (is_string($error) && trim($error) !== ''): ?>
+    <section class="mb-6 rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+        Killmail overview could not load fully. <?= htmlspecialchars($error, ENT_QUOTES) ?>
+    </section>
+<?php endif; ?>
+
+<section class="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-xl border border-border bg-card p-5">
+    <div>
+        <p class="text-xs uppercase tracking-[0.2em] text-muted">Operational visibility</p>
+        <h2 class="mt-1 text-lg font-medium text-slate-50">Recent killmail ingestion at a glance</h2>
+        <p class="mt-2 max-w-3xl text-sm text-muted">Use this page to confirm the killmail pipeline is alive, local killmails are being stored, and tracked alliances or corporations are being matched before deeper analytics are added.</p>
+    </div>
+    <div class="flex flex-wrap gap-2">
+        <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= ($status['ingestion_enabled'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-amber-500/40 bg-amber-500/10 text-amber-100' ?>">
+            <?= ($status['ingestion_enabled'] ?? false) ? 'Ingestion enabled' : 'Ingestion disabled' ?>
+        </span>
+        <span class="rounded-full border border-border bg-black/20 px-3 py-1 text-xs uppercase tracking-[0.15em] text-slate-200">
+            Last sync: <?= htmlspecialchars((string) ($status['last_sync_outcome'] ?? 'Unknown'), ENT_QUOTES) ?>
+        </span>
+    </div>
+</section>
+
+<section class="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+    <?php foreach ($summary as $card): ?>
+        <article class="rounded-xl border border-border/90 bg-gradient-to-b from-card to-black/40 p-5 shadow-lg shadow-black/20 ring-1 ring-white/5">
+            <p class="text-xs uppercase tracking-[0.2em] text-muted"><?= htmlspecialchars((string) ($card['label'] ?? ''), ENT_QUOTES) ?></p>
+            <p class="mt-2 text-2xl font-semibold text-slate-50"><?= htmlspecialchars((string) ($card['value'] ?? '—'), ENT_QUOTES) ?></p>
+            <p class="mt-2 text-sm text-muted"><?= htmlspecialchars((string) ($card['context'] ?? ''), ENT_QUOTES) ?></p>
+        </article>
+    <?php endforeach; ?>
+</section>
+
+<section class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
+    <article class="rounded-xl border border-border bg-card p-5">
+        <div class="flex items-center justify-between gap-3">
+            <h2 class="text-base font-medium text-slate-50">Pipeline status</h2>
+            <span class="text-xs uppercase tracking-[0.15em] text-muted"><?= htmlspecialchars((string) ($status['sync_status'] ?? 'idle'), ENT_QUOTES) ?></span>
+        </div>
+        <div class="mt-4 grid gap-3 md:grid-cols-2">
+            <div class="rounded-lg border border-border bg-black/20 p-4">
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Cursor position</p>
+                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($status['current_cursor'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
+                <p class="mt-1 text-sm text-muted">Current saved stream cursor / last processed sequence if available.</p>
+            </div>
+            <div class="rounded-lg border border-border bg-black/20 p-4">
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Latest run outcome</p>
+                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($status['last_sync_outcome'] ?? 'Unknown'), ENT_QUOTES) ?></p>
+                <p class="mt-1 text-sm text-muted">Source rows <?= number_format((int) ($status['last_run_source_rows'] ?? 0)) ?> · inserted <?= number_format((int) ($status['last_run_written_rows'] ?? 0)) ?></p>
+            </div>
+            <div class="rounded-lg border border-border bg-black/20 p-4">
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Last successful sync</p>
+                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($status['last_sync_relative'] ?? 'Never'), ENT_QUOTES) ?></p>
+                <p class="mt-1 text-sm text-muted"><?= htmlspecialchars((string) ($status['last_success_at'] ?? '—'), ENT_QUOTES) ?></p>
+            </div>
+            <div class="rounded-lg border border-border bg-black/20 p-4">
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Latest stored killmail</p>
+                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($status['last_ingested_at'] ?? '—'), ENT_QUOTES) ?></p>
+                <p class="mt-1 text-sm text-muted">Latest uploaded_at <?= htmlspecialchars((string) ($status['last_uploaded_at'] ?? '—'), ENT_QUOTES) ?></p>
+            </div>
+        </div>
+        <?php if ((string) ($status['last_error'] ?? '') !== ''): ?>
+            <div class="mt-4 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+                Last sync error: <?= htmlspecialchars((string) $status['last_error'], ENT_QUOTES) ?>
+            </div>
+        <?php endif; ?>
+    </article>
+
+    <article class="rounded-xl border border-border bg-card p-5">
+        <div class="flex items-center justify-between gap-3">
+            <h2 class="text-base font-medium text-slate-50">Tracked entity context</h2>
+            <span class="text-xs text-muted">Validation foundation</span>
+        </div>
+        <div class="mt-4 space-y-3">
+            <div class="rounded-lg border border-border bg-black/20 px-4 py-3">
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Tracked alliances</p>
+                <p class="mt-2 text-xl font-semibold text-slate-50"><?= number_format((int) ($status['tracked_alliance_count'] ?? 0)) ?></p>
+            </div>
+            <div class="rounded-lg border border-border bg-black/20 px-4 py-3">
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Tracked corporations</p>
+                <p class="mt-2 text-xl font-semibold text-slate-50"><?= number_format((int) ($status['tracked_corporation_count'] ?? 0)) ?></p>
+            </div>
+            <div class="rounded-lg border border-dashed border-border bg-black/10 px-4 py-3 text-sm text-muted">
+                This first page focuses on operational verification: stored killmails, current feed freshness, and tracked-entity matching. It is ready to grow into detail pages, doctrine views, and demand-signal analytics later.
+            </div>
+        </div>
+    </article>
+</section>
+
+<section class="mt-6 rounded-xl border border-border bg-card p-5 shadow-lg shadow-black/20">
+    <form method="get" action="<?= htmlspecialchars(current_path(), ENT_QUOTES) ?>" class="rounded-xl border border-border/80 bg-black/20 p-4">
+        <div class="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto] xl:items-end">
+            <label class="block text-sm text-muted">
+                <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Search killmails</span>
+                <input type="search" name="q" value="<?= htmlspecialchars((string) ($filters['search'] ?? ''), ENT_QUOTES) ?>" placeholder="Search sequence, killmail ID, ship, system, or tracked labels..." class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-slate-100 placeholder:text-muted focus:border-accent/70 focus:outline-none">
+            </label>
+            <label class="block text-sm text-muted">
+                <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Alliance</span>
+                <select name="alliance_id" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-slate-100 focus:border-accent/70 focus:outline-none">
+                    <?php foreach ((array) ($filters['alliance_options'] ?? []) as $optionValue => $optionLabel): ?>
+                        <option value="<?= htmlspecialchars((string) $optionValue, ENT_QUOTES) ?>" <?= (string) $optionValue === (string) ($filters['alliance_id'] ?? 0) ? 'selected' : '' ?>><?= htmlspecialchars((string) $optionLabel, ENT_QUOTES) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="block text-sm text-muted">
+                <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Corporation</span>
+                <select name="corporation_id" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-slate-100 focus:border-accent/70 focus:outline-none">
+                    <?php foreach ((array) ($filters['corporation_options'] ?? []) as $optionValue => $optionLabel): ?>
+                        <option value="<?= htmlspecialchars((string) $optionValue, ENT_QUOTES) ?>" <?= (string) $optionValue === (string) ($filters['corporation_id'] ?? 0) ? 'selected' : '' ?>><?= htmlspecialchars((string) $optionLabel, ENT_QUOTES) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="block text-sm text-muted">
+                <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Page size</span>
+                <select name="page_size" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-slate-100 focus:border-accent/70 focus:outline-none">
+                    <?php foreach ((array) ($filters['page_size_options'] ?? [25, 50, 100]) as $option): ?>
+                        <?php $sizeValue = max(1, (int) $option); ?>
+                        <option value="<?= $sizeValue ?>" <?= $sizeValue === (int) ($pagination['page_size'] ?? 25) ? 'selected' : '' ?>><?= $sizeValue ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 px-4 py-2 text-sm text-slate-200">
+                <input type="hidden" name="tracked_only" value="0">
+                <input type="checkbox" name="tracked_only" value="1" <?= ($filters['tracked_only'] ?? false) ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                <span>Tracked matches only</span>
+            </label>
+        </div>
+        <div class="mt-4 flex flex-wrap items-center justify-between gap-3">
+            <div class="text-sm text-muted">
+                Showing <?= (int) ($pagination['showing_from'] ?? 0) ?>-<?= (int) ($pagination['showing_to'] ?? 0) ?> of <?= number_format((int) ($pagination['total_items'] ?? 0)) ?> stored killmails
+            </div>
+            <div class="flex flex-wrap gap-2">
+                <button type="submit" class="rounded-lg border border-border bg-accent/40 px-4 py-2 text-sm font-medium text-white transition hover:bg-accent/60">Apply filters</button>
+                <a href="<?= htmlspecialchars(current_path(), ENT_QUOTES) ?>" class="rounded-lg border border-border px-4 py-2 text-sm text-slate-200 transition hover:bg-white/5">Reset</a>
+            </div>
+        </div>
+        <input type="hidden" name="page" value="1">
+    </form>
+
+    <div class="mt-5 overflow-x-auto rounded-lg border border-border/80">
+        <table class="min-w-full text-sm">
+            <thead>
+            <tr class="border-b border-border/80 bg-white/[0.03] text-left text-xs uppercase tracking-[0.15em] text-muted">
+                <th class="px-3 py-2 font-medium">Killmail Time</th>
+                <th class="px-3 py-2 font-medium">Sequence</th>
+                <th class="px-3 py-2 font-medium">Victim Corp / Alliance</th>
+                <th class="px-3 py-2 font-medium">Ship Type</th>
+                <th class="px-3 py-2 font-medium">System / Region</th>
+                <th class="px-3 py-2 font-medium">Tracked Match</th>
+                <th class="px-3 py-2 font-medium">Ingestion Context</th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php if ($rows === []): ?>
+                <tr>
+                    <td colspan="7" class="px-4 py-8">
+                        <div class="rounded-xl border border-dashed border-border bg-black/10 p-5">
+                            <p class="text-base font-medium text-slate-50">No killmails to show yet.</p>
+                            <p class="mt-2 text-sm text-muted"><?= htmlspecialchars($emptyMessage, ENT_QUOTES) ?></p>
+                        </div>
+                    </td>
+                </tr>
+            <?php else: ?>
+                <?php foreach ($rows as $index => $row): ?>
+                    <tr class="border-b border-border/60 text-slate-200 transition hover:bg-accent/10 <?= $index % 2 === 1 ? 'bg-white/[0.01]' : '' ?>">
+                        <td class="px-3 py-3 align-top">
+                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted">Uploaded <?= htmlspecialchars((string) ($row['uploaded_at_display'] ?? '—'), ENT_QUOTES) ?></p>
+                        </td>
+                        <td class="px-3 py-3 align-top">
+                            <p class="font-semibold text-slate-50">#<?= htmlspecialchars(number_format((int) ($row['sequence_id'] ?? 0)), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted">Killmail <?= htmlspecialchars((string) ($row['killmail_id'] ?? '—'), ENT_QUOTES) ?></p>
+                        </td>
+                        <td class="px-3 py-3 align-top">
+                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['victim_corporation'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['victim_alliance'] ?? '—'), ENT_QUOTES) ?></p>
+                        </td>
+                        <td class="px-3 py-3 align-top">
+                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['ship_type'] ?? '—'), ENT_QUOTES) ?></p>
+                        </td>
+                        <td class="px-3 py-3 align-top">
+                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['system'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['region'] ?? '—'), ENT_QUOTES) ?></p>
+                        </td>
+                        <td class="px-3 py-3 align-top">
+                            <span class="rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] <?= ($row['matched_tracked'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-slate-500/40 bg-slate-500/10 text-slate-300' ?>">
+                                <?= ($row['matched_tracked'] ?? false) ? 'Matched' : 'Unmatched' ?>
+                            </span>
+                            <p class="mt-2 max-w-xs text-xs text-muted"><?= htmlspecialchars((string) ($row['match_context'] ?? ''), ENT_QUOTES) ?></p>
+                        </td>
+                        <td class="px-3 py-3 align-top">
+                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['created_at_display'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted">Stored locally</p>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm text-muted">
+        <p>Page <?= max(1, (int) ($pagination['page'] ?? 1)) ?> / <?= max(1, (int) ($pagination['total_pages'] ?? 1)) ?></p>
+        <div class="flex items-center gap-2">
+            <a href="<?= htmlspecialchars($buildPageUrl(((int) ($pagination['page'] ?? 1)) - 1), ENT_QUOTES) ?>" class="rounded-md border border-border px-3 py-1.5 text-slate-200 transition hover:bg-white/5 <?= ((int) ($pagination['page'] ?? 1)) <= 1 ? 'pointer-events-none opacity-40' : '' ?>">Previous</a>
+            <a href="<?= htmlspecialchars($buildPageUrl(((int) ($pagination['page'] ?? 1)) + 1), ENT_QUOTES) ?>" class="rounded-md border border-border px-3 py-1.5 text-slate-200 transition hover:bg-white/5 <?= ((int) ($pagination['page'] ?? 1)) >= ((int) ($pagination['total_pages'] ?? 1)) ? 'pointer-events-none opacity-40' : '' ?>">Next</a>
+        </div>
+    </div>
+</section>
+
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/src/db.php
+++ b/src/db.php
@@ -2002,15 +2002,44 @@ function db_killmail_tracked_corporations_active(): array
     return db_select('SELECT corporation_id, label FROM killmail_tracked_corporations WHERE is_active = 1 ORDER BY corporation_id ASC');
 }
 
+function db_killmail_tracked_match_sql(string $eventAlias = 'e'): string
+{
+    $eventAlias = preg_replace('/[^a-zA-Z0-9_]/', '', $eventAlias) ?: 'e';
+
+    return "(
+        EXISTS (SELECT 1 FROM killmail_tracked_alliances ta WHERE ta.is_active = 1 AND ta.alliance_id = {$eventAlias}.victim_alliance_id)
+        OR EXISTS (SELECT 1 FROM killmail_tracked_corporations tc WHERE tc.is_active = 1 AND tc.corporation_id = {$eventAlias}.victim_corporation_id)
+        OR EXISTS (
+            SELECT 1
+            FROM killmail_attackers a
+            WHERE a.sequence_id = {$eventAlias}.sequence_id
+              AND (
+                  EXISTS (SELECT 1 FROM killmail_tracked_alliances ta2 WHERE ta2.is_active = 1 AND ta2.alliance_id = a.alliance_id)
+                  OR EXISTS (SELECT 1 FROM killmail_tracked_corporations tc2 WHERE tc2.is_active = 1 AND tc2.corporation_id = a.corporation_id)
+              )
+        )
+    )";
+}
+
 function db_killmail_ingestion_status(): array
 {
     $state = db_sync_state_get('killmail.r2z2.stream');
-    $latest = db_select_one('SELECT MAX(sequence_id) AS max_sequence_id, MAX(uploaded_at) AS max_uploaded_at FROM killmail_events');
+    $latest = db_select_one('SELECT MAX(sequence_id) AS max_sequence_id, MAX(uploaded_at) AS max_uploaded_at, MAX(created_at) AS max_created_at FROM killmail_events');
+    $latestRun = db_sync_run_latest_by_dataset('killmail.r2z2.stream');
+    $trackedCounts = db_select_one(
+        'SELECT
+            (SELECT COUNT(*) FROM killmail_tracked_alliances WHERE is_active = 1) AS tracked_alliance_count,
+            (SELECT COUNT(*) FROM killmail_tracked_corporations WHERE is_active = 1) AS tracked_corporation_count'
+    );
 
     return [
         'state' => $state,
         'max_sequence_id' => isset($latest['max_sequence_id']) ? (int) $latest['max_sequence_id'] : null,
         'max_uploaded_at' => $latest['max_uploaded_at'] ?? null,
+        'max_created_at' => $latest['max_created_at'] ?? null,
+        'latest_run' => $latestRun,
+        'tracked_alliance_count' => (int) ($trackedCounts['tracked_alliance_count'] ?? 0),
+        'tracked_corporation_count' => (int) ($trackedCounts['tracked_corporation_count'] ?? 0),
     ];
 }
 
@@ -2037,4 +2066,184 @@ function db_killmail_filtered_recent(int $limit = 50): array
          ORDER BY e.sequence_id DESC
          LIMIT {$limit}"
     );
+}
+
+function db_killmail_overview_summary(int $recentHours = 24): array
+{
+    $safeRecentHours = max(1, min(24 * 30, $recentHours));
+    $matchSql = db_killmail_tracked_match_sql('e');
+
+    return db_select_one(
+        "SELECT
+            COUNT(*) AS total_count,
+            SUM(CASE WHEN e.created_at >= (UTC_TIMESTAMP() - INTERVAL {$safeRecentHours} HOUR) THEN 1 ELSE 0 END) AS recent_count,
+            SUM(CASE WHEN {$matchSql} THEN 1 ELSE 0 END) AS tracked_match_count,
+            MAX(e.sequence_id) AS max_sequence_id,
+            MAX(e.created_at) AS last_ingested_at,
+            MAX(e.uploaded_at) AS latest_uploaded_at
+         FROM killmail_events e"
+    ) ?? [];
+}
+
+function db_killmail_overview_filter_options(): array
+{
+    $alliances = db_select(
+        "SELECT DISTINCT
+            e.victim_alliance_id AS entity_id,
+            COALESCE(NULLIF(ta.label, ''), CONCAT('Alliance #', e.victim_alliance_id)) AS entity_label
+         FROM killmail_events e
+         LEFT JOIN killmail_tracked_alliances ta
+           ON ta.alliance_id = e.victim_alliance_id
+          AND ta.is_active = 1
+         WHERE e.victim_alliance_id IS NOT NULL
+           AND e.victim_alliance_id > 0
+         ORDER BY entity_label ASC"
+    );
+
+    $corporations = db_select(
+        "SELECT DISTINCT
+            e.victim_corporation_id AS entity_id,
+            COALESCE(NULLIF(tc.label, ''), CONCAT('Corporation #', e.victim_corporation_id)) AS entity_label
+         FROM killmail_events e
+         LEFT JOIN killmail_tracked_corporations tc
+           ON tc.corporation_id = e.victim_corporation_id
+          AND tc.is_active = 1
+         WHERE e.victim_corporation_id IS NOT NULL
+           AND e.victim_corporation_id > 0
+         ORDER BY entity_label ASC"
+    );
+
+    return [
+        'alliances' => $alliances,
+        'corporations' => $corporations,
+    ];
+}
+
+function db_killmail_overview_page(array $filters = []): array
+{
+    $page = max(1, (int) ($filters['page'] ?? 1));
+    $pageSize = max(1, min(100, (int) ($filters['page_size'] ?? 25)));
+    $offset = ($page - 1) * $pageSize;
+    $allianceId = max(0, (int) ($filters['alliance_id'] ?? 0));
+    $corporationId = max(0, (int) ($filters['corporation_id'] ?? 0));
+    $trackedOnly = (bool) ($filters['tracked_only'] ?? false);
+    $search = trim((string) ($filters['search'] ?? ''));
+    $matchSql = db_killmail_tracked_match_sql('e');
+
+    $fromSql = " FROM killmail_events e
+        LEFT JOIN ref_item_types ship ON ship.type_id = e.victim_ship_type_id
+        LEFT JOIN ref_systems system_ref ON system_ref.system_id = e.solar_system_id
+        LEFT JOIN ref_regions region_ref ON region_ref.region_id = e.region_id
+        LEFT JOIN killmail_tracked_alliances victim_ta
+          ON victim_ta.alliance_id = e.victim_alliance_id
+         AND victim_ta.is_active = 1
+        LEFT JOIN killmail_tracked_corporations victim_tc
+          ON victim_tc.corporation_id = e.victim_corporation_id
+         AND victim_tc.is_active = 1";
+
+    $conditions = [];
+    $params = [];
+
+    if ($allianceId > 0) {
+        $conditions[] = 'e.victim_alliance_id = ?';
+        $params[] = $allianceId;
+    }
+
+    if ($corporationId > 0) {
+        $conditions[] = 'e.victim_corporation_id = ?';
+        $params[] = $corporationId;
+    }
+
+    if ($trackedOnly) {
+        $conditions[] = $matchSql;
+    }
+
+    if ($search !== '') {
+        $needle = '%' . $search . '%';
+        $conditions[] = '(
+            CAST(e.sequence_id AS CHAR) LIKE ?
+            OR CAST(e.killmail_id AS CHAR) LIKE ?
+            OR COALESCE(victim_ta.label, \'\') LIKE ?
+            OR COALESCE(victim_tc.label, \'\') LIKE ?
+            OR COALESCE(ship.type_name, \'\') LIKE ?
+            OR COALESCE(system_ref.system_name, \'\') LIKE ?
+            OR COALESCE(region_ref.region_name, \'\') LIKE ?
+        )';
+        array_push($params, $needle, $needle, $needle, $needle, $needle, $needle, $needle);
+    }
+
+    $whereSql = $conditions === [] ? '' : (' WHERE ' . implode(' AND ', $conditions));
+
+    $countRow = db_select_one(
+        'SELECT COUNT(*) AS total_items' . $fromSql . $whereSql,
+        $params
+    );
+    $totalItems = (int) ($countRow['total_items'] ?? 0);
+    $totalPages = max(1, (int) ceil($totalItems / $pageSize));
+    $page = min($page, $totalPages);
+    $offset = ($page - 1) * $pageSize;
+
+    $rows = db_select(
+        "SELECT
+            e.sequence_id,
+            e.killmail_id,
+            e.killmail_hash,
+            e.killmail_time,
+            e.uploaded_at,
+            e.created_at,
+            e.victim_corporation_id,
+            e.victim_alliance_id,
+            e.victim_ship_type_id,
+            e.solar_system_id,
+            e.region_id,
+            COALESCE(NULLIF(victim_tc.label, ''), CONCAT('Corporation #', e.victim_corporation_id)) AS victim_corporation_label,
+            COALESCE(NULLIF(victim_ta.label, ''), CONCAT('Alliance #', e.victim_alliance_id)) AS victim_alliance_label,
+            COALESCE(NULLIF(ship.type_name, ''), CONCAT('Type #', e.victim_ship_type_id)) AS ship_type_name,
+            COALESCE(NULLIF(system_ref.system_name, ''), CONCAT('System #', e.solar_system_id)) AS system_name,
+            COALESCE(NULLIF(region_ref.region_name, ''), CONCAT('Region #', e.region_id)) AS region_name,
+            CASE WHEN EXISTS (
+                SELECT 1 FROM killmail_tracked_alliances ta WHERE ta.is_active = 1 AND ta.alliance_id = e.victim_alliance_id
+            ) THEN 1 ELSE 0 END AS matches_victim_alliance,
+            CASE WHEN EXISTS (
+                SELECT 1 FROM killmail_tracked_corporations tc WHERE tc.is_active = 1 AND tc.corporation_id = e.victim_corporation_id
+            ) THEN 1 ELSE 0 END AS matches_victim_corporation,
+            CASE WHEN EXISTS (
+                SELECT 1
+                FROM killmail_attackers attacker_alliance
+                WHERE attacker_alliance.sequence_id = e.sequence_id
+                  AND EXISTS (
+                      SELECT 1
+                      FROM killmail_tracked_alliances ta2
+                      WHERE ta2.is_active = 1
+                        AND ta2.alliance_id = attacker_alliance.alliance_id
+                  )
+            ) THEN 1 ELSE 0 END AS matches_attacker_alliance,
+            CASE WHEN EXISTS (
+                SELECT 1
+                FROM killmail_attackers attacker_corporation
+                WHERE attacker_corporation.sequence_id = e.sequence_id
+                  AND EXISTS (
+                      SELECT 1
+                      FROM killmail_tracked_corporations tc2
+                      WHERE tc2.is_active = 1
+                        AND tc2.corporation_id = attacker_corporation.corporation_id
+                  )
+            ) THEN 1 ELSE 0 END AS matches_attacker_corporation,
+            CASE WHEN {$matchSql} THEN 1 ELSE 0 END AS matched_tracked
+            {$fromSql}
+            {$whereSql}
+         ORDER BY e.sequence_id DESC
+         LIMIT {$pageSize} OFFSET {$offset}",
+        $params
+    );
+
+    return [
+        'rows' => $rows,
+        'page' => $page,
+        'page_size' => $pageSize,
+        'total_items' => $totalItems,
+        'total_pages' => $totalPages,
+        'showing_from' => $totalItems > 0 ? $offset + 1 : 0,
+        'showing_to' => min($offset + $pageSize, $totalItems),
+    ];
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -64,6 +64,14 @@ function nav_items(): array
             ],
         ],
         [
+            'label' => 'Killmail Intelligence',
+            'path' => '/killmail-intelligence',
+            'icon' => '💥',
+            'children' => [
+                ['label' => 'Recent Killmails', 'path' => '/killmail-intelligence'],
+            ],
+        ],
+        [
             'label' => 'Settings',
             'path' => '/settings',
             'icon' => '⚙️',
@@ -1388,6 +1396,236 @@ function current_alliance_market_status_data(): array
             'showing_from' => $totalItems > 0 ? $offset + 1 : 0,
             'showing_to' => min($offset + $pageSize, $totalItems),
         ],
+    ];
+}
+
+function killmail_format_datetime(?string $value): string
+{
+    $trimmed = trim((string) $value);
+    if ($trimmed === '') {
+        return '—';
+    }
+
+    try {
+        $date = new DateTimeImmutable($trimmed, new DateTimeZone('UTC'));
+        $timezone = new DateTimeZone(app_timezone());
+
+        return $date->setTimezone($timezone)->format('Y-m-d H:i:s T');
+    } catch (Throwable) {
+        return $trimmed;
+    }
+}
+
+function killmail_relative_datetime(?string $value): string
+{
+    $trimmed = trim((string) $value);
+    if ($trimmed === '') {
+        return 'Never';
+    }
+
+    try {
+        $date = new DateTimeImmutable($trimmed, new DateTimeZone('UTC'));
+        $age = time() - $date->getTimestamp();
+
+        return $age <= 0 ? 'just now' : (human_duration_ago($age) . ' ago');
+    } catch (Throwable) {
+        return 'Unknown';
+    }
+}
+
+function killmail_last_sync_outcome_label(?array $latestRun): string
+{
+    if (!is_array($latestRun) || $latestRun === []) {
+        return 'No sync runs yet';
+    }
+
+    $status = (string) ($latestRun['run_status'] ?? 'unknown');
+    if ($status !== 'success') {
+        return 'Failed';
+    }
+
+    $writtenRows = (int) ($latestRun['written_rows'] ?? 0);
+    if ($writtenRows > 0) {
+        return 'Inserted ' . number_format($writtenRows) . ' new killmail' . ($writtenRows === 1 ? '' : 's');
+    }
+
+    return 'No-op';
+}
+
+function killmail_match_sources(array $row): array
+{
+    $sources = [];
+
+    if ((int) ($row['matches_victim_alliance'] ?? 0) === 1) {
+        $sources[] = 'victim alliance';
+    }
+
+    if ((int) ($row['matches_victim_corporation'] ?? 0) === 1) {
+        $sources[] = 'victim corporation';
+    }
+
+    if ((int) ($row['matches_attacker_alliance'] ?? 0) === 1) {
+        $sources[] = 'attacker alliance';
+    }
+
+    if ((int) ($row['matches_attacker_corporation'] ?? 0) === 1) {
+        $sources[] = 'attacker corporation';
+    }
+
+    return $sources;
+}
+
+function killmail_overview_data(): array
+{
+    $recentHours = 24;
+    $allowedPageSizes = [25, 50, 100];
+    $pageSize = (int) ($_GET['page_size'] ?? 25);
+    if (!in_array($pageSize, $allowedPageSizes, true)) {
+        $pageSize = 25;
+    }
+
+    $filters = [
+        'search' => trim((string) ($_GET['q'] ?? '')),
+        'alliance_id' => max(0, (int) ($_GET['alliance_id'] ?? 0)),
+        'corporation_id' => max(0, (int) ($_GET['corporation_id'] ?? 0)),
+        'tracked_only' => sanitize_enabled_flag($_GET['tracked_only'] ?? '0') === '1',
+        'page' => max(1, (int) ($_GET['page'] ?? 1)),
+        'page_size' => $pageSize,
+    ];
+
+    try {
+        $summaryRow = db_killmail_overview_summary($recentHours);
+        $status = db_killmail_ingestion_status();
+        $options = db_killmail_overview_filter_options();
+        $listing = db_killmail_overview_page($filters);
+    } catch (Throwable $exception) {
+        return [
+            'error' => $exception->getMessage(),
+            'summary' => [],
+            'status' => [
+                'ingestion_enabled' => killmail_ingestion_enabled(),
+                'last_sync_outcome' => 'Unavailable',
+            ],
+            'rows' => [],
+            'filters' => $filters + [
+                'page_size_options' => $allowedPageSizes,
+                'alliance_options' => ['0' => 'All alliances'],
+                'corporation_options' => ['0' => 'All corporations'],
+            ],
+            'pagination' => [
+                'page' => 1,
+                'page_size' => $pageSize,
+                'page_size_options' => $allowedPageSizes,
+                'total_pages' => 1,
+                'total_items' => 0,
+                'showing_from' => 0,
+                'showing_to' => 0,
+            ],
+            'empty_message' => 'Killmail overview is unavailable because the database query failed.',
+        ];
+    }
+
+    $totalCount = (int) ($summaryRow['total_count'] ?? 0);
+    $recentCount = (int) ($summaryRow['recent_count'] ?? 0);
+    $trackedMatchCount = (int) ($summaryRow['tracked_match_count'] ?? 0);
+    $maxSequenceId = (int) ($summaryRow['max_sequence_id'] ?? ($status['max_sequence_id'] ?? 0));
+    $state = is_array($status['state'] ?? null) ? $status['state'] : [];
+    $latestRun = is_array($status['latest_run'] ?? null) ? $status['latest_run'] : null;
+    $lastSuccessAt = isset($state['last_success_at']) ? (string) $state['last_success_at'] : null;
+    $lastIngestedAt = isset($summaryRow['last_ingested_at']) ? (string) $summaryRow['last_ingested_at'] : null;
+    $latestUploadedAt = isset($summaryRow['latest_uploaded_at']) ? (string) $summaryRow['latest_uploaded_at'] : null;
+    $cursor = isset($state['last_cursor']) ? trim((string) $state['last_cursor']) : '';
+
+    $allianceOptions = ['0' => 'All alliances'];
+    foreach ((array) ($options['alliances'] ?? []) as $row) {
+        $id = (int) ($row['entity_id'] ?? 0);
+        if ($id <= 0) {
+            continue;
+        }
+
+        $allianceOptions[(string) $id] = (string) ($row['entity_label'] ?? ('Alliance #' . $id));
+    }
+
+    $corporationOptions = ['0' => 'All corporations'];
+    foreach ((array) ($options['corporations'] ?? []) as $row) {
+        $id = (int) ($row['entity_id'] ?? 0);
+        if ($id <= 0) {
+            continue;
+        }
+
+        $corporationOptions[(string) $id] = (string) ($row['entity_label'] ?? ('Corporation #' . $id));
+    }
+
+    $rows = array_map(static function (array $row): array {
+        $matchSources = killmail_match_sources($row);
+        $allianceLabel = trim((string) ($row['victim_alliance_label'] ?? ''));
+        $corporationLabel = trim((string) ($row['victim_corporation_label'] ?? ''));
+        $shipType = trim((string) ($row['ship_type_name'] ?? ''));
+        $system = trim((string) ($row['system_name'] ?? ''));
+        $region = trim((string) ($row['region_name'] ?? ''));
+
+        return [
+            'sequence_id' => (int) ($row['sequence_id'] ?? 0),
+            'killmail_id' => (int) ($row['killmail_id'] ?? 0),
+            'killmail_time_display' => killmail_format_datetime(isset($row['killmail_time']) ? (string) $row['killmail_time'] : null),
+            'uploaded_at_display' => killmail_format_datetime(isset($row['uploaded_at']) ? (string) $row['uploaded_at'] : null),
+            'created_at_display' => killmail_format_datetime(isset($row['created_at']) ? (string) $row['created_at'] : null),
+            'victim_alliance' => $allianceLabel !== '' ? $allianceLabel : 'Alliance unavailable',
+            'victim_corporation' => $corporationLabel !== '' ? $corporationLabel : 'Corporation unavailable',
+            'ship_type' => $shipType !== '' ? $shipType : 'Ship type unavailable',
+            'system' => $system !== '' ? $system : 'System unavailable',
+            'region' => $region !== '' ? $region : 'Region unavailable',
+            'matched_tracked' => (int) ($row['matched_tracked'] ?? 0) === 1,
+            'match_context' => $matchSources === [] ? 'No current tracked-entity match.' : ('Matched on ' . implode(', ', $matchSources) . '.'),
+        ];
+    }, (array) ($listing['rows'] ?? []));
+
+    $emptyMessage = $totalCount === 0
+        ? 'No killmails have been stored yet. Enable killmail ingestion, run the sync worker, and this view will populate as local killmails arrive.'
+        : 'No killmails matched the current filters. Try clearing search or filter controls.';
+
+    return [
+        'error' => null,
+        'summary' => [
+            ['label' => 'Total Ingested', 'value' => number_format($totalCount), 'context' => 'Killmails stored locally'],
+            ['label' => 'Recent Ingestion', 'value' => number_format($recentCount), 'context' => 'Stored in the last ' . $recentHours . ' hours'],
+            ['label' => 'Tracked Matches', 'value' => number_format($trackedMatchCount), 'context' => 'Rows matching current tracked entities'],
+            ['label' => 'Last Processed Sequence', 'value' => $maxSequenceId > 0 ? number_format($maxSequenceId) : '—', 'context' => $cursor !== '' ? ('Cursor ' . $cursor) : 'Cursor not recorded yet'],
+            ['label' => 'Sync Freshness', 'value' => killmail_relative_datetime($lastSuccessAt), 'context' => $lastSuccessAt !== null ? ('Last success ' . killmail_format_datetime($lastSuccessAt)) : 'No successful sync recorded'],
+        ],
+        'status' => [
+            'ingestion_enabled' => killmail_ingestion_enabled(),
+            'current_cursor' => $cursor !== '' ? $cursor : 'Unavailable',
+            'last_sync_outcome' => killmail_last_sync_outcome_label($latestRun),
+            'last_success_at' => killmail_format_datetime($lastSuccessAt),
+            'last_sync_relative' => killmail_relative_datetime($lastSuccessAt),
+            'last_uploaded_at' => killmail_format_datetime($latestUploadedAt),
+            'last_ingested_at' => killmail_format_datetime($lastIngestedAt),
+            'tracked_alliance_count' => (int) ($status['tracked_alliance_count'] ?? 0),
+            'tracked_corporation_count' => (int) ($status['tracked_corporation_count'] ?? 0),
+            'sync_status' => (string) ($state['status'] ?? 'idle'),
+            'last_run_status' => (string) ($latestRun['run_status'] ?? 'not_run'),
+            'last_run_source_rows' => (int) ($latestRun['source_rows'] ?? 0),
+            'last_run_written_rows' => (int) ($latestRun['written_rows'] ?? 0),
+            'last_run_finished_at' => killmail_format_datetime(isset($latestRun['finished_at']) ? (string) $latestRun['finished_at'] : null),
+            'last_error' => trim((string) ($state['last_error_message'] ?? '')),
+        ],
+        'rows' => $rows,
+        'filters' => $filters + [
+            'page_size_options' => $allowedPageSizes,
+            'alliance_options' => $allianceOptions,
+            'corporation_options' => $corporationOptions,
+        ],
+        'pagination' => [
+            'page' => (int) ($listing['page'] ?? 1),
+            'page_size' => (int) ($listing['page_size'] ?? $pageSize),
+            'page_size_options' => $allowedPageSizes,
+            'total_pages' => (int) ($listing['total_pages'] ?? 1),
+            'total_items' => (int) ($listing['total_items'] ?? 0),
+            'showing_from' => (int) ($listing['showing_from'] ?? 0),
+            'showing_to' => (int) ($listing['showing_to'] ?? 0),
+        ],
+        'empty_message' => $emptyMessage,
     ];
 }
 


### PR DESCRIPTION
### Motivation

- Provide a first product-facing visibility page for the existing killmail ingestion pipeline so operators can confirm ingestion, freshness, and tracked-entity matching before building analytics. 
- Surface simple operational metrics and quick validation tools (search, filters, pagination) to make it easy to answer whether killmails are being stored and matched. 

### Description

- Add a new navigation area `Killmail Intelligence` with an initial page `Recent Killmails` via `nav_items()` to keep navigation centralized. 
- Add DB helpers in `src/db.php` to support overview requirements: `db_killmail_tracked_match_sql()`, enriched `db_killmail_ingestion_status()`, `db_killmail_overview_summary()`, `db_killmail_overview_filter_options()`, and `db_killmail_overview_page()` for summary metrics, filter option generation, tracked-match SQL, and paginated recent-killmail queries. 
- Add shared logic helpers in `src/functions.php`: datetime formatting (`killmail_format_datetime`, `killmail_relative_datetime`), sync outcome label, match-source helpers, and `killmail_overview_data()` which composes DB results into the UI shape and handles empty/error paths. 
- Add the UI page `public/killmail-intelligence/index.php` implementing summary cards, pipeline status, tracked-entity context, search, alliance/corporation/tracked-only filters, pagination, and clear empty/error states using the existing dark Tailwind/shadcn-inspired styles. 

### Testing

- Ran PHP syntax checks: `php -l src/db.php`, `php -l src/functions.php`, and `php -l public/killmail-intelligence/index.php`, all reporting no syntax errors. 
- Executed a runtime probe `php -r 'require "src/bootstrap.php"; $data = killmail_overview_data(); ...'` which exercised the data-path; the helper returned an error-state in this environment because no database connection was available, demonstrating the code correctly falls back to an informative error/empty state. 
- No other automated test suites were present or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba17d97c24832fa483ccef9a64778c)