### PR TITLE
Refine Killmail Intelligence UI for victim-focused loss inspection

### DIFF
--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../src/bootstrap.php';
 
-$title = 'Killmail Overview';
+$title = 'Killmail Loss Overview';
 $data = killmail_overview_data();
 $summary = $data['summary'] ?? [];
 $status = $data['status'] ?? [];
@@ -33,8 +33,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
 <section class="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-xl border border-border bg-card p-5">
     <div>
         <p class="text-xs uppercase tracking-[0.2em] text-muted">Operational visibility</p>
-        <h2 class="mt-1 text-lg font-medium text-slate-50">Recent killmail ingestion at a glance</h2>
-        <p class="mt-2 max-w-3xl text-sm text-muted">Use this page to confirm the killmail pipeline is alive, local killmails are being stored, and tracked alliances or corporations are being matched before deeper analytics are added.</p>
+        <h2 class="mt-1 text-lg font-medium text-slate-50">Tracked victim losses, stored locally</h2>
+        <p class="mt-2 max-w-3xl text-sm text-muted">Use this workspace to validate that killmail ingestion is capturing the victim side correctly, inspect stored loss items, and prepare for future loss-vs-market analysis without centering raw database IDs.</p>
     </div>
     <div class="flex flex-wrap gap-2">
         <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= ($status['ingestion_enabled'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-amber-500/40 bg-amber-500/10 text-amber-100' ?>">
@@ -93,8 +93,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
     <article class="rounded-xl border border-border bg-card p-5">
         <div class="flex items-center justify-between gap-3">
-            <h2 class="text-base font-medium text-slate-50">Tracked entity context</h2>
-            <span class="text-xs text-muted">Validation foundation</span>
+            <h2 class="text-base font-medium text-slate-50">Victim tracking context</h2>
+            <span class="text-xs text-muted">Loss validation foundation</span>
         </div>
         <div class="mt-4 space-y-3">
             <div class="rounded-lg border border-border bg-black/20 px-4 py-3">
@@ -106,7 +106,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <p class="mt-2 text-xl font-semibold text-slate-50"><?= number_format((int) ($status['tracked_corporation_count'] ?? 0)) ?></p>
             </div>
             <div class="rounded-lg border border-dashed border-border bg-black/10 px-4 py-3 text-sm text-muted">
-                This first page focuses on operational verification: stored killmails, current feed freshness, and tracked-entity matching. It is ready to grow into detail pages, doctrine views, and demand-signal analytics later.
+                Tracked matching is now victim-only. The overview highlights losses suffered by the tracked alliances and corporations, while attacker data is reserved for detail inspection.
             </div>
         </div>
     </article>
@@ -114,13 +114,13 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
 <section class="mt-6 rounded-xl border border-border bg-card p-5 shadow-lg shadow-black/20">
     <form method="get" action="<?= htmlspecialchars(current_path(), ENT_QUOTES) ?>" class="rounded-xl border border-border/80 bg-black/20 p-4">
-        <div class="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto] xl:items-end">
+        <div class="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto] xl:items-end">
             <label class="block text-sm text-muted">
-                <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Search killmails</span>
-                <input type="search" name="q" value="<?= htmlspecialchars((string) ($filters['search'] ?? ''), ENT_QUOTES) ?>" placeholder="Search sequence, killmail ID, ship, system, or tracked labels..." class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-slate-100 placeholder:text-muted focus:border-accent/70 focus:outline-none">
+                <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Search stored losses</span>
+                <input type="search" name="q" value="<?= htmlspecialchars((string) ($filters['search'] ?? ''), ENT_QUOTES) ?>" placeholder="Search sequence, killmail ID, ship, system, region, or tracked victim labels..." class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-slate-100 placeholder:text-muted focus:border-accent/70 focus:outline-none">
             </label>
             <label class="block text-sm text-muted">
-                <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Alliance</span>
+                <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Victim alliance</span>
                 <select name="alliance_id" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-slate-100 focus:border-accent/70 focus:outline-none">
                     <?php foreach ((array) ($filters['alliance_options'] ?? []) as $optionValue => $optionLabel): ?>
                         <option value="<?= htmlspecialchars((string) $optionValue, ENT_QUOTES) ?>" <?= (string) $optionValue === (string) ($filters['alliance_id'] ?? 0) ? 'selected' : '' ?>><?= htmlspecialchars((string) $optionLabel, ENT_QUOTES) ?></option>
@@ -128,7 +128,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 </select>
             </label>
             <label class="block text-sm text-muted">
-                <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Corporation</span>
+                <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Victim corporation</span>
                 <select name="corporation_id" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-slate-100 focus:border-accent/70 focus:outline-none">
                     <?php foreach ((array) ($filters['corporation_options'] ?? []) as $optionValue => $optionLabel): ?>
                         <option value="<?= htmlspecialchars((string) $optionValue, ENT_QUOTES) ?>" <?= (string) $optionValue === (string) ($filters['corporation_id'] ?? 0) ? 'selected' : '' ?>><?= htmlspecialchars((string) $optionLabel, ENT_QUOTES) ?></option>
@@ -147,12 +147,12 @@ include __DIR__ . '/../../src/views/partials/header.php';
             <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 px-4 py-2 text-sm text-slate-200">
                 <input type="hidden" name="tracked_only" value="0">
                 <input type="checkbox" name="tracked_only" value="1" <?= ($filters['tracked_only'] ?? false) ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
-                <span>Tracked matches only</span>
+                <span>Tracked victim losses only</span>
             </label>
         </div>
         <div class="mt-4 flex flex-wrap items-center justify-between gap-3">
             <div class="text-sm text-muted">
-                Showing <?= (int) ($pagination['showing_from'] ?? 0) ?>-<?= (int) ($pagination['showing_to'] ?? 0) ?> of <?= number_format((int) ($pagination['total_items'] ?? 0)) ?> stored killmails
+                Showing <?= (int) ($pagination['showing_from'] ?? 0) ?>-<?= (int) ($pagination['showing_to'] ?? 0) ?> of <?= number_format((int) ($pagination['total_items'] ?? 0)) ?> stored losses
             </div>
             <div class="flex flex-wrap gap-2">
                 <button type="submit" class="rounded-lg border border-border bg-accent/40 px-4 py-2 text-sm font-medium text-white transition hover:bg-accent/60">Apply filters</button>
@@ -166,13 +166,13 @@ include __DIR__ . '/../../src/views/partials/header.php';
         <table class="min-w-full text-sm">
             <thead>
             <tr class="border-b border-border/80 bg-white/[0.03] text-left text-xs uppercase tracking-[0.15em] text-muted">
-                <th class="px-3 py-2 font-medium">Killmail Time</th>
-                <th class="px-3 py-2 font-medium">Sequence</th>
-                <th class="px-3 py-2 font-medium">Victim Corp / Alliance</th>
-                <th class="px-3 py-2 font-medium">Ship Type</th>
-                <th class="px-3 py-2 font-medium">System / Region</th>
-                <th class="px-3 py-2 font-medium">Tracked Match</th>
-                <th class="px-3 py-2 font-medium">Ingestion Context</th>
+                <th class="px-3 py-2 font-medium">Loss</th>
+                <th class="px-3 py-2 font-medium">Victim</th>
+                <th class="px-3 py-2 font-medium">Ship lost</th>
+                <th class="px-3 py-2 font-medium">Location</th>
+                <th class="px-3 py-2 font-medium">Tracked victim match</th>
+                <th class="px-3 py-2 font-medium">Stored locally</th>
+                <th class="px-3 py-2 font-medium">Inspect</th>
             </tr>
             </thead>
             <tbody>
@@ -190,32 +190,37 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <tr class="border-b border-border/60 text-slate-200 transition hover:bg-accent/10 <?= $index % 2 === 1 ? 'bg-white/[0.01]' : '' ?>">
                         <td class="px-3 py-3 align-top">
                             <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
-                            <p class="mt-1 text-xs text-muted">Uploaded <?= htmlspecialchars((string) ($row['uploaded_at_display'] ?? '—'), ENT_QUOTES) ?></p>
-                        </td>
-                        <td class="px-3 py-3 align-top">
-                            <p class="font-semibold text-slate-50">#<?= htmlspecialchars(number_format((int) ($row['sequence_id'] ?? 0)), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted">Sequence #<?= htmlspecialchars(number_format((int) ($row['sequence_id'] ?? 0)), ENT_QUOTES) ?></p>
                             <p class="mt-1 text-xs text-muted">Killmail <?= htmlspecialchars((string) ($row['killmail_id'] ?? '—'), ENT_QUOTES) ?></p>
                         </td>
                         <td class="px-3 py-3 align-top">
                             <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['victim_corporation'] ?? '—'), ENT_QUOTES) ?></p>
-                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['victim_alliance'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['victim_corporation_id_display'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-2 text-xs text-slate-300"><?= htmlspecialchars((string) ($row['victim_alliance'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['victim_alliance_id_display'] ?? '—'), ENT_QUOTES) ?></p>
                         </td>
                         <td class="px-3 py-3 align-top">
                             <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['ship_type'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['ship_type_id_display'] ?? '—'), ENT_QUOTES) ?></p>
                         </td>
                         <td class="px-3 py-3 align-top">
                             <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['system'] ?? '—'), ENT_QUOTES) ?></p>
-                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['region'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['system_id_display'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-2 text-xs text-slate-300"><?= htmlspecialchars((string) ($row['region'] ?? '—'), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['region_id_display'] ?? '—'), ENT_QUOTES) ?></p>
                         </td>
                         <td class="px-3 py-3 align-top">
                             <span class="rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] <?= ($row['matched_tracked'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-slate-500/40 bg-slate-500/10 text-slate-300' ?>">
-                                <?= ($row['matched_tracked'] ?? false) ? 'Matched' : 'Unmatched' ?>
+                                <?= ($row['matched_tracked'] ?? false) ? 'Tracked victim' : 'Untracked victim' ?>
                             </span>
                             <p class="mt-2 max-w-xs text-xs text-muted"><?= htmlspecialchars((string) ($row['match_context'] ?? ''), ENT_QUOTES) ?></p>
                         </td>
                         <td class="px-3 py-3 align-top">
                             <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['created_at_display'] ?? '—'), ENT_QUOTES) ?></p>
-                            <p class="mt-1 text-xs text-muted">Stored locally</p>
+                            <p class="mt-1 text-xs text-muted">Uploaded <?= htmlspecialchars((string) ($row['uploaded_at_display'] ?? '—'), ENT_QUOTES) ?></p>
+                        </td>
+                        <td class="px-3 py-3 align-top">
+                            <a href="<?= htmlspecialchars((string) ($row['inspect_url'] ?? '#'), ENT_QUOTES) ?>" class="inline-flex items-center rounded-lg border border-accent/50 bg-accent/15 px-3 py-2 text-sm font-medium text-slate-50 transition hover:bg-accent/25">Inspect loss</a>
                         </td>
                     </tr>
                 <?php endforeach; ?>

--- a/public/killmail-intelligence/view.php
+++ b/public/killmail-intelligence/view.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Killmail Loss Detail';
+$data = killmail_detail_data();
+$error = $data['error'] ?? null;
+$detail = $data['detail'] ?? null;
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<div class="mb-6 flex items-center justify-between gap-3">
+    <div>
+        <a href="/killmail-intelligence" class="text-sm text-accent hover:text-blue-300">← Back to loss overview</a>
+        <p class="mt-2 text-sm text-muted">Inspect the locally stored victim-side loss record and verify the item data foundation for future market comparison.</p>
+    </div>
+</div>
+
+<?php if (is_string($error) && trim($error) !== ''): ?>
+    <section class="rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+        <?= htmlspecialchars($error, ENT_QUOTES) ?>
+    </section>
+<?php elseif (is_array($detail)): ?>
+    <?php $victim = $detail['victim'] ?? []; ?>
+    <?php $ship = $detail['ship'] ?? []; ?>
+    <?php $location = $detail['location'] ?? []; ?>
+    <?php $attackers = $detail['attackers'] ?? []; ?>
+    <?php $items = $detail['items'] ?? []; ?>
+    <?php $zkb = $detail['zkb'] ?? []; ?>
+
+    <section class="rounded-xl border border-border bg-card p-5 shadow-lg shadow-black/20">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+            <div>
+                <p class="text-xs uppercase tracking-[0.2em] text-muted">Stored victim loss</p>
+                <h2 class="mt-1 text-xl font-semibold text-slate-50"><?= htmlspecialchars((string) ($ship['name'] ?? 'Killmail loss'), ENT_QUOTES) ?></h2>
+                <p class="mt-2 text-sm text-muted"><?= htmlspecialchars((string) ($victim['corporation_display'] ?? 'Victim corporation unavailable'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($location['system_display'] ?? 'System unavailable'), ENT_QUOTES) ?></p>
+            </div>
+            <div class="flex flex-wrap gap-2">
+                <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= ($detail['tracked_victim_loss'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-slate-500/40 bg-slate-500/10 text-slate-300' ?>">
+                    <?= ($detail['tracked_victim_loss'] ?? false) ? 'Tracked victim loss' : 'Stored loss' ?>
+                </span>
+                <span class="rounded-full border border-border bg-black/20 px-3 py-1 text-xs uppercase tracking-[0.15em] text-slate-200">Sequence #<?= htmlspecialchars(number_format((int) ($detail['sequence_id'] ?? 0)), ENT_QUOTES) ?></span>
+            </div>
+        </div>
+        <p class="mt-4 max-w-4xl text-sm text-muted"><?= htmlspecialchars((string) ($detail['match_context'] ?? ''), ENT_QUOTES) ?></p>
+    </section>
+
+    <section class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]">
+        <article class="rounded-xl border border-border bg-card p-5">
+            <div class="grid gap-4 md:grid-cols-2">
+                <div class="rounded-lg border border-border bg-black/20 p-4">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Killmail time</p>
+                    <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($detail['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
+                    <p class="mt-1 text-sm text-muted">Uploaded <?= htmlspecialchars((string) ($detail['uploaded_at_display'] ?? '—'), ENT_QUOTES) ?></p>
+                </div>
+                <div class="rounded-lg border border-border bg-black/20 p-4">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Stored references</p>
+                    <p class="mt-2 text-lg font-semibold text-slate-50">Killmail <?= htmlspecialchars((string) ($detail['killmail_id'] ?? '—'), ENT_QUOTES) ?></p>
+                    <p class="mt-1 text-sm text-muted">Sequence <?= htmlspecialchars((string) ($detail['sequence_id'] ?? '—'), ENT_QUOTES) ?> · Hash <?= htmlspecialchars((string) ($detail['killmail_hash'] ?? '—'), ENT_QUOTES) ?></p>
+                </div>
+                <div class="rounded-lg border border-border bg-black/20 p-4">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Victim details</p>
+                    <p class="mt-2 text-base font-semibold text-slate-50"><?= htmlspecialchars((string) ($victim['corporation_display'] ?? '—'), ENT_QUOTES) ?></p>
+                    <p class="mt-1 text-sm text-slate-300"><?= htmlspecialchars((string) ($victim['alliance_display'] ?? '—'), ENT_QUOTES) ?></p>
+                    <div class="mt-3 space-y-1 text-xs text-muted">
+                        <p><?= htmlspecialchars((string) ($victim['character_id_display'] ?? '—'), ENT_QUOTES) ?></p>
+                        <p><?= htmlspecialchars((string) ($victim['corporation_id_display'] ?? '—'), ENT_QUOTES) ?></p>
+                        <p><?= htmlspecialchars((string) ($victim['alliance_id_display'] ?? '—'), ENT_QUOTES) ?></p>
+                        <p>Damage taken <?= htmlspecialchars((string) ($victim['damage_taken'] ?? '0'), ENT_QUOTES) ?></p>
+                    </div>
+                </div>
+                <div class="rounded-lg border border-border bg-black/20 p-4">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Ship and location</p>
+                    <p class="mt-2 text-base font-semibold text-slate-50"><?= htmlspecialchars((string) ($ship['name'] ?? '—'), ENT_QUOTES) ?></p>
+                    <p class="mt-1 text-sm text-slate-300"><?= htmlspecialchars((string) ($location['system_display'] ?? '—'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($location['region_display'] ?? '—'), ENT_QUOTES) ?></p>
+                    <div class="mt-3 space-y-1 text-xs text-muted">
+                        <p><?= htmlspecialchars((string) ($ship['type_id_display'] ?? '—'), ENT_QUOTES) ?></p>
+                        <p><?= htmlspecialchars((string) ($location['system_id_display'] ?? '—'), ENT_QUOTES) ?></p>
+                        <p><?= htmlspecialchars((string) ($location['region_id_display'] ?? '—'), ENT_QUOTES) ?></p>
+                    </div>
+                </div>
+            </div>
+        </article>
+
+        <article class="rounded-xl border border-border bg-card p-5">
+            <div class="flex items-center justify-between gap-3">
+                <h2 class="text-base font-medium text-slate-50">Attackers summary</h2>
+                <span class="text-xs uppercase tracking-[0.15em] text-muted"><?= number_format((int) ($attackers['count'] ?? 0)) ?> attackers</span>
+            </div>
+            <div class="mt-4 space-y-3">
+                <div class="rounded-lg border border-border bg-black/20 p-4">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Final blow</p>
+                    <?php if (is_array($attackers['final_blow'] ?? null)): ?>
+                        <p class="mt-2 text-base font-semibold text-slate-50"><?= htmlspecialchars((string) (($attackers['final_blow']['corporation_display'] ?? 'Unknown attacker')), ENT_QUOTES) ?></p>
+                        <p class="mt-1 text-sm text-slate-300"><?= htmlspecialchars((string) (($attackers['final_blow']['ship_display'] ?? 'Unknown ship') . ' · ' . ($attackers['final_blow']['weapon_display'] ?? 'Unknown weapon')), ENT_QUOTES) ?></p>
+                    <?php else: ?>
+                        <p class="mt-2 text-sm text-muted">No final blow row stored.</p>
+                    <?php endif; ?>
+                </div>
+                <div class="rounded-lg border border-border bg-black/10 p-4">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Top attacker rows</p>
+                    <div class="mt-3 space-y-3">
+                        <?php foreach ((array) ($attackers['top_rows'] ?? []) as $attacker): ?>
+                            <div class="rounded-lg border border-border/70 bg-black/20 p-3">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div>
+                                        <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($attacker['corporation_display'] ?? '—'), ENT_QUOTES) ?></p>
+                                        <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($attacker['alliance_display'] ?? '—'), ENT_QUOTES) ?></p>
+                                    </div>
+                                    <?php if ($attacker['final_blow'] ?? false): ?>
+                                        <span class="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] text-emerald-200">Final blow</span>
+                                    <?php endif; ?>
+                                </div>
+                                <p class="mt-2 text-sm text-muted"><?= htmlspecialchars((string) (($attacker['ship_display'] ?? '—') . ' · ' . ($attacker['weapon_display'] ?? '—')), ENT_QUOTES) ?></p>
+                                <p class="mt-2 text-xs text-muted"><?= htmlspecialchars((string) ($attacker['corporation_id_display'] ?? '—'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($attacker['alliance_id_display'] ?? '—'), ENT_QUOTES) ?> · Sec <?= htmlspecialchars((string) ($attacker['security_status'] ?? '—'), ENT_QUOTES) ?></p>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+                <div class="rounded-lg border border-dashed border-border bg-black/10 px-4 py-3 text-sm text-muted">
+                    Attacker rows are secondary context only. The primary intelligence target remains the victim-side loss and its locally stored item rows.
+                </div>
+            </div>
+        </article>
+    </section>
+
+    <section class="mt-6 rounded-xl border border-border bg-card p-5 shadow-lg shadow-black/20">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+            <div>
+                <p class="text-xs uppercase tracking-[0.2em] text-muted">Loss item intelligence</p>
+                <h2 class="mt-1 text-lg font-medium text-slate-50">Stored loss items ready for analysis</h2>
+                <p class="mt-2 max-w-4xl text-sm text-muted">This section is organized around the locally stored item rows so future market availability, hub pricing, and restock-worthiness comparisons can plug in cleanly.</p>
+            </div>
+            <div class="grid gap-2 sm:grid-cols-3">
+                <div class="rounded-lg border border-border bg-black/20 px-4 py-3 text-center">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Dropped qty</p>
+                    <p class="mt-1 text-lg font-semibold text-slate-50"><?= number_format((int) ($detail['item_totals']['dropped'] ?? 0)) ?></p>
+                </div>
+                <div class="rounded-lg border border-border bg-black/20 px-4 py-3 text-center">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Destroyed qty</p>
+                    <p class="mt-1 text-lg font-semibold text-slate-50"><?= number_format((int) ($detail['item_totals']['destroyed'] ?? 0)) ?></p>
+                </div>
+                <div class="rounded-lg border border-border bg-black/20 px-4 py-3 text-center">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Stored item rows</p>
+                    <p class="mt-1 text-lg font-semibold text-slate-50"><?= number_format((int) ($detail['stored_item_count'] ?? 0)) ?></p>
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-6 grid gap-4 xl:grid-cols-3">
+            <?php foreach ((array) $items as $groupKey => $group): ?>
+                <article class="rounded-xl border border-border/80 bg-black/20 p-4">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <h3 class="text-base font-semibold text-slate-50"><?= htmlspecialchars((string) ($group['label'] ?? $groupKey), ENT_QUOTES) ?></h3>
+                            <p class="mt-1 text-sm text-muted"><?= htmlspecialchars((string) ($group['description'] ?? ''), ENT_QUOTES) ?></p>
+                        </div>
+                        <span class="rounded-full border border-border px-2 py-0.5 text-xs text-slate-300"><?= number_format((int) ($group['total_quantity'] ?? 0)) ?></span>
+                    </div>
+                    <?php if (((array) ($group['rows'] ?? [])) === []): ?>
+                        <div class="mt-4 rounded-lg border border-dashed border-border bg-black/10 px-4 py-5 text-sm text-muted">No <?= htmlspecialchars(strtolower((string) ($group['label'] ?? $groupKey)), ENT_QUOTES) ?> stored for this loss.</div>
+                    <?php else: ?>
+                        <div class="mt-4 space-y-3">
+                            <?php foreach ((array) ($group['rows'] ?? []) as $itemRow): ?>
+                                <div class="rounded-lg border border-border/70 bg-black/30 p-3">
+                                    <div class="flex items-start justify-between gap-3">
+                                        <div>
+                                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($itemRow['item_name'] ?? 'Unknown item'), ENT_QUOTES) ?></p>
+                                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ('Type ID ' . number_format((int) ($itemRow['item_type_id'] ?? 0))), ENT_QUOTES) ?></p>
+                                        </div>
+                                        <span class="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 text-xs text-slate-100">Qty <?= number_format((int) ($itemRow['quantity'] ?? 0)) ?></span>
+                                    </div>
+                                    <div class="mt-3 grid gap-2 text-xs text-muted sm:grid-cols-3">
+                                        <p>Flag <?= htmlspecialchars((string) (($itemRow['item_flag'] ?? null) !== null ? (string) $itemRow['item_flag'] : '—'), ENT_QUOTES) ?></p>
+                                        <p>Singleton <?= htmlspecialchars((string) (($itemRow['singleton'] ?? null) !== null ? (string) $itemRow['singleton'] : '—'), ENT_QUOTES) ?></p>
+                                        <p>Stored <?= htmlspecialchars((string) ($itemRow['stored_at_display'] ?? '—'), ENT_QUOTES) ?></p>
+                                    </div>
+                                </div>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </article>
+            <?php endforeach; ?>
+        </div>
+
+        <div class="mt-6 rounded-xl border border-dashed border-border bg-black/10 px-4 py-4 text-sm text-muted">
+            Future extension points: compare these stored loss items against alliance market availability, reference-hub pricing, and restock thresholds without redesigning the loss detail layout.
+        </div>
+    </section>
+
+    <section class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+        <article class="rounded-xl border border-border bg-card p-5">
+            <h2 class="text-base font-medium text-slate-50">Storage proof</h2>
+            <div class="mt-4 grid gap-3 md:grid-cols-2">
+                <div class="rounded-lg border border-border bg-black/20 p-4">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Locally written</p>
+                    <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($detail['created_at_display'] ?? '—'), ENT_QUOTES) ?></p>
+                    <p class="mt-1 text-sm text-muted">Updated <?= htmlspecialchars((string) ($detail['updated_at_display'] ?? '—'), ENT_QUOTES) ?></p>
+                </div>
+                <div class="rounded-lg border border-border bg-black/20 p-4">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Item rows stored</p>
+                    <p class="mt-2 text-lg font-semibold text-slate-50"><?= number_format((int) ($detail['stored_item_count'] ?? 0)) ?></p>
+                    <p class="mt-1 text-sm text-muted">Ready for downstream market and price analytics.</p>
+                </div>
+            </div>
+        </article>
+
+        <article class="rounded-xl border border-border bg-card p-5">
+            <h2 class="text-base font-medium text-slate-50">zKill metadata</h2>
+            <div class="mt-4 space-y-3 text-sm text-slate-200">
+                <div class="rounded-lg border border-border bg-black/20 px-4 py-3">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Estimated value</p>
+                    <p class="mt-1 text-base font-semibold text-slate-50"><?= htmlspecialchars((string) ($zkb['total_value_display'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
+                </div>
+                <div class="rounded-lg border border-border bg-black/20 px-4 py-3">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Metadata flags</p>
+                    <p class="mt-1 text-sm text-slate-300">Points <?= htmlspecialchars((string) ($zkb['points_display'] ?? 'Unavailable'), ENT_QUOTES) ?> · NPC <?= !empty($zkb['npc']) ? 'Yes' : 'No' ?> · Solo <?= !empty($zkb['solo']) ? 'Yes' : 'No' ?> · Awox <?= !empty($zkb['awox']) ? 'Yes' : 'No' ?></p>
+                    <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($zkb['location_id_display'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
+                </div>
+                <?php if ((string) ($zkb['href'] ?? '') !== ''): ?>
+                    <a href="<?= htmlspecialchars((string) $zkb['href'], ENT_QUOTES) ?>" target="_blank" rel="noreferrer" class="inline-flex items-center rounded-lg border border-border px-3 py-2 text-sm text-slate-200 transition hover:bg-white/5">Open zKill reference</a>
+                <?php else: ?>
+                    <div class="rounded-lg border border-dashed border-border bg-black/10 px-4 py-3 text-sm text-muted">No zKill reference URL was stored for this loss.</div>
+                <?php endif; ?>
+            </div>
+        </article>
+    </section>
+<?php endif; ?>
+
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/src/db.php
+++ b/src/db.php
@@ -2029,15 +2029,6 @@ function db_killmail_tracked_match_sql(string $eventAlias = 'e'): string
     return "(
         EXISTS (SELECT 1 FROM killmail_tracked_alliances ta WHERE ta.is_active = 1 AND ta.alliance_id = {$eventAlias}.victim_alliance_id)
         OR EXISTS (SELECT 1 FROM killmail_tracked_corporations tc WHERE tc.is_active = 1 AND tc.corporation_id = {$eventAlias}.victim_corporation_id)
-        OR EXISTS (
-            SELECT 1
-            FROM killmail_attackers a
-            WHERE a.sequence_id = {$eventAlias}.sequence_id
-              AND (
-                  EXISTS (SELECT 1 FROM killmail_tracked_alliances ta2 WHERE ta2.is_active = 1 AND ta2.alliance_id = a.alliance_id)
-                  OR EXISTS (SELECT 1 FROM killmail_tracked_corporations tc2 WHERE tc2.is_active = 1 AND tc2.corporation_id = a.corporation_id)
-              )
-        )
     )";
 }
 
@@ -2074,14 +2065,6 @@ function db_killmail_filtered_recent(int $limit = 50): array
          WHERE (
             EXISTS (SELECT 1 FROM killmail_tracked_alliances ta WHERE ta.is_active = 1 AND ta.alliance_id = e.victim_alliance_id)
             OR EXISTS (SELECT 1 FROM killmail_tracked_corporations tc WHERE tc.is_active = 1 AND tc.corporation_id = e.victim_corporation_id)
-            OR EXISTS (
-                SELECT 1 FROM killmail_attackers a
-                WHERE a.sequence_id = e.sequence_id
-                  AND (
-                      EXISTS (SELECT 1 FROM killmail_tracked_alliances ta2 WHERE ta2.is_active = 1 AND ta2.alliance_id = a.alliance_id)
-                      OR EXISTS (SELECT 1 FROM killmail_tracked_corporations tc2 WHERE tc2.is_active = 1 AND tc2.corporation_id = a.corporation_id)
-                  )
-            )
          )
          ORDER BY e.sequence_id DESC
          LIMIT {$limit}"
@@ -2137,6 +2120,114 @@ function db_killmail_overview_filter_options(): array
         'alliances' => $alliances,
         'corporations' => $corporations,
     ];
+}
+
+function db_killmail_detail(int $sequenceId): ?array
+{
+    if ($sequenceId <= 0) {
+        return null;
+    }
+
+    $matchSql = db_killmail_tracked_match_sql('e');
+
+    return db_select_one(
+        "SELECT
+            e.sequence_id,
+            e.killmail_id,
+            e.killmail_hash,
+            e.uploaded_at,
+            e.sequence_updated,
+            e.killmail_time,
+            e.solar_system_id,
+            e.region_id,
+            e.victim_character_id,
+            e.victim_corporation_id,
+            e.victim_alliance_id,
+            e.victim_ship_type_id,
+            e.zkb_json,
+            e.raw_killmail_json,
+            e.created_at,
+            e.updated_at,
+            COALESCE(NULLIF(victim_tc.label, ''), '') AS victim_corporation_label,
+            COALESCE(NULLIF(victim_ta.label, ''), '') AS victim_alliance_label,
+            COALESCE(NULLIF(ship.type_name, ''), '') AS ship_type_name,
+            COALESCE(NULLIF(system_ref.system_name, ''), '') AS system_name,
+            COALESCE(NULLIF(region_ref.region_name, ''), '') AS region_name,
+            CASE WHEN EXISTS (
+                SELECT 1 FROM killmail_tracked_alliances ta WHERE ta.is_active = 1 AND ta.alliance_id = e.victim_alliance_id
+            ) THEN 1 ELSE 0 END AS matches_victim_alliance,
+            CASE WHEN EXISTS (
+                SELECT 1 FROM killmail_tracked_corporations tc WHERE tc.is_active = 1 AND tc.corporation_id = e.victim_corporation_id
+            ) THEN 1 ELSE 0 END AS matches_victim_corporation,
+            CASE WHEN {$matchSql} THEN 1 ELSE 0 END AS matched_tracked
+         FROM killmail_events e
+         LEFT JOIN ref_item_types ship ON ship.type_id = e.victim_ship_type_id
+         LEFT JOIN ref_systems system_ref ON system_ref.system_id = e.solar_system_id
+         LEFT JOIN ref_regions region_ref ON region_ref.region_id = e.region_id
+         LEFT JOIN killmail_tracked_alliances victim_ta
+           ON victim_ta.alliance_id = e.victim_alliance_id
+          AND victim_ta.is_active = 1
+         LEFT JOIN killmail_tracked_corporations victim_tc
+           ON victim_tc.corporation_id = e.victim_corporation_id
+          AND victim_tc.is_active = 1
+         WHERE e.sequence_id = ?
+         LIMIT 1",
+        [$sequenceId]
+    );
+}
+
+function db_killmail_attackers_by_sequence(int $sequenceId): array
+{
+    if ($sequenceId <= 0) {
+        return [];
+    }
+
+    return db_select(
+        "SELECT
+            a.sequence_id,
+            a.attacker_index,
+            a.character_id,
+            a.corporation_id,
+            a.alliance_id,
+            a.ship_type_id,
+            a.weapon_type_id,
+            a.final_blow,
+            a.security_status,
+            COALESCE(NULLIF(ship.type_name, ''), '') AS ship_type_name,
+            COALESCE(NULLIF(weapon.type_name, ''), '') AS weapon_type_name
+         FROM killmail_attackers a
+         LEFT JOIN ref_item_types ship ON ship.type_id = a.ship_type_id
+         LEFT JOIN ref_item_types weapon ON weapon.type_id = a.weapon_type_id
+         WHERE a.sequence_id = ?
+         ORDER BY a.final_blow DESC, a.attacker_index ASC",
+        [$sequenceId]
+    );
+}
+
+function db_killmail_items_by_sequence(int $sequenceId): array
+{
+    if ($sequenceId <= 0) {
+        return [];
+    }
+
+    return db_select(
+        "SELECT
+            i.sequence_id,
+            i.item_index,
+            i.item_type_id,
+            i.item_flag,
+            i.quantity_dropped,
+            i.quantity_destroyed,
+            i.singleton,
+            i.item_role,
+            i.created_at,
+            COALESCE(NULLIF(t.type_name, ''), '') AS item_type_name
+         FROM killmail_items i
+         LEFT JOIN ref_item_types t ON t.type_id = i.item_type_id
+         WHERE i.sequence_id = ?
+         ORDER BY FIELD(i.item_role, 'dropped', 'destroyed', 'fitted', 'other'), i.item_index ASC",
+        [$sequenceId]
+    );
 }
 
 function db_killmail_overview_page(array $filters = []): array
@@ -2227,28 +2318,6 @@ function db_killmail_overview_page(array $filters = []): array
             CASE WHEN EXISTS (
                 SELECT 1 FROM killmail_tracked_corporations tc WHERE tc.is_active = 1 AND tc.corporation_id = e.victim_corporation_id
             ) THEN 1 ELSE 0 END AS matches_victim_corporation,
-            CASE WHEN EXISTS (
-                SELECT 1
-                FROM killmail_attackers attacker_alliance
-                WHERE attacker_alliance.sequence_id = e.sequence_id
-                  AND EXISTS (
-                      SELECT 1
-                      FROM killmail_tracked_alliances ta2
-                      WHERE ta2.is_active = 1
-                        AND ta2.alliance_id = attacker_alliance.alliance_id
-                  )
-            ) THEN 1 ELSE 0 END AS matches_attacker_alliance,
-            CASE WHEN EXISTS (
-                SELECT 1
-                FROM killmail_attackers attacker_corporation
-                WHERE attacker_corporation.sequence_id = e.sequence_id
-                  AND EXISTS (
-                      SELECT 1
-                      FROM killmail_tracked_corporations tc2
-                      WHERE tc2.is_active = 1
-                        AND tc2.corporation_id = attacker_corporation.corporation_id
-                  )
-            ) THEN 1 ELSE 0 END AS matches_attacker_corporation,
             CASE WHEN {$matchSql} THEN 1 ELSE 0 END AS matched_tracked
             {$fromSql}
             {$whereSql}

--- a/src/functions.php
+++ b/src/functions.php
@@ -1481,22 +1481,220 @@ function killmail_match_sources(array $row): array
     $sources = [];
 
     if ((int) ($row['matches_victim_alliance'] ?? 0) === 1) {
-        $sources[] = 'victim alliance';
+        $sources[] = 'tracked victim alliance';
     }
 
     if ((int) ($row['matches_victim_corporation'] ?? 0) === 1) {
-        $sources[] = 'victim corporation';
-    }
-
-    if ((int) ($row['matches_attacker_alliance'] ?? 0) === 1) {
-        $sources[] = 'attacker alliance';
-    }
-
-    if ((int) ($row['matches_attacker_corporation'] ?? 0) === 1) {
-        $sources[] = 'attacker corporation';
+        $sources[] = 'tracked victim corporation';
     }
 
     return $sources;
+}
+
+function killmail_entity_display_name(?string $label, string $fallbackPrefix, ?int $id): string
+{
+    $label = trim((string) $label);
+    if ($label !== '') {
+        return $label;
+    }
+
+    if ($id !== null && $id > 0) {
+        return $fallbackPrefix . ' ' . number_format($id);
+    }
+
+    return $fallbackPrefix . ' unavailable';
+}
+
+function killmail_secondary_id(?int $id, string $prefix = 'ID'): string
+{
+    if ($id === null || $id <= 0) {
+        return $prefix . ' unavailable';
+    }
+
+    return $prefix . ' ' . number_format($id);
+}
+
+function killmail_decode_json_array(?string $json): array
+{
+    $json = trim((string) $json);
+    if ($json === '') {
+        return [];
+    }
+
+    $decoded = json_decode($json, true);
+
+    return is_array($decoded) ? $decoded : [];
+}
+
+function killmail_item_role_label(string $role): string
+{
+    return match ($role) {
+        'dropped' => 'Dropped items',
+        'destroyed' => 'Destroyed items',
+        'fitted' => 'Fitted items',
+        default => 'Other stored items',
+    };
+}
+
+function killmail_loss_item_groups(array $items): array
+{
+    $groups = [
+        'dropped' => ['label' => killmail_item_role_label('dropped'), 'description' => 'Recovered from the stored victim-side loss record.', 'rows' => [], 'total_quantity' => 0],
+        'destroyed' => ['label' => killmail_item_role_label('destroyed'), 'description' => 'Destroyed in the stored victim-side loss record.', 'rows' => [], 'total_quantity' => 0],
+        'fitted' => ['label' => killmail_item_role_label('fitted'), 'description' => 'Fitted modules with no explicit drop or destroy quantity in the killmail payload.', 'rows' => [], 'total_quantity' => 0],
+    ];
+
+    foreach ($items as $item) {
+        if (!is_array($item)) {
+            continue;
+        }
+
+        $role = (string) ($item['item_role'] ?? 'other');
+        if (!isset($groups[$role])) {
+            continue;
+        }
+
+        $quantity = 0;
+        if ($role === 'dropped') {
+            $quantity = max(1, (int) ($item['quantity_dropped'] ?? 0));
+        } elseif ($role === 'destroyed') {
+            $quantity = max(1, (int) ($item['quantity_destroyed'] ?? 0));
+        } else {
+            $quantity = max(1, (int) ($item['quantity_destroyed'] ?? 0), (int) ($item['quantity_dropped'] ?? 0));
+        }
+
+        $groups[$role]['rows'][] = [
+            'item_name' => killmail_entity_display_name(isset($item['item_type_name']) ? (string) $item['item_type_name'] : '', 'Item', isset($item['item_type_id']) ? (int) $item['item_type_id'] : null),
+            'item_type_id' => isset($item['item_type_id']) ? (int) $item['item_type_id'] : null,
+            'quantity' => $quantity,
+            'item_flag' => isset($item['item_flag']) ? (int) $item['item_flag'] : null,
+            'singleton' => isset($item['singleton']) ? (int) $item['singleton'] : null,
+            'stored_at_display' => killmail_format_datetime(isset($item['created_at']) ? (string) $item['created_at'] : null),
+        ];
+        $groups[$role]['total_quantity'] += $quantity;
+    }
+
+    return $groups;
+}
+
+function killmail_detail_data(): array
+{
+    $sequenceId = max(0, (int) ($_GET['sequence_id'] ?? 0));
+    if ($sequenceId <= 0) {
+        return [
+            'error' => 'Select a stored killmail to inspect.',
+            'detail' => null,
+        ];
+    }
+
+    try {
+        $event = db_killmail_detail($sequenceId);
+        if ($event === null) {
+            return [
+                'error' => 'The requested killmail is not stored locally.',
+                'detail' => null,
+            ];
+        }
+
+        $attackers = db_killmail_attackers_by_sequence($sequenceId);
+        $items = db_killmail_items_by_sequence($sequenceId);
+    } catch (Throwable $exception) {
+        return [
+            'error' => $exception->getMessage(),
+            'detail' => null,
+        ];
+    }
+
+    $killmail = killmail_decode_json_array(isset($event['raw_killmail_json']) ? (string) $event['raw_killmail_json'] : null);
+    $victim = is_array($killmail['victim'] ?? null) ? $killmail['victim'] : [];
+    $zkb = killmail_decode_json_array(isset($event['zkb_json']) ? (string) $event['zkb_json'] : null);
+    $matchSources = killmail_match_sources($event);
+    $groupedItems = killmail_loss_item_groups($items);
+
+    $formattedAttackers = [];
+    foreach ($attackers as $attacker) {
+        if (!is_array($attacker)) {
+            continue;
+        }
+
+        $formattedAttackers[] = [
+            'attacker_index' => (int) ($attacker['attacker_index'] ?? 0),
+            'character_id_display' => killmail_secondary_id(isset($attacker['character_id']) ? (int) $attacker['character_id'] : null, 'Character'),
+            'corporation_display' => killmail_entity_display_name('', 'Corporation', isset($attacker['corporation_id']) ? (int) $attacker['corporation_id'] : null),
+            'corporation_id_display' => killmail_secondary_id(isset($attacker['corporation_id']) ? (int) $attacker['corporation_id'] : null, 'Corp ID'),
+            'alliance_display' => killmail_entity_display_name('', 'Alliance', isset($attacker['alliance_id']) ? (int) $attacker['alliance_id'] : null),
+            'alliance_id_display' => killmail_secondary_id(isset($attacker['alliance_id']) ? (int) $attacker['alliance_id'] : null, 'Alliance ID'),
+            'ship_display' => killmail_entity_display_name(isset($attacker['ship_type_name']) ? (string) $attacker['ship_type_name'] : '', 'Ship', isset($attacker['ship_type_id']) ? (int) $attacker['ship_type_id'] : null),
+            'weapon_display' => killmail_entity_display_name(isset($attacker['weapon_type_name']) ? (string) $attacker['weapon_type_name'] : '', 'Weapon', isset($attacker['weapon_type_id']) ? (int) $attacker['weapon_type_id'] : null),
+            'final_blow' => (int) ($attacker['final_blow'] ?? 0) === 1,
+            'security_status' => isset($attacker['security_status']) && $attacker['security_status'] !== null ? number_format((float) $attacker['security_status'], 2) : '—',
+        ];
+    }
+
+    $topAttackers = array_slice($formattedAttackers, 0, 5);
+    $finalBlow = null;
+    foreach ($formattedAttackers as $attacker) {
+        if ($attacker['final_blow']) {
+            $finalBlow = $attacker;
+            break;
+        }
+    }
+
+    return [
+        'error' => null,
+        'detail' => [
+            'sequence_id' => (int) ($event['sequence_id'] ?? 0),
+            'killmail_id' => (int) ($event['killmail_id'] ?? 0),
+            'killmail_hash' => (string) ($event['killmail_hash'] ?? ''),
+            'killmail_time_display' => killmail_format_datetime(isset($event['killmail_time']) ? (string) $event['killmail_time'] : null),
+            'uploaded_at_display' => killmail_format_datetime(isset($event['uploaded_at']) ? (string) $event['uploaded_at'] : null),
+            'created_at_display' => killmail_format_datetime(isset($event['created_at']) ? (string) $event['created_at'] : null),
+            'updated_at_display' => killmail_format_datetime(isset($event['updated_at']) ? (string) $event['updated_at'] : null),
+            'victim' => [
+                'character_id_display' => killmail_secondary_id(isset($event['victim_character_id']) ? (int) $event['victim_character_id'] : null, 'Character'),
+                'corporation_display' => killmail_entity_display_name(isset($event['victim_corporation_label']) ? (string) $event['victim_corporation_label'] : '', 'Corporation', isset($event['victim_corporation_id']) ? (int) $event['victim_corporation_id'] : null),
+                'corporation_id_display' => killmail_secondary_id(isset($event['victim_corporation_id']) ? (int) $event['victim_corporation_id'] : null, 'Corp ID'),
+                'alliance_display' => killmail_entity_display_name(isset($event['victim_alliance_label']) ? (string) $event['victim_alliance_label'] : '', 'Alliance', isset($event['victim_alliance_id']) ? (int) $event['victim_alliance_id'] : null),
+                'alliance_id_display' => killmail_secondary_id(isset($event['victim_alliance_id']) ? (int) $event['victim_alliance_id'] : null, 'Alliance ID'),
+                'damage_taken' => number_format((int) ($victim['damage_taken'] ?? 0)),
+                'tracked_badges' => $matchSources,
+            ],
+            'ship' => [
+                'name' => killmail_entity_display_name(isset($event['ship_type_name']) ? (string) $event['ship_type_name'] : '', 'Ship', isset($event['victim_ship_type_id']) ? (int) $event['victim_ship_type_id'] : null),
+                'type_id_display' => killmail_secondary_id(isset($event['victim_ship_type_id']) ? (int) $event['victim_ship_type_id'] : null, 'Type ID'),
+            ],
+            'location' => [
+                'system_display' => killmail_entity_display_name(isset($event['system_name']) ? (string) $event['system_name'] : '', 'System', isset($event['solar_system_id']) ? (int) $event['solar_system_id'] : null),
+                'system_id_display' => killmail_secondary_id(isset($event['solar_system_id']) ? (int) $event['solar_system_id'] : null, 'System ID'),
+                'region_display' => killmail_entity_display_name(isset($event['region_name']) ? (string) $event['region_name'] : '', 'Region', isset($event['region_id']) ? (int) $event['region_id'] : null),
+                'region_id_display' => killmail_secondary_id(isset($event['region_id']) ? (int) $event['region_id'] : null, 'Region ID'),
+            ],
+            'attackers' => [
+                'count' => count($formattedAttackers),
+                'top_rows' => $topAttackers,
+                'rows' => $formattedAttackers,
+                'final_blow' => $finalBlow,
+            ],
+            'items' => $groupedItems,
+            'item_totals' => [
+                'dropped' => (int) ($groupedItems['dropped']['total_quantity'] ?? 0),
+                'destroyed' => (int) ($groupedItems['destroyed']['total_quantity'] ?? 0),
+                'fitted' => (int) ($groupedItems['fitted']['total_quantity'] ?? 0),
+            ],
+            'stored_item_count' => count($items),
+            'tracked_victim_loss' => (int) ($event['matched_tracked'] ?? 0) === 1,
+            'match_context' => $matchSources === [] ? 'No tracked victim entity currently matches this stored loss.' : ('Matched on ' . implode(' and ', $matchSources) . '.'),
+            'zkb' => [
+                'total_value_display' => isset($zkb['totalValue']) ? number_format((float) $zkb['totalValue'], 0) . ' ISK' : 'Unavailable',
+                'points_display' => isset($zkb['points']) ? number_format((int) $zkb['points']) : 'Unavailable',
+                'npc' => !empty($zkb['npc']),
+                'solo' => !empty($zkb['solo']),
+                'awox' => !empty($zkb['awox']),
+                'href' => isset($zkb['href']) ? (string) $zkb['href'] : '',
+                'location_id_display' => isset($zkb['locationID']) ? killmail_secondary_id((int) $zkb['locationID'], 'zKill location') : 'Unavailable',
+            ],
+        ],
+    ];
 }
 
 function killmail_overview_data(): array
@@ -1582,11 +1780,6 @@ function killmail_overview_data(): array
 
     $rows = array_map(static function (array $row): array {
         $matchSources = killmail_match_sources($row);
-        $allianceLabel = trim((string) ($row['victim_alliance_label'] ?? ''));
-        $corporationLabel = trim((string) ($row['victim_corporation_label'] ?? ''));
-        $shipType = trim((string) ($row['ship_type_name'] ?? ''));
-        $system = trim((string) ($row['system_name'] ?? ''));
-        $region = trim((string) ($row['region_name'] ?? ''));
 
         return [
             'sequence_id' => (int) ($row['sequence_id'] ?? 0),
@@ -1594,13 +1787,19 @@ function killmail_overview_data(): array
             'killmail_time_display' => killmail_format_datetime(isset($row['killmail_time']) ? (string) $row['killmail_time'] : null),
             'uploaded_at_display' => killmail_format_datetime(isset($row['uploaded_at']) ? (string) $row['uploaded_at'] : null),
             'created_at_display' => killmail_format_datetime(isset($row['created_at']) ? (string) $row['created_at'] : null),
-            'victim_alliance' => $allianceLabel !== '' ? $allianceLabel : 'Alliance unavailable',
-            'victim_corporation' => $corporationLabel !== '' ? $corporationLabel : 'Corporation unavailable',
-            'ship_type' => $shipType !== '' ? $shipType : 'Ship type unavailable',
-            'system' => $system !== '' ? $system : 'System unavailable',
-            'region' => $region !== '' ? $region : 'Region unavailable',
+            'victim_alliance' => killmail_entity_display_name(isset($row['victim_alliance_label']) ? (string) $row['victim_alliance_label'] : '', 'Alliance', isset($row['victim_alliance_id']) ? (int) $row['victim_alliance_id'] : null),
+            'victim_alliance_id_display' => killmail_secondary_id(isset($row['victim_alliance_id']) ? (int) $row['victim_alliance_id'] : null, 'Alliance ID'),
+            'victim_corporation' => killmail_entity_display_name(isset($row['victim_corporation_label']) ? (string) $row['victim_corporation_label'] : '', 'Corporation', isset($row['victim_corporation_id']) ? (int) $row['victim_corporation_id'] : null),
+            'victim_corporation_id_display' => killmail_secondary_id(isset($row['victim_corporation_id']) ? (int) $row['victim_corporation_id'] : null, 'Corp ID'),
+            'ship_type' => killmail_entity_display_name(isset($row['ship_type_name']) ? (string) $row['ship_type_name'] : '', 'Ship', isset($row['victim_ship_type_id']) ? (int) $row['victim_ship_type_id'] : null),
+            'ship_type_id_display' => killmail_secondary_id(isset($row['victim_ship_type_id']) ? (int) $row['victim_ship_type_id'] : null, 'Type ID'),
+            'system' => killmail_entity_display_name(isset($row['system_name']) ? (string) $row['system_name'] : '', 'System', isset($row['solar_system_id']) ? (int) $row['solar_system_id'] : null),
+            'system_id_display' => killmail_secondary_id(isset($row['solar_system_id']) ? (int) $row['solar_system_id'] : null, 'System ID'),
+            'region' => killmail_entity_display_name(isset($row['region_name']) ? (string) $row['region_name'] : '', 'Region', isset($row['region_id']) ? (int) $row['region_id'] : null),
+            'region_id_display' => killmail_secondary_id(isset($row['region_id']) ? (int) $row['region_id'] : null, 'Region ID'),
             'matched_tracked' => (int) ($row['matched_tracked'] ?? 0) === 1,
-            'match_context' => $matchSources === [] ? 'No current tracked-entity match.' : ('Matched on ' . implode(', ', $matchSources) . '.'),
+            'match_context' => $matchSources === [] ? 'No tracked victim entity currently matches this stored loss.' : ('Matched on ' . implode(', ', $matchSources) . '.'),
+            'inspect_url' => '/killmail-intelligence/view.php?sequence_id=' . urlencode((string) ((int) ($row['sequence_id'] ?? 0))),
         ];
     }, (array) ($listing['rows'] ?? []));
 
@@ -1613,7 +1812,7 @@ function killmail_overview_data(): array
         'summary' => [
             ['label' => 'Total Ingested', 'value' => number_format($totalCount), 'context' => 'Killmails stored locally'],
             ['label' => 'Recent Ingestion', 'value' => number_format($recentCount), 'context' => 'Stored in the last ' . $recentHours . ' hours'],
-            ['label' => 'Tracked Matches', 'value' => number_format($trackedMatchCount), 'context' => 'Rows matching current tracked entities'],
+            ['label' => 'Tracked Victim Losses', 'value' => number_format($trackedMatchCount), 'context' => 'Stored losses where the victim matches a tracked alliance or corporation'],
             ['label' => 'Last Processed Sequence', 'value' => $maxSequenceId > 0 ? number_format($maxSequenceId) : '—', 'context' => $cursor !== '' ? ('Cursor ' . $cursor) : 'Cursor not recorded yet'],
             ['label' => 'Sync Freshness', 'value' => killmail_relative_datetime($lastSuccessAt), 'context' => $lastSuccessAt !== null ? ('Last success ' . killmail_format_datetime($lastSuccessAt)) : 'No successful sync recorded'],
         ],
@@ -5784,27 +5983,8 @@ function killmail_event_matches_tracked_entities(array $event, array $attackers,
     }
 
     $victimCorporationId = (int) ($event['victim_corporation_id'] ?? 0);
-    if ($victimCorporationId > 0 && isset($trackedCorporationIds[$victimCorporationId])) {
-        return true;
-    }
 
-    foreach ($attackers as $attacker) {
-        if (!is_array($attacker)) {
-            continue;
-        }
-
-        $attackerAllianceId = (int) ($attacker['alliance_id'] ?? 0);
-        if ($attackerAllianceId > 0 && isset($trackedAllianceIds[$attackerAllianceId])) {
-            return true;
-        }
-
-        $attackerCorporationId = (int) ($attacker['corporation_id'] ?? 0);
-        if ($attackerCorporationId > 0 && isset($trackedCorporationIds[$attackerCorporationId])) {
-            return true;
-        }
-    }
-
-    return false;
+    return $victimCorporationId > 0 && isset($trackedCorporationIds[$victimCorporationId]);
 }
 
 function killmail_transform_r2z2_payload(array $payload): array


### PR DESCRIPTION
### Motivation
- Make the Killmail Intelligence flow focused on victim-side losses so tracked alliances/corporations represent losses they suffered, not attacker-side activity. 
- Reduce raw numeric-ID noise in the overview and surface human-readable names while keeping IDs available in a subtle secondary form. 
- Provide a practical, inspectable killmail detail view that proves ingestion and item-storage are working and that is ready for future loss-vs-market comparisons. 
- Preserve the existing dark Tailwind/shadcn UI feel and keep attacker information as secondary context.

### Description
- Switch tracked-entity matching to victim-only: removed attacker-side matching from the tracked-match SQL and ingestion/filter queries and simplified `killmail_event_matches_tracked_entities` to check victim alliance/corporation only. (`src/db.php`, `src/functions.php`).
- Added detail-level DB helpers: `db_killmail_detail`, `db_killmail_attackers_by_sequence`, and `db_killmail_items_by_sequence` to fetch a stored event, its attackers, and its item rows with joined human-readable names. (`src/db.php`).
- Added presentation & formatting helpers: `killmail_entity_display_name`, `killmail_secondary_id`, `killmail_loss_item_groups` and `killmail_detail_data` to prepare a structured detail payload (grouped dropped/destroyed/fitted items, ID displays, zKill metadata). (`src/functions.php`).
- Reworked overview output to be human-first: victim/ship/system/region display names with subtle ID lines, clearer labels, victim-only tracked-match wording, and an `Inspect loss` action for each row. (`src/functions.php`, `public/killmail-intelligence/index.php`).
- New killmail loss detail page: `public/killmail-intelligence/view.php` (new) shows stored loss proof (time, sequence, killmail id/hash), victim summary, attacker summary as secondary context, grouped item sections (dropped/destroyed/fitted) with quantities, and zKill metadata as supportive info; layout prepared for future market/price comparisons.

### Testing
- Ran PHP syntax checks: `php -l src/functions.php` (passed) and `php -l src/db.php` (passed). 
- Linted the public pages: `php -l public/killmail-intelligence/index.php` and `php -l public/killmail-intelligence/view.php` (both passed).
- Ran repository checks: `git diff --check` and `git status --short` to validate diff cleanliness (no issues reported).
All automated checks executed for the modified files succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba7d53ae00832f983ba05944a556d4)