### PR TITLE
Rename application branding from EveMarket to SupplyCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# EveMarket Foundation
+# SupplyCore Foundation
 
-A production-oriented baseline for **EveMarket** built with **PHP 8+, MySQL, Apache2**, and a modern **Tailwind CSS v4 + shadcn/ui-inspired** interface.
+A production-oriented baseline for **SupplyCore** built with **PHP 8+, MySQL, Apache2**, and a modern **Tailwind CSS v4 + shadcn/ui-inspired** interface.
 
 This repository establishes a clean architecture that can scale from an initial dashboard/settings app into a complete market, trading, and ESI-integrated platform.
 
@@ -46,8 +46,8 @@ README.md
 
 1. **Create database and import schema**
    ```bash
-   mysql -u root -p -e "CREATE DATABASE IF NOT EXISTS evemarket CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-   mysql -u root -p evemarket < database/schema.sql
+   mysql -u root -p -e "CREATE DATABASE IF NOT EXISTS supplycore CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+   mysql -u root -p supplycore < database/schema.sql
    ```
 
 > Upgrading an existing installation? Apply schema changes before the next sync run, for example: `ALTER TABLE market_hub_local_history_daily MODIFY spread_percent DECIMAL(20,4) NULL;`.
@@ -58,7 +58,7 @@ README.md
    export APP_BASE_URL=http://localhost:8080
    export DB_HOST=127.0.0.1
    export DB_PORT=3306
-   export DB_DATABASE=evemarket
+   export DB_DATABASE=supplycore
    export DB_USERNAME=root
    export DB_PASSWORD=secret
    ```
@@ -82,7 +82,7 @@ README.md
 
 ### Ensure cron is installed and enabled
 
-EveMarket sync pipelines depend on the `cron` daemon being present and running on server boot.
+SupplyCore sync pipelines depend on the `cron` daemon being present and running on server boot.
 
 1. Install cron (if missing):
    ```bash
@@ -113,7 +113,7 @@ EveMarket sync pipelines depend on the `cron` daemon being present and running o
 
 1. Determine the final app path and PHP binary path:
    ```bash
-   APP_PATH=$(realpath /var/www/evemarket)
+   APP_PATH=$(realpath /var/www/supplycore)
    PHP_BIN=$(command -v php)
    echo "$APP_PATH"
    echo "$PHP_BIN"
@@ -125,14 +125,14 @@ EveMarket sync pipelines depend on the `cron` daemon being present and running o
    ```
 
    ```cron
-   * * * * * cd /var/www/evemarket && /usr/bin/php bin/cron_tick.php >> storage/logs/cron.log 2>&1
+   * * * * * cd /var/www/supplycore && /usr/bin/php bin/cron_tick.php >> storage/logs/cron.log 2>&1
    ```
 
 3. Ensure the log directory exists and is writable by the cron user:
    ```bash
-   mkdir -p /var/www/evemarket/storage/logs
-   chown -R www-data:www-data /var/www/evemarket/storage
-   chmod -R u+rwX /var/www/evemarket/storage
+   mkdir -p /var/www/supplycore/storage/logs
+   chown -R www-data:www-data /var/www/supplycore/storage
+   chmod -R u+rwX /var/www/supplycore/storage
    ```
 
 4. Validate the installed crontab:
@@ -157,8 +157,8 @@ Cron must run with the same environment the app expects:
 - App config vars: `APP_ENV`, `APP_BASE_URL`, `APP_TIMEZONE`
 - Database vars: `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD`
 - Pipeline source vars (when those pipelines are enabled):
-  - `EVEMARKET_ALLIANCE_SOURCE_ID` (for `alliance-current` and `alliance-history`)
-  - `EVEMARKET_HUB_SOURCE_ID` (for `hub-current`, `hub-history`, and local-history generation)
+  - `SUPPLYCORE_ALLIANCE_SOURCE_ID` (for `alliance-current` and `alliance-history`)
+  - `SUPPLYCORE_HUB_SOURCE_ID` (for `hub-current`, `hub-history`, and local-history generation)
 
 The canonical log path for the cron tick is `storage/logs/cron.log` (relative to app root).
 Raw order snapshots are pruned according to `raw_order_snapshot_retention_days` from Settings → Data Sync.
@@ -201,7 +201,7 @@ systemctl status cron
 Tail the cron tick log:
 
 ```bash
-tail -f /var/www/evemarket/storage/logs/cron.log
+tail -f /var/www/supplycore/storage/logs/cron.log
 ```
 
 Inspect scheduler state tables:
@@ -219,7 +219,7 @@ If you previously had one cron line per pipeline/job, remove those entries and k
 
 ## Killmail Intelligence Foundation (zKillboard R2Z2)
 
-EveMarket now includes a first-pass killmail intelligence ingestion foundation built around the zKillboard **R2Z2 ordered sequence feed**.
+SupplyCore now includes a first-pass killmail intelligence ingestion foundation built around the zKillboard **R2Z2 ordered sequence feed**.
 
 - Stream source:
   - sequence pointer: `https://r2z2.zkillboard.com/ephemeral/sequence.json`
@@ -286,7 +286,7 @@ Configure ingestion + tracked alliances/corporations at:
 
 ## EVE Static Data Import Pipeline
 
-EveMarket includes a local reference-data pipeline for EVE static data exports.
+SupplyCore includes a local reference-data pipeline for EVE static data exports.
 
 ### What it does
 
@@ -322,7 +322,7 @@ php bin/static_data_import.php --mode=incremental
 
 ### Source format note
 
-The current importer reads required datasets directly from the official JSONL ZIP archive (for example `mapRegions.jsonl`, `mapSolarSystems.jsonl`, `types.jsonl`, and `marketGroups.jsonl`) and maps them into EveMarket reference tables.
+The current importer reads required datasets directly from the official JSONL ZIP archive (for example `mapRegions.jsonl`, `mapSolarSystems.jsonl`, `types.jsonl`, and `marketGroups.jsonl`) and maps them into SupplyCore reference tables.
 
 ### Data-boundary policy
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -401,7 +401,12 @@ INSERT INTO trading_stations (station_name, station_type) VALUES
 ON DUPLICATE KEY UPDATE station_name = VALUES(station_name);
 
 INSERT INTO app_settings (setting_key, setting_value) VALUES
-    ('app_name', 'EveMarket'),
+    ('app_name', 'SupplyCore'),
+    ('brand_family_name', 'SupplyCore'),
+    ('brand_console_label', 'SupplyCore Console'),
+    ('brand_tagline', 'Alliance logistics intelligence platform'),
+    ('brand_logo_path', '/assets/branding/supplycore-logo.svg'),
+    ('brand_favicon_path', '/assets/branding/supplycore-favicon.svg'),
     ('app_timezone', 'UTC'),
     ('default_currency', 'ISK'),
     ('incremental_updates_enabled', '1'),

--- a/public/assets/branding/supplycore-favicon.svg
+++ b/public/assets/branding/supplycore-favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="16" fill="#0f172a"/>
+  <path d="M14 32c0-9.941 8.059-18 18-18h10v8H32c-5.523 0-10 4.477-10 10s4.477 10 10 10h10v8H32c-9.941 0-18-8.059-18-18Z" fill="#e2e8f0"/>
+  <circle cx="46" cy="32" r="6" fill="#38bdf8"/>
+</svg>

--- a/public/assets/branding/supplycore-logo.svg
+++ b/public/assets/branding/supplycore-logo.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">SupplyCore logo placeholder</title>
+  <desc id="desc">Placeholder logo for the SupplyCore alliance logistics platform.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+    <linearGradient id="core" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#e2e8f0" />
+      <stop offset="100%" stop-color="#93c5fd" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#bg)" />
+  <path d="M26 64c0-21 17-38 38-38h20v16H64c-12.15 0-22 9.85-22 22s9.85 22 22 22h20v16H64c-21 0-38-17-38-38Z" fill="url(#core)" />
+  <path d="M74 34h12c9.941 0 18 8.059 18 18v24c0 9.941-8.059 18-18 18H74V78h10c1.105 0 2-.895 2-2V52c0-1.105-.895-2-2-2H74V34Z" fill="#38bdf8" />
+  <circle cx="96" cy="64" r="6" fill="#f8fafc" />
+</svg>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -23,6 +23,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         case 'general':
             $saved = save_settings([
                 'app_name' => sanitize_app_name((string) ($_POST['app_name'] ?? app_name())),
+                'brand_family_name' => sanitize_app_name((string) ($_POST['brand_family_name'] ?? brand_family_name())),
+                'brand_console_label' => sanitize_brand_label((string) ($_POST['brand_console_label'] ?? brand_console_label()), brand_family_name() . ' Console'),
+                'brand_tagline' => sanitize_brand_label((string) ($_POST['brand_tagline'] ?? brand_tagline()), 'Alliance logistics intelligence platform'),
+                'brand_logo_path' => sanitize_brand_asset_path((string) ($_POST['brand_logo_path'] ?? brand_logo_path()), '/assets/branding/supplycore-logo.svg'),
+                'brand_favicon_path' => sanitize_brand_asset_path((string) ($_POST['brand_favicon_path'] ?? brand_favicon_path()), '/assets/branding/supplycore-favicon.svg'),
                 'app_timezone' => sanitize_timezone((string) ($_POST['app_timezone'] ?? 'UTC')),
                 'default_currency' => sanitize_currency((string) ($_POST['default_currency'] ?? 'ISK')),
             ]);
@@ -113,6 +118,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $settingValues = get_settings([
     'app_name',
+    'brand_family_name',
+    'brand_console_label',
+    'brand_tagline',
+    'brand_logo_path',
+    'brand_favicon_path',
     'app_timezone',
     'default_currency',
     'market_station_id',
@@ -232,6 +242,28 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <label class="block space-y-2">
                     <span class="text-sm text-muted">Application Name</span>
                     <input name="app_name" value="<?= htmlspecialchars($settingValues['app_name'] ?? app_name(), ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                </label>
+                <label class="block space-y-2">
+                    <span class="text-sm text-muted">Brand Family</span>
+                    <input name="brand_family_name" value="<?= htmlspecialchars($settingValues['brand_family_name'] ?? brand_family_name(), ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                    <p class="text-xs text-muted">Use this shared family label to support future products like SupplyCore Intelligence, SupplyCore AI, and SupplyCore Logistics.</p>
+                </label>
+                <label class="block space-y-2">
+                    <span class="text-sm text-muted">Console Label</span>
+                    <input name="brand_console_label" value="<?= htmlspecialchars($settingValues['brand_console_label'] ?? brand_console_label(), ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                </label>
+                <label class="block space-y-2">
+                    <span class="text-sm text-muted">Brand Tagline</span>
+                    <input name="brand_tagline" value="<?= htmlspecialchars($settingValues['brand_tagline'] ?? brand_tagline(), ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                </label>
+                <label class="block space-y-2">
+                    <span class="text-sm text-muted">Logo Asset Path</span>
+                    <input name="brand_logo_path" value="<?= htmlspecialchars($settingValues['brand_logo_path'] ?? brand_logo_path(), ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
+                    <p class="text-xs text-muted">Default placeholder logo is ready at <span class="font-medium text-slate-100">/assets/branding/supplycore-logo.svg</span>.</p>
+                </label>
+                <label class="block space-y-2">
+                    <span class="text-sm text-muted">Favicon Asset Path</span>
+                    <input name="brand_favicon_path" value="<?= htmlspecialchars($settingValues['brand_favicon_path'] ?? brand_favicon_path(), ENT_QUOTES) ?>" class="w-full rounded-lg border border-border bg-black/30 px-3 py-2 text-sm outline-none ring-accent focus:ring" />
                 </label>
                 <label class="block space-y-2">
                     <span class="text-sm text-muted">Timezone</span>

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return [
     'app' => [
-        'name' => 'EveMarket',
+        'name' => 'SupplyCore',
         'env' => getenv('APP_ENV') ?: 'development',
         'base_url' => getenv('APP_BASE_URL') ?: 'http://localhost:8080',
         'timezone' => getenv('APP_TIMEZONE') ?: 'UTC',
@@ -12,7 +12,7 @@ return [
     'db' => [
         'host' => getenv('DB_HOST') ?: '127.0.0.1',
         'port' => (int) (getenv('DB_PORT') ?: 3306),
-        'database' => getenv('DB_DATABASE') ?: 'evemarket',
+        'database' => getenv('DB_DATABASE') ?: 'supplycore',
         'username' => getenv('DB_USERNAME') ?: 'root',
         'password' => getenv('DB_PASSWORD') ?: '',
         'charset' => 'utf8mb4',

--- a/src/functions.php
+++ b/src/functions.php
@@ -8,9 +8,44 @@ date_default_timezone_set(app_timezone());
 
 function app_name(): string
 {
-    $configured = trim((string) get_setting('app_name', config('app.name', 'EveMarket')));
+    $configured = trim((string) get_setting('app_name', config('app.name', 'SupplyCore')));
 
     return sanitize_app_name($configured);
+}
+
+function brand_family_name(): string
+{
+    $configured = trim((string) get_setting('brand_family_name', 'SupplyCore'));
+
+    return sanitize_app_name($configured);
+}
+
+function brand_console_label(): string
+{
+    $configured = trim((string) get_setting('brand_console_label', brand_family_name() . ' Console'));
+
+    return sanitize_brand_label($configured, brand_family_name() . ' Console');
+}
+
+function brand_tagline(): string
+{
+    $configured = trim((string) get_setting('brand_tagline', 'Alliance logistics intelligence platform'));
+
+    return sanitize_brand_label($configured, 'Alliance logistics intelligence platform');
+}
+
+function brand_logo_path(): string
+{
+    $configured = trim((string) get_setting('brand_logo_path', '/assets/branding/supplycore-logo.svg'));
+
+    return sanitize_brand_asset_path($configured, '/assets/branding/supplycore-logo.svg');
+}
+
+function brand_favicon_path(): string
+{
+    $configured = trim((string) get_setting('brand_favicon_path', '/assets/branding/supplycore-favicon.svg'));
+
+    return sanitize_brand_asset_path($configured, '/assets/branding/supplycore-favicon.svg');
 }
 
 function app_timezone(): string
@@ -175,10 +210,36 @@ function sanitize_app_name(string $name): string
     $name = trim($name);
 
     if ($name === '') {
-        return 'EveMarket';
+        return 'SupplyCore';
     }
 
     return mb_substr($name, 0, 120);
+}
+
+function sanitize_brand_label(string $value, string $default): string
+{
+    $value = trim($value);
+
+    if ($value === '') {
+        return $default;
+    }
+
+    return mb_substr($value, 0, 160);
+}
+
+function sanitize_brand_asset_path(string $path, string $default): string
+{
+    $path = trim($path);
+
+    if ($path === '') {
+        return $default;
+    }
+
+    if ($path[0] !== '/' || preg_match('/[[:cntrl:]]/', $path) === 1) {
+        return $default;
+    }
+
+    return mb_substr($path, 0, 255);
 }
 
 function sanitize_timezone(string $timezone): string
@@ -5130,11 +5191,11 @@ function esi_valid_access_token(int $refreshWindowSeconds = 120): string
 
 function esi_user_agent(): string
 {
-    $configured = trim((string) get_setting('app_name', 'EveMarket'));
+    $configured = trim((string) get_setting('app_name', 'SupplyCore'));
 
     return $configured !== ''
-        ? $configured . ' eve-market/1.0 (+https://github.com/cvweiss/evemarket)'
-        : 'EveMarket eve-market/1.0 (+https://github.com/cvweiss/evemarket)';
+        ? $configured . ' supplycore/1.0 (+https://github.com/cvweiss/supplycore)'
+        : 'SupplyCore supplycore/1.0 (+https://github.com/cvweiss/supplycore)';
 }
 
 function esi_lookup_context(array $requiredScopes = []): array
@@ -6383,14 +6444,14 @@ function killmail_resolve_tracked_entities(string $allianceText, string $corpora
 
 function killmail_r2z2_fetch_json(string $url): array
 {
-    $userAgent = trim((string) get_setting('app_name', 'EveMarket'));
+    $userAgent = trim((string) get_setting('app_name', 'SupplyCore'));
     if ($userAgent === '') {
-        $userAgent = 'EveMarket';
+        $userAgent = 'SupplyCore';
     }
 
     $headers = [
         'Accept: application/json',
-        'User-Agent: ' . $userAgent . ' killmail-ingestion/1.0 (+https://github.com/cvweiss/evemarket)',
+        'User-Agent: ' . $userAgent . ' killmail-ingestion/1.0 (+https://github.com/cvweiss/supplycore)',
     ];
 
     $ch = curl_init($url);

--- a/src/views/partials/footer.php
+++ b/src/views/partials/footer.php
@@ -1,3 +1,9 @@
+        <footer class="mt-8 border-t border-border pt-4 text-sm text-muted">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+                <p><?= htmlspecialchars(app_name(), ENT_QUOTES) ?> · <?= htmlspecialchars(brand_tagline(), ENT_QUOTES) ?></p>
+                <p>Brand family: <?= htmlspecialchars(brand_family_name(), ENT_QUOTES) ?></p>
+            </div>
+        </footer>
     </main>
 </div>
 </body>

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -5,8 +5,12 @@ $notice = flash('success');
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="application-name" content="<?= htmlspecialchars(app_name(), ENT_QUOTES) ?>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?= htmlspecialchars($title ?? app_name(), ENT_QUOTES) ?> | <?= htmlspecialchars(app_name(), ENT_QUOTES) ?></title>
+    <?php $pageTitle = trim((string) ($title ?? app_name())); ?>
+    <title><?= htmlspecialchars($pageTitle, ENT_QUOTES) ?><?= $pageTitle !== app_name() ? " | " . htmlspecialchars(app_name(), ENT_QUOTES) : "" ?></title>
+    <link rel="icon" type="image/svg+xml" href="<?= htmlspecialchars(brand_favicon_path(), ENT_QUOTES) ?>">
+    <link rel="shortcut icon" href="<?= htmlspecialchars(brand_favicon_path(), ENT_QUOTES) ?>">
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
     <style type="text/tailwindcss">
         @theme {
@@ -26,8 +30,9 @@ $notice = flash('success');
     <main class="flex-1 px-6 py-8 lg:px-10">
         <header class="mb-8 flex flex-wrap items-center justify-between gap-4">
             <div>
-                <p class="text-xs uppercase tracking-[0.2em] text-muted">EveMarket Console</p>
+                <p class="text-xs uppercase tracking-[0.2em] text-muted"><?= htmlspecialchars(brand_console_label(), ENT_QUOTES) ?></p>
                 <h1 class="text-2xl font-semibold"><?= htmlspecialchars($title ?? 'Dashboard', ENT_QUOTES) ?></h1>
+                <p class="mt-1 text-sm text-muted"><?= htmlspecialchars(brand_tagline(), ENT_QUOTES) ?></p>
             </div>
             <div class="rounded-xl border border-border bg-card px-4 py-2 text-sm text-muted">Built for PHP + MySQL + Apache2</div>
         </header>

--- a/src/views/partials/sidebar.php
+++ b/src/views/partials/sidebar.php
@@ -1,7 +1,12 @@
 <aside class="hidden w-80 shrink-0 border-r border-border bg-black/30 p-6 lg:block">
     <a href="/" class="mb-8 block rounded-xl border border-border bg-card px-4 py-3">
-        <p class="text-xs uppercase tracking-[0.2em] text-muted">Project</p>
-        <p class="text-lg font-semibold"><?= htmlspecialchars(app_name(), ENT_QUOTES) ?></p>
+        <div class="flex items-center gap-3">
+            <img src="<?= htmlspecialchars(brand_logo_path(), ENT_QUOTES) ?>" alt="<?= htmlspecialchars(app_name(), ENT_QUOTES) ?> logo" class="h-11 w-11 rounded-xl border border-border bg-black/20 p-1.5">
+            <div>
+                <p class="text-xs uppercase tracking-[0.2em] text-muted"><?= htmlspecialchars(brand_family_name(), ENT_QUOTES) ?></p>
+                <p class="text-lg font-semibold"><?= htmlspecialchars(app_name(), ENT_QUOTES) ?></p>
+            </div>
+        </div>
     </a>
 
     <nav class="space-y-4">


### PR DESCRIPTION
### Motivation
- Standardize product identity across code, docs, and runtime so the app presents as a professional platform named `SupplyCore` rather than a side project label.
- Centralize branding so future sub-products (e.g. SupplyCore Intelligence/AI/Logistics) can reuse shared family/console/tagline/logo settings instead of scattered literals.
- Keep behavior, routes, and database structures stable while providing safe seed defaults and backward-compatible configuration choices.

### Description
- Change default product name in configuration from `EveMarket` to `SupplyCore` in `src/config/app.php` and seed `app_settings` in `database/schema.sql` so new installs default to `SupplyCore`.
- Add centralized branding helpers in `src/functions.php`: `brand_family_name()`, `brand_console_label()`, `brand_tagline()`, `brand_logo_path()`, `brand_favicon_path()`, plus sanitizers `sanitize_brand_label()` and `sanitize_brand_asset_path()`.
- Expose new branding fields in the General Settings UI (`public/settings/index.php`) and persist them via existing `save_settings()` primitives so branding is editable at runtime.
- Update layout partials (`src/views/partials/header.php`, `src/views/partials/sidebar.php`, `src/views/partials/footer.php`) to render the new console label, tagline, favicon, logo area, and browser title logic without changing routes or page logic.
- Update backend integration identifiers: ESI user-agent and killmail ingestion user-agent strings now identify as SupplyCore (in `src/functions.php`) to reflect the product rename when calling external services.
- Add placeholder branding assets under `public/assets/branding/` (`supplycore-logo.svg`, `supplycore-favicon.svg`) and seed their default paths in `database/schema.sql`.
- Refresh documentation and operational examples in `README.md` (database name, paths, environment var names like `SUPPLYCORE_*`) to match the rename while preserving the application behavior.

### Testing
- Ran PHP lint checks: `php -l src/functions.php`, `php -l src/views/partials/header.php`, `php -l src/views/partials/sidebar.php`, `php -l src/views/partials/footer.php`, and the main public pages; all reported no syntax errors (success).
- Searched for remaining legacy branding with `rg -n --hidden -S "EveMarket|evemarket|EVEMARKET_"` across `src`, `public`, `bin`, `database`, and `README.md` and found no lingering matches in application code or docs (success).
- Verified diffs include added settings/schema seeds, new helpers, updated partials, updated config, placeholder assets, and README updates (changes committed to branch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba894ebd24832f8165a3ad430e5a3a)