### PR TITLE
Add Doctrine fit import workflow and market mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository establishes a clean architecture that can scale from an initial 
 - ESI cache tables (`esi_cache_namespaces`, `esi_cache_entries`) for structured `cache.esi.*` namespaces
 - Incremental sync state tables (`sync_state`, `sync_runs`) for watermark/cursor tracking and run observability
 - Reusable entity metadata cache for human-readable killmail, market, and analytics surfaces
+- Doctrine fit import workflow with EFT/BuyAll parsing, item-name cache, doctrine group pages, and alliance-vs-hub market mapping
 - Secure CSRF-protected settings forms
 - Session-based flash messaging
 
@@ -29,6 +30,7 @@ This repository establishes a clean architecture that can scale from an initial 
 public/
   index.php                 # Dashboard
   settings/index.php        # Modular settings controller/view
+  doctrine/                 # Doctrine groups, import, and fit detail pages
   .htaccess                 # Apache rewrite rules
 src/
   bootstrap.php             # Session + shared bootstrap

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -391,6 +391,60 @@ CREATE TABLE IF NOT EXISTS ref_item_types (
     KEY idx_published (published)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS item_name_cache (
+    normalized_name VARCHAR(190) PRIMARY KEY,
+    item_name VARCHAR(255) NOT NULL,
+    type_id INT UNSIGNED DEFAULT NULL,
+    resolution_source ENUM('cache', 'ref', 'esi', 'missing') NOT NULL DEFAULT 'ref',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_type_id (type_id),
+    KEY idx_resolution_source (resolution_source)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS doctrine_groups (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    group_name VARCHAR(190) NOT NULL,
+    description TEXT DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_group_name (group_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS doctrine_fits (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    doctrine_group_id INT UNSIGNED NOT NULL,
+    fit_name VARCHAR(190) NOT NULL,
+    ship_name VARCHAR(255) NOT NULL,
+    ship_type_id INT UNSIGNED DEFAULT NULL,
+    source_format ENUM('eft', 'buyall') NOT NULL,
+    import_body LONGTEXT NOT NULL,
+    item_count INT UNSIGNED NOT NULL DEFAULT 0,
+    unresolved_count INT UNSIGNED NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_doctrine_group_id (doctrine_group_id),
+    KEY idx_ship_type_id (ship_type_id),
+    CONSTRAINT fk_doctrine_fits_group FOREIGN KEY (doctrine_group_id) REFERENCES doctrine_groups(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS doctrine_fit_items (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    doctrine_fit_id INT UNSIGNED NOT NULL,
+    line_number SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+    slot_category VARCHAR(80) NOT NULL DEFAULT 'Items',
+    item_name VARCHAR(255) NOT NULL,
+    type_id INT UNSIGNED DEFAULT NULL,
+    quantity INT UNSIGNED NOT NULL DEFAULT 1,
+    resolution_source ENUM('cache', 'ref', 'esi', 'missing') NOT NULL DEFAULT 'ref',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_doctrine_fit_id (doctrine_fit_id),
+    KEY idx_type_id (type_id),
+    KEY idx_slot_category (slot_category),
+    CONSTRAINT fk_doctrine_fit_items_fit FOREIGN KEY (doctrine_fit_id) REFERENCES doctrine_fits(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 INSERT INTO trading_stations (station_name, station_type) VALUES
     ('Rens VI - Moon 8 - Brutor Tribe Treasury', 'market'),
     ('Amarr VIII (Oris) - Emperor Family Academy', 'market'),
@@ -432,8 +486,13 @@ INSERT INTO app_settings (setting_key, setting_value) VALUES
     ('esi_client_id', '961316f6177d4a0283fef0bd72fbd224'),
     ('esi_client_secret', 'eat_iasVmhqov40Ud568JVAyctOErv5E6AgV_3S6eiZ'),
     ('esi_callback_url', 'http://192.168.178.47/callback'),
-    ('esi_scopes', 'publicData esi-location.read_location.v1 esi-search.search_structures.v1 esi-universe.read_structures.v1 esi-markets.structure_markets.v1')
+    ('esi_scopes', 'publicData esi-location.read_location.v1 esi-search.search_structures.v1 esi-universe.read_structures.v1 esi-markets.structure_markets.v1'),
+    ('doctrine.default_group', 'SupplyCore Doctrine')
 ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value);
+
+INSERT INTO doctrine_groups (group_name, description) VALUES
+    ('SupplyCore Doctrine', 'Baseline doctrine fits used for gap detection, restock generation, and hauling prep.')
+ON DUPLICATE KEY UPDATE description = VALUES(description);
 
 INSERT INTO sync_schedules (job_key, enabled, interval_seconds, next_run_at, last_run_at, last_status, last_error, locked_until) VALUES
     ('alliance_current_sync', 1, 300, NULL, NULL, NULL, NULL, NULL),

--- a/public/doctrine/fit.php
+++ b/public/doctrine/fit.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$fitId = max(0, (int) ($_GET['fit_id'] ?? 0));
+$data = doctrine_fit_detail_view_model($fitId);
+$fit = $data['fit'] ?? null;
+$categories = $data['categories'] ?? [];
+$summary = $data['summary'] ?? [];
+$title = $fit !== null ? ((string) ($fit['fit_name'] ?? 'Doctrine Fit')) : 'Doctrine Fit';
+
+$statusTone = static function (string $status): string {
+    return match ($status) {
+        'ok' => 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100',
+        'low' => 'border-amber-400/20 bg-amber-500/10 text-amber-100',
+        default => 'border-rose-400/20 bg-rose-500/10 text-rose-200',
+    };
+};
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<?php if ($fit === null): ?>
+    <section class="surface-secondary">
+        <div class="section-header">
+            <div>
+                <p class="eyebrow">Doctrine fit</p>
+                <h2 class="mt-2 section-title">Doctrine fit not found</h2>
+            </div>
+            <a href="/doctrine" class="btn-secondary">Back to groups</a>
+        </div>
+        <p class="text-sm text-slate-400">The requested doctrine fit does not exist yet or the database is unavailable.</p>
+    </section>
+<?php else: ?>
+    <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <?php foreach ($summary as $card): ?>
+            <article class="surface-secondary">
+                <p class="eyebrow"><?= htmlspecialchars((string) ($card['label'] ?? ''), ENT_QUOTES) ?></p>
+                <p class="mt-3 text-3xl metric-value"><?= htmlspecialchars((string) ($card['value'] ?? ''), ENT_QUOTES) ?></p>
+                <p class="mt-2 text-sm text-slate-300"><?= htmlspecialchars((string) ($card['context'] ?? ''), ENT_QUOTES) ?></p>
+            </article>
+        <?php endforeach; ?>
+    </section>
+
+    <section class="mt-8 grid gap-6 xl:grid-cols-[minmax(280px,360px)_minmax(0,1fr)]">
+        <aside class="surface-secondary">
+            <div class="section-header">
+                <div>
+                    <p class="eyebrow">Hull profile</p>
+                    <h2 class="mt-2 section-title"><?= htmlspecialchars((string) ($fit['ship_name'] ?? ''), ENT_QUOTES) ?></h2>
+                    <p class="mt-2 text-sm text-slate-400"><?= htmlspecialchars((string) ($fit['fit_name'] ?? ''), ENT_QUOTES) ?></p>
+                </div>
+                <span class="badge border-cyan-400/18 bg-cyan-500/10 text-cyan-100"><?= htmlspecialchars((string) strtoupper((string) ($fit['source_format'] ?? 'buyall')), ENT_QUOTES) ?></span>
+            </div>
+            <div class="overflow-hidden rounded-[1.35rem] border border-white/8 bg-slate-950/70 p-6">
+                <?php if (!empty($fit['ship_image_url'])): ?>
+                    <img src="<?= htmlspecialchars((string) $fit['ship_image_url'], ENT_QUOTES) ?>" alt="<?= htmlspecialchars((string) ($fit['ship_name'] ?? ''), ENT_QUOTES) ?>" class="mx-auto h-48 w-48 object-contain">
+                <?php else: ?>
+                    <div class="flex h-48 items-center justify-center text-sm text-slate-500">Ship image unavailable</div>
+                <?php endif; ?>
+            </div>
+            <div class="mt-4 space-y-3 text-sm text-slate-300">
+                <div class="surface-tertiary">
+                    <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Doctrine group</p>
+                    <p class="mt-2 font-semibold text-slate-100"><?= htmlspecialchars((string) ($fit['group_name'] ?? ''), ENT_QUOTES) ?></p>
+                </div>
+                <div class="surface-tertiary">
+                    <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Purpose</p>
+                    <p class="mt-2 text-slate-400">Baseline data for supply gap detection, restock generation, and hauling suggestions.</p>
+                </div>
+                <div class="flex gap-3">
+                    <a href="/doctrine/group?group_id=<?= (int) ($fit['doctrine_group_id'] ?? 0) ?>" class="btn-secondary">Back to group</a>
+                    <a href="/doctrine/import" class="btn-primary">Import fit</a>
+                </div>
+            </div>
+        </aside>
+
+        <article class="surface-secondary">
+            <div class="section-header">
+                <div>
+                    <p class="eyebrow">Market mapping</p>
+                    <h2 class="mt-2 section-title">Required items by category</h2>
+                    <p class="mt-2 text-sm text-slate-400">Each line compares required fit quantity against alliance stock plus the reference hub price floor.</p>
+                </div>
+                <span class="badge border-sky-400/18 bg-sky-500/10 text-sky-100">Green / Yellow / Red</span>
+            </div>
+
+            <?php if ($categories === []): ?>
+                <div class="surface-tertiary text-sm text-slate-400">No doctrine items were stored for this fit.</div>
+            <?php else: ?>
+                <div class="space-y-6">
+                    <?php foreach ($categories as $category => $rows): ?>
+                        <section>
+                            <div class="mb-3 flex items-center justify-between gap-3">
+                                <h3 class="text-base font-semibold text-slate-100"><?= htmlspecialchars((string) $category, ENT_QUOTES) ?></h3>
+                                <span class="text-xs uppercase tracking-[0.16em] text-slate-500"><?= doctrine_format_quantity(count($rows)) ?> lines</span>
+                            </div>
+                            <div class="overflow-hidden rounded-[1.25rem] border border-white/8">
+                                <table class="table-ui">
+                                    <thead>
+                                        <tr>
+                                            <th>Item</th>
+                                            <th class="text-right">Required Qty</th>
+                                            <th class="text-right">Local Qty</th>
+                                            <th class="text-right">Missing Qty</th>
+                                            <th class="text-right">Hub Price</th>
+                                            <th class="text-right">Local Price</th>
+                                            <th>Status</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <?php foreach ($rows as $row): ?>
+                                            <tr>
+                                                <td class="font-semibold text-slate-50"><?= htmlspecialchars((string) ($row['item_name'] ?? ''), ENT_QUOTES) ?></td>
+                                                <td class="text-right tabular-nums"><?= htmlspecialchars((string) ($row['required_qty_label'] ?? '0'), ENT_QUOTES) ?></td>
+                                                <td class="text-right tabular-nums"><?= htmlspecialchars((string) ($row['local_available_qty_label'] ?? '0'), ENT_QUOTES) ?></td>
+                                                <td class="text-right tabular-nums"><?= htmlspecialchars((string) ($row['missing_qty_label'] ?? '0'), ENT_QUOTES) ?></td>
+                                                <td class="text-right tabular-nums text-sky-300"><?= htmlspecialchars((string) ($row['hub_price_label'] ?? '—'), ENT_QUOTES) ?></td>
+                                                <td class="text-right tabular-nums text-sky-300"><?= htmlspecialchars((string) ($row['local_price_label'] ?? '—'), ENT_QUOTES) ?></td>
+                                                <td>
+                                                    <span class="rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] <?= $statusTone((string) ($row['market_status'] ?? 'missing')) ?>">
+                                                        <?= htmlspecialchars((string) ($row['market_label'] ?? 'Missing'), ENT_QUOTES) ?>
+                                                    </span>
+                                                </td>
+                                            </tr>
+                                        <?php endforeach; ?>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </section>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        </article>
+    </section>
+<?php endif; ?>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/doctrine/group.php
+++ b/public/doctrine/group.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$groupId = max(0, (int) ($_GET['group_id'] ?? 0));
+$data = doctrine_group_detail_data($groupId);
+$group = $data['group'] ?? null;
+$fits = $data['fits'] ?? [];
+$title = $group !== null ? ((string) ($group['group_name'] ?? 'Doctrine Group')) : 'Doctrine Group';
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<?php if ($group === null): ?>
+    <section class="surface-secondary">
+        <div class="section-header">
+            <div>
+                <p class="eyebrow">Doctrine registry</p>
+                <h2 class="mt-2 section-title">Doctrine group not found</h2>
+            </div>
+            <a href="/doctrine" class="btn-secondary">Back to groups</a>
+        </div>
+        <p class="text-sm text-slate-400">The requested doctrine group does not exist yet or the database is unavailable.</p>
+    </section>
+<?php else: ?>
+    <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <article class="surface-secondary">
+            <p class="eyebrow">Doctrine fits</p>
+            <p class="mt-3 text-3xl metric-value"><?= doctrine_format_quantity((int) ($group['fit_count'] ?? 0)) ?></p>
+            <p class="mt-2 text-sm text-slate-300">Imported fits stored in this group.</p>
+        </article>
+        <article class="surface-secondary">
+            <p class="eyebrow">Tracked items</p>
+            <p class="mt-3 text-3xl metric-value"><?= doctrine_format_quantity((int) ($group['item_count'] ?? 0)) ?></p>
+            <p class="mt-2 text-sm text-slate-300">Normalized doctrine lines ready for market mapping.</p>
+        </article>
+        <article class="surface-secondary">
+            <p class="eyebrow">Last updated</p>
+            <p class="mt-3 text-3xl metric-value"><?= htmlspecialchars(killmail_relative_datetime($group['last_fit_updated_at'] ?? null), ENT_QUOTES) ?></p>
+            <p class="mt-2 text-sm text-slate-300">Most recent fit refresh inside this doctrine group.</p>
+        </article>
+        <article class="surface-secondary">
+            <p class="eyebrow">Baseline goal</p>
+            <p class="mt-3 text-3xl metric-value">Ready</p>
+            <p class="mt-2 text-sm text-slate-300">Gap detection, restocks, and hauling suggestions build from these fits.</p>
+        </article>
+    </section>
+
+    <section class="surface-secondary mt-8">
+        <div class="section-header">
+            <div>
+                <p class="eyebrow">Fit inventory</p>
+                <h2 class="mt-2 section-title"><?= htmlspecialchars((string) ($group['group_name'] ?? ''), ENT_QUOTES) ?></h2>
+                <p class="mt-2 text-sm text-slate-400"><?= htmlspecialchars((string) ($group['description'] ?? 'Doctrine fit collection for SupplyCore.'), ENT_QUOTES) ?></p>
+            </div>
+            <div class="flex flex-wrap gap-3">
+                <a href="/doctrine/import?group_id=<?= (int) ($group['id'] ?? 0) ?>" class="btn-primary">Import another fit</a>
+                <a href="/doctrine" class="btn-secondary">All groups</a>
+            </div>
+        </div>
+
+        <?php if ($fits === []): ?>
+            <div class="surface-tertiary text-sm text-slate-400">No fits have been imported into this group yet.</div>
+        <?php else: ?>
+            <div class="grid gap-4 lg:grid-cols-2">
+                <?php foreach ($fits as $fit): ?>
+                    <a href="/doctrine/fit?fit_id=<?= (int) ($fit['id'] ?? 0) ?>" class="block rounded-[1.3rem] border border-white/8 bg-white/[0.03] p-4 transition hover:bg-white/[0.05]">
+                        <div class="flex items-start justify-between gap-4">
+                            <div class="flex items-center gap-4">
+                                <div class="h-14 w-14 overflow-hidden rounded-2xl border border-white/10 bg-slate-950/70 p-2">
+                                    <?php if (!empty($fit['ship_image_url'])): ?>
+                                        <img src="<?= htmlspecialchars((string) $fit['ship_image_url'], ENT_QUOTES) ?>" alt="<?= htmlspecialchars((string) ($fit['ship_name'] ?? ''), ENT_QUOTES) ?>" class="h-full w-full object-contain">
+                                    <?php else: ?>
+                                        <div class="flex h-full w-full items-center justify-center text-xs text-slate-500">N/A</div>
+                                    <?php endif; ?>
+                                </div>
+                                <div>
+                                    <h3 class="text-lg font-semibold text-white"><?= htmlspecialchars((string) ($fit['fit_name'] ?? ''), ENT_QUOTES) ?></h3>
+                                    <p class="mt-1 text-sm text-slate-400"><?= htmlspecialchars((string) ($fit['ship_name'] ?? ''), ENT_QUOTES) ?></p>
+                                </div>
+                            </div>
+                            <span class="badge border-sky-400/18 bg-sky-500/10 text-sky-100"><?= htmlspecialchars(strtoupper((string) ($fit['source_format'] ?? 'buyall')), ENT_QUOTES) ?></span>
+                        </div>
+                        <div class="mt-4 grid gap-3 sm:grid-cols-3">
+                            <div class="surface-tertiary">
+                                <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Item lines</p>
+                                <p class="mt-2 text-xl font-semibold text-slate-100"><?= doctrine_format_quantity((int) ($fit['item_count'] ?? 0)) ?></p>
+                            </div>
+                            <div class="surface-tertiary">
+                                <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Required qty</p>
+                                <p class="mt-2 text-xl font-semibold text-slate-100"><?= htmlspecialchars((string) ($fit['required_quantity_label'] ?? '0'), ENT_QUOTES) ?></p>
+                            </div>
+                            <div class="surface-tertiary">
+                                <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Updated</p>
+                                <p class="mt-2 text-sm font-medium text-slate-100"><?= htmlspecialchars(killmail_relative_datetime($fit['updated_at'] ?? null), ENT_QUOTES) ?></p>
+                            </div>
+                        </div>
+                    </a>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </section>
+<?php endif; ?>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/doctrine/import.php
+++ b/public/doctrine/import.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Import Doctrine Fit';
+$groupOptions = doctrine_group_options();
+$defaultGroupId = max(0, (int) ($_GET['group_id'] ?? 0));
+foreach ($groupOptions as $groupOption) {
+    $candidateId = (int) ($groupOption['id'] ?? 0);
+    if ($defaultGroupId <= 0 && $candidateId > 0) {
+        $defaultGroupId = $candidateId;
+        break;
+    }
+}
+
+$formValues = [
+    'group_id' => (string) $defaultGroupId,
+    'new_group_name' => '',
+    'new_group_description' => '',
+    'fit_payload' => '',
+];
+$preview = null;
+$errorMessage = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_csrf($_POST['_token'] ?? null)) {
+        http_response_code(419);
+        exit('Invalid CSRF token');
+    }
+
+    $formValues = [
+        'group_id' => (string) ($_POST['group_id'] ?? ''),
+        'new_group_name' => (string) ($_POST['new_group_name'] ?? ''),
+        'new_group_description' => (string) ($_POST['new_group_description'] ?? ''),
+        'fit_payload' => (string) ($_POST['fit_payload'] ?? ''),
+    ];
+
+    $result = doctrine_import_fit_from_request($_POST);
+    if (($result['ok'] ?? false) === true) {
+        flash('success', (string) ($result['message'] ?? 'Doctrine fit imported successfully.'));
+        header('Location: /doctrine/fit?fit_id=' . (int) ($result['fit_id'] ?? 0));
+        exit;
+    }
+
+    $errorMessage = (string) ($result['message'] ?? 'Doctrine import failed.');
+
+    try {
+        $previewParsed = doctrine_parse_import_text((string) $formValues['fit_payload']);
+        $preview = doctrine_resolve_parsed_fit($previewParsed, (string) $formValues['fit_payload']);
+    } catch (Throwable) {
+        $preview = $result['resolved'] ?? null;
+    }
+}
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<section class="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+    <article class="surface-secondary">
+        <div class="section-header">
+            <div>
+                <p class="eyebrow">Doctrine ingest</p>
+                <h2 class="mt-2 section-title">Import alliance fitting payload</h2>
+                <p class="mt-2 text-sm text-slate-400">Paste EFT or BuyAll text. SupplyCore auto-detects the format, normalizes ship + item quantities, resolves real type names, and stores the fit once every line maps cleanly.</p>
+            </div>
+            <span class="badge border-emerald-400/20 bg-emerald-500/10 text-emerald-100">EFT + BuyAll</span>
+        </div>
+
+        <?php if ($errorMessage !== null): ?>
+            <div class="mb-5 rounded-2xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100"><?= htmlspecialchars($errorMessage, ENT_QUOTES) ?></div>
+        <?php endif; ?>
+
+        <form method="post" class="space-y-4">
+            <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
+            <div class="grid gap-4 md:grid-cols-2">
+                <label class="block">
+                    <span class="mb-2 block field-label">Doctrine group</span>
+                    <select name="group_id" class="field-select">
+                        <option value="">Select a group</option>
+                        <?php foreach ($groupOptions as $group): ?>
+                            <option value="<?= (int) ($group['id'] ?? 0) ?>" <?= (string) ($group['id'] ?? '') === (string) $formValues['group_id'] ? 'selected' : '' ?>>
+                                <?= htmlspecialchars((string) ($group['group_name'] ?? ''), ENT_QUOTES) ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <div class="surface-tertiary text-sm text-slate-400">
+                    Pick an existing group or enter a new one below. New group data wins when you fill both.
+                </div>
+            </div>
+            <div class="grid gap-4 md:grid-cols-2">
+                <label class="block">
+                    <span class="mb-2 block field-label">New group name</span>
+                    <input type="text" name="new_group_name" class="field-input" maxlength="190" value="<?= htmlspecialchars((string) $formValues['new_group_name'], ENT_QUOTES) ?>" placeholder="Optional new doctrine group">
+                </label>
+                <label class="block">
+                    <span class="mb-2 block field-label">New group description</span>
+                    <input type="text" name="new_group_description" class="field-input" maxlength="1000" value="<?= htmlspecialchars((string) $formValues['new_group_description'], ENT_QUOTES) ?>" placeholder="Optional context for the doctrine group">
+                </label>
+            </div>
+            <label class="block">
+                <span class="mb-2 block field-label">Fit payload</span>
+                <textarea name="fit_payload" class="field-input font-mono text-sm" style="min-height: 26rem;" spellcheck="false" placeholder="[Scimitar, Shield Scimi]\nDamage Control II\nNanofiber Internal Structure II\n\nLarge Shield Extender II\n10MN Afterburner II\n\nLarge Remote Shield Booster II x4\n\nMedium Core Defense Field Extender II x2\n\nWarrior II x5"><?= htmlspecialchars((string) $formValues['fit_payload'], ENT_QUOTES) ?></textarea>
+            </label>
+            <div class="flex flex-wrap items-center justify-between gap-3">
+                <div class="text-sm text-slate-400">
+                    Quantity defaults to <span class="text-slate-100">1</span>, supports <span class="text-slate-100">xN</span>, ignores empty lines, and trims whitespace automatically.
+                </div>
+                <button type="submit" class="btn-primary">Import doctrine fit</button>
+            </div>
+        </form>
+    </article>
+
+    <aside class="surface-secondary">
+        <div class="section-header">
+            <div>
+                <p class="eyebrow">Import behavior</p>
+                <h2 class="mt-2 section-title">Resolution pipeline</h2>
+            </div>
+            <span class="badge border-cyan-400/18 bg-cyan-500/10 text-cyan-100">Local first</span>
+        </div>
+        <div class="space-y-3 text-sm text-slate-300">
+            <div class="surface-tertiary">
+                <p class="font-semibold text-slate-100">1. Parse</p>
+                <p class="mt-2 text-slate-400">Detect EFT vs BuyAll, extract hull, and normalize line quantities.</p>
+            </div>
+            <div class="surface-tertiary">
+                <p class="font-semibold text-slate-100">2. Resolve</p>
+                <p class="mt-2 text-slate-400">Check <code>item_name_cache</code>, fall back to local reference types, then try ESI lookups for any missing lines.</p>
+            </div>
+            <div class="surface-tertiary">
+                <p class="font-semibold text-slate-100">3. Store</p>
+                <p class="mt-2 text-slate-400">Persist the fit only when every imported line maps to a real item name.</p>
+            </div>
+        </div>
+
+        <?php if (is_array($preview) && ($preview['items'] ?? []) !== []): ?>
+            <div class="mt-6">
+                <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Last preview</p>
+                <div class="mt-3 surface-tertiary space-y-3">
+                    <div>
+                        <p class="text-sm font-semibold text-slate-100"><?= htmlspecialchars((string) (($preview['fit']['fit_name'] ?? '') ?: 'Import preview'), ENT_QUOTES) ?></p>
+                        <p class="mt-1 text-sm text-slate-400"><?= htmlspecialchars((string) (($preview['fit']['ship_name'] ?? '') ?: 'Unknown hull'), ENT_QUOTES) ?></p>
+                    </div>
+                    <div class="grid gap-3 sm:grid-cols-2">
+                        <div>
+                            <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Resolved lines</p>
+                            <p class="mt-2 text-lg font-semibold text-emerald-100"><?= doctrine_format_quantity(count((array) ($preview['items'] ?? []))) ?></p>
+                        </div>
+                        <div>
+                            <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Unresolved</p>
+                            <p class="mt-2 text-lg font-semibold text-amber-100"><?= doctrine_format_quantity(count((array) ($preview['unresolved'] ?? []))) ?></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        <?php endif; ?>
+    </aside>
+</section>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/doctrine/index.php
+++ b/public/doctrine/index.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Doctrine Groups';
+$data = doctrine_groups_overview_data();
+$summary = $data['summary'] ?? [];
+$groups = $data['groups'] ?? [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_csrf($_POST['_token'] ?? null)) {
+        http_response_code(419);
+        exit('Invalid CSRF token');
+    }
+
+    $groupName = doctrine_sanitize_group_name((string) ($_POST['group_name'] ?? ''));
+    $description = doctrine_sanitize_description($_POST['description'] ?? null);
+
+    try {
+        $groupId = db_doctrine_group_create($groupName, $description);
+        flash('success', 'Doctrine group saved successfully.');
+        header('Location: /doctrine/group?group_id=' . $groupId);
+        exit;
+    } catch (Throwable $exception) {
+        flash('success', 'Doctrine group save failed: ' . $exception->getMessage());
+        header('Location: /doctrine');
+        exit;
+    }
+}
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+    <?php foreach ($summary as $card): ?>
+        <article class="surface-secondary">
+            <p class="eyebrow"><?= htmlspecialchars((string) ($card['label'] ?? ''), ENT_QUOTES) ?></p>
+            <p class="mt-3 text-3xl metric-value"><?= htmlspecialchars((string) ($card['value'] ?? ''), ENT_QUOTES) ?></p>
+            <p class="mt-2 text-sm text-slate-300"><?= htmlspecialchars((string) ($card['context'] ?? ''), ENT_QUOTES) ?></p>
+        </article>
+    <?php endforeach; ?>
+</section>
+
+<section class="mt-8 grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
+    <article class="surface-secondary">
+        <div class="section-header">
+            <div>
+                <p class="eyebrow">Doctrine registry</p>
+                <h2 class="mt-2 section-title">Alliance doctrine groups</h2>
+                <p class="mt-2 text-sm text-slate-400">Use groups to organize fleet comps, staging doctrines, and import batches before gap detection workflows kick in.</p>
+            </div>
+            <a href="/doctrine/import" class="btn-primary">Import fit</a>
+        </div>
+
+        <?php if ($groups === []): ?>
+            <div class="surface-tertiary text-sm text-slate-400">No doctrine groups yet. Create one, then import an EFT or BuyAll payload.</div>
+        <?php else: ?>
+            <div class="space-y-4">
+                <?php foreach ($groups as $group): ?>
+                    <a href="/doctrine/group?group_id=<?= (int) ($group['id'] ?? 0) ?>" class="block rounded-[1.3rem] border border-white/8 bg-white/[0.03] p-4 transition hover:bg-white/[0.05]">
+                        <div class="flex flex-wrap items-start justify-between gap-4">
+                            <div>
+                                <h3 class="text-lg font-semibold text-white"><?= htmlspecialchars((string) ($group['group_name'] ?? ''), ENT_QUOTES) ?></h3>
+                                <p class="mt-2 max-w-2xl text-sm text-slate-400"><?= htmlspecialchars((string) ($group['description'] ?? 'Doctrine fit collection for SupplyCore workflows.'), ENT_QUOTES) ?></p>
+                            </div>
+                            <span class="badge border-cyan-400/18 bg-cyan-500/10 text-cyan-100"><?= doctrine_format_quantity((int) ($group['fit_count'] ?? 0)) ?> fits</span>
+                        </div>
+                        <div class="mt-4 grid gap-3 sm:grid-cols-3">
+                            <div class="surface-tertiary">
+                                <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Tracked fits</p>
+                                <p class="mt-2 text-xl font-semibold text-slate-100"><?= doctrine_format_quantity((int) ($group['fit_count'] ?? 0)) ?></p>
+                            </div>
+                            <div class="surface-tertiary">
+                                <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Tracked items</p>
+                                <p class="mt-2 text-xl font-semibold text-slate-100"><?= doctrine_format_quantity((int) ($group['item_count'] ?? 0)) ?></p>
+                            </div>
+                            <div class="surface-tertiary">
+                                <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Last update</p>
+                                <p class="mt-2 text-sm font-medium text-slate-100"><?= htmlspecialchars(killmail_relative_datetime($group['last_fit_updated_at'] ?? null), ENT_QUOTES) ?></p>
+                            </div>
+                        </div>
+                    </a>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </article>
+
+    <aside class="surface-secondary">
+        <div class="section-header">
+            <div>
+                <p class="eyebrow">New group</p>
+                <h2 class="mt-2 section-title">Create doctrine group</h2>
+            </div>
+            <span class="badge border-sky-400/18 bg-sky-500/10 text-sky-100">Lean workflow</span>
+        </div>
+        <form method="post" class="space-y-4">
+            <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
+            <label class="block">
+                <span class="mb-2 block field-label">Group name</span>
+                <input type="text" name="group_name" class="field-input" maxlength="190" placeholder="e.g. Muninn Mainline">
+            </label>
+            <label class="block">
+                <span class="mb-2 block field-label">Description</span>
+                <textarea name="description" class="field-input" style="min-height: 8rem;" placeholder="What this doctrine group covers, when it is used, or who owns the restock workflow."></textarea>
+            </label>
+            <div class="surface-tertiary text-sm text-slate-400">
+                This group becomes the baseline bucket for imported fittings, supply gap reports, and future hauling suggestions.
+            </div>
+            <button type="submit" class="btn-primary w-full justify-center">Save group</button>
+        </form>
+    </aside>
+</section>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/src/db.php
+++ b/src/db.php
@@ -2500,3 +2500,232 @@ function db_killmail_overview_page(array $filters = []): array
         'showing_to' => min($offset + $pageSize, $totalItems),
     ];
 }
+
+function db_ref_item_types_by_names(array $names): array
+{
+    $safeNames = array_values(array_unique(array_filter(array_map(static fn (mixed $name): string => trim((string) $name), $names), static fn (string $name): bool => $name !== '')));
+    if ($safeNames === []) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($safeNames), '?'));
+
+    return db_select(
+        "SELECT type_id, type_name, group_id, market_group_id, description, published, volume
+         FROM ref_item_types
+         WHERE LOWER(type_name) IN ($placeholders)",
+        array_map(static fn (string $name): string => mb_strtolower($name), $safeNames)
+    );
+}
+
+function db_item_name_cache_get_many(array $normalizedNames): array
+{
+    $safeNames = array_values(array_unique(array_filter(array_map(static fn (mixed $name): string => trim((string) $name), $normalizedNames), static fn (string $name): bool => $name !== '')));
+    if ($safeNames === []) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($safeNames), '?'));
+
+    return db_select(
+        "SELECT normalized_name, item_name, type_id, resolution_source, created_at, updated_at
+         FROM item_name_cache
+         WHERE normalized_name IN ($placeholders)",
+        $safeNames
+    );
+}
+
+function db_item_name_cache_upsert(string $normalizedName, string $itemName, ?int $typeId, string $resolutionSource): bool
+{
+    return db_execute(
+        'INSERT INTO item_name_cache (normalized_name, item_name, type_id, resolution_source)
+         VALUES (?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+            item_name = VALUES(item_name),
+            type_id = VALUES(type_id),
+            resolution_source = VALUES(resolution_source),
+            updated_at = CURRENT_TIMESTAMP',
+        [$normalizedName, $itemName, $typeId, $resolutionSource]
+    );
+}
+
+function db_doctrine_groups_all(): array
+{
+    return db_select(
+        'SELECT
+            dg.id,
+            dg.group_name,
+            dg.description,
+            dg.created_at,
+            dg.updated_at,
+            COUNT(DISTINCT df.id) AS fit_count,
+            COALESCE(SUM(df.item_count), 0) AS item_count,
+            MAX(df.updated_at) AS last_fit_updated_at
+         FROM doctrine_groups dg
+         LEFT JOIN doctrine_fits df ON df.doctrine_group_id = dg.id
+         GROUP BY dg.id, dg.group_name, dg.description, dg.created_at, dg.updated_at
+         ORDER BY dg.group_name ASC'
+    );
+}
+
+function db_doctrine_group_by_id(int $groupId): ?array
+{
+    if ($groupId <= 0) {
+        return null;
+    }
+
+    return db_select_one(
+        'SELECT
+            dg.id,
+            dg.group_name,
+            dg.description,
+            dg.created_at,
+            dg.updated_at,
+            COUNT(DISTINCT df.id) AS fit_count,
+            COALESCE(SUM(df.item_count), 0) AS item_count,
+            MAX(df.updated_at) AS last_fit_updated_at
+         FROM doctrine_groups dg
+         LEFT JOIN doctrine_fits df ON df.doctrine_group_id = dg.id
+         WHERE dg.id = ?
+         GROUP BY dg.id, dg.group_name, dg.description, dg.created_at, dg.updated_at
+         LIMIT 1',
+        [$groupId]
+    );
+}
+
+function db_doctrine_group_create(string $groupName, ?string $description = null): int
+{
+    db_execute(
+        'INSERT INTO doctrine_groups (group_name, description) VALUES (?, ?)
+         ON DUPLICATE KEY UPDATE
+            description = COALESCE(VALUES(description), description),
+            id = LAST_INSERT_ID(id),
+            updated_at = CURRENT_TIMESTAMP',
+        [$groupName, $description]
+    );
+
+    return (int) db()->lastInsertId();
+}
+
+function db_doctrine_fits_by_group(int $groupId): array
+{
+    if ($groupId <= 0) {
+        return [];
+    }
+
+    return db_select(
+        'SELECT
+            df.id,
+            df.doctrine_group_id,
+            df.fit_name,
+            df.ship_name,
+            df.ship_type_id,
+            df.source_format,
+            df.item_count,
+            df.unresolved_count,
+            df.created_at,
+            df.updated_at,
+            COALESCE(SUM(dfi.quantity), 0) AS required_quantity,
+            COUNT(dfi.id) AS fit_line_count
+         FROM doctrine_fits df
+         LEFT JOIN doctrine_fit_items dfi ON dfi.doctrine_fit_id = df.id
+         WHERE df.doctrine_group_id = ?
+         GROUP BY df.id, df.doctrine_group_id, df.fit_name, df.ship_name, df.ship_type_id, df.source_format, df.item_count, df.unresolved_count, df.created_at, df.updated_at
+         ORDER BY df.updated_at DESC, df.fit_name ASC',
+        [$groupId]
+    );
+}
+
+function db_doctrine_fit_by_id(int $fitId): ?array
+{
+    if ($fitId <= 0) {
+        return null;
+    }
+
+    return db_select_one(
+        'SELECT df.*, dg.group_name, dg.description AS group_description
+         FROM doctrine_fits df
+         INNER JOIN doctrine_groups dg ON dg.id = df.doctrine_group_id
+         WHERE df.id = ?
+         LIMIT 1',
+        [$fitId]
+    );
+}
+
+function db_doctrine_fit_items_by_fit(int $fitId): array
+{
+    if ($fitId <= 0) {
+        return [];
+    }
+
+    return db_select(
+        'SELECT
+            dfi.id,
+            dfi.doctrine_fit_id,
+            dfi.line_number,
+            dfi.slot_category,
+            dfi.item_name,
+            dfi.type_id,
+            dfi.quantity,
+            dfi.resolution_source,
+            rit.type_name
+         FROM doctrine_fit_items dfi
+         LEFT JOIN ref_item_types rit ON rit.type_id = dfi.type_id
+         WHERE dfi.doctrine_fit_id = ?
+         ORDER BY dfi.line_number ASC, dfi.id ASC',
+        [$fitId]
+    );
+}
+
+function db_doctrine_fit_create(array $fit, array $items): int
+{
+    return db_transaction(function () use ($fit, $items): int {
+        db_execute(
+            'INSERT INTO doctrine_fits (
+                doctrine_group_id,
+                fit_name,
+                ship_name,
+                ship_type_id,
+                source_format,
+                import_body,
+                item_count,
+                unresolved_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                (int) ($fit['doctrine_group_id'] ?? 0),
+                (string) ($fit['fit_name'] ?? ''),
+                (string) ($fit['ship_name'] ?? ''),
+                isset($fit['ship_type_id']) ? (int) $fit['ship_type_id'] : null,
+                (string) ($fit['source_format'] ?? 'buyall'),
+                (string) ($fit['import_body'] ?? ''),
+                (int) ($fit['item_count'] ?? 0),
+                (int) ($fit['unresolved_count'] ?? 0),
+            ]
+        );
+
+        $fitId = (int) db()->lastInsertId();
+
+        if ($items !== []) {
+            $rows = [];
+            foreach ($items as $item) {
+                $rows[] = [
+                    'doctrine_fit_id' => $fitId,
+                    'line_number' => (int) ($item['line_number'] ?? 0),
+                    'slot_category' => (string) ($item['slot_category'] ?? 'Items'),
+                    'item_name' => (string) ($item['item_name'] ?? ''),
+                    'type_id' => isset($item['type_id']) ? (int) $item['type_id'] : null,
+                    'quantity' => max(1, (int) ($item['quantity'] ?? 1)),
+                    'resolution_source' => (string) ($item['resolution_source'] ?? 'ref'),
+                ];
+            }
+
+            db_bulk_insert_or_upsert(
+                'doctrine_fit_items',
+                ['doctrine_fit_id', 'line_number', 'slot_category', 'item_name', 'type_id', 'quantity', 'resolution_source'],
+                $rows
+            );
+        }
+
+        return $fitId;
+    });
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -107,6 +107,15 @@ function nav_items(): array
             ],
         ],
         [
+            'label' => 'Doctrine Fits',
+            'path' => '/doctrine',
+            'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 5h14v14H5z"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 9h6M9 13h6M9 17h4"/></svg>',
+            'children' => [
+                ['label' => 'Doctrine Groups', 'path' => '/doctrine'],
+                ['label' => 'Import Fit', 'path' => '/doctrine/import'],
+            ],
+        ],
+        [
             'label' => 'Settings',
             'path' => '/settings',
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 15.5A3.5 3.5 0 1 0 12 8.5a3.5 3.5 0 0 0 0 7Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6 1.65 1.65 0 0 0-.33 1V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-.33-1 1.65 1.65 0 0 0-1-.6 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-.6-1 1.65 1.65 0 0 0-1-.33H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1-.33 1.65 1.65 0 0 0 .6-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-.6 1.65 1.65 0 0 0 .33-1V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 .33 1 1.65 1.65 0 0 0 1 .6 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9c.3.3.5.68.6 1 .23.1.66.1 1 .1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1 .33c-.44.25-.79.6-1.01 1.07Z"/></svg>',
@@ -6968,4 +6977,801 @@ function sync_killmail_r2z2_stream(string $runMode = 'incremental'): array
         sync_run_finalize_failure($runId, $datasetKey, $runMode, $exception->getMessage());
         throw $exception;
     }
+}
+
+function doctrine_default_group_name(): string
+{
+    return trim((string) get_setting('doctrine.default_group', 'SupplyCore Doctrine')) ?: 'SupplyCore Doctrine';
+}
+
+function doctrine_group_options(): array
+{
+    try {
+        $groups = db_doctrine_groups_all();
+    } catch (Throwable) {
+        $groups = [];
+    }
+
+    if ($groups === []) {
+        return [
+            [
+                'id' => 0,
+                'group_name' => doctrine_default_group_name(),
+                'description' => 'Create your first doctrine group to start importing alliance fits.',
+                'fit_count' => 0,
+                'item_count' => 0,
+                'last_fit_updated_at' => null,
+            ],
+        ];
+    }
+
+    return $groups;
+}
+
+function doctrine_sanitize_group_name(string $name): string
+{
+    $clean = preg_replace('/\s+/', ' ', trim($name));
+    if (!is_string($clean) || $clean === '') {
+        return doctrine_default_group_name();
+    }
+
+    return mb_substr($clean, 0, 190);
+}
+
+function doctrine_sanitize_description(?string $value): ?string
+{
+    $clean = trim((string) $value);
+
+    return $clean === '' ? null : mb_substr($clean, 0, 1000);
+}
+
+function doctrine_normalize_item_name(string $name): string
+{
+    $clean = preg_replace('/\s+/', ' ', trim($name));
+
+    return mb_strtolower((string) $clean);
+}
+
+function doctrine_detect_format(string $text): string
+{
+    foreach (preg_split('/\R/', $text) as $line) {
+        $trimmed = trim((string) $line);
+        if ($trimmed === '') {
+            continue;
+        }
+
+        return preg_match('/^\[[^\],]+\s*,\s*[^\]]+\]$/', $trimmed) === 1 ? 'eft' : 'buyall';
+    }
+
+    return 'buyall';
+}
+
+function doctrine_parse_quantity_and_name(string $line): array
+{
+    $trimmed = preg_replace('/\s+/', ' ', trim($line));
+    if (!is_string($trimmed) || $trimmed === '') {
+        return ['item_name' => '', 'quantity' => 0];
+    }
+
+    if (preg_match('/^(.*?)\s+x\s*(\d+)$/i', $trimmed, $matches) === 1) {
+        return [
+            'item_name' => trim($matches[1]),
+            'quantity' => max(1, (int) $matches[2]),
+        ];
+    }
+
+    if (preg_match('/^(\d+)\s*x\s+(.*?)$/i', $trimmed, $matches) === 1) {
+        return [
+            'item_name' => trim($matches[2]),
+            'quantity' => max(1, (int) $matches[1]),
+        ];
+    }
+
+    if (preg_match('/^(\d+)\s+(.*?)$/', $trimmed, $matches) === 1) {
+        return [
+            'item_name' => trim($matches[2]),
+            'quantity' => max(1, (int) $matches[1]),
+        ];
+    }
+
+    return ['item_name' => $trimmed, 'quantity' => 1];
+}
+
+function doctrine_eft_category_label(int $blockIndex, string $itemName): string
+{
+    $normalized = doctrine_normalize_item_name($itemName);
+
+    if (str_contains($normalized, 'nanite repair paste') || str_contains($normalized, 'mobile depot')) {
+        return 'Cargo';
+    }
+
+    $map = [
+        0 => 'Low Slots',
+        1 => 'Medium Slots',
+        2 => 'High Slots',
+        3 => 'Rig Slots',
+        4 => 'Drone Bay',
+        5 => 'Cargo',
+        6 => 'Implants',
+        7 => 'Boosters',
+        8 => 'Subsystems',
+        9 => 'Service Slots',
+    ];
+
+    return $map[$blockIndex] ?? 'Additional Items';
+}
+
+function doctrine_parse_eft(string $text): array
+{
+    $lines = preg_split('/\R/', $text) ?: [];
+    $header = null;
+    $items = [];
+    $blockIndex = 0;
+    $sawItemInBlock = false;
+
+    foreach ($lines as $rawLine) {
+        $line = trim((string) $rawLine);
+
+        if ($line === '') {
+            if ($sawItemInBlock) {
+                $blockIndex++;
+                $sawItemInBlock = false;
+            }
+            continue;
+        }
+
+        if ($header === null) {
+            if (preg_match('/^\[\s*(.+?)\s*,\s*(.+?)\s*\]$/', $line, $matches) !== 1) {
+                throw new RuntimeException('EFT import must begin with a [Ship, Fit Name] header.');
+            }
+
+            $header = [
+                'ship_name' => trim($matches[1]),
+                'fit_name' => trim($matches[2]),
+            ];
+            continue;
+        }
+
+        if (preg_match('/^\[empty.+slot\]$/i', $line) === 1) {
+            $sawItemInBlock = true;
+            continue;
+        }
+
+        $parsed = doctrine_parse_quantity_and_name($line);
+        $itemName = trim((string) ($parsed['item_name'] ?? ''));
+        if ($itemName === '') {
+            continue;
+        }
+
+        $items[] = [
+            'line_number' => count($items) + 1,
+            'slot_category' => doctrine_eft_category_label($blockIndex, $itemName),
+            'item_name' => $itemName,
+            'quantity' => max(1, (int) ($parsed['quantity'] ?? 1)),
+        ];
+        $sawItemInBlock = true;
+    }
+
+    if ($header === null) {
+        throw new RuntimeException('No EFT header was found in the import payload.');
+    }
+
+    return [
+        'format' => 'eft',
+        'fit_name' => $header['fit_name'],
+        'ship_name' => $header['ship_name'],
+        'items' => $items,
+    ];
+}
+
+function doctrine_parse_buyall(string $text): array
+{
+    $items = [];
+
+    foreach (preg_split('/\R/', $text) ?: [] as $rawLine) {
+        $line = trim((string) $rawLine);
+        if ($line === '') {
+            continue;
+        }
+
+        $parsed = doctrine_parse_quantity_and_name($line);
+        $itemName = trim((string) ($parsed['item_name'] ?? ''));
+        if ($itemName === '') {
+            continue;
+        }
+
+        $items[] = [
+            'line_number' => count($items) + 1,
+            'slot_category' => count($items) === 0 ? 'Hull' : 'Items',
+            'item_name' => $itemName,
+            'quantity' => max(1, (int) ($parsed['quantity'] ?? 1)),
+        ];
+    }
+
+    $shipName = 'Unspecified Hull';
+    $fitName = 'Imported BuyAll List';
+    if ($items !== []) {
+        $shipName = (string) ($items[0]['item_name'] ?? $shipName);
+        $fitName = $shipName . ' BuyAll';
+    }
+
+    return [
+        'format' => 'buyall',
+        'fit_name' => $fitName,
+        'ship_name' => $shipName,
+        'items' => $items,
+    ];
+}
+
+function doctrine_parse_import_text(string $text): array
+{
+    $trimmed = trim($text);
+    if ($trimmed === '') {
+        throw new RuntimeException('Paste an EFT fit or BuyAll list before importing.');
+    }
+
+    return doctrine_detect_format($trimmed) === 'eft'
+        ? doctrine_parse_eft($trimmed)
+        : doctrine_parse_buyall($trimmed);
+}
+
+function doctrine_extract_inventory_type_rows(array $payload): array
+{
+    foreach (['inventory_types', 'inventoryTypes', 'types'] as $key) {
+        $rows = $payload[$key] ?? null;
+        if (is_array($rows)) {
+            return $rows;
+        }
+    }
+
+    return [];
+}
+
+function doctrine_resolve_names_from_esi_ids(array $names): array
+{
+    if ($names === []) {
+        return [];
+    }
+
+    try {
+        $payload = killmail_universe_ids_lookup($names);
+    } catch (Throwable) {
+        return [];
+    }
+
+    $resolved = [];
+    foreach (doctrine_extract_inventory_type_rows($payload) as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+
+        $canonicalName = trim((string) ($row['name'] ?? ''));
+        $typeId = (int) ($row['id'] ?? 0);
+        if ($canonicalName === '' || $typeId <= 0) {
+            continue;
+        }
+
+        $resolved[doctrine_normalize_item_name($canonicalName)] = [
+            'item_name' => $canonicalName,
+            'type_id' => $typeId,
+            'resolution_source' => 'esi',
+        ];
+    }
+
+    return $resolved;
+}
+
+function doctrine_search_inventory_type_esi(string $query): ?array
+{
+    $term = trim($query);
+    if ($term === '') {
+        return null;
+    }
+
+    $context = esi_lookup_context();
+    if (($context['ok'] ?? false) !== true) {
+        return null;
+    }
+
+    $characterId = (int) (($context['token']['character_id'] ?? 0) ?: ($context['token']['characterId'] ?? 0));
+    if ($characterId <= 0) {
+        $token = db_latest_esi_oauth_token();
+        $characterId = (int) ($token['character_id'] ?? 0);
+    }
+    if ($characterId <= 0) {
+        return null;
+    }
+
+    try {
+        $accessToken = esi_valid_access_token();
+        $response = http_get_json(
+            'https://esi.evetech.net/latest/characters/' . $characterId . '/search/?categories=inventory_type&strict=true&search=' . rawurlencode($term),
+            [
+                'Authorization: Bearer ' . $accessToken,
+                'Accept: application/json',
+                'User-Agent: ' . esi_user_agent(),
+            ]
+        );
+    } catch (Throwable) {
+        return null;
+    }
+
+    if ((int) ($response['status'] ?? 500) >= 400) {
+        return null;
+    }
+
+    $ids = array_values(array_filter(array_map('intval', (array) ($response['json']['inventory_type'] ?? [])), static fn (int $id): bool => $id > 0));
+    if ($ids === []) {
+        return null;
+    }
+
+    try {
+        $names = esi_universe_names_lookup($ids);
+    } catch (Throwable) {
+        return null;
+    }
+
+    foreach ($names as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+
+        $name = trim((string) ($row['name'] ?? ''));
+        $id = (int) ($row['id'] ?? 0);
+        if ($id <= 0 || $name === '') {
+            continue;
+        }
+
+        if (doctrine_normalize_item_name($name) !== doctrine_normalize_item_name($term)) {
+            continue;
+        }
+
+        return [
+            'item_name' => $name,
+            'type_id' => $id,
+            'resolution_source' => 'esi',
+        ];
+    }
+
+    return null;
+}
+
+function doctrine_resolve_item_names(array $names): array
+{
+    $unique = [];
+    foreach ($names as $name) {
+        $trimmed = trim((string) $name);
+        if ($trimmed === '') {
+            continue;
+        }
+        $unique[doctrine_normalize_item_name($trimmed)] = $trimmed;
+    }
+
+    if ($unique === []) {
+        return [];
+    }
+
+    $resolved = [];
+
+    try {
+        foreach (db_item_name_cache_get_many(array_keys($unique)) as $row) {
+            $normalized = doctrine_normalize_item_name((string) ($row['normalized_name'] ?? ''));
+            if ($normalized === '') {
+                continue;
+            }
+
+            $resolved[$normalized] = [
+                'item_name' => (string) ($row['item_name'] ?? ($unique[$normalized] ?? '')),
+                'type_id' => isset($row['type_id']) && $row['type_id'] !== null ? (int) $row['type_id'] : null,
+                'resolution_source' => (string) ($row['resolution_source'] ?? 'cache'),
+            ];
+        }
+    } catch (Throwable) {
+        // Cache unavailable; continue to reference tables.
+    }
+
+    $lookupNames = [];
+    foreach ($unique as $normalized => $original) {
+        if (!isset($resolved[$normalized]) || (int) ($resolved[$normalized]['type_id'] ?? 0) <= 0) {
+            $lookupNames[$normalized] = $original;
+        }
+    }
+
+    if ($lookupNames !== []) {
+        try {
+            foreach (db_ref_item_types_by_names(array_values($lookupNames)) as $row) {
+                $normalized = doctrine_normalize_item_name((string) ($row['type_name'] ?? ''));
+                $typeId = (int) ($row['type_id'] ?? 0);
+                if ($normalized === '' || $typeId <= 0) {
+                    continue;
+                }
+
+                $resolved[$normalized] = [
+                    'item_name' => (string) ($row['type_name'] ?? ''),
+                    'type_id' => $typeId,
+                    'resolution_source' => 'ref',
+                ];
+                try {
+                    db_item_name_cache_upsert($normalized, (string) ($row['type_name'] ?? ''), $typeId, 'ref');
+                } catch (Throwable) {
+                    // Ignore cache write failures.
+                }
+                unset($lookupNames[$normalized]);
+            }
+        } catch (Throwable) {
+            // Continue to ESI lookup.
+        }
+    }
+
+    if ($lookupNames !== []) {
+        foreach (doctrine_resolve_names_from_esi_ids(array_values($lookupNames)) as $normalized => $row) {
+            $resolved[$normalized] = $row;
+            try {
+                db_item_name_cache_upsert($normalized, (string) ($row['item_name'] ?? $lookupNames[$normalized] ?? ''), (int) ($row['type_id'] ?? 0), 'esi');
+            } catch (Throwable) {
+                // Ignore cache write failures.
+            }
+            unset($lookupNames[$normalized]);
+        }
+    }
+
+    if ($lookupNames !== []) {
+        foreach ($lookupNames as $normalized => $original) {
+            $found = doctrine_search_inventory_type_esi($original);
+            if ($found !== null) {
+                $resolved[$normalized] = $found;
+                try {
+                    db_item_name_cache_upsert($normalized, (string) $found['item_name'], (int) ($found['type_id'] ?? 0), 'esi');
+                } catch (Throwable) {
+                    // Ignore cache write failures.
+                }
+                continue;
+            }
+
+            $resolved[$normalized] = [
+                'item_name' => $original,
+                'type_id' => null,
+                'resolution_source' => 'missing',
+            ];
+            try {
+                db_item_name_cache_upsert($normalized, $original, null, 'missing');
+            } catch (Throwable) {
+                // Ignore cache write failures.
+            }
+        }
+    }
+
+    return $resolved;
+}
+
+function doctrine_resolve_parsed_fit(array $parsed, string $rawText): array
+{
+    $names = [$parsed['ship_name'] ?? ''];
+    foreach ((array) ($parsed['items'] ?? []) as $item) {
+        $names[] = (string) ($item['item_name'] ?? '');
+    }
+
+    $resolvedLookup = doctrine_resolve_item_names($names);
+    $shipKey = doctrine_normalize_item_name((string) ($parsed['ship_name'] ?? ''));
+    $shipResolved = $resolvedLookup[$shipKey] ?? [
+        'item_name' => (string) ($parsed['ship_name'] ?? ''),
+        'type_id' => null,
+        'resolution_source' => 'missing',
+    ];
+
+    $resolvedItems = [];
+    $unresolvedItems = [];
+    foreach ((array) ($parsed['items'] ?? []) as $item) {
+        $itemKey = doctrine_normalize_item_name((string) ($item['item_name'] ?? ''));
+        $resolved = $resolvedLookup[$itemKey] ?? [
+            'item_name' => (string) ($item['item_name'] ?? ''),
+            'type_id' => null,
+            'resolution_source' => 'missing',
+        ];
+
+        $resolvedItem = [
+            'line_number' => (int) ($item['line_number'] ?? count($resolvedItems) + 1),
+            'slot_category' => (string) ($item['slot_category'] ?? 'Items'),
+            'item_name' => (string) ($resolved['item_name'] ?? ($item['item_name'] ?? '')),
+            'type_id' => isset($resolved['type_id']) && $resolved['type_id'] !== null ? (int) $resolved['type_id'] : null,
+            'quantity' => max(1, (int) ($item['quantity'] ?? 1)),
+            'resolution_source' => (string) ($resolved['resolution_source'] ?? 'missing'),
+        ];
+
+        if (($resolvedItem['type_id'] ?? null) === null) {
+            $unresolvedItems[] = $resolvedItem['item_name'];
+        }
+
+        $resolvedItems[] = $resolvedItem;
+    }
+
+    $fitName = trim((string) ($parsed['fit_name'] ?? ''));
+    if ($fitName === '') {
+        $fitName = trim((string) ($shipResolved['item_name'] ?? $parsed['ship_name'] ?? 'Imported Doctrine Fit'));
+    }
+
+    return [
+        'fit' => [
+            'fit_name' => mb_substr($fitName, 0, 190),
+            'ship_name' => trim((string) ($shipResolved['item_name'] ?? $parsed['ship_name'] ?? 'Unknown Hull')),
+            'ship_type_id' => isset($shipResolved['type_id']) && $shipResolved['type_id'] !== null ? (int) $shipResolved['type_id'] : null,
+            'source_format' => (string) ($parsed['format'] ?? doctrine_detect_format($rawText)),
+            'import_body' => $rawText,
+            'item_count' => count($resolvedItems),
+            'unresolved_count' => count($unresolvedItems) + ((int) ($shipResolved['type_id'] ?? 0) > 0 ? 0 : 1),
+        ],
+        'items' => $resolvedItems,
+        'ship' => $shipResolved,
+        'unresolved' => array_values(array_unique(array_filter(array_merge(
+            (int) ($shipResolved['type_id'] ?? 0) > 0 ? [] : [trim((string) ($shipResolved['item_name'] ?? $parsed['ship_name'] ?? 'Unknown Hull'))],
+            $unresolvedItems
+        )))),
+    ];
+}
+
+function doctrine_resolve_group_id_from_request(array $post): int
+{
+    $existingGroupId = max(0, (int) ($post['group_id'] ?? 0));
+    $newGroupName = doctrine_sanitize_group_name((string) ($post['new_group_name'] ?? ''));
+    $newGroupDescription = doctrine_sanitize_description($post['new_group_description'] ?? null);
+
+    if ($existingGroupId > 0 && trim((string) ($post['new_group_name'] ?? '')) === '') {
+        return $existingGroupId;
+    }
+
+    try {
+        return db_doctrine_group_create($newGroupName, $newGroupDescription);
+    } catch (Throwable) {
+        return $existingGroupId;
+    }
+}
+
+function doctrine_import_fit_from_request(array $post): array
+{
+    $rawText = trim((string) ($post['fit_payload'] ?? ''));
+    if ($rawText === '') {
+        return ['ok' => false, 'message' => 'Paste a doctrine fit payload before importing.'];
+    }
+
+    $groupId = doctrine_resolve_group_id_from_request($post);
+    if ($groupId <= 0) {
+        return ['ok' => false, 'message' => 'Select an existing doctrine group or enter a new group name.'];
+    }
+
+    try {
+        $parsed = doctrine_parse_import_text($rawText);
+        $resolved = doctrine_resolve_parsed_fit($parsed, $rawText);
+    } catch (Throwable $exception) {
+        return ['ok' => false, 'message' => $exception->getMessage()];
+    }
+
+    if (($resolved['unresolved'] ?? []) !== []) {
+        return [
+            'ok' => false,
+            'message' => 'Unable to resolve all items to real EVE types. Resolve these names first: ' . implode(', ', array_slice((array) $resolved['unresolved'], 0, 12)),
+            'parsed' => $parsed,
+            'resolved' => $resolved,
+        ];
+    }
+
+    $fit = (array) ($resolved['fit'] ?? []);
+    $fit['doctrine_group_id'] = $groupId;
+
+    try {
+        $fitId = db_doctrine_fit_create($fit, (array) ($resolved['items'] ?? []));
+    } catch (Throwable $exception) {
+        return ['ok' => false, 'message' => 'Doctrine fit import failed: ' . $exception->getMessage()];
+    }
+
+    return [
+        'ok' => true,
+        'message' => 'Doctrine fit imported successfully.',
+        'fit_id' => $fitId,
+        'group_id' => $groupId,
+        'parsed' => $parsed,
+        'resolved' => $resolved,
+    ];
+}
+
+function doctrine_ship_image_url(?int $typeId, int $size = 128): ?string
+{
+    $safeTypeId = max(0, (int) $typeId);
+    if ($safeTypeId <= 0) {
+        return null;
+    }
+
+    $safeSize = max(32, min(512, $size));
+
+    return 'https://images.evetech.net/types/' . $safeTypeId . '/icon?size=' . $safeSize;
+}
+
+function doctrine_format_quantity(int $value): string
+{
+    return number_format(max(0, $value));
+}
+
+function doctrine_fit_item_market_rows(array $items): array
+{
+    $typeIds = [];
+    foreach ($items as $item) {
+        $typeId = (int) ($item['type_id'] ?? 0);
+        if ($typeId > 0) {
+            $typeIds[] = $typeId;
+        }
+    }
+
+    $comparisonRows = market_comparison_outcomes($typeIds)['rows'] ?? [];
+    $comparisonByTypeId = [];
+    foreach ($comparisonRows as $row) {
+        $typeId = (int) ($row['type_id'] ?? 0);
+        if ($typeId > 0) {
+            $comparisonByTypeId[$typeId] = $row;
+        }
+    }
+
+    $rows = [];
+    foreach ($items as $item) {
+        $typeId = (int) ($item['type_id'] ?? 0);
+        $market = $comparisonByTypeId[$typeId] ?? [];
+        $requiredQty = max(1, (int) ($item['quantity'] ?? 1));
+        $localQty = max(0, (int) ($market['alliance_total_sell_volume'] ?? 0));
+        $missingQty = max(0, $requiredQty - $localQty);
+        $coverageRatio = $requiredQty > 0 ? ($localQty / $requiredQty) : 0.0;
+        $status = $missingQty <= 0 ? 'ok' : ($coverageRatio >= 0.5 ? 'low' : 'missing');
+
+        $rows[] = $item + [
+            'local_available_qty' => $localQty,
+            'missing_qty' => $missingQty,
+            'local_price' => isset($market['alliance_best_sell_price']) ? (float) $market['alliance_best_sell_price'] : null,
+            'hub_price' => isset($market['reference_best_sell_price']) ? (float) $market['reference_best_sell_price'] : null,
+            'market_status' => $status,
+            'market_label' => match ($status) {
+                'ok' => 'Stock OK',
+                'low' => 'Low',
+                default => 'Missing',
+            },
+            'observed_at' => $market['alliance_last_observed_at'] ?? null,
+        ];
+    }
+
+    return $rows;
+}
+
+function doctrine_category_sort_order(string $category): int
+{
+    $map = [
+        'Hull' => 5,
+        'Low Slots' => 10,
+        'Medium Slots' => 20,
+        'High Slots' => 30,
+        'Rig Slots' => 40,
+        'Subsystems' => 50,
+        'Service Slots' => 60,
+        'Drone Bay' => 70,
+        'Cargo' => 80,
+        'Implants' => 90,
+        'Boosters' => 100,
+        'Items' => 110,
+        'Additional Items' => 120,
+    ];
+
+    return $map[$category] ?? 999;
+}
+
+function doctrine_group_market_rows_by_category(array $items): array
+{
+    $categories = [];
+    foreach (doctrine_fit_item_market_rows($items) as $row) {
+        $category = trim((string) ($row['slot_category'] ?? 'Items'));
+        if ($category === '') {
+            $category = 'Items';
+        }
+
+        $categories[$category][] = $row;
+    }
+
+    uksort($categories, static function (string $a, string $b): int {
+        return doctrine_category_sort_order($a) <=> doctrine_category_sort_order($b) ?: strcasecmp($a, $b);
+    });
+
+    return $categories;
+}
+
+function doctrine_groups_overview_data(): array
+{
+    $groups = doctrine_group_options();
+    $fitCount = 0;
+    $itemCount = 0;
+    foreach ($groups as $group) {
+        $fitCount += (int) ($group['fit_count'] ?? 0);
+        $itemCount += (int) ($group['item_count'] ?? 0);
+    }
+
+    return [
+        'summary' => [
+            ['label' => 'Doctrine Groups', 'value' => (string) count($groups), 'context' => 'Organized doctrine collections ready for market mapping'],
+            ['label' => 'Imported Fits', 'value' => (string) $fitCount, 'context' => 'Alliance fit payloads normalized and stored'],
+            ['label' => 'Tracked Items', 'value' => (string) $itemCount, 'context' => 'Doctrine lines prepared for gap detection'],
+            ['label' => 'Baseline Goal', 'value' => 'Ready', 'context' => 'Restock, hauling, and supply-gap workflows'],
+        ],
+        'groups' => $groups,
+    ];
+}
+
+function doctrine_group_detail_data(int $groupId): array
+{
+    try {
+        $group = db_doctrine_group_by_id($groupId);
+        $fits = db_doctrine_fits_by_group($groupId);
+    } catch (Throwable) {
+        $group = null;
+        $fits = [];
+    }
+
+    if ($group === null) {
+        return ['group' => null, 'fits' => []];
+    }
+
+    foreach ($fits as &$fit) {
+        $requiredQty = max(0, (int) ($fit['required_quantity'] ?? 0));
+        $fit['required_quantity_label'] = doctrine_format_quantity($requiredQty);
+        $fit['ship_image_url'] = doctrine_ship_image_url(isset($fit['ship_type_id']) ? (int) $fit['ship_type_id'] : null, 64);
+    }
+    unset($fit);
+
+    return ['group' => $group, 'fits' => $fits];
+}
+
+function doctrine_fit_detail_view_model(int $fitId): array
+{
+    try {
+        $fit = db_doctrine_fit_by_id($fitId);
+        $items = db_doctrine_fit_items_by_fit($fitId);
+    } catch (Throwable) {
+        $fit = null;
+        $items = [];
+    }
+
+    if ($fit === null) {
+        return ['fit' => null, 'categories' => [], 'summary' => []];
+    }
+
+    $categories = doctrine_group_market_rows_by_category($items);
+    $totalRequired = 0;
+    $totalLocal = 0;
+    $missingLines = 0;
+    $okLines = 0;
+
+    foreach ($categories as &$rows) {
+        foreach ($rows as &$row) {
+            $totalRequired += max(1, (int) ($row['quantity'] ?? 1));
+            $totalLocal += max(0, (int) ($row['local_available_qty'] ?? 0));
+            if ((int) ($row['missing_qty'] ?? 0) > 0) {
+                $missingLines++;
+            } else {
+                $okLines++;
+            }
+
+            $row['required_qty_label'] = doctrine_format_quantity((int) ($row['quantity'] ?? 1));
+            $row['local_available_qty_label'] = doctrine_format_quantity((int) ($row['local_available_qty'] ?? 0));
+            $row['missing_qty_label'] = doctrine_format_quantity((int) ($row['missing_qty'] ?? 0));
+            $row['local_price_label'] = market_format_isk(isset($row['local_price']) ? (float) $row['local_price'] : null);
+            $row['hub_price_label'] = market_format_isk(isset($row['hub_price']) ? (float) $row['hub_price'] : null);
+        }
+        unset($row);
+    }
+    unset($rows);
+
+    $fit['ship_image_url'] = doctrine_ship_image_url(isset($fit['ship_type_id']) ? (int) $fit['ship_type_id'] : null, 256);
+
+    return [
+        'fit' => $fit,
+        'categories' => $categories,
+        'summary' => [
+            ['label' => 'Required Units', 'value' => doctrine_format_quantity($totalRequired), 'context' => 'Doctrine demand to satisfy one complete fit'],
+            ['label' => 'Local Units', 'value' => doctrine_format_quantity($totalLocal), 'context' => 'Alliance market quantity available right now'],
+            ['label' => 'Missing Lines', 'value' => doctrine_format_quantity($missingLines), 'context' => 'Immediate supply gaps to restock or haul'],
+            ['label' => 'Stock OK Lines', 'value' => doctrine_format_quantity($okLines), 'context' => 'Lines already covered in alliance stock'],
+        ],
+    ];
 }


### PR DESCRIPTION
### Motivation

- Provide a baseline Doctrine system to import alliance fittings (EFT / BuyAll), normalize them, resolve items to real EVE types, and map doctrine demand against alliance and reference hub markets for gap detection and restock workflows.
- Keep logic centralized in the existing DB and helper layers so imports, resolution, caching, and market mapping are reusable across pages.

### Description

- Schema: add `item_name_cache`, `doctrine_groups`, `doctrine_fits`, and `doctrine_fit_items` and seed a default doctrine group and a `doctrine.default_group` setting in `database/schema.sql`.
- DB helpers: add reusable DB functions in `src/db.php` for item-name cache and doctrine CRUD (`db_item_name_cache_*`, `db_ref_item_types_by_names`, `db_doctrine_*`, etc.).
- Parsing & resolution: implement robust EFT and BuyAll parsers and normalization rules in `src/functions.php` (format auto-detection, `xN` quantity support, empty-line handling, hull detection), plus name-resolution pipeline that consults `item_name_cache`, local `ref_item_types`, and falls back to ESI lookups and caching (`doctrine_parse_*`, `doctrine_resolve_item_names`, `doctrine_resolve_parsed_fit`).
- Import flow and storage: add `doctrine_import_fit_from_request()` and transactional storage that writes `doctrine_fits` and `doctrine_fit_items` only when items resolve cleanly.
- Market mapping & UI model: implement mapping of fit items to alliance vs reference hub market aggregates and produce per-item rows with required/local/missing quantities, hub/local prices and status indicators (green/yellow/red) in `src/functions.php` helpers (`doctrine_fit_item_market_rows`, category grouping, and view models).
- UI: add pages and routes under `public/doctrine/` — Groups overview (`index.php`), Import (`import.php`), Group detail (`group.php`), and Fit detail (`fit.php`) — and wire navigation via `nav_items()` in `src/functions.php`.
- Docs: update `README.md` to document the new doctrine surface.

### Testing

- Syntax checks: ran `php -l` on `src/db.php`, `src/functions.php`, and the new pages (`public/doctrine/*.php`) and all returned no syntax errors.
- Parser unit checks (manual CLI smoke tests): ran `doctrine_parse_import_text()` via `php -r` on both an EFT sample and a BuyAll sample and received the expected parsed JSON output (format, ship, and normalized items with quantities).
- Local server smoke tests: started PHP dev server and exercised the new pages with `curl` (HTTP 200 OK for `/doctrine`, `/doctrine/import`, `/doctrine/group?group_id=1`, `/doctrine/fit?fit_id=1`).
- All above automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baab09cc40832f8826b6e4ca570eda)