### PR TITLE
Drop extreme local-history spread_percent values and document recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ README.md
    ```
 
 > Upgrading an existing installation? Apply schema changes before the next sync run, for example: `ALTER TABLE market_hub_local_history_daily MODIFY spread_percent DECIMAL(20,4) NULL;`.
+>
+> If local-history sync previously failed with `Out of range value for column 'spread_percent'`, re-run that `ALTER TABLE` first, then trigger the **Local History** job again from **Settings → Data Sync** or `php bin/sync_runner.php --job=market-hub-local-history --mode=full --window-days=30`.
 
 2. **Set environment variables** (example)
    ```bash

--- a/src/db.php
+++ b/src/db.php
@@ -698,7 +698,11 @@ function db_market_hub_local_history_daily_normalize_spread_percent(mixed $value
     }
 
     $spreadPercent = round($spreadPercent, 4);
-    $maxAbsValue = 9999999999999999.9999;
+    // Keep local-history writes compatible with legacy installs that still
+    // have a narrower DECIMAL definition for spread_percent. Extremely large
+    // values are usually caused by near-zero buy orders and are not useful for
+    // dashboard trend commentary, so drop them instead of failing the sync.
+    $maxAbsValue = 9999.9999;
     if (abs($spreadPercent) > $maxAbsValue) {
         return null;
     }


### PR DESCRIPTION
### Motivation
- Local-history syncs could fail on older installations when `spread_percent` values exceeded a narrower DECIMAL column, causing `Out of range value for column 'spread_percent'` errors and preventing history from populating.

### Description
- Change normalization in `src/db.php` to discard absurd `spread_percent` values by lowering the allowed max magnitude to `9999.9999` and adding a comment explaining the compatibility rationale. 
- Add a recovery note to `README.md` that instructs operators to run `ALTER TABLE market_hub_local_history_daily MODIFY spread_percent DECIMAL(20,4) NULL;` if they encounter the out-of-range error, and how to re-run the Local History sync (via Settings → Data Sync or `php bin/sync_runner.php --job=market-hub-local-history --mode=full --window-days=30`).

### Testing
- Ran PHP lint on the modified file with `php -l src/db.php`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba99ad12fc832fa1b6aa13ac7f08ab)