### PR TITLE
Fix doctrine schema transaction handling

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -2587,42 +2587,40 @@ function doctrine_db_ensure_schema(): void
         return;
     }
 
-    db_transaction(static function (): void {
-        if (db_table_exists('doctrine_fits') && db_column_exists('doctrine_fits', 'doctrine_group_id')) {
-            $column = db_select_one(
-                'SELECT IS_NULLABLE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1',
-                ['doctrine_fits', 'doctrine_group_id']
-            );
-            if (strtoupper((string) ($column['IS_NULLABLE'] ?? 'NO')) !== 'YES') {
-                db()->exec('ALTER TABLE doctrine_fits MODIFY doctrine_group_id INT UNSIGNED DEFAULT NULL');
-            }
-
-            $deleteRule = db_foreign_key_delete_rule('fk_doctrine_fits_group');
-            if ($deleteRule !== null && $deleteRule !== 'SET NULL') {
-                db()->exec('ALTER TABLE doctrine_fits DROP FOREIGN KEY fk_doctrine_fits_group');
-                db()->exec('ALTER TABLE doctrine_fits ADD CONSTRAINT fk_doctrine_fits_group FOREIGN KEY (doctrine_group_id) REFERENCES doctrine_groups(id) ON DELETE SET NULL');
-            }
+    if (db_table_exists('doctrine_fits') && db_column_exists('doctrine_fits', 'doctrine_group_id')) {
+        $column = db_select_one(
+            'SELECT IS_NULLABLE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1',
+            ['doctrine_fits', 'doctrine_group_id']
+        );
+        if (strtoupper((string) ($column['IS_NULLABLE'] ?? 'NO')) !== 'YES') {
+            db()->exec('ALTER TABLE doctrine_fits MODIFY doctrine_group_id INT UNSIGNED DEFAULT NULL');
         }
 
-        db()->exec(
-            'CREATE TABLE IF NOT EXISTS doctrine_fit_groups (
-                doctrine_fit_id INT UNSIGNED NOT NULL,
-                doctrine_group_id INT UNSIGNED NOT NULL,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (doctrine_fit_id, doctrine_group_id),
-                KEY idx_doctrine_fit_groups_group (doctrine_group_id),
-                CONSTRAINT fk_doctrine_fit_groups_fit FOREIGN KEY (doctrine_fit_id) REFERENCES doctrine_fits(id) ON DELETE CASCADE,
-                CONSTRAINT fk_doctrine_fit_groups_group FOREIGN KEY (doctrine_group_id) REFERENCES doctrine_groups(id) ON DELETE CASCADE
-            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
-        );
+        $deleteRule = db_foreign_key_delete_rule('fk_doctrine_fits_group');
+        if ($deleteRule !== null && $deleteRule !== 'SET NULL') {
+            db()->exec('ALTER TABLE doctrine_fits DROP FOREIGN KEY fk_doctrine_fits_group');
+            db()->exec('ALTER TABLE doctrine_fits ADD CONSTRAINT fk_doctrine_fits_group FOREIGN KEY (doctrine_group_id) REFERENCES doctrine_groups(id) ON DELETE SET NULL');
+        }
+    }
 
-        db()->exec(
-            'INSERT IGNORE INTO doctrine_fit_groups (doctrine_fit_id, doctrine_group_id)
-             SELECT id, doctrine_group_id
-             FROM doctrine_fits
-             WHERE doctrine_group_id IS NOT NULL'
-        );
-    });
+    db()->exec(
+        'CREATE TABLE IF NOT EXISTS doctrine_fit_groups (
+            doctrine_fit_id INT UNSIGNED NOT NULL,
+            doctrine_group_id INT UNSIGNED NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (doctrine_fit_id, doctrine_group_id),
+            KEY idx_doctrine_fit_groups_group (doctrine_group_id),
+            CONSTRAINT fk_doctrine_fit_groups_fit FOREIGN KEY (doctrine_fit_id) REFERENCES doctrine_fits(id) ON DELETE CASCADE,
+            CONSTRAINT fk_doctrine_fit_groups_group FOREIGN KEY (doctrine_group_id) REFERENCES doctrine_groups(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+    );
+
+    db()->exec(
+        'INSERT IGNORE INTO doctrine_fit_groups (doctrine_fit_id, doctrine_group_id)
+         SELECT id, doctrine_group_id
+         FROM doctrine_fits
+         WHERE doctrine_group_id IS NOT NULL'
+    );
 
     $ensured = true;
 }


### PR DESCRIPTION
### Motivation
- Running DDL inside `db_transaction()` for doctrine schema bootstrapping could trigger MySQL implicit commits and leave the transaction wrapper with no active transaction, leading to `There is no active transaction` when saving doctrine groups.
- The schema bootstrapping must run without interfering with higher-level transactional flows while preserving idempotent migration and backfill behavior.

### Description
- Remove the `db_transaction(...)` wrapper around the schema migration, DDL, and backfill logic in `doctrine_db_ensure_schema()` in `src/db.php`.
- Keep all existing schema checks and operations intact, including the `ALTER TABLE` adjustments for `doctrine_fits`, foreign key fixup, `CREATE TABLE IF NOT EXISTS doctrine_fit_groups`, and the `INSERT IGNORE` backfill from `doctrine_fits`.
- This ensures implicit commits from DDL do not clobber an outer transaction while preserving the original bootstrapping behavior.

### Testing
- Ran PHP syntax checks with `php -l src/db.php` and `php -l public/doctrine/index.php`, and both checks succeeded.
- No additional automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bacef55128832f9a4645d9ac36b513)