### PR TITLE
Include resolved ship hull as tracked item for doctrine imports

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -8007,12 +8007,22 @@ function doctrine_resolve_parsed_fit(array $parsed, string $rawText): array
         $resolvedItems[] = $resolvedItem;
     }
 
+    $resolvedItems = doctrine_ensure_hull_item(
+        $resolvedItems,
+        $shipResolved,
+        (string) ($parsed['ship_name'] ?? '')
+    );
+
     $fitName = trim((string) ($parsed['fit_name'] ?? ''));
     if ($fitName === '') {
         $fitName = trim((string) ($shipResolved['item_name'] ?? $parsed['ship_name'] ?? 'Imported Doctrine Fit'));
     }
 
     $shipMissing = (int) ($shipResolved['type_id'] ?? 0) <= 0;
+    $unresolved = array_values(array_unique(array_filter(array_merge(
+        $shipMissing ? [trim((string) ($shipResolved['item_name'] ?? $parsed['ship_name'] ?? 'Unknown Hull'))] : [],
+        $unresolvedItems
+    ))));
 
     return [
         'fit' => [
@@ -8022,16 +8032,65 @@ function doctrine_resolve_parsed_fit(array $parsed, string $rawText): array
             'source_format' => (string) ($parsed['format'] ?? doctrine_detect_format($rawText)),
             'import_body' => $rawText,
             'item_count' => count($resolvedItems),
-            'unresolved_count' => count($unresolvedItems) + ($shipMissing ? 1 : 0),
+            'unresolved_count' => count($unresolved),
         ],
         'items' => $resolvedItems,
         'ship' => $shipResolved,
-        'unresolved' => array_values(array_unique(array_filter(array_merge(
-            $shipMissing ? [trim((string) ($shipResolved['item_name'] ?? $parsed['ship_name'] ?? 'Unknown Hull'))] : [],
-            $unresolvedItems
-        )))),
+        'unresolved' => $unresolved,
         'ship_missing' => $shipMissing,
     ];
+}
+
+function doctrine_ensure_hull_item(array $items, array $shipResolved, string $fallbackShipName = ''): array
+{
+    $shipName = trim((string) ($shipResolved['item_name'] ?? $fallbackShipName));
+    if ($shipName === '') {
+        return $items;
+    }
+
+    $shipKey = doctrine_normalize_item_name($shipName);
+    $shipTypeId = isset($shipResolved['type_id']) && $shipResolved['type_id'] !== null ? (int) $shipResolved['type_id'] : null;
+    $hullIndex = null;
+
+    foreach ($items as $index => $item) {
+        $itemKey = doctrine_normalize_item_name((string) ($item['item_name'] ?? ''));
+        $itemTypeId = isset($item['type_id']) && $item['type_id'] !== null ? (int) $item['type_id'] : null;
+
+        if (($shipTypeId !== null && $itemTypeId === $shipTypeId) || ($shipKey !== '' && $itemKey === $shipKey)) {
+            $hullIndex = $index;
+            break;
+        }
+    }
+
+    if ($hullIndex === null) {
+        array_unshift($items, [
+            'line_number' => 1,
+            'slot_category' => 'Hull',
+            'item_name' => $shipName,
+            'type_id' => $shipTypeId,
+            'quantity' => 1,
+            'resolution_source' => (string) ($shipResolved['resolution_source'] ?? 'missing'),
+        ]);
+    } else {
+        $items[$hullIndex]['slot_category'] = 'Hull';
+        $items[$hullIndex]['item_name'] = $shipName;
+        $items[$hullIndex]['type_id'] = $shipTypeId;
+        $items[$hullIndex]['quantity'] = max(1, (int) ($items[$hullIndex]['quantity'] ?? 1));
+        $items[$hullIndex]['resolution_source'] = (string) ($items[$hullIndex]['resolution_source'] ?? ($shipResolved['resolution_source'] ?? 'missing'));
+
+        if ($hullIndex !== 0) {
+            $hullItem = $items[$hullIndex];
+            array_splice($items, $hullIndex, 1);
+            array_unshift($items, $hullItem);
+        }
+    }
+
+    foreach ($items as $index => &$item) {
+        $item['line_number'] = $index + 1;
+    }
+    unset($item);
+
+    return $items;
 }
 
 function doctrine_selected_group_ids(array $post): array


### PR DESCRIPTION
### Motivation
- EFT imports resolved the ship type but did not always add the hull to the fit item list, leaving hulls untracked for supply/gap calculations.
- Ensure doctrine fit drafts consistently include the hull as a `Hull` line so supply summaries, group suggestions, and item counts are correct.

### Description
- Added a helper `doctrine_ensure_hull_item()` that inserts or normalizes a hull item row, forces its `slot_category` to `Hull`, moves it to the front when present elsewhere, and re-sequences `line_number` values. (`src/functions.php`)
- Hooked the helper into the fit resolution flow by calling it after resolving parsed items in `doctrine_resolve_parsed_fit()` so EFT/BuyAll imports always include the hull in `items` returned by the resolver. (`src/functions.php`)
- Changed unresolved-name counting to deduplicate the hull name so an unresolved hull is counted only once in `fit.unresolved` and `fit.unresolved_count`. (`src/functions.php`)

### Testing
- Ran syntax check with `php -l src/functions.php` which returned no errors. (passed)
- Executed a functional import/resolution smoke test with `php -r 'require "src/functions.php"; $parsed = doctrine_parse_import_text("[Scimitar, Test Fit]\nDamage Control II\n\nLarge Shield Extender II"); $resolved = doctrine_resolve_parsed_fit($parsed, "[Scimitar, Test Fit]\nDamage Control II\n\nLarge Shield Extender II"); foreach ($resolved["items"] as $item) { echo $item["line_number"]."|".$item["slot_category"]."|".$item["item_name"]."|".$item["quantity"].PHP_EOL; } echo "item_count=".$resolved["fit"]["item_count"].PHP_EOL;'` which showed the hull at line 1 with category `Hull` and updated `item_count`. (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bad14dd81c832f9cc7188d8ca7d537)