### PR TITLE
Guard market-hub spread_percent overflow

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -692,7 +692,18 @@ function db_market_hub_local_history_daily_normalize_spread_percent(mixed $value
         return null;
     }
 
-    return round((float) $value, 4);
+    $spreadPercent = (float) $value;
+    if (!is_finite($spreadPercent)) {
+        return null;
+    }
+
+    $spreadPercent = round($spreadPercent, 4);
+    $maxAbsValue = 9999999999999999.9999;
+    if (abs($spreadPercent) > $maxAbsValue) {
+        return null;
+    }
+
+    return $spreadPercent;
 }
 
 function db_market_hub_local_history_daily_normalize_row(array $row): array

--- a/src/functions.php
+++ b/src/functions.php
@@ -2709,8 +2709,8 @@ function market_hub_current_snapshot_finalize_metric(array $metric): ?array
         return null;
     }
 
-    $sellPrice = isset($metric['best_sell_price']) && $metric['best_sell_price'] !== null ? (float) $metric['best_sell_price'] : null;
-    $buyPrice = isset($metric['best_buy_price']) && $metric['best_buy_price'] !== null ? (float) $metric['best_buy_price'] : null;
+    $sellPrice = isset($metric['best_sell_price']) && $metric['best_sell_price'] !== null ? round((float) $metric['best_sell_price'], 2) : null;
+    $buyPrice = isset($metric['best_buy_price']) && $metric['best_buy_price'] !== null ? round((float) $metric['best_buy_price'], 2) : null;
     $closePrice = $sellPrice ?? $buyPrice;
     if ($closePrice === null) {
         return null;


### PR DESCRIPTION
### Motivation

- Prevent sync failures caused by out-of-range `spread_percent` values which produce `SQLSTATE[22003]` during bulk upserts.
- Avoid producing extreme spread ratios from tiny fractional snapshot prices by aligning snapshot rounding with the storage precision.

### Description

- Round snapshot `best_buy_price` and `best_sell_price` to 2 decimal places in `market_hub_current_snapshot_finalize_metric` before deriving spread metrics (`src/functions.php`).
- Harden `db_market_hub_local_history_daily_normalize_spread_percent` to treat non-finite values as `NULL`, round to 4 decimals, and cap very large absolute values so out-of-range numbers are saved as `NULL` instead of causing DB errors (`src/db.php`).
- Changes keep the resulting `spread_percent` within safe MySQL DECIMAL(20,4) bounds and preserve existing nullable semantics.

### Testing

- Ran syntax checks with `php -l src/db.php` and `php -l src/functions.php`, both succeeded.
- Exercised normalization with `php -r 'require "src/db.php"; var_export(db_market_hub_local_history_daily_normalize_spread_percent(INF)); var_export(db_market_hub_local_history_daily_normalize_spread_percent(1.0e20)); var_export(db_market_hub_local_history_daily_normalize_spread_percent(12.34567));'` which returned safe `NULL` for invalid/oversized inputs and a rounded value for normal inputs.
- Exercised metric finalization with `php -r 'require "src/functions.php"; $row = market_hub_current_snapshot_finalize_metric([...]); var_export($row);'` which produced expected rounded prices and `NULL` spread_percent when appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba191878bc832faea695711bc78051)