### PR TITLE
Fix dashboard alliance structure helper

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -1394,7 +1394,7 @@ function dashboard_intelligence_data(): array
     usort($risks, static fn (array $a, array $b): int => (($b['risk_score'] ?? 0) <=> ($a['risk_score'] ?? 0)) ?: (($b['stock_score'] ?? 0) <=> ($a['stock_score'] ?? 0)));
 
     $marketHubRef = market_hub_setting_reference();
-    $allianceStructureId = selected_alliance_structure_id();
+    $allianceStructureId = configured_alliance_structure_id();
     $allianceSync = $allianceStructureId !== null
         ? sync_status_for_dataset_keys([sync_dataset_key_alliance_structure_orders_current($allianceStructureId)])
         : ['states' => [], 'runs' => [], 'last_success_at' => null, 'last_error_message' => null, 'recent_rows_written' => 0];


### PR DESCRIPTION
### Motivation
- Replace the undefined `selected_alliance_structure_id()` used in dashboard assembly which triggered a fatal error and align with the repository's centralized helper conventions.

### Description
- Swap the call in `dashboard_intelligence_data()` from `selected_alliance_structure_id()` to `configured_alliance_structure_id()` in `src/functions.php` so the dashboard reads the configured alliance structure consistently.

### Testing
- Ran `php -l src/functions.php` to validate syntax and it reported no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babd328de8832fb3ac55ce63d06e6e)