### PR TITLE
Add cached entity metadata resolution and EIS-backed Killmail detail UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository establishes a clean architecture that can scale from an initial 
 - ESI OAuth callback (`/callback`) with token verification and DB persistence
 - ESI cache tables (`esi_cache_namespaces`, `esi_cache_entries`) for structured `cache.esi.*` namespaces
 - Incremental sync state tables (`sync_state`, `sync_runs`) for watermark/cursor tracking and run observability
+- Reusable entity metadata cache for human-readable killmail, market, and analytics surfaces
 - Secure CSRF-protected settings forms
 - Session-based flash messaging
 
@@ -234,6 +235,12 @@ EveMarket now includes a first-pass killmail intelligence ingestion foundation b
   - `killmail_items`
   - `killmail_tracked_alliances`
   - `killmail_tracked_corporations`
+  - `entity_metadata_cache`
+- Resolution model:
+  - prefer local reference tables for item types, solar systems, and regions
+  - cache dynamic alliance, corporation, and character names locally
+  - prime metadata during ingestion so detail pages can stay image-rich without repeatedly calling ESI
+  - build EVE Image Server URLs directly at render time instead of proxying or storing binaries locally
 
 ### Operations
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -194,6 +194,25 @@ CREATE TABLE IF NOT EXISTS killmail_tracked_corporations (
     KEY idx_active (is_active)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS entity_metadata_cache (
+    entity_type ENUM('alliance', 'corporation', 'character', 'type', 'system', 'region') NOT NULL,
+    entity_id BIGINT UNSIGNED NOT NULL,
+    entity_name VARCHAR(255) DEFAULT NULL,
+    image_url VARCHAR(255) DEFAULT NULL,
+    metadata_json JSON DEFAULT NULL,
+    source_system VARCHAR(40) NOT NULL DEFAULT 'cache',
+    resolution_status ENUM('pending', 'resolved', 'failed') NOT NULL DEFAULT 'pending',
+    expires_at DATETIME DEFAULT NULL,
+    last_requested_at DATETIME DEFAULT NULL,
+    resolved_at DATETIME DEFAULT NULL,
+    last_error_message VARCHAR(255) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (entity_type, entity_id),
+    KEY idx_resolution_status (resolution_status, entity_type, updated_at),
+    KEY idx_expires_at (expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 
 CREATE TABLE IF NOT EXISTS market_orders_current (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,

--- a/public/killmail-intelligence/view.php
+++ b/public/killmail-intelligence/view.php
@@ -30,100 +30,103 @@ include __DIR__ . '/../../src/views/partials/header.php';
     <?php $items = $detail['items'] ?? []; ?>
     <?php $zkb = $detail['zkb'] ?? []; ?>
 
-    <section class="rounded-xl border border-border bg-card p-5 shadow-lg shadow-black/20">
-        <div class="flex flex-wrap items-start justify-between gap-4">
-            <div>
-                <p class="text-xs uppercase tracking-[0.2em] text-muted">Stored victim loss</p>
-                <h2 class="mt-1 text-xl font-semibold text-slate-50"><?= htmlspecialchars((string) ($ship['name'] ?? 'Killmail loss'), ENT_QUOTES) ?></h2>
-                <p class="mt-2 text-sm text-muted"><?= htmlspecialchars((string) ($victim['corporation_display'] ?? 'Victim corporation unavailable'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($location['system_display'] ?? 'System unavailable'), ENT_QUOTES) ?></p>
+    <section class="overflow-hidden rounded-2xl border border-border bg-card shadow-lg shadow-black/20">
+        <div class="grid gap-6 p-6 xl:grid-cols-[minmax(280px,420px)_minmax(0,1fr)]">
+            <div class="rounded-2xl border border-border/80 bg-black/30 p-4">
+                <?php if ((string) ($ship['render_url'] ?? '') !== ''): ?>
+                    <img
+                        src="<?= htmlspecialchars((string) $ship['render_url'], ENT_QUOTES) ?>"
+                        alt="<?= htmlspecialchars((string) ($ship['name'] ?? 'Victim ship'), ENT_QUOTES) ?>"
+                        class="mx-auto aspect-square w-full max-w-sm rounded-2xl object-contain"
+                        loading="eager"
+                    >
+                <?php else: ?>
+                    <div class="flex aspect-square items-center justify-center rounded-2xl border border-dashed border-border bg-black/20 text-sm text-muted">
+                        Ship render unavailable
+                    </div>
+                <?php endif; ?>
             </div>
-            <div class="flex flex-wrap gap-2">
-                <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= ($detail['tracked_victim_loss'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-slate-500/40 bg-slate-500/10 text-slate-300' ?>">
-                    <?= ($detail['tracked_victim_loss'] ?? false) ? 'Tracked victim loss' : 'Stored loss' ?>
-                </span>
-                <span class="rounded-full border border-border bg-black/20 px-3 py-1 text-xs uppercase tracking-[0.15em] text-slate-200">Sequence #<?= htmlspecialchars(number_format((int) ($detail['sequence_id'] ?? 0)), ENT_QUOTES) ?></span>
+
+            <div class="flex flex-col justify-between gap-6">
+                <div class="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                        <p class="text-xs uppercase tracking-[0.2em] text-muted">Stored victim loss</p>
+                        <h2 class="mt-2 text-3xl font-semibold text-slate-50"><?= htmlspecialchars((string) ($ship['name'] ?? 'Killmail loss'), ENT_QUOTES) ?></h2>
+                        <p class="mt-2 text-base text-slate-200"><?= htmlspecialchars((string) ($victim['character_name'] ?? 'Victim unavailable'), ENT_QUOTES) ?></p>
+                        <p class="mt-2 text-sm text-muted">
+                            <?= htmlspecialchars((string) ($location['system_display'] ?? 'Unknown system'), ENT_QUOTES) ?>
+                            ·
+                            <?= htmlspecialchars((string) ($location['region_display'] ?? 'Unknown region'), ENT_QUOTES) ?>
+                            <?php if ((string) ($location['security_status'] ?? '') !== ''): ?>
+                                · Sec <?= htmlspecialchars((string) $location['security_status'], ENT_QUOTES) ?>
+                            <?php endif; ?>
+                        </p>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                        <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= ($detail['tracked_victim_loss'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-slate-500/40 bg-slate-500/10 text-slate-300' ?>">
+                            <?= ($detail['tracked_victim_loss'] ?? false) ? 'Tracked victim loss' : 'Stored loss' ?>
+                        </span>
+                        <span class="rounded-full border border-border bg-black/20 px-3 py-1 text-xs uppercase tracking-[0.15em] text-slate-300">Attackers <?= htmlspecialchars(number_format((int) ($attackers['count'] ?? 0)), ENT_QUOTES) ?></span>
+                    </div>
+                </div>
+
+                <div class="grid gap-4 md:grid-cols-3">
+                    <div class="rounded-xl border border-border bg-black/20 p-4">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Victim</p>
+                        <div class="mt-3 flex items-center gap-3">
+                            <?php if ((string) ($victim['character_portrait_url'] ?? '') !== ''): ?>
+                                <img src="<?= htmlspecialchars((string) $victim['character_portrait_url'], ENT_QUOTES) ?>" alt="" class="h-12 w-12 rounded-xl object-cover">
+                            <?php endif; ?>
+                            <div>
+                                <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($victim['character_name'] ?? 'Unknown character'), ENT_QUOTES) ?></p>
+                                <p class="mt-1 text-xs text-muted">Damage taken <?= htmlspecialchars((string) ($victim['damage_taken'] ?? '0'), ENT_QUOTES) ?></p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="rounded-xl border border-border bg-black/20 p-4">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Corporation</p>
+                        <div class="mt-3 flex items-center gap-3">
+                            <?php if ((string) ($victim['corporation_logo_url'] ?? '') !== ''): ?>
+                                <img src="<?= htmlspecialchars((string) $victim['corporation_logo_url'], ENT_QUOTES) ?>" alt="" class="h-12 w-12 rounded-xl object-cover">
+                            <?php endif; ?>
+                            <div>
+                                <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($victim['corporation_display'] ?? 'Unknown corporation'), ENT_QUOTES) ?></p>
+                                <p class="mt-1 text-xs text-muted">Victim corporation</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="rounded-xl border border-border bg-black/20 p-4">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Alliance</p>
+                        <div class="mt-3 flex items-center gap-3">
+                            <?php if ((string) ($victim['alliance_logo_url'] ?? '') !== ''): ?>
+                                <img src="<?= htmlspecialchars((string) $victim['alliance_logo_url'], ENT_QUOTES) ?>" alt="" class="h-12 w-12 rounded-xl object-cover">
+                            <?php endif; ?>
+                            <div>
+                                <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($victim['alliance_display'] ?? 'Unknown alliance'), ENT_QUOTES) ?></p>
+                                <p class="mt-1 text-xs text-muted">Victim alliance</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="grid gap-4 md:grid-cols-3">
+                    <div class="rounded-xl border border-border bg-black/20 p-4">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Kill time</p>
+                        <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($detail['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
+                        <p class="mt-1 text-sm text-muted">Uploaded <?= htmlspecialchars((string) ($detail['uploaded_at_display'] ?? '—'), ENT_QUOTES) ?></p>
+                    </div>
+                    <div class="rounded-xl border border-border bg-black/20 p-4">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Context</p>
+                        <p class="mt-2 text-sm text-slate-200"><?= htmlspecialchars((string) ($detail['match_context'] ?? 'No tracked match context available.'), ENT_QUOTES) ?></p>
+                    </div>
+                    <div class="rounded-xl border border-border bg-black/20 p-4">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Stored references</p>
+                        <p class="mt-2 text-sm text-slate-200">Killmail <?= htmlspecialchars((string) ($detail['killmail_id'] ?? '—'), ENT_QUOTES) ?> · Sequence <?= htmlspecialchars((string) ($detail['sequence_id'] ?? '—'), ENT_QUOTES) ?></p>
+                        <p class="mt-1 truncate text-xs text-muted">Hash <?= htmlspecialchars((string) ($detail['killmail_hash'] ?? '—'), ENT_QUOTES) ?></p>
+                    </div>
+                </div>
             </div>
         </div>
-        <p class="mt-4 max-w-4xl text-sm text-muted"><?= htmlspecialchars((string) ($detail['match_context'] ?? ''), ENT_QUOTES) ?></p>
-    </section>
-
-    <section class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]">
-        <article class="rounded-xl border border-border bg-card p-5">
-            <div class="grid gap-4 md:grid-cols-2">
-                <div class="rounded-lg border border-border bg-black/20 p-4">
-                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Killmail time</p>
-                    <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($detail['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
-                    <p class="mt-1 text-sm text-muted">Uploaded <?= htmlspecialchars((string) ($detail['uploaded_at_display'] ?? '—'), ENT_QUOTES) ?></p>
-                </div>
-                <div class="rounded-lg border border-border bg-black/20 p-4">
-                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Stored references</p>
-                    <p class="mt-2 text-lg font-semibold text-slate-50">Killmail <?= htmlspecialchars((string) ($detail['killmail_id'] ?? '—'), ENT_QUOTES) ?></p>
-                    <p class="mt-1 text-sm text-muted">Sequence <?= htmlspecialchars((string) ($detail['sequence_id'] ?? '—'), ENT_QUOTES) ?> · Hash <?= htmlspecialchars((string) ($detail['killmail_hash'] ?? '—'), ENT_QUOTES) ?></p>
-                </div>
-                <div class="rounded-lg border border-border bg-black/20 p-4">
-                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Victim details</p>
-                    <p class="mt-2 text-base font-semibold text-slate-50"><?= htmlspecialchars((string) ($victim['corporation_display'] ?? '—'), ENT_QUOTES) ?></p>
-                    <p class="mt-1 text-sm text-slate-300"><?= htmlspecialchars((string) ($victim['alliance_display'] ?? '—'), ENT_QUOTES) ?></p>
-                    <div class="mt-3 space-y-1 text-xs text-muted">
-                        <p><?= htmlspecialchars((string) ($victim['character_id_display'] ?? '—'), ENT_QUOTES) ?></p>
-                        <p><?= htmlspecialchars((string) ($victim['corporation_id_display'] ?? '—'), ENT_QUOTES) ?></p>
-                        <p><?= htmlspecialchars((string) ($victim['alliance_id_display'] ?? '—'), ENT_QUOTES) ?></p>
-                        <p>Damage taken <?= htmlspecialchars((string) ($victim['damage_taken'] ?? '0'), ENT_QUOTES) ?></p>
-                    </div>
-                </div>
-                <div class="rounded-lg border border-border bg-black/20 p-4">
-                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Ship and location</p>
-                    <p class="mt-2 text-base font-semibold text-slate-50"><?= htmlspecialchars((string) ($ship['name'] ?? '—'), ENT_QUOTES) ?></p>
-                    <p class="mt-1 text-sm text-slate-300"><?= htmlspecialchars((string) ($location['system_display'] ?? '—'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($location['region_display'] ?? '—'), ENT_QUOTES) ?></p>
-                    <div class="mt-3 space-y-1 text-xs text-muted">
-                        <p><?= htmlspecialchars((string) ($ship['type_id_display'] ?? '—'), ENT_QUOTES) ?></p>
-                        <p><?= htmlspecialchars((string) ($location['system_id_display'] ?? '—'), ENT_QUOTES) ?></p>
-                        <p><?= htmlspecialchars((string) ($location['region_id_display'] ?? '—'), ENT_QUOTES) ?></p>
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <article class="rounded-xl border border-border bg-card p-5">
-            <div class="flex items-center justify-between gap-3">
-                <h2 class="text-base font-medium text-slate-50">Attackers summary</h2>
-                <span class="text-xs uppercase tracking-[0.15em] text-muted"><?= number_format((int) ($attackers['count'] ?? 0)) ?> attackers</span>
-            </div>
-            <div class="mt-4 space-y-3">
-                <div class="rounded-lg border border-border bg-black/20 p-4">
-                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Final blow</p>
-                    <?php if (is_array($attackers['final_blow'] ?? null)): ?>
-                        <p class="mt-2 text-base font-semibold text-slate-50"><?= htmlspecialchars((string) (($attackers['final_blow']['corporation_display'] ?? 'Unknown attacker')), ENT_QUOTES) ?></p>
-                        <p class="mt-1 text-sm text-slate-300"><?= htmlspecialchars((string) (($attackers['final_blow']['ship_display'] ?? 'Unknown ship') . ' · ' . ($attackers['final_blow']['weapon_display'] ?? 'Unknown weapon')), ENT_QUOTES) ?></p>
-                    <?php else: ?>
-                        <p class="mt-2 text-sm text-muted">No final blow row stored.</p>
-                    <?php endif; ?>
-                </div>
-                <div class="rounded-lg border border-border bg-black/10 p-4">
-                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Top attacker rows</p>
-                    <div class="mt-3 space-y-3">
-                        <?php foreach ((array) ($attackers['top_rows'] ?? []) as $attacker): ?>
-                            <div class="rounded-lg border border-border/70 bg-black/20 p-3">
-                                <div class="flex items-start justify-between gap-3">
-                                    <div>
-                                        <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($attacker['corporation_display'] ?? '—'), ENT_QUOTES) ?></p>
-                                        <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($attacker['alliance_display'] ?? '—'), ENT_QUOTES) ?></p>
-                                    </div>
-                                    <?php if ($attacker['final_blow'] ?? false): ?>
-                                        <span class="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] text-emerald-200">Final blow</span>
-                                    <?php endif; ?>
-                                </div>
-                                <p class="mt-2 text-sm text-muted"><?= htmlspecialchars((string) (($attacker['ship_display'] ?? '—') . ' · ' . ($attacker['weapon_display'] ?? '—')), ENT_QUOTES) ?></p>
-                                <p class="mt-2 text-xs text-muted"><?= htmlspecialchars((string) ($attacker['corporation_id_display'] ?? '—'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($attacker['alliance_id_display'] ?? '—'), ENT_QUOTES) ?> · Sec <?= htmlspecialchars((string) ($attacker['security_status'] ?? '—'), ENT_QUOTES) ?></p>
-                            </div>
-                        <?php endforeach; ?>
-                    </div>
-                </div>
-                <div class="rounded-lg border border-dashed border-border bg-black/10 px-4 py-3 text-sm text-muted">
-                    Attacker rows are secondary context only. The primary intelligence target remains the victim-side loss and its locally stored item rows.
-                </div>
-            </div>
-        </article>
     </section>
 
     <section class="mt-6 rounded-xl border border-border bg-card p-5 shadow-lg shadow-black/20">
@@ -165,12 +168,17 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <div class="mt-4 space-y-3">
                             <?php foreach ((array) ($group['rows'] ?? []) as $itemRow): ?>
                                 <div class="rounded-lg border border-border/70 bg-black/30 p-3">
-                                    <div class="flex items-start justify-between gap-3">
-                                        <div>
-                                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($itemRow['item_name'] ?? 'Unknown item'), ENT_QUOTES) ?></p>
-                                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ('Type ID ' . number_format((int) ($itemRow['item_type_id'] ?? 0))), ENT_QUOTES) ?></p>
+                                    <div class="flex items-start gap-3">
+                                        <?php if ((string) ($itemRow['item_icon_url'] ?? '') !== ''): ?>
+                                            <img src="<?= htmlspecialchars((string) $itemRow['item_icon_url'], ENT_QUOTES) ?>" alt="" class="h-12 w-12 rounded-lg bg-black/30 object-contain p-1">
+                                        <?php endif; ?>
+                                        <div class="min-w-0 flex-1">
+                                            <div class="flex flex-wrap items-start justify-between gap-2">
+                                                <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($itemRow['item_name'] ?? 'Unknown item'), ENT_QUOTES) ?></p>
+                                                <span class="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 text-xs text-slate-100"><?= htmlspecialchars((string) ($itemRow['quantity_label'] ?? 'Qty 0'), ENT_QUOTES) ?></span>
+                                            </div>
+                                            <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($itemRow['state_label'] ?? ''), ENT_QUOTES) ?></p>
                                         </div>
-                                        <span class="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 text-xs text-slate-100">Qty <?= number_format((int) ($itemRow['quantity'] ?? 0)) ?></span>
                                     </div>
                                     <div class="mt-3 grid gap-2 text-xs text-muted sm:grid-cols-3">
                                         <p>Flag <?= htmlspecialchars((string) (($itemRow['item_flag'] ?? null) !== null ? (string) $itemRow['item_flag'] : '—'), ENT_QUOTES) ?></p>
@@ -191,6 +199,72 @@ include __DIR__ . '/../../src/views/partials/header.php';
     </section>
 
     <section class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+        <article class="rounded-xl border border-border bg-card p-5">
+            <div class="flex items-center justify-between gap-3">
+                <h2 class="text-base font-medium text-slate-50">Attacker context</h2>
+                <span class="text-xs uppercase tracking-[0.15em] text-muted">Secondary view</span>
+            </div>
+            <div class="mt-4 space-y-3">
+                <div class="rounded-lg border border-border bg-black/20 p-4">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Final blow</p>
+                    <?php if (is_array($attackers['final_blow'] ?? null)): ?>
+                        <div class="mt-3 flex items-center gap-3">
+                            <?php if ((string) (($attackers['final_blow']['ship_icon_url'] ?? '')) !== ''): ?>
+                                <img src="<?= htmlspecialchars((string) $attackers['final_blow']['ship_icon_url'], ENT_QUOTES) ?>" alt="" class="h-11 w-11 rounded-lg bg-black/30 object-contain p-1">
+                            <?php endif; ?>
+                            <div>
+                                <p class="font-medium text-slate-50"><?= htmlspecialchars((string) (($attackers['final_blow']['character_name'] ?? 'Unknown attacker')), ENT_QUOTES) ?></p>
+                                <p class="mt-1 text-sm text-slate-300"><?= htmlspecialchars((string) (($attackers['final_blow']['corporation_display'] ?? 'Unknown corporation') . ' · ' . ($attackers['final_blow']['alliance_display'] ?? 'Unknown alliance')), ENT_QUOTES) ?></p>
+                                <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) (($attackers['final_blow']['ship_display'] ?? 'Unknown ship') . ' · ' . ($attackers['final_blow']['weapon_display'] ?? 'Unknown weapon')), ENT_QUOTES) ?></p>
+                            </div>
+                        </div>
+                    <?php else: ?>
+                        <p class="mt-2 text-sm text-muted">No final blow row stored.</p>
+                    <?php endif; ?>
+                </div>
+                <div class="rounded-lg border border-border bg-black/10 p-4">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Top attacker rows</p>
+                    <div class="mt-3 space-y-3">
+                        <?php foreach ((array) ($attackers['top_rows'] ?? []) as $attacker): ?>
+                            <div class="rounded-lg border border-border/70 bg-black/20 p-3 opacity-90">
+                                <div class="flex items-start gap-3">
+                                    <?php if ((string) ($attacker['ship_icon_url'] ?? '') !== ''): ?>
+                                        <img src="<?= htmlspecialchars((string) $attacker['ship_icon_url'], ENT_QUOTES) ?>" alt="" class="h-10 w-10 rounded-lg bg-black/30 object-contain p-1">
+                                    <?php endif; ?>
+                                    <div class="min-w-0 flex-1">
+                                        <div class="flex items-start justify-between gap-3">
+                                            <div>
+                                                <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($attacker['character_name'] ?? 'Unknown attacker'), ENT_QUOTES) ?></p>
+                                                <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-300">
+                                                    <?php if ((string) ($attacker['corporation_logo_url'] ?? '') !== ''): ?>
+                                                        <img src="<?= htmlspecialchars((string) $attacker['corporation_logo_url'], ENT_QUOTES) ?>" alt="" class="h-5 w-5 rounded-md object-cover">
+                                                    <?php endif; ?>
+                                                    <span><?= htmlspecialchars((string) ($attacker['corporation_display'] ?? 'Unknown corporation'), ENT_QUOTES) ?></span>
+                                                </div>
+                                                <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted">
+                                                    <?php if ((string) ($attacker['alliance_logo_url'] ?? '') !== ''): ?>
+                                                        <img src="<?= htmlspecialchars((string) $attacker['alliance_logo_url'], ENT_QUOTES) ?>" alt="" class="h-5 w-5 rounded-md object-cover">
+                                                    <?php endif; ?>
+                                                    <span><?= htmlspecialchars((string) ($attacker['alliance_display'] ?? 'Unknown alliance'), ENT_QUOTES) ?></span>
+                                                </div>
+                                            </div>
+                                            <?php if ($attacker['final_blow'] ?? false): ?>
+                                                <span class="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] text-emerald-200">Final blow</span>
+                                            <?php endif; ?>
+                                        </div>
+                                        <p class="mt-2 text-xs text-muted"><?= htmlspecialchars((string) (($attacker['ship_display'] ?? '—') . ' · ' . ($attacker['weapon_display'] ?? '—') . ' · Sec ' . ($attacker['security_status'] ?? '—')), ENT_QUOTES) ?></p>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+                <div class="rounded-lg border border-dashed border-border bg-black/10 px-4 py-3 text-sm text-muted">
+                    Attacker rows stay visible for combat context, but the primary intelligence target remains the victim fit and dropped/destroyed inventory.
+                </div>
+            </div>
+        </article>
+
         <article class="rounded-xl border border-border bg-card p-5">
             <h2 class="text-base font-medium text-slate-50">Storage proof</h2>
             <div class="mt-4 grid gap-3 md:grid-cols-2">
@@ -217,7 +291,6 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <div class="rounded-lg border border-border bg-black/20 px-4 py-3">
                     <p class="text-xs uppercase tracking-[0.15em] text-muted">Metadata flags</p>
                     <p class="mt-1 text-sm text-slate-300">Points <?= htmlspecialchars((string) ($zkb['points_display'] ?? 'Unavailable'), ENT_QUOTES) ?> · NPC <?= !empty($zkb['npc']) ? 'Yes' : 'No' ?> · Solo <?= !empty($zkb['solo']) ? 'Yes' : 'No' ?> · Awox <?= !empty($zkb['awox']) ? 'Yes' : 'No' ?></p>
-                    <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($zkb['location_id_display'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
                 </div>
                 <?php if ((string) ($zkb['href'] ?? '') !== ''): ?>
                     <a href="<?= htmlspecialchars((string) $zkb['href'], ENT_QUOTES) ?>" target="_blank" rel="noreferrer" class="inline-flex items-center rounded-lg border border-border px-3 py-2 text-sm text-slate-200 transition hover:bg-white/5">Open zKill reference</a>

--- a/src/db.php
+++ b/src/db.php
@@ -1812,6 +1812,165 @@ function db_ref_item_types_bulk_upsert(array $rows, ?int $chunkSize = null): int
     return db_bulk_insert_or_upsert('ref_item_types', ['type_id', 'group_id', 'market_group_id', 'type_name', 'description', 'published', 'volume'], $rows, ['group_id', 'market_group_id', 'type_name', 'description', 'published', 'volume'], $chunkSize);
 }
 
+function db_ref_item_types_by_ids(array $typeIds): array
+{
+    $ids = array_values(array_unique(array_filter(array_map(static fn (mixed $id): int => (int) $id, $typeIds), static fn (int $id): bool => $id > 0)));
+    if ($ids === []) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+
+    return db_select(
+        "SELECT type_id, type_name, group_id, market_group_id, description, published, volume
+         FROM ref_item_types
+         WHERE type_id IN ($placeholders)",
+        $ids
+    );
+}
+
+function db_ref_systems_by_ids(array $systemIds): array
+{
+    $ids = array_values(array_unique(array_filter(array_map(static fn (mixed $id): int => (int) $id, $systemIds), static fn (int $id): bool => $id > 0)));
+    if ($ids === []) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+
+    return db_select(
+        "SELECT system_id, constellation_id, region_id, system_name, security
+         FROM ref_systems
+         WHERE system_id IN ($placeholders)",
+        $ids
+    );
+}
+
+function db_ref_regions_by_ids(array $regionIds): array
+{
+    $ids = array_values(array_unique(array_filter(array_map(static fn (mixed $id): int => (int) $id, $regionIds), static fn (int $id): bool => $id > 0)));
+    if ($ids === []) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+
+    return db_select(
+        "SELECT region_id, region_name
+         FROM ref_regions
+         WHERE region_id IN ($placeholders)",
+        $ids
+    );
+}
+
+function db_entity_metadata_cache_get_many(string $entityType, array $entityIds): array
+{
+    $type = trim($entityType);
+    $ids = array_values(array_unique(array_filter(array_map(static fn (mixed $id): int => (int) $id, $entityIds), static fn (int $id): bool => $id > 0)));
+    if ($type === '' || $ids === []) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+
+    return db_select(
+        "SELECT entity_type, entity_id, entity_name, image_url, metadata_json, source_system, resolution_status, expires_at, last_requested_at, resolved_at, last_error_message, updated_at
+         FROM entity_metadata_cache
+         WHERE entity_type = ?
+           AND entity_id IN ($placeholders)",
+        array_merge([$type], $ids)
+    );
+}
+
+function db_entity_metadata_cache_upsert(array $rows): int
+{
+    $normalizedRows = [];
+
+    foreach ($rows as $row) {
+        $entityType = trim((string) ($row['entity_type'] ?? ''));
+        $entityId = (int) ($row['entity_id'] ?? 0);
+        if ($entityType === '' || $entityId <= 0) {
+            continue;
+        }
+
+        $normalizedRows[] = [
+            'entity_type' => $entityType,
+            'entity_id' => $entityId,
+            'entity_name' => ($name = trim((string) ($row['entity_name'] ?? ''))) !== '' ? $name : null,
+            'image_url' => ($imageUrl = trim((string) ($row['image_url'] ?? ''))) !== '' ? $imageUrl : null,
+            'metadata_json' => $row['metadata_json'] ?? null,
+            'source_system' => ($source = trim((string) ($row['source_system'] ?? 'cache'))) !== '' ? $source : 'cache',
+            'resolution_status' => in_array((string) ($row['resolution_status'] ?? 'pending'), ['pending', 'resolved', 'failed'], true) ? (string) $row['resolution_status'] : 'pending',
+            'expires_at' => $row['expires_at'] ?? null,
+            'last_requested_at' => $row['last_requested_at'] ?? gmdate('Y-m-d H:i:s'),
+            'resolved_at' => $row['resolved_at'] ?? (((string) ($row['resolution_status'] ?? 'pending')) === 'resolved' ? gmdate('Y-m-d H:i:s') : null),
+            'last_error_message' => isset($row['last_error_message']) ? mb_substr(trim((string) $row['last_error_message']), 0, 255) : null,
+        ];
+    }
+
+    if ($normalizedRows === []) {
+        return 0;
+    }
+
+    return db_bulk_insert_or_upsert(
+        'entity_metadata_cache',
+        [
+            'entity_type',
+            'entity_id',
+            'entity_name',
+            'image_url',
+            'metadata_json',
+            'source_system',
+            'resolution_status',
+            'expires_at',
+            'last_requested_at',
+            'resolved_at',
+            'last_error_message',
+        ],
+        $normalizedRows,
+        [
+            'entity_name',
+            'image_url',
+            'metadata_json',
+            'source_system',
+            'resolution_status',
+            'expires_at',
+            'last_requested_at',
+            'resolved_at',
+            'last_error_message',
+        ]
+    );
+}
+
+function db_entity_metadata_cache_mark_pending(string $entityType, array $entityIds, ?string $errorMessage = null): int
+{
+    $type = trim($entityType);
+    $ids = array_values(array_unique(array_filter(array_map(static fn (mixed $id): int => (int) $id, $entityIds), static fn (int $id): bool => $id > 0)));
+    if ($type === '' || $ids === []) {
+        return 0;
+    }
+
+    $rows = [];
+    $requestedAt = gmdate('Y-m-d H:i:s');
+    foreach ($ids as $id) {
+        $rows[] = [
+            'entity_type' => $type,
+            'entity_id' => $id,
+            'entity_name' => null,
+            'image_url' => null,
+            'metadata_json' => null,
+            'source_system' => 'queue',
+            'resolution_status' => 'pending',
+            'expires_at' => null,
+            'last_requested_at' => $requestedAt,
+            'resolved_at' => null,
+            'last_error_message' => $errorMessage,
+        ];
+    }
+
+    return db_entity_metadata_cache_upsert($rows);
+}
+
 function db_killmail_event_upsert(array $event): bool
 {
     return db_execute(

--- a/src/functions.php
+++ b/src/functions.php
@@ -1536,7 +1536,460 @@ function killmail_item_role_label(string $role): string
     };
 }
 
-function killmail_loss_item_groups(array $items): array
+function killmail_entity_cacheable_types(): array
+{
+    return ['alliance', 'corporation', 'character', 'type', 'system', 'region'];
+}
+
+function killmail_entity_type_label_human(string $entityType): string
+{
+    return match ($entityType) {
+        'alliance' => 'Alliance',
+        'corporation' => 'Corporation',
+        'character' => 'Character',
+        'type' => 'Type',
+        'system' => 'System',
+        'region' => 'Region',
+        default => 'Entity',
+    };
+}
+
+function killmail_entity_image_url(string $entityType, ?int $entityId, string $variation = 'default', int $size = 128): ?string
+{
+    $id = (int) $entityId;
+    if ($id <= 0) {
+        return null;
+    }
+
+    $category = null;
+    $resolvedVariation = $variation;
+    $resolvedSize = max(32, min(1024, $size));
+
+    switch ($entityType) {
+        case 'alliance':
+            $category = 'alliances';
+            $resolvedVariation = $variation === 'default' ? 'logo' : $variation;
+            break;
+        case 'corporation':
+            $category = 'corporations';
+            $resolvedVariation = $variation === 'default' ? 'logo' : $variation;
+            break;
+        case 'character':
+            $category = 'characters';
+            $resolvedVariation = $variation === 'default' ? 'portrait' : $variation;
+            break;
+        case 'type':
+            $category = 'types';
+            $resolvedVariation = $variation === 'default' ? 'icon' : $variation;
+            break;
+    }
+
+    if ($category === null) {
+        return null;
+    }
+
+    return sprintf(
+        'https://images.evetech.net/%s/%d/%s?size=%d',
+        rawurlencode($category),
+        $id,
+        rawurlencode($resolvedVariation),
+        $resolvedSize
+    );
+}
+
+function killmail_entity_cache_ttl(string $entityType): ?string
+{
+    if (in_array($entityType, ['type', 'system', 'region'], true)) {
+        return null;
+    }
+
+    return gmdate('Y-m-d H:i:s', strtotime('+30 days'));
+}
+
+function killmail_entity_resolution_requests(array $event, array $attackers = [], array $items = []): array
+{
+    $requests = array_fill_keys(killmail_entity_cacheable_types(), []);
+
+    $add = static function (string $type, ?int $id) use (&$requests): void {
+        $entityId = (int) $id;
+        if (!isset($requests[$type]) || $entityId <= 0) {
+            return;
+        }
+
+        $requests[$type][$entityId] = $entityId;
+    };
+
+    $add('character', isset($event['victim_character_id']) ? (int) $event['victim_character_id'] : null);
+    $add('corporation', isset($event['victim_corporation_id']) ? (int) $event['victim_corporation_id'] : null);
+    $add('alliance', isset($event['victim_alliance_id']) ? (int) $event['victim_alliance_id'] : null);
+    $add('type', isset($event['victim_ship_type_id']) ? (int) $event['victim_ship_type_id'] : null);
+    $add('system', isset($event['solar_system_id']) ? (int) $event['solar_system_id'] : null);
+    $add('region', isset($event['region_id']) ? (int) $event['region_id'] : null);
+
+    foreach ($attackers as $attacker) {
+        if (!is_array($attacker)) {
+            continue;
+        }
+
+        $add('character', isset($attacker['character_id']) ? (int) $attacker['character_id'] : null);
+        $add('corporation', isset($attacker['corporation_id']) ? (int) $attacker['corporation_id'] : null);
+        $add('alliance', isset($attacker['alliance_id']) ? (int) $attacker['alliance_id'] : null);
+        $add('type', isset($attacker['ship_type_id']) ? (int) $attacker['ship_type_id'] : null);
+        $add('type', isset($attacker['weapon_type_id']) ? (int) $attacker['weapon_type_id'] : null);
+    }
+
+    foreach ($items as $item) {
+        if (!is_array($item)) {
+            continue;
+        }
+
+        $add('type', isset($item['item_type_id']) ? (int) $item['item_type_id'] : null);
+    }
+
+    foreach ($requests as $type => $ids) {
+        $requests[$type] = array_values($ids);
+    }
+
+    return $requests;
+}
+
+function killmail_entity_cache_prefill_from_references(array $requests): void
+{
+    $upserts = [];
+
+    foreach (db_ref_item_types_by_ids($requests['type'] ?? []) as $row) {
+        $typeId = (int) ($row['type_id'] ?? 0);
+        if ($typeId <= 0) {
+            continue;
+        }
+
+        $upserts[] = [
+            'entity_type' => 'type',
+            'entity_id' => $typeId,
+            'entity_name' => trim((string) ($row['type_name'] ?? '')),
+            'image_url' => killmail_entity_image_url('type', $typeId, 'icon', 128),
+            'metadata_json' => json_encode([
+                'group_id' => isset($row['group_id']) ? (int) $row['group_id'] : null,
+                'market_group_id' => isset($row['market_group_id']) ? (int) $row['market_group_id'] : null,
+                'published' => isset($row['published']) ? (int) $row['published'] : null,
+            ], JSON_THROW_ON_ERROR),
+            'source_system' => 'local_ref',
+            'resolution_status' => 'resolved',
+            'expires_at' => null,
+            'resolved_at' => gmdate('Y-m-d H:i:s'),
+        ];
+    }
+
+    foreach (db_ref_systems_by_ids($requests['system'] ?? []) as $row) {
+        $systemId = (int) ($row['system_id'] ?? 0);
+        if ($systemId <= 0) {
+            continue;
+        }
+
+        $upserts[] = [
+            'entity_type' => 'system',
+            'entity_id' => $systemId,
+            'entity_name' => trim((string) ($row['system_name'] ?? '')),
+            'image_url' => null,
+            'metadata_json' => json_encode([
+                'region_id' => isset($row['region_id']) ? (int) $row['region_id'] : null,
+                'security' => isset($row['security']) ? (float) $row['security'] : null,
+            ], JSON_THROW_ON_ERROR),
+            'source_system' => 'local_ref',
+            'resolution_status' => 'resolved',
+            'expires_at' => null,
+            'resolved_at' => gmdate('Y-m-d H:i:s'),
+        ];
+    }
+
+    foreach (db_ref_regions_by_ids($requests['region'] ?? []) as $row) {
+        $regionId = (int) ($row['region_id'] ?? 0);
+        if ($regionId <= 0) {
+            continue;
+        }
+
+        $upserts[] = [
+            'entity_type' => 'region',
+            'entity_id' => $regionId,
+            'entity_name' => trim((string) ($row['region_name'] ?? '')),
+            'image_url' => null,
+            'metadata_json' => null,
+            'source_system' => 'local_ref',
+            'resolution_status' => 'resolved',
+            'expires_at' => null,
+            'resolved_at' => gmdate('Y-m-d H:i:s'),
+        ];
+    }
+
+    if ($upserts !== []) {
+        db_entity_metadata_cache_upsert($upserts);
+    }
+}
+
+function killmail_entity_cache_rows_by_type(array $requests): array
+{
+    $rowsByType = [];
+
+    foreach ($requests as $type => $ids) {
+        $rowsByType[$type] = [];
+        foreach (db_entity_metadata_cache_get_many($type, (array) $ids) as $row) {
+            $rowsByType[$type][(int) ($row['entity_id'] ?? 0)] = $row;
+        }
+    }
+
+    return $rowsByType;
+}
+
+function killmail_entity_cache_is_current(array $row): bool
+{
+    if (($row['resolution_status'] ?? '') !== 'resolved') {
+        return false;
+    }
+
+    $expiresAt = trim((string) ($row['expires_at'] ?? ''));
+    if ($expiresAt === '') {
+        return true;
+    }
+
+    return strtotime($expiresAt) !== false && strtotime($expiresAt) > time();
+}
+
+function killmail_entity_public_endpoint(string $entityType, int $entityId): ?string
+{
+    if ($entityId <= 0) {
+        return null;
+    }
+
+    return match ($entityType) {
+        'alliance' => 'https://esi.evetech.net/latest/alliances/' . $entityId . '/?datasource=tranquility',
+        'corporation' => 'https://esi.evetech.net/latest/corporations/' . $entityId . '/?datasource=tranquility',
+        'character' => 'https://esi.evetech.net/latest/characters/' . $entityId . '/?datasource=tranquility',
+        default => null,
+    };
+}
+
+function killmail_entity_network_resolve(array $missingByType): void
+{
+    $dynamicIds = [];
+    foreach (['alliance', 'corporation', 'character'] as $type) {
+        foreach ((array) ($missingByType[$type] ?? []) as $id) {
+            $entityId = (int) $id;
+            if ($entityId > 0) {
+                $dynamicIds[$entityId] = $entityId;
+            }
+        }
+    }
+
+    $upserts = [];
+    $resolvedByType = ['alliance' => [], 'corporation' => [], 'character' => []];
+
+    if ($dynamicIds !== []) {
+        try {
+            $nameRows = esi_universe_names_lookup(array_values($dynamicIds));
+        } catch (Throwable) {
+            $nameRows = [];
+        }
+
+        foreach ($nameRows as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $id = (int) ($row['id'] ?? 0);
+            $type = strtolower(trim((string) ($row['category'] ?? '')));
+            $name = trim((string) ($row['name'] ?? ''));
+            if ($id <= 0 || $name === '' || !isset($resolvedByType[$type])) {
+                continue;
+            }
+
+            $resolvedByType[$type][$id] = true;
+            $upserts[] = [
+                'entity_type' => $type,
+                'entity_id' => $id,
+                'entity_name' => $name,
+                'image_url' => killmail_entity_image_url($type, $id),
+                'metadata_json' => json_encode(['via' => 'universe_names'], JSON_THROW_ON_ERROR),
+                'source_system' => 'esi',
+                'resolution_status' => 'resolved',
+                'expires_at' => killmail_entity_cache_ttl($type),
+                'resolved_at' => gmdate('Y-m-d H:i:s'),
+                'last_error_message' => null,
+            ];
+        }
+    }
+
+    foreach (['alliance', 'corporation', 'character'] as $type) {
+        foreach ((array) ($missingByType[$type] ?? []) as $id) {
+            $entityId = (int) $id;
+            if ($entityId <= 0 || isset($resolvedByType[$type][$entityId])) {
+                continue;
+            }
+
+            $endpoint = killmail_entity_public_endpoint($type, $entityId);
+            if ($endpoint === null) {
+                continue;
+            }
+
+            try {
+                $response = http_get_json($endpoint, [
+                    'Accept: application/json',
+                    'User-Agent: ' . esi_user_agent(),
+                ]);
+            } catch (Throwable $exception) {
+                $response = ['status' => 599, 'json' => [], 'body' => '', 'error_message' => $exception->getMessage()];
+            }
+
+            if (($response['status'] ?? 500) >= 400) {
+                db_entity_metadata_cache_upsert([[
+                    'entity_type' => $type,
+                    'entity_id' => $entityId,
+                    'entity_name' => null,
+                    'image_url' => killmail_entity_image_url($type, $entityId),
+                    'metadata_json' => null,
+                    'source_system' => 'esi',
+                    'resolution_status' => 'failed',
+                    'expires_at' => gmdate('Y-m-d H:i:s', strtotime('+6 hours')),
+                    'resolved_at' => null,
+                    'last_error_message' => 'ESI profile lookup failed with status ' . (int) ($response['status'] ?? 0),
+                ]]);
+                continue;
+            }
+
+            $name = trim((string) ($response['json']['name'] ?? ''));
+            if ($name === '') {
+                continue;
+            }
+
+            $resolvedByType[$type][$entityId] = true;
+            $upserts[] = [
+                'entity_type' => $type,
+                'entity_id' => $entityId,
+                'entity_name' => $name,
+                'image_url' => killmail_entity_image_url($type, $entityId),
+                'metadata_json' => json_encode((array) ($response['json'] ?? []), JSON_THROW_ON_ERROR),
+                'source_system' => 'esi',
+                'resolution_status' => 'resolved',
+                'expires_at' => killmail_entity_cache_ttl($type),
+                'resolved_at' => gmdate('Y-m-d H:i:s'),
+                'last_error_message' => null,
+            ];
+        }
+    }
+
+    if ($upserts !== []) {
+        db_entity_metadata_cache_upsert($upserts);
+    }
+}
+
+function killmail_entity_placeholder(string $entityType, int $entityId): string
+{
+    return 'Unknown ' . strtolower(killmail_entity_type_label_human($entityType)) . ' (ID cached for resolution)';
+}
+
+function killmail_entity_resolve_batch(array $requests, bool $allowNetworkFallback = false): array
+{
+    $normalized = [];
+    foreach (killmail_entity_cacheable_types() as $type) {
+        $ids = array_values(array_unique(array_filter(
+            array_map(static fn (mixed $id): int => (int) $id, (array) ($requests[$type] ?? [])),
+            static fn (int $id): bool => $id > 0
+        )));
+        $normalized[$type] = $ids;
+    }
+
+    killmail_entity_cache_prefill_from_references($normalized);
+    $cacheRowsByType = killmail_entity_cache_rows_by_type($normalized);
+
+    $missingByType = [];
+    foreach ($normalized as $type => $ids) {
+        $missingByType[$type] = [];
+        foreach ($ids as $id) {
+            $row = $cacheRowsByType[$type][$id] ?? null;
+            if (!is_array($row)) {
+                $missingByType[$type][] = $id;
+                continue;
+            }
+
+            if ($allowNetworkFallback && !killmail_entity_cache_is_current($row)) {
+                $missingByType[$type][] = $id;
+            }
+        }
+    }
+
+    if ($allowNetworkFallback) {
+        killmail_entity_network_resolve($missingByType);
+        $cacheRowsByType = killmail_entity_cache_rows_by_type($normalized);
+    }
+
+    $resolved = [];
+    foreach ($normalized as $type => $ids) {
+        $resolved[$type] = [];
+        $stillMissing = [];
+
+        foreach ($ids as $id) {
+            $row = $cacheRowsByType[$type][$id] ?? null;
+            $name = trim((string) ($row['entity_name'] ?? ''));
+            $resolved[$type][$id] = [
+                'entity_type' => $type,
+                'entity_id' => $id,
+                'name' => $name !== '' ? $name : killmail_entity_placeholder($type, $id),
+                'image_url' => ($imageUrl = trim((string) ($row['image_url'] ?? ''))) !== '' ? $imageUrl : killmail_entity_image_url($type, $id),
+                'status' => $name !== '' ? (string) ($row['resolution_status'] ?? 'resolved') : 'pending',
+                'source_system' => (string) ($row['source_system'] ?? ($name !== '' ? 'cache' : 'queue')),
+                'metadata' => killmail_decode_json_array(isset($row['metadata_json']) ? (string) $row['metadata_json'] : null),
+            ];
+
+            if ($name === '') {
+                $stillMissing[] = $id;
+            }
+        }
+
+        if ($stillMissing !== []) {
+            db_entity_metadata_cache_mark_pending($type, $stillMissing);
+        }
+    }
+
+    return $resolved;
+}
+
+function killmail_prime_entity_metadata(array $requests): void
+{
+    try {
+        killmail_entity_resolve_batch($requests, true);
+    } catch (Throwable) {
+        foreach ($requests as $type => $ids) {
+            db_entity_metadata_cache_mark_pending((string) $type, (array) $ids);
+        }
+    }
+}
+
+function killmail_resolved_entity(array $resolved, string $type, ?int $id, ?string $fallbackName = null): array
+{
+    $entityId = (int) $id;
+    $fallback = trim((string) $fallbackName);
+    $row = $entityId > 0 ? ($resolved[$type][$entityId] ?? null) : null;
+    $name = trim((string) ($row['name'] ?? ''));
+
+    if ($name === '' && $fallback !== '') {
+        $name = $fallback;
+    }
+
+    if ($name === '') {
+        $name = $entityId > 0
+            ? killmail_entity_placeholder($type, $entityId)
+            : killmail_entity_type_label_human($type) . ' unavailable';
+    }
+
+    return [
+        'id' => $entityId > 0 ? $entityId : null,
+        'name' => $name,
+        'status' => (string) ($row['status'] ?? ($entityId > 0 ? 'pending' : 'unavailable')),
+        'image_url' => $entityId > 0 ? (($row['image_url'] ?? null) ?: killmail_entity_image_url($type, $entityId)) : null,
+        'metadata' => is_array($row['metadata'] ?? null) ? $row['metadata'] : [],
+    ];
+}
+
+function killmail_loss_item_groups(array $items, array $resolvedEntities = []): array
 {
     $groups = [
         'dropped' => ['label' => killmail_item_role_label('dropped'), 'description' => 'Recovered from the stored victim-side loss record.', 'rows' => [], 'total_quantity' => 0],
@@ -1563,10 +2016,20 @@ function killmail_loss_item_groups(array $items): array
             $quantity = max(1, (int) ($item['quantity_destroyed'] ?? 0), (int) ($item['quantity_dropped'] ?? 0));
         }
 
+        $typeId = isset($item['item_type_id']) ? (int) $item['item_type_id'] : null;
+        $resolvedItem = killmail_resolved_entity($resolvedEntities, 'type', $typeId, isset($item['item_type_name']) ? (string) $item['item_type_name'] : null);
+
         $groups[$role]['rows'][] = [
-            'item_name' => killmail_entity_display_name(isset($item['item_type_name']) ? (string) $item['item_type_name'] : '', 'Item', isset($item['item_type_id']) ? (int) $item['item_type_id'] : null),
-            'item_type_id' => isset($item['item_type_id']) ? (int) $item['item_type_id'] : null,
+            'item_name' => $resolvedItem['name'],
+            'item_type_id' => $typeId,
+            'item_icon_url' => $typeId !== null ? killmail_entity_image_url('type', $typeId, 'icon', 64) : null,
             'quantity' => $quantity,
+            'quantity_label' => 'Qty ' . number_format($quantity),
+            'state_label' => match ($role) {
+                'dropped' => number_format($quantity) . ' dropped',
+                'destroyed' => number_format($quantity) . ' destroyed',
+                default => number_format($quantity) . ' fitted',
+            },
             'item_flag' => isset($item['item_flag']) ? (int) $item['item_flag'] : null,
             'singleton' => isset($item['singleton']) ? (int) $item['singleton'] : null,
             'stored_at_display' => killmail_format_datetime(isset($item['created_at']) ? (string) $item['created_at'] : null),
@@ -1609,7 +2072,25 @@ function killmail_detail_data(): array
     $victim = is_array($killmail['victim'] ?? null) ? $killmail['victim'] : [];
     $zkb = killmail_decode_json_array(isset($event['zkb_json']) ? (string) $event['zkb_json'] : null);
     $matchSources = killmail_match_sources($event);
-    $groupedItems = killmail_loss_item_groups($items);
+    $resolutionRequests = killmail_entity_resolution_requests($event, $attackers, $items);
+    $resolvedEntities = killmail_entity_resolve_batch($resolutionRequests, false);
+    $groupedItems = killmail_loss_item_groups($items, $resolvedEntities);
+    $victimCharacter = killmail_resolved_entity($resolvedEntities, 'character', isset($event['victim_character_id']) ? (int) $event['victim_character_id'] : null);
+    $victimCorporation = killmail_resolved_entity(
+        $resolvedEntities,
+        'corporation',
+        isset($event['victim_corporation_id']) ? (int) $event['victim_corporation_id'] : null,
+        isset($event['victim_corporation_label']) ? (string) $event['victim_corporation_label'] : null
+    );
+    $victimAlliance = killmail_resolved_entity(
+        $resolvedEntities,
+        'alliance',
+        isset($event['victim_alliance_id']) ? (int) $event['victim_alliance_id'] : null,
+        isset($event['victim_alliance_label']) ? (string) $event['victim_alliance_label'] : null
+    );
+    $victimShip = killmail_resolved_entity($resolvedEntities, 'type', isset($event['victim_ship_type_id']) ? (int) $event['victim_ship_type_id'] : null, isset($event['ship_type_name']) ? (string) $event['ship_type_name'] : null);
+    $system = killmail_resolved_entity($resolvedEntities, 'system', isset($event['solar_system_id']) ? (int) $event['solar_system_id'] : null, isset($event['system_name']) ? (string) $event['system_name'] : null);
+    $region = killmail_resolved_entity($resolvedEntities, 'region', isset($event['region_id']) ? (int) $event['region_id'] : null, isset($event['region_name']) ? (string) $event['region_name'] : null);
 
     $formattedAttackers = [];
     foreach ($attackers as $attacker) {
@@ -1617,15 +2098,23 @@ function killmail_detail_data(): array
             continue;
         }
 
+        $attackerCharacter = killmail_resolved_entity($resolvedEntities, 'character', isset($attacker['character_id']) ? (int) $attacker['character_id'] : null);
+        $attackerCorporation = killmail_resolved_entity($resolvedEntities, 'corporation', isset($attacker['corporation_id']) ? (int) $attacker['corporation_id'] : null);
+        $attackerAlliance = killmail_resolved_entity($resolvedEntities, 'alliance', isset($attacker['alliance_id']) ? (int) $attacker['alliance_id'] : null);
+        $attackerShip = killmail_resolved_entity($resolvedEntities, 'type', isset($attacker['ship_type_id']) ? (int) $attacker['ship_type_id'] : null, isset($attacker['ship_type_name']) ? (string) $attacker['ship_type_name'] : null);
+        $attackerWeapon = killmail_resolved_entity($resolvedEntities, 'type', isset($attacker['weapon_type_id']) ? (int) $attacker['weapon_type_id'] : null, isset($attacker['weapon_type_name']) ? (string) $attacker['weapon_type_name'] : null);
+
         $formattedAttackers[] = [
             'attacker_index' => (int) ($attacker['attacker_index'] ?? 0),
-            'character_id_display' => killmail_secondary_id(isset($attacker['character_id']) ? (int) $attacker['character_id'] : null, 'Character'),
-            'corporation_display' => killmail_entity_display_name('', 'Corporation', isset($attacker['corporation_id']) ? (int) $attacker['corporation_id'] : null),
-            'corporation_id_display' => killmail_secondary_id(isset($attacker['corporation_id']) ? (int) $attacker['corporation_id'] : null, 'Corp ID'),
-            'alliance_display' => killmail_entity_display_name('', 'Alliance', isset($attacker['alliance_id']) ? (int) $attacker['alliance_id'] : null),
-            'alliance_id_display' => killmail_secondary_id(isset($attacker['alliance_id']) ? (int) $attacker['alliance_id'] : null, 'Alliance ID'),
-            'ship_display' => killmail_entity_display_name(isset($attacker['ship_type_name']) ? (string) $attacker['ship_type_name'] : '', 'Ship', isset($attacker['ship_type_id']) ? (int) $attacker['ship_type_id'] : null),
-            'weapon_display' => killmail_entity_display_name(isset($attacker['weapon_type_name']) ? (string) $attacker['weapon_type_name'] : '', 'Weapon', isset($attacker['weapon_type_id']) ? (int) $attacker['weapon_type_id'] : null),
+            'character_name' => $attackerCharacter['name'],
+            'character_image_url' => $attackerCharacter['id'] !== null ? killmail_entity_image_url('character', (int) $attackerCharacter['id'], 'portrait', 128) : null,
+            'corporation_display' => $attackerCorporation['name'],
+            'corporation_logo_url' => $attackerCorporation['id'] !== null ? killmail_entity_image_url('corporation', (int) $attackerCorporation['id'], 'logo', 64) : null,
+            'alliance_display' => $attackerAlliance['name'],
+            'alliance_logo_url' => $attackerAlliance['id'] !== null ? killmail_entity_image_url('alliance', (int) $attackerAlliance['id'], 'logo', 64) : null,
+            'ship_display' => $attackerShip['name'],
+            'ship_icon_url' => $attackerShip['id'] !== null ? killmail_entity_image_url('type', (int) $attackerShip['id'], 'icon', 64) : null,
+            'weapon_display' => $attackerWeapon['name'],
             'final_blow' => (int) ($attacker['final_blow'] ?? 0) === 1,
             'security_status' => isset($attacker['security_status']) && $attacker['security_status'] !== null ? number_format((float) $attacker['security_status'], 2) : '—',
         ];
@@ -1651,23 +2140,24 @@ function killmail_detail_data(): array
             'created_at_display' => killmail_format_datetime(isset($event['created_at']) ? (string) $event['created_at'] : null),
             'updated_at_display' => killmail_format_datetime(isset($event['updated_at']) ? (string) $event['updated_at'] : null),
             'victim' => [
-                'character_id_display' => killmail_secondary_id(isset($event['victim_character_id']) ? (int) $event['victim_character_id'] : null, 'Character'),
-                'corporation_display' => killmail_entity_display_name(isset($event['victim_corporation_label']) ? (string) $event['victim_corporation_label'] : '', 'Corporation', isset($event['victim_corporation_id']) ? (int) $event['victim_corporation_id'] : null),
-                'corporation_id_display' => killmail_secondary_id(isset($event['victim_corporation_id']) ? (int) $event['victim_corporation_id'] : null, 'Corp ID'),
-                'alliance_display' => killmail_entity_display_name(isset($event['victim_alliance_label']) ? (string) $event['victim_alliance_label'] : '', 'Alliance', isset($event['victim_alliance_id']) ? (int) $event['victim_alliance_id'] : null),
-                'alliance_id_display' => killmail_secondary_id(isset($event['victim_alliance_id']) ? (int) $event['victim_alliance_id'] : null, 'Alliance ID'),
+                'character_name' => $victimCharacter['name'],
+                'character_portrait_url' => $victimCharacter['id'] !== null ? killmail_entity_image_url('character', (int) $victimCharacter['id'], 'portrait', 256) : null,
+                'corporation_display' => $victimCorporation['name'],
+                'corporation_logo_url' => $victimCorporation['id'] !== null ? killmail_entity_image_url('corporation', (int) $victimCorporation['id'], 'logo', 128) : null,
+                'alliance_display' => $victimAlliance['name'],
+                'alliance_logo_url' => $victimAlliance['id'] !== null ? killmail_entity_image_url('alliance', (int) $victimAlliance['id'], 'logo', 128) : null,
                 'damage_taken' => number_format((int) ($victim['damage_taken'] ?? 0)),
                 'tracked_badges' => $matchSources,
             ],
             'ship' => [
-                'name' => killmail_entity_display_name(isset($event['ship_type_name']) ? (string) $event['ship_type_name'] : '', 'Ship', isset($event['victim_ship_type_id']) ? (int) $event['victim_ship_type_id'] : null),
-                'type_id_display' => killmail_secondary_id(isset($event['victim_ship_type_id']) ? (int) $event['victim_ship_type_id'] : null, 'Type ID'),
+                'name' => $victimShip['name'],
+                'render_url' => $victimShip['id'] !== null ? killmail_entity_image_url('type', (int) $victimShip['id'], 'render', 512) : null,
+                'icon_url' => $victimShip['id'] !== null ? killmail_entity_image_url('type', (int) $victimShip['id'], 'icon', 128) : null,
             ],
             'location' => [
-                'system_display' => killmail_entity_display_name(isset($event['system_name']) ? (string) $event['system_name'] : '', 'System', isset($event['solar_system_id']) ? (int) $event['solar_system_id'] : null),
-                'system_id_display' => killmail_secondary_id(isset($event['solar_system_id']) ? (int) $event['solar_system_id'] : null, 'System ID'),
-                'region_display' => killmail_entity_display_name(isset($event['region_name']) ? (string) $event['region_name'] : '', 'Region', isset($event['region_id']) ? (int) $event['region_id'] : null),
-                'region_id_display' => killmail_secondary_id(isset($event['region_id']) ? (int) $event['region_id'] : null, 'Region ID'),
+                'system_display' => $system['name'],
+                'region_display' => $region['name'],
+                'security_status' => isset($system['metadata']['security']) ? number_format((float) $system['metadata']['security'], 1) : null,
             ],
             'attackers' => [
                 'count' => count($formattedAttackers),
@@ -1691,7 +2181,6 @@ function killmail_detail_data(): array
                 'solo' => !empty($zkb['solo']),
                 'awox' => !empty($zkb['awox']),
                 'href' => isset($zkb['href']) ? (string) $zkb['href'] : '',
-                'location_id_display' => isset($zkb['locationID']) ? killmail_secondary_id((int) $zkb['locationID'], 'zKill location') : 'Unavailable',
             ],
         ],
     ];
@@ -6180,6 +6669,12 @@ function sync_killmail_r2z2_stream(string $runMode = 'incremental'): array
                 usleep(100000);
                 continue;
             }
+
+            killmail_prime_entity_metadata(killmail_entity_resolution_requests(
+                $event,
+                (array) ($transformed['attackers'] ?? []),
+                (array) ($transformed['items'] ?? [])
+            ));
 
             db_transaction(static function () use ($transformed, $sequenceId, &$rowsWritten): void {
                 db_killmail_event_upsert($transformed['event']);


### PR DESCRIPTION
### Motivation

- Remove ID-first noise from the killmail loss detail and show human-readable names and imagery for alliances, corporations, characters, types, systems and regions.
- Centralize ID → name/image/metadata resolution into a reusable service to avoid scattering logic across pages.
- Use the EVE Image Server (EIS) as the CDN source for portraits, logos, icons and ship renders while preferring local static reference data first.
- Prime and cache resolution during ingestion to avoid runtime ESI calls and make the detail page fast and image-rich.

### Description

- Added a new `entity_metadata_cache` table and DB helpers (`db_entity_metadata_cache_*`, `db_ref_*_by_ids`) to `src/db.php` for reading/upserting batched resolved rows and marking pending requests. 
- Implemented a reusable resolution layer in `src/functions.php` that: prefers local reference tables (`ref_item_types`, `ref_systems`, `ref_regions`), composes EIS URLs via `killmail_entity_image_url()`, falls back to ESI (`/universe/names` and per-entity endpoints) when allowed, and caches results with TTL rules (static data cached indefinitely, dynamic names cached with expiry). 
- Primes resolution during killmail ingestion by calling `killmail_prime_entity_metadata()` in the ingestion path so names/images are available when rendering; unresolved IDs are queued/marked `pending`. 
- Refactored killmail assembly to use resolved entities everywhere (victim, attackers, ship, system, region, and stored items) while preserving internal numeric IDs for backend/market use via `killmail_resolved_entity()` and `killmail_loss_item_groups()`. 
- Upgraded `public/killmail-intelligence/view.php` to an image-forward, scannable intelligence layout: ship render header, victim portrait + corp/alliance logos, icon-led item rows (no raw IDs shown), and a de-emphasized but context-rich attacker panel that still resolves names/logos; images are referenced directly from EIS (no local proxy). 
- Documented the new cache/resolution model in `README.md` and kept database static-data importer/refs unchanged for local-first resolution.

### Testing

- Ran `php -l src/functions.php` and the file passed PHP lint with no syntax errors. 
- Ran `php -l src/db.php` and `php -l public/killmail-intelligence/view.php`, both passed PHP lint with no syntax errors. 
- Ran repository checks (`git diff --check`) and there were no whitespace or diff-check warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba8374cd74832f89010a5d2e24a4c7)