### PR TITLE
Refactor item scope: add categoryID and operational filtering model

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -405,6 +405,7 @@ CREATE TABLE IF NOT EXISTS ref_meta_groups (
 
 CREATE TABLE IF NOT EXISTS ref_item_types (
     type_id INT UNSIGNED PRIMARY KEY,
+    category_id INT UNSIGNED NOT NULL,
     group_id INT UNSIGNED NOT NULL,
     market_group_id INT UNSIGNED DEFAULT NULL,
     meta_group_id INT UNSIGNED DEFAULT NULL,
@@ -414,6 +415,7 @@ CREATE TABLE IF NOT EXISTS ref_item_types (
     volume DECIMAL(20,6) DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_category_id (category_id),
     KEY idx_group_id (group_id),
     KEY idx_market_group_id (market_group_id),
     KEY idx_meta_group_id (meta_group_id),
@@ -520,7 +522,10 @@ INSERT INTO app_settings (setting_key, setting_value) VALUES
     ('market_compare_deviation_percent', '5'),
     ('market_compare_min_alliance_sell_volume', '50'),
     ('market_compare_min_alliance_sell_orders', '3'),
-    ('item_scope_mode', 'allow_all'),
+    ('item_scope_mode', 'allow_list'),
+    ('item_scope_operational_category_keys', '["ships","modules","rigs","ammo_charges","drones_fighters","fuel_structures","boosters"]'),
+    ('item_scope_tier_meta_group_ids', '[1,2]'),
+    ('item_scope_noise_filter_keys', '["exclude_commodities_consumer_goods","exclude_civilian_items","exclude_blueprints","exclude_skins","exclude_non_market_mission_items"]'),
     ('item_scope_include_category_ids', '[]'),
     ('item_scope_exclude_category_ids', '[]'),
     ('item_scope_include_group_ids', '[]'),

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -516,6 +516,9 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 $itemScopeConfig = $itemScope['config'] ?? item_scope_default_config();
                 $itemScopeCatalog = $itemScope['catalog'] ?? ['categories' => [], 'groups' => [], 'market_groups' => [], 'meta_groups' => []];
                 $itemScopeStats = $itemScope['stats'] ?? ['published_count' => 0, 'in_scope_count' => 0, 'excluded_count' => 0];
+                $operationalRows = $itemScope['operational_rows'] ?? [];
+                $tierRows = $itemScope['tier_rows'] ?? [];
+                $noiseRows = $itemScope['noise_rows'] ?? [];
                 $includeOverridesText = implode("\n", array_map(
                     static fn (array $row): string => (string) ((int) ($row['type_id'] ?? 0)) . ' | ' . (string) ($row['type_name'] ?? ('Type #' . (int) ($row['type_id'] ?? 0))),
                     (array) (($itemScope['override_rows']['include'] ?? []))
@@ -529,22 +532,22 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <div class="rounded-2xl border border-white/8 bg-white/[0.03] p-4">
                     <p class="text-xs uppercase tracking-[0.16em] text-muted">Published Types</p>
                     <p class="mt-2 text-2xl font-semibold text-slate-50"><?= number_format((int) ($itemScopeStats['published_count'] ?? 0)) ?></p>
-                    <p class="mt-1 text-sm text-muted">Local reference items available for scope evaluation.</p>
+                    <p class="mt-1 text-sm text-muted">Reference inventory available to the shared item-scope service.</p>
                 </div>
                 <div class="rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-4">
                     <p class="text-xs uppercase tracking-[0.16em] text-emerald-200/80">Currently In Scope</p>
                     <p class="mt-2 text-2xl font-semibold text-emerald-100"><?= number_format((int) ($itemScopeStats['in_scope_count'] ?? 0)) ?></p>
-                    <p class="mt-1 text-sm text-emerald-100/70">Used by market comparison, doctrine readiness, and loss-demand signals.</p>
+                    <p class="mt-1 text-sm text-emerald-100/70">Shared across doctrine readiness, market gaps, dashboard summaries, and killmail demand.</p>
                 </div>
                 <div class="rounded-2xl border border-amber-500/20 bg-amber-500/10 p-4">
                     <p class="text-xs uppercase tracking-[0.16em] text-amber-200/80">Filtered Out</p>
                     <p class="mt-2 text-2xl font-semibold text-amber-100"><?= number_format((int) ($itemScopeStats['excluded_count'] ?? 0)) ?></p>
-                    <p class="mt-1 text-sm text-amber-100/70">Ignored unless re-enabled by explicit item override.</p>
+                    <p class="mt-1 text-sm text-amber-100/70">Removed by the operational allow-list, tier controls, noise filters, or explicit overrides.</p>
                 </div>
             </div>
 
             <div class="mt-6 rounded-2xl border border-white/8 bg-white/[0.03] p-4">
-                <h3 class="text-sm font-semibold text-slate-100">Current Rule Summary</h3>
+                <h3 class="text-sm font-semibold text-slate-100">Operational Summary</h3>
                 <ul class="mt-3 space-y-2 text-sm text-muted">
                     <?php foreach ((array) ($itemScope['summary_lines'] ?? []) as $line): ?>
                         <li>• <?= htmlspecialchars((string) $line, ENT_QUOTES) ?></li>
@@ -556,106 +559,181 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
                 <input type="hidden" name="section" value="item-scope">
 
-                <div class="grid gap-4 lg:grid-cols-2">
+                <div class="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
                     <label class="rounded-2xl border border-white/8 bg-white/[0.03] p-4">
                         <span class="text-sm font-medium text-slate-100">Scope Mode</span>
                         <select name="item_scope_mode" class="mt-3 w-full field-input">
-                            <option value="allow_all" <?= ($itemScopeConfig['mode'] ?? 'allow_all') === 'allow_all' ? 'selected' : '' ?>>Allow all published items, then exclude noise</option>
-                            <option value="allow_list" <?= ($itemScopeConfig['mode'] ?? 'allow_all') === 'allow_list' ? 'selected' : '' ?>>Only include selected classes</option>
+                            <option value="allow_list" <?= ($itemScopeConfig['mode'] ?? 'allow_list') === 'allow_list' ? 'selected' : '' ?>>Alliance logistics allow-list</option>
+                            <option value="allow_all" <?= ($itemScopeConfig['mode'] ?? 'allow_list') === 'allow_all' ? 'selected' : '' ?>>Allow all published items, then apply shared exclusions</option>
                         </select>
-                        <p class="mt-2 text-xs text-muted">If you choose opt-in mode, an item must match at least one broad include rule unless it is explicitly re-enabled by override.</p>
+                        <p class="mt-2 text-xs text-muted">Allow-list mode is the recommended default: it keeps the scope centered on operational categories instead of the full SDE universe.</p>
                     </label>
 
                     <div class="rounded-2xl border border-white/8 bg-white/[0.03] p-4 text-sm text-muted">
                         <p class="font-medium text-slate-100">Rule precedence</p>
-                        <ol class="mt-3 space-y-2 list-decimal pl-5">
-                            <li>Explicit item overrides win.</li>
-                            <li>Broad excludes remove matching categories, groups, market groups, or meta groups.</li>
-                            <li>Broad includes add matching items when scope mode is opt-in or when you want to re-focus the operational universe.</li>
+                        <ol class="mt-3 list-decimal space-y-2 pl-5">
+                            <li>Explicit item overrides always win.</li>
+                            <li>Noise filters and advanced excludes remove unwanted inventory before it reaches downstream analytics.</li>
+                            <li>Operational categories and advanced includes define the baseline logistics universe in allow-list mode.</li>
+                            <li>Tier toggles use metaGroupID so doctrine-safe tiers can be curated without using raw meta levels.</li>
                         </ol>
+                    </div>
+                </div>
+
+                <div class="rounded-2xl border border-cyan-500/20 bg-cyan-500/10 p-5">
+                    <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold text-cyan-100">Operational categories</h3>
+                            <p class="mt-1 text-xs text-cyan-100/70">High-level alliance logistics buckets mapped from categoryID first, then refined with group and market taxonomy only where needed.</p>
+                        </div>
+                        <p class="text-xs text-cyan-100/60">Default profile surfaces doctrine-ready ships, modules, rigs, charges, drones, structure fuel, and boosters.</p>
+                    </div>
+                    <div class="mt-4 grid gap-3 xl:grid-cols-2">
+                        <?php foreach ((array) $operationalRows as $row): ?>
+                            <?php $rowKey = (string) ($row['key'] ?? ''); ?>
+                            <?php if ($rowKey === '') { continue; } ?>
+                            <label class="flex items-start gap-3 rounded-2xl border border-cyan-400/15 bg-black/20 p-4 text-sm text-cyan-50">
+                                <input type="checkbox" name="item_scope_operational_category_keys[]" value="<?= htmlspecialchars($rowKey, ENT_QUOTES) ?>" class="mt-1" <?= !empty($row['selected']) ? 'checked' : '' ?>>
+                                <span class="block min-w-0 flex-1">
+                                    <span class="flex items-center gap-2">
+                                        <span class="font-medium"><?= htmlspecialchars((string) ($row['label'] ?? $rowKey), ENT_QUOTES) ?></span>
+                                        <?php if (!empty($row['default'])): ?>
+                                            <span class="rounded-full border border-cyan-300/30 bg-cyan-400/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.2em] text-cyan-100/70">Default</span>
+                                        <?php endif; ?>
+                                    </span>
+                                    <span class="mt-1 block text-xs text-cyan-100/70"><?= htmlspecialchars((string) ($row['description'] ?? ''), ENT_QUOTES) ?></span>
+                                    <span class="mt-2 block text-xs text-cyan-100/60"><?= number_format((int) ($row['type_count'] ?? 0)) ?> published types currently map here</span>
+                                </span>
+                            </label>
+                        <?php endforeach; ?>
                     </div>
                 </div>
 
                 <div class="grid gap-4 xl:grid-cols-2">
                     <div class="rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-4">
-                        <h3 class="text-sm font-semibold text-emerald-100">Broad include rules</h3>
-                        <p class="mt-1 text-xs text-emerald-100/70">Use these when you want to focus SupplyCore on doctrine-safe or alliance-relevant item classes.</p>
-                        <div class="mt-4 grid gap-4">
-                            <?php
-                                $includeSections = [
-                                    'item_scope_include_meta_group_ids' => ['title' => 'Meta / tech tier', 'rows' => $itemScopeCatalog['meta_groups'] ?? [], 'id' => 'meta_group_id', 'label' => 'meta_group_name', 'count' => 'type_count'],
-                                    'item_scope_include_category_ids' => ['title' => 'Categories', 'rows' => $itemScopeCatalog['categories'] ?? [], 'id' => 'category_id', 'label' => 'category_name', 'count' => 'type_count'],
-                                    'item_scope_include_group_ids' => ['title' => 'Groups', 'rows' => $itemScopeCatalog['groups'] ?? [], 'id' => 'group_id', 'label' => 'group_name', 'count' => 'type_count'],
-                                    'item_scope_include_market_group_ids' => ['title' => 'Market groups', 'rows' => $itemScopeCatalog['market_groups'] ?? [], 'id' => 'market_group_id', 'label' => 'market_group_name', 'count' => 'type_count'],
-                                ];
-                            ?>
-                            <?php foreach ($includeSections as $fieldName => $meta): ?>
-                                <div>
-                                    <p class="text-xs uppercase tracking-[0.16em] text-emerald-100/70"><?= htmlspecialchars((string) $meta['title'], ENT_QUOTES) ?></p>
-                                    <div class="mt-2 max-h-48 space-y-2 overflow-y-auto rounded-xl border border-emerald-400/15 bg-black/20 p-3">
-                                        <?php foreach ((array) $meta['rows'] as $row): ?>
-                                            <?php $rowId = (int) ($row[$meta['id']] ?? 0); ?>
-                                            <?php if ($rowId <= 0) { continue; } ?>
-                                            <label class="flex items-start gap-3 text-sm text-emerald-50">
-                                                <input type="checkbox" name="<?= htmlspecialchars($fieldName, ENT_QUOTES) ?>[]" value="<?= $rowId ?>" class="mt-1" <?= in_array($rowId, (array) ($itemScopeConfig[str_replace('item_scope_', '', $fieldName)] ?? []), true) ? 'checked' : '' ?>>
-                                                <span>
-                                                    <span class="block"><?= htmlspecialchars((string) ($row[$meta['label']] ?? ('#' . $rowId)), ENT_QUOTES) ?></span>
-                                                    <span class="text-xs text-emerald-100/60"><?= number_format((int) ($row[$meta['count']] ?? 0)) ?> published types</span>
-                                                </span>
-                                            </label>
-                                        <?php endforeach; ?>
-                                    </div>
-                                </div>
+                        <h3 class="text-sm font-semibold text-emerald-100">Tier filtering</h3>
+                        <p class="mt-1 text-xs text-emerald-100/70">Simple metaGroupID toggles for alliance-ready tiers. Tech I and Tech II are enabled by default; Deadspace and Officer stay off unless explicitly enabled.</p>
+                        <div class="mt-4 grid gap-3">
+                            <?php foreach ((array) $tierRows as $row): ?>
+                                <?php $tierId = (int) ($row['meta_group_id'] ?? 0); ?>
+                                <?php if ($tierId <= 0) { continue; } ?>
+                                <label class="flex items-start gap-3 rounded-xl border border-emerald-400/15 bg-black/20 p-3 text-sm text-emerald-50">
+                                    <input type="checkbox" name="item_scope_tier_meta_group_ids[]" value="<?= $tierId ?>" class="mt-1" <?= !empty($row['selected']) ? 'checked' : '' ?>>
+                                    <span>
+                                        <span class="block font-medium"><?= htmlspecialchars((string) ($row['meta_group_name'] ?? ('Meta Group #' . $tierId)), ENT_QUOTES) ?></span>
+                                        <span class="text-xs text-emerald-100/60"><?= number_format((int) ($row['type_count'] ?? 0)) ?> published types with this meta group</span>
+                                    </span>
+                                </label>
                             <?php endforeach; ?>
                         </div>
                     </div>
 
                     <div class="rounded-2xl border border-rose-500/20 bg-rose-500/10 p-4">
-                        <h3 class="text-sm font-semibold text-rose-100">Broad exclude rules</h3>
-                        <p class="mt-1 text-xs text-rose-100/70">Use these to remove consumer goods, officer modules, deadspace tiers, or any other noise from downstream analytics.</p>
-                        <div class="mt-4 grid gap-4">
-                            <?php
-                                $excludeSections = [
-                                    'item_scope_exclude_meta_group_ids' => ['title' => 'Meta / tech tier', 'rows' => $itemScopeCatalog['meta_groups'] ?? [], 'id' => 'meta_group_id', 'label' => 'meta_group_name', 'count' => 'type_count'],
-                                    'item_scope_exclude_category_ids' => ['title' => 'Categories', 'rows' => $itemScopeCatalog['categories'] ?? [], 'id' => 'category_id', 'label' => 'category_name', 'count' => 'type_count'],
-                                    'item_scope_exclude_group_ids' => ['title' => 'Groups', 'rows' => $itemScopeCatalog['groups'] ?? [], 'id' => 'group_id', 'label' => 'group_name', 'count' => 'type_count'],
-                                    'item_scope_exclude_market_group_ids' => ['title' => 'Market groups', 'rows' => $itemScopeCatalog['market_groups'] ?? [], 'id' => 'market_group_id', 'label' => 'market_group_name', 'count' => 'type_count'],
-                                ];
-                            ?>
-                            <?php foreach ($excludeSections as $fieldName => $meta): ?>
-                                <div>
-                                    <p class="text-xs uppercase tracking-[0.16em] text-rose-100/70"><?= htmlspecialchars((string) $meta['title'], ENT_QUOTES) ?></p>
-                                    <div class="mt-2 max-h-48 space-y-2 overflow-y-auto rounded-xl border border-rose-400/15 bg-black/20 p-3">
-                                        <?php foreach ((array) $meta['rows'] as $row): ?>
-                                            <?php $rowId = (int) ($row[$meta['id']] ?? 0); ?>
-                                            <?php if ($rowId <= 0) { continue; } ?>
-                                            <label class="flex items-start gap-3 text-sm text-rose-50">
-                                                <input type="checkbox" name="<?= htmlspecialchars($fieldName, ENT_QUOTES) ?>[]" value="<?= $rowId ?>" class="mt-1" <?= in_array($rowId, (array) ($itemScopeConfig[str_replace('item_scope_', '', $fieldName)] ?? []), true) ? 'checked' : '' ?>>
-                                                <span>
-                                                    <span class="block"><?= htmlspecialchars((string) ($row[$meta['label']] ?? ('#' . $rowId)), ENT_QUOTES) ?></span>
-                                                    <span class="text-xs text-rose-100/60"><?= number_format((int) ($row[$meta['count']] ?? 0)) ?> published types</span>
-                                                </span>
-                                            </label>
-                                        <?php endforeach; ?>
-                                    </div>
-                                </div>
+                        <h3 class="text-sm font-semibold text-rose-100">Noise filters</h3>
+                        <p class="mt-1 text-xs text-rose-100/70">Shared exclusions applied before market, doctrine, and loss-demand analytics are evaluated.</p>
+                        <div class="mt-4 grid gap-3">
+                            <?php foreach ((array) $noiseRows as $row): ?>
+                                <?php $rowKey = (string) ($row['key'] ?? ''); ?>
+                                <?php if ($rowKey === '') { continue; } ?>
+                                <label class="flex items-start gap-3 rounded-xl border border-rose-400/15 bg-black/20 p-3 text-sm text-rose-50">
+                                    <input type="checkbox" name="item_scope_noise_filter_keys[]" value="<?= htmlspecialchars($rowKey, ENT_QUOTES) ?>" class="mt-1" <?= !empty($row['selected']) ? 'checked' : '' ?>>
+                                    <span>
+                                        <span class="flex items-center gap-2">
+                                            <span class="font-medium"><?= htmlspecialchars((string) ($row['label'] ?? $rowKey), ENT_QUOTES) ?></span>
+                                            <?php if (!empty($row['default'])): ?>
+                                                <span class="rounded-full border border-rose-300/30 bg-rose-400/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.2em] text-rose-100/70">Default</span>
+                                            <?php endif; ?>
+                                        </span>
+                                        <span class="mt-1 block text-xs text-rose-100/70"><?= htmlspecialchars((string) ($row['description'] ?? ''), ENT_QUOTES) ?></span>
+                                        <span class="mt-2 block text-xs text-rose-100/60"><?= number_format((int) ($row['type_count'] ?? 0)) ?> published types currently match this filter</span>
+                                    </span>
+                                </label>
                             <?php endforeach; ?>
                         </div>
                     </div>
                 </div>
 
-                <div class="grid gap-4 xl:grid-cols-2">
-                    <label class="rounded-2xl border border-white/8 bg-white/[0.03] p-4">
-                        <span class="text-sm font-semibold text-slate-100">Explicit include overrides</span>
-                        <textarea name="item_scope_include_overrides" rows="8" class="mt-3 w-full field-input font-mono" placeholder="Exact item name or numeric type ID per line"><?= htmlspecialchars($includeOverridesText, ENT_QUOTES) ?></textarea>
-                        <p class="mt-2 text-xs text-muted">Use this when an item should stay in scope even if a broader exclude rule would normally remove it.</p>
-                    </label>
-                    <label class="rounded-2xl border border-white/8 bg-white/[0.03] p-4">
-                        <span class="text-sm font-semibold text-slate-100">Explicit exclude overrides</span>
-                        <textarea name="item_scope_exclude_overrides" rows="8" class="mt-3 w-full field-input font-mono" placeholder="Exact item name or numeric type ID per line"><?= htmlspecialchars($excludeOverridesText, ENT_QUOTES) ?></textarea>
-                        <p class="mt-2 text-xs text-muted">Use this when one item should be suppressed even though its wider category or tier remains enabled.</p>
-                    </label>
-                </div>
+                <details class="rounded-2xl border border-white/8 bg-white/[0.03] p-4">
+                    <summary class="cursor-pointer list-none text-sm font-semibold text-slate-100">Advanced mode</summary>
+                    <p class="mt-2 text-xs text-muted">Advanced controls stay hidden by default. Use them only when you need group-level or market-group-level exceptions beyond the curated operational model.</p>
+
+                    <div class="mt-4 grid gap-4 xl:grid-cols-2">
+                        <div class="rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-4">
+                            <h4 class="text-sm font-semibold text-emerald-100">Advanced include rules</h4>
+                            <p class="mt-1 text-xs text-emerald-100/70">Use these to extend the operational universe with specific groups or market branches.</p>
+                            <div class="mt-4 grid gap-4">
+                                <?php
+                                    $advancedIncludeSections = [
+                                        'item_scope_include_group_ids' => ['title' => 'Groups', 'rows' => $itemScopeCatalog['groups'] ?? [], 'id' => 'group_id', 'label' => 'group_name', 'count' => 'type_count'],
+                                        'item_scope_include_market_group_ids' => ['title' => 'Market groups', 'rows' => $itemScopeCatalog['market_groups'] ?? [], 'id' => 'market_group_id', 'label' => 'market_group_name', 'count' => 'type_count'],
+                                    ];
+                                ?>
+                                <?php foreach ($advancedIncludeSections as $fieldName => $meta): ?>
+                                    <div>
+                                        <p class="text-xs uppercase tracking-[0.16em] text-emerald-100/70"><?= htmlspecialchars((string) $meta['title'], ENT_QUOTES) ?></p>
+                                        <div class="mt-2 max-h-56 space-y-2 overflow-y-auto rounded-xl border border-emerald-400/15 bg-black/20 p-3">
+                                            <?php foreach ((array) $meta['rows'] as $row): ?>
+                                                <?php $rowId = (int) ($row[$meta['id']] ?? 0); ?>
+                                                <?php if ($rowId <= 0) { continue; } ?>
+                                                <label class="flex items-start gap-3 text-sm text-emerald-50">
+                                                    <input type="checkbox" name="<?= htmlspecialchars($fieldName, ENT_QUOTES) ?>[]" value="<?= $rowId ?>" class="mt-1" <?= in_array($rowId, (array) ($itemScopeConfig[str_replace('item_scope_', '', $fieldName)] ?? []), true) ? 'checked' : '' ?>>
+                                                    <span>
+                                                        <span class="block"><?= htmlspecialchars((string) ($row[$meta['label']] ?? ('#' . $rowId)), ENT_QUOTES) ?></span>
+                                                        <span class="text-xs text-emerald-100/60"><?= number_format((int) ($row[$meta['count']] ?? 0)) ?> published types</span>
+                                                    </span>
+                                                </label>
+                                            <?php endforeach; ?>
+                                        </div>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                        </div>
+
+                        <div class="rounded-2xl border border-rose-500/20 bg-rose-500/10 p-4">
+                            <h4 class="text-sm font-semibold text-rose-100">Advanced exclude rules</h4>
+                            <p class="mt-1 text-xs text-rose-100/70">Use these to carve out specific problem groups or market branches after the shared defaults have done most of the work.</p>
+                            <div class="mt-4 grid gap-4">
+                                <?php
+                                    $advancedExcludeSections = [
+                                        'item_scope_exclude_group_ids' => ['title' => 'Groups', 'rows' => $itemScopeCatalog['groups'] ?? [], 'id' => 'group_id', 'label' => 'group_name', 'count' => 'type_count'],
+                                        'item_scope_exclude_market_group_ids' => ['title' => 'Market groups', 'rows' => $itemScopeCatalog['market_groups'] ?? [], 'id' => 'market_group_id', 'label' => 'market_group_name', 'count' => 'type_count'],
+                                    ];
+                                ?>
+                                <?php foreach ($advancedExcludeSections as $fieldName => $meta): ?>
+                                    <div>
+                                        <p class="text-xs uppercase tracking-[0.16em] text-rose-100/70"><?= htmlspecialchars((string) $meta['title'], ENT_QUOTES) ?></p>
+                                        <div class="mt-2 max-h-56 space-y-2 overflow-y-auto rounded-xl border border-rose-400/15 bg-black/20 p-3">
+                                            <?php foreach ((array) $meta['rows'] as $row): ?>
+                                                <?php $rowId = (int) ($row[$meta['id']] ?? 0); ?>
+                                                <?php if ($rowId <= 0) { continue; } ?>
+                                                <label class="flex items-start gap-3 text-sm text-rose-50">
+                                                    <input type="checkbox" name="<?= htmlspecialchars($fieldName, ENT_QUOTES) ?>[]" value="<?= $rowId ?>" class="mt-1" <?= in_array($rowId, (array) ($itemScopeConfig[str_replace('item_scope_', '', $fieldName)] ?? []), true) ? 'checked' : '' ?>>
+                                                    <span>
+                                                        <span class="block"><?= htmlspecialchars((string) ($row[$meta['label']] ?? ('#' . $rowId)), ENT_QUOTES) ?></span>
+                                                        <span class="text-xs text-rose-100/60"><?= number_format((int) ($row[$meta['count']] ?? 0)) ?> published types</span>
+                                                    </span>
+                                                </label>
+                                            <?php endforeach; ?>
+                                        </div>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="mt-4 grid gap-4 xl:grid-cols-2">
+                        <label class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                            <span class="text-sm font-semibold text-slate-100">Explicit include overrides</span>
+                            <textarea name="item_scope_include_overrides" rows="8" class="mt-3 w-full field-input font-mono" placeholder="Exact item name or numeric type ID per line"><?= htmlspecialchars($includeOverridesText, ENT_QUOTES) ?></textarea>
+                            <p class="mt-2 text-xs text-muted">Use this when one item must remain visible even if broader rules would remove it.</p>
+                        </label>
+                        <label class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                            <span class="text-sm font-semibold text-slate-100">Explicit exclude overrides</span>
+                            <textarea name="item_scope_exclude_overrides" rows="8" class="mt-3 w-full field-input font-mono" placeholder="Exact item name or numeric type ID per line"><?= htmlspecialchars($excludeOverridesText, ENT_QUOTES) ?></textarea>
+                            <p class="mt-2 text-xs text-muted">Use this when one item should stay suppressed even though its category or group remains enabled.</p>
+                        </label>
+                    </div>
+                </details>
 
                 <button class="btn-primary">Save Item Scope</button>
             </form>

--- a/src/db.php
+++ b/src/db.php
@@ -1888,7 +1888,7 @@ function db_ref_item_types_bulk_upsert(array $rows, ?int $chunkSize = null): int
 {
     item_scope_db_ensure_schema();
 
-    return db_bulk_insert_or_upsert('ref_item_types', ['type_id', 'group_id', 'market_group_id', 'meta_group_id', 'type_name', 'description', 'published', 'volume'], $rows, ['group_id', 'market_group_id', 'meta_group_id', 'type_name', 'description', 'published', 'volume'], $chunkSize);
+    return db_bulk_insert_or_upsert('ref_item_types', ['type_id', 'category_id', 'group_id', 'market_group_id', 'meta_group_id', 'type_name', 'description', 'published', 'volume'], $rows, ['category_id', 'group_id', 'market_group_id', 'meta_group_id', 'type_name', 'description', 'published', 'volume'], $chunkSize);
 }
 
 function db_ref_item_types_by_ids(array $typeIds): array
@@ -1903,7 +1903,7 @@ function db_ref_item_types_by_ids(array $typeIds): array
     $placeholders = implode(',', array_fill(0, count($ids), '?'));
 
     return db_select(
-        "SELECT type_id, type_name, group_id, market_group_id, meta_group_id, description, published, volume
+        "SELECT type_id, type_name, category_id, group_id, market_group_id, meta_group_id, description, published, volume
          FROM ref_item_types
          WHERE type_id IN ($placeholders)",
         $ids
@@ -2656,7 +2656,7 @@ function db_ref_item_types_by_names(array $names): array
     $placeholders = implode(',', array_fill(0, count($safeNames), '?'));
 
     return db_select(
-        "SELECT type_id, type_name, group_id, market_group_id, meta_group_id, description, published, volume
+        "SELECT type_id, type_name, category_id, group_id, market_group_id, meta_group_id, description, published, volume
          FROM ref_item_types
          WHERE LOWER(type_name) IN ($placeholders)",
         array_map(static fn (string $name): string => mb_strtolower($name), $safeNames)
@@ -2678,9 +2678,9 @@ function db_ref_item_scope_metadata_by_ids(array $typeIds): array
         "SELECT
             rit.type_id,
             rit.type_name,
+            COALESCE(rit.category_id, rig.category_id) AS category_id,
             rit.group_id,
             rig.group_name,
-            rig.category_id,
             ric.category_name,
             rit.market_group_id,
             rmg.market_group_name,
@@ -2691,7 +2691,7 @@ function db_ref_item_scope_metadata_by_ids(array $typeIds): array
             rit.volume
          FROM ref_item_types rit
          LEFT JOIN ref_item_groups rig ON rig.group_id = rit.group_id
-         LEFT JOIN ref_item_categories ric ON ric.category_id = rig.category_id
+         LEFT JOIN ref_item_categories ric ON ric.category_id = COALESCE(rit.category_id, rig.category_id)
          LEFT JOIN ref_market_groups rmg ON rmg.market_group_id = rit.market_group_id
          LEFT JOIN ref_meta_groups rmeta ON rmeta.meta_group_id = rit.meta_group_id
          WHERE rit.type_id IN ($placeholders)",
@@ -2865,6 +2865,13 @@ function item_scope_db_ensure_schema(): void
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
     );
+
+    if (db_table_exists('ref_item_types') && !db_column_exists('ref_item_types', 'category_id')) {
+        db()->exec('ALTER TABLE ref_item_types ADD COLUMN category_id INT UNSIGNED DEFAULT NULL AFTER type_id');
+        db()->exec('UPDATE ref_item_types rit INNER JOIN ref_item_groups rig ON rig.group_id = rit.group_id SET rit.category_id = rig.category_id WHERE rit.category_id IS NULL');
+        db()->exec('ALTER TABLE ref_item_types MODIFY COLUMN category_id INT UNSIGNED NOT NULL');
+        db()->exec('ALTER TABLE ref_item_types ADD KEY idx_category_id (category_id)');
+    }
 
     if (db_table_exists('ref_item_types') && !db_column_exists('ref_item_types', 'meta_group_id')) {
         db()->exec('ALTER TABLE ref_item_types ADD COLUMN meta_group_id INT UNSIGNED DEFAULT NULL AFTER market_group_id');

--- a/src/functions.php
+++ b/src/functions.php
@@ -198,6 +198,9 @@ function item_scope_setting_keys(): array
 {
     return [
         'item_scope_mode',
+        'item_scope_operational_category_keys',
+        'item_scope_tier_meta_group_ids',
+        'item_scope_noise_filter_keys',
         'item_scope_include_category_ids',
         'item_scope_exclude_category_ids',
         'item_scope_include_group_ids',
@@ -216,10 +219,25 @@ function item_scope_default_meta_groups(): array
     return [
         ['meta_group_id' => 1, 'meta_group_name' => 'Tech I', 'type_count' => 0],
         ['meta_group_id' => 2, 'meta_group_name' => 'Tech II', 'type_count' => 0],
-        ['meta_group_id' => 3, 'meta_group_name' => 'Storyline', 'type_count' => 0],
         ['meta_group_id' => 4, 'meta_group_name' => 'Faction', 'type_count' => 0],
-        ['meta_group_id' => 5, 'meta_group_name' => 'Officer', 'type_count' => 0],
         ['meta_group_id' => 6, 'meta_group_name' => 'Deadspace', 'type_count' => 0],
+        ['meta_group_id' => 5, 'meta_group_name' => 'Officer', 'type_count' => 0],
+    ];
+}
+
+function item_scope_default_operational_category_keys(): array
+{
+    return ['ships', 'modules', 'rigs', 'ammo_charges', 'drones_fighters', 'fuel_structures', 'boosters'];
+}
+
+function item_scope_default_noise_filter_keys(): array
+{
+    return [
+        'exclude_commodities_consumer_goods',
+        'exclude_civilian_items',
+        'exclude_blueprints',
+        'exclude_skins',
+        'exclude_non_market_mission_items',
     ];
 }
 
@@ -248,10 +266,40 @@ function item_scope_encode_int_list(array $ids): string
     return json_encode(item_scope_decode_int_list($ids), JSON_THROW_ON_ERROR);
 }
 
+function item_scope_decode_string_list(mixed $value): array
+{
+    if (is_array($value)) {
+        $decoded = $value;
+    } else {
+        $raw = trim((string) $value);
+        if ($raw === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            $decoded = preg_split('/[\r\n,]+/', $raw) ?: [];
+        }
+    }
+
+    $normalized = array_map(static fn (mixed $entry): string => trim(mb_strtolower((string) $entry)), $decoded);
+
+    return array_values(array_unique(array_filter($normalized, static fn (string $entry): bool => $entry !== '')));
+}
+
+function item_scope_encode_string_list(array $values): string
+{
+    return json_encode(item_scope_decode_string_list($values), JSON_THROW_ON_ERROR);
+}
+
 function item_scope_default_config(): array
 {
     return [
-        'mode' => 'allow_all',
+        'mode' => 'allow_list',
+        'operational_category_keys' => item_scope_default_operational_category_keys(),
+        'tier_meta_group_ids' => [1, 2],
+        'noise_filter_keys' => item_scope_default_noise_filter_keys(),
         'include_category_ids' => [],
         'exclude_category_ids' => [],
         'include_group_ids' => [],
@@ -267,7 +315,7 @@ function item_scope_default_config(): array
 
 function item_scope_normalize_mode(string $mode): string
 {
-    return $mode === 'allow_list' ? 'allow_list' : 'allow_all';
+    return $mode === 'allow_all' ? 'allow_all' : 'allow_list';
 }
 
 function item_scope_settings_to_config(array $settings): array
@@ -276,6 +324,9 @@ function item_scope_settings_to_config(array $settings): array
 
     return [
         'mode' => item_scope_normalize_mode((string) ($settings['item_scope_mode'] ?? $defaults['mode'])),
+        'operational_category_keys' => item_scope_decode_string_list($settings['item_scope_operational_category_keys'] ?? $defaults['operational_category_keys']),
+        'tier_meta_group_ids' => item_scope_decode_int_list($settings['item_scope_tier_meta_group_ids'] ?? $defaults['tier_meta_group_ids']),
+        'noise_filter_keys' => item_scope_decode_string_list($settings['item_scope_noise_filter_keys'] ?? $defaults['noise_filter_keys']),
         'include_category_ids' => item_scope_decode_int_list($settings['item_scope_include_category_ids'] ?? $defaults['include_category_ids']),
         'exclude_category_ids' => item_scope_decode_int_list($settings['item_scope_exclude_category_ids'] ?? $defaults['exclude_category_ids']),
         'include_group_ids' => item_scope_decode_int_list($settings['item_scope_include_group_ids'] ?? $defaults['include_group_ids']),
@@ -300,6 +351,138 @@ function item_scope_config(): array
     $config = item_scope_settings_to_config(get_settings(item_scope_setting_keys()));
 
     return $config;
+}
+
+function item_scope_operational_definitions(): array
+{
+    return [
+        'ships' => [
+            'label' => 'Ships',
+            'description' => 'Combat hulls and logistics ships tracked as the alliance operating fleet.',
+            'default' => true,
+            'clauses' => [
+                ['category_names' => ['ship']],
+            ],
+        ],
+        'modules' => [
+            'label' => 'Modules',
+            'description' => 'Standard fit components, including subsystems, but excluding rig-only lines.',
+            'default' => true,
+            'clauses' => [
+                [
+                    'category_names' => ['module', 'subsystem'],
+                    'exclude_group_keywords' => ['rig'],
+                    'exclude_market_group_keywords' => ['rig'],
+                ],
+            ],
+        ],
+        'rigs' => [
+            'label' => 'Rigs',
+            'description' => 'Rig market segments separated from the wider module universe.',
+            'default' => true,
+            'clauses' => [
+                ['category_names' => ['module'], 'group_keywords' => ['rig']],
+                ['category_names' => ['module'], 'market_group_keywords' => ['rig']],
+            ],
+        ],
+        'ammo_charges' => [
+            'label' => 'Ammo & Charges',
+            'description' => 'Ammunition, scripts, crystals, bombs, and other consumable charge-based items.',
+            'default' => true,
+            'clauses' => [
+                ['category_names' => ['charge']],
+            ],
+        ],
+        'drones_fighters' => [
+            'label' => 'Drones & Fighters',
+            'description' => 'Drone bays, carrier support, and fighter wings used in doctrine fits.',
+            'default' => true,
+            'clauses' => [
+                ['category_names' => ['drone', 'fighter']],
+            ],
+        ],
+        'fuel_structures' => [
+            'label' => 'Fuel & Structures',
+            'description' => 'Structure hulls, deployables, and operational fuel inputs for alliance infrastructure.',
+            'default' => true,
+            'clauses' => [
+                ['category_names' => ['structure', 'deployable', 'starbase']],
+                ['category_names' => ['charge'], 'group_keywords' => ['fuel', 'isotope', 'strontium', 'liquid ozone', 'heavy water']],
+                ['category_names' => ['charge'], 'market_group_keywords' => ['fuel']],
+            ],
+        ],
+        'boosters' => [
+            'label' => 'Boosters',
+            'description' => 'Combat and support boosters surfaced separately from general implants.',
+            'default' => true,
+            'clauses' => [
+                ['category_names' => ['implant'], 'group_keywords' => ['booster']],
+                ['category_names' => ['implant'], 'market_group_keywords' => ['booster']],
+            ],
+        ],
+        'industry' => [
+            'label' => 'Industry',
+            'description' => 'Optional manufacturing and input chains for blueprints, materials, and components.',
+            'default' => false,
+            'clauses' => [
+                ['category_names' => ['blueprint']],
+                ['category_names' => ['commodity', 'planetary commodities'], 'market_group_keywords' => ['planetary', 'component', 'reaction', 'salvage', 'materials']],
+            ],
+        ],
+    ];
+}
+
+function item_scope_noise_filter_definitions(): array
+{
+    return [
+        'exclude_commodities_consumer_goods' => [
+            'label' => 'Exclude commodities / consumer goods',
+            'description' => 'Suppress commodity-style goods and planetary trade cargo by category and market taxonomy.',
+            'default' => true,
+            'clauses' => [
+                ['category_names' => ['commodity', 'planetary commodities']],
+                ['market_group_keywords' => ['commodity', 'consumer goods', 'trade goods', 'planetary']],
+            ],
+        ],
+        'exclude_civilian_items' => [
+            'label' => 'Exclude civilian items',
+            'description' => 'Remove tutorial and civilian equipment from logistics views.',
+            'default' => true,
+            'clauses' => [
+                ['group_keywords' => ['civilian']],
+                ['market_group_keywords' => ['civilian']],
+                ['type_name_keywords' => ['civilian']],
+            ],
+        ],
+        'exclude_blueprints' => [
+            'label' => 'Exclude blueprints',
+            'description' => 'Filter blueprint categories unless Industry mode is explicitly enabled.',
+            'default' => true,
+            'clauses' => [
+                ['category_names' => ['blueprint']],
+                ['market_group_keywords' => ['blueprint']],
+            ],
+        ],
+        'exclude_skins' => [
+            'label' => 'Exclude skins',
+            'description' => 'Remove cosmetic SKIN inventory and cosmetic market branches.',
+            'default' => true,
+            'clauses' => [
+                ['category_names' => ['skin', 'skins']],
+                ['market_group_keywords' => ['skin']],
+                ['group_keywords' => ['skin']],
+            ],
+        ],
+        'exclude_non_market_mission_items' => [
+            'label' => 'Exclude mission / non-market / irrelevant items',
+            'description' => 'Suppress unpublished, unmarketed, and mission-only inventory that should not drive alliance logistics.',
+            'default' => true,
+            'clauses' => [
+                ['requires_missing_market_group' => true],
+                ['market_group_keywords' => ['mission']],
+            ],
+        ],
+    ];
 }
 
 function item_scope_catalog(): array
@@ -336,6 +519,8 @@ function item_scope_catalog(): array
             'type_count' => (int) ($row['type_count'] ?? 0),
         ];
     }
+
+    $metaGroups = array_intersect_key($metaGroups, array_flip([1, 2, 4, 5, 6]));
     ksort($metaGroups);
     $catalog['meta_groups'] = array_values($metaGroups);
 
@@ -354,6 +539,23 @@ function item_scope_market_group_parent_index(?array $catalog = null): array
         }
 
         $index[$marketGroupId] = (int) ($row['parent_group_id'] ?? 0);
+    }
+
+    return $index;
+}
+
+function item_scope_market_group_name_index(?array $catalog = null): array
+{
+    $catalog ??= item_scope_catalog();
+    $index = [];
+
+    foreach ((array) ($catalog['market_groups'] ?? []) as $row) {
+        $marketGroupId = (int) ($row['market_group_id'] ?? 0);
+        if ($marketGroupId <= 0) {
+            continue;
+        }
+
+        $index[$marketGroupId] = (string) ($row['market_group_name'] ?? '');
     }
 
     return $index;
@@ -389,6 +591,7 @@ function item_scope_metadata_by_type_ids(array $typeIds): array
 
     if ($missing !== []) {
         $parentIndex = item_scope_market_group_parent_index();
+        $marketGroupNameIndex = item_scope_market_group_name_index();
         try {
             $rows = db_ref_item_scope_metadata_by_ids($missing);
         } catch (Throwable) {
@@ -405,6 +608,12 @@ function item_scope_metadata_by_type_ids(array $typeIds): array
                 continue;
             }
 
+            $marketGroupPathIds = item_scope_expand_market_group_ids(isset($row['market_group_id']) ? (int) $row['market_group_id'] : null, $parentIndex);
+            $marketGroupPathNames = array_values(array_filter(array_map(
+                static fn (int $marketGroupId): string => trim((string) ($marketGroupNameIndex[$marketGroupId] ?? '')),
+                $marketGroupPathIds
+            ), static fn (string $name): bool => $name !== ''));
+
             $cache[$typeId] = [
                 'type_id' => $typeId,
                 'type_name' => (string) ($row['type_name'] ?? ''),
@@ -417,7 +626,8 @@ function item_scope_metadata_by_type_ids(array $typeIds): array
                 'meta_group_id' => isset($row['meta_group_id']) ? (int) $row['meta_group_id'] : null,
                 'meta_group_name' => (string) ($row['meta_group_name'] ?? ''),
                 'published' => (int) ($row['published'] ?? 0) === 1,
-                'market_group_path_ids' => item_scope_expand_market_group_ids(isset($row['market_group_id']) ? (int) $row['market_group_id'] : null, $parentIndex),
+                'market_group_path_ids' => $marketGroupPathIds,
+                'market_group_path_names' => $marketGroupPathNames,
             ];
         }
     }
@@ -432,10 +642,103 @@ function item_scope_metadata_by_type_ids(array $typeIds): array
     return $resolved;
 }
 
-function item_scope_has_broad_includes(array $config): bool
+function item_scope_normalize_token(string $value): string
 {
-    return $config['mode'] === 'allow_list'
-        || $config['include_category_ids'] !== []
+    return trim(mb_strtolower($value));
+}
+
+function item_scope_text_contains_keywords(array $texts, array $keywords): bool
+{
+    $keywords = array_values(array_filter(array_map(static fn (string $keyword): string => item_scope_normalize_token($keyword), $keywords), static fn (string $keyword): bool => $keyword !== ''));
+    if ($keywords === []) {
+        return true;
+    }
+
+    foreach ($texts as $text) {
+        $normalized = item_scope_normalize_token((string) $text);
+        if ($normalized === '') {
+            continue;
+        }
+
+        foreach ($keywords as $keyword) {
+            if (str_contains($normalized, $keyword)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+function item_scope_metadata_matches_clause(array $metadata, array $clause): bool
+{
+    $categoryNames = array_map(static fn (string $name): string => item_scope_normalize_token($name), (array) ($clause['category_names'] ?? []));
+    $categoryName = item_scope_normalize_token((string) ($metadata['category_name'] ?? ''));
+    if ($categoryNames !== [] && !in_array($categoryName, $categoryNames, true)) {
+        return false;
+    }
+
+    if (($clause['requires_missing_market_group'] ?? false) === true && ($metadata['market_group_id'] ?? null) !== null) {
+        return false;
+    }
+
+    $groupTexts = [(string) ($metadata['group_name'] ?? '')];
+    $marketTexts = array_merge([(string) ($metadata['market_group_name'] ?? '')], (array) ($metadata['market_group_path_names'] ?? []));
+    $typeTexts = [(string) ($metadata['type_name'] ?? '')];
+
+    if (!item_scope_text_contains_keywords($groupTexts, (array) ($clause['group_keywords'] ?? []))) {
+        return false;
+    }
+    if (!item_scope_text_contains_keywords($marketTexts, (array) ($clause['market_group_keywords'] ?? []))) {
+        return false;
+    }
+    if (!item_scope_text_contains_keywords($typeTexts, (array) ($clause['type_name_keywords'] ?? []))) {
+        return false;
+    }
+
+    if (($clause['exclude_group_keywords'] ?? []) !== [] && item_scope_text_contains_keywords($groupTexts, (array) $clause['exclude_group_keywords'])) {
+        return false;
+    }
+    if (($clause['exclude_market_group_keywords'] ?? []) !== [] && item_scope_text_contains_keywords($marketTexts, (array) $clause['exclude_market_group_keywords'])) {
+        return false;
+    }
+    if (($clause['exclude_type_name_keywords'] ?? []) !== [] && item_scope_text_contains_keywords($typeTexts, (array) $clause['exclude_type_name_keywords'])) {
+        return false;
+    }
+
+    return true;
+}
+
+function item_scope_metadata_matches_definition(array $metadata, array $definition): bool
+{
+    foreach ((array) ($definition['clauses'] ?? []) as $clause) {
+        if (item_scope_metadata_matches_clause($metadata, (array) $clause)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function item_scope_matches_operational_category(array $metadata, string $key): bool
+{
+    $definitions = item_scope_operational_definitions();
+    $definition = $definitions[$key] ?? null;
+
+    return is_array($definition) ? item_scope_metadata_matches_definition($metadata, $definition) : false;
+}
+
+function item_scope_matches_noise_filter(array $metadata, string $key): bool
+{
+    $definitions = item_scope_noise_filter_definitions();
+    $definition = $definitions[$key] ?? null;
+
+    return is_array($definition) ? item_scope_metadata_matches_definition($metadata, $definition) : false;
+}
+
+function item_scope_has_advanced_includes(array $config): bool
+{
+    return $config['include_category_ids'] !== []
         || $config['include_group_ids'] !== []
         || $config['include_market_group_ids'] !== []
         || $config['include_meta_group_ids'] !== [];
@@ -465,11 +768,24 @@ function item_scope_metadata_matches(array $metadata, array $config, string $pre
         || ($metadata['meta_group_id'] !== null && in_array((int) $metadata['meta_group_id'], $config[$prefix . '_meta_group_ids'], true));
 }
 
+function item_scope_has_meta_group_catalog_data(?array $catalog = null): bool
+{
+    $catalog ??= item_scope_catalog();
+
+    foreach ((array) ($catalog['meta_groups'] ?? []) as $row) {
+        if ((int) ($row['type_count'] ?? 0) > 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function item_scope_type_metadata_in_scope(array $metadata, ?array $config = null): bool
 {
     $config ??= item_scope_config();
     $typeId = (int) ($metadata['type_id'] ?? 0);
-    if ($typeId <= 0) {
+    if ($typeId <= 0 || !((bool) ($metadata['published'] ?? false))) {
         return false;
     }
 
@@ -481,8 +797,30 @@ function item_scope_type_metadata_in_scope(array $metadata, ?array $config = nul
         return false;
     }
 
-    $included = item_scope_has_broad_includes($config) ? item_scope_metadata_matches($metadata, $config, 'include') : true;
-    if (!$included) {
+    foreach ($config['noise_filter_keys'] as $noiseKey) {
+        if (item_scope_matches_noise_filter($metadata, $noiseKey)) {
+            return false;
+        }
+    }
+
+    $tierFilterActive = $config['tier_meta_group_ids'] !== [] && item_scope_has_meta_group_catalog_data();
+    if ($tierFilterActive) {
+        $metaGroupId = isset($metadata['meta_group_id']) ? (int) $metadata['meta_group_id'] : null;
+        if ($metaGroupId === null || !in_array($metaGroupId, $config['tier_meta_group_ids'], true)) {
+            return false;
+        }
+    }
+
+    $operationalMatch = false;
+    foreach ($config['operational_category_keys'] as $categoryKey) {
+        if (item_scope_matches_operational_category($metadata, (string) $categoryKey)) {
+            $operationalMatch = true;
+            break;
+        }
+    }
+
+    $advancedIncludeMatch = item_scope_metadata_matches($metadata, $config, 'include');
+    if ($config['mode'] === 'allow_list' && !$operationalMatch && !$advancedIncludeMatch) {
         return false;
     }
 
@@ -594,7 +932,10 @@ function item_scope_settings_payload_from_request(array $request): array
 
     return [
         'settings' => [
-            'item_scope_mode' => item_scope_normalize_mode((string) ($request['item_scope_mode'] ?? 'allow_all')),
+            'item_scope_mode' => item_scope_normalize_mode((string) ($request['item_scope_mode'] ?? 'allow_list')),
+            'item_scope_operational_category_keys' => item_scope_encode_string_list((array) ($request['item_scope_operational_category_keys'] ?? [])),
+            'item_scope_tier_meta_group_ids' => item_scope_encode_int_list((array) ($request['item_scope_tier_meta_group_ids'] ?? [])),
+            'item_scope_noise_filter_keys' => item_scope_encode_string_list((array) ($request['item_scope_noise_filter_keys'] ?? [])),
             'item_scope_include_category_ids' => item_scope_encode_int_list((array) ($request['item_scope_include_category_ids'] ?? [])),
             'item_scope_exclude_category_ids' => item_scope_encode_int_list((array) ($request['item_scope_exclude_category_ids'] ?? [])),
             'item_scope_include_group_ids' => item_scope_encode_int_list((array) ($request['item_scope_include_group_ids'] ?? [])),
@@ -616,38 +957,46 @@ function item_scope_settings_payload_from_request(array $request): array
 function item_scope_summary_lines(array $config, ?array $catalog = null): array
 {
     $catalog ??= item_scope_catalog();
-    $hasBroadIncludes = item_scope_has_broad_includes($config);
-    $labelMaps = [
-        'include_category_ids' => array_column((array) ($catalog['categories'] ?? []), 'category_name', 'category_id'),
-        'exclude_category_ids' => array_column((array) ($catalog['categories'] ?? []), 'category_name', 'category_id'),
-        'include_group_ids' => array_column((array) ($catalog['groups'] ?? []), 'group_name', 'group_id'),
-        'exclude_group_ids' => array_column((array) ($catalog['groups'] ?? []), 'group_name', 'group_id'),
-        'include_market_group_ids' => array_column((array) ($catalog['market_groups'] ?? []), 'market_group_name', 'market_group_id'),
-        'exclude_market_group_ids' => array_column((array) ($catalog['market_groups'] ?? []), 'market_group_name', 'market_group_id'),
-        'include_meta_group_ids' => array_column((array) ($catalog['meta_groups'] ?? []), 'meta_group_name', 'meta_group_id'),
-        'exclude_meta_group_ids' => array_column((array) ($catalog['meta_groups'] ?? []), 'meta_group_name', 'meta_group_id'),
-    ];
+    $operationalDefinitions = item_scope_operational_definitions();
+    $noiseDefinitions = item_scope_noise_filter_definitions();
+    $tierLabels = array_column((array) ($catalog['meta_groups'] ?? []), 'meta_group_name', 'meta_group_id');
 
-    $lines = [
-        $hasBroadIncludes
-            ? 'Broad include rules are active. Items must match at least one include rule unless an explicit type override says otherwise.'
-            : 'No broad include rules are active. All published items remain in scope unless excluded.',
-    ];
-
-    foreach ($labelMaps as $key => $labels) {
-        $ids = item_scope_decode_int_list($config[$key] ?? []);
-        if ($ids === []) {
-            continue;
+    $operationalLabels = [];
+    foreach ($config['operational_category_keys'] as $key) {
+        if (isset($operationalDefinitions[$key])) {
+            $operationalLabels[] = (string) $operationalDefinitions[$key]['label'];
         }
-
-        $names = array_map(static fn (int $id): string => (string) ($labels[$id] ?? ('#' . $id)), array_slice($ids, 0, 6));
-        if (count($ids) > 6) {
-            $names[] = '+' . (count($ids) - 6) . ' more';
-        }
-
-        $lines[] = ucfirst(str_replace('_ids', '', str_replace('_', ' ', $key))) . ': ' . implode(', ', $names) . '.';
     }
 
+    $noiseLabels = [];
+    foreach ($config['noise_filter_keys'] as $key) {
+        if (isset($noiseDefinitions[$key])) {
+            $noiseLabels[] = (string) $noiseDefinitions[$key]['label'];
+        }
+    }
+
+    $tierNames = array_map(static fn (int $id): string => (string) ($tierLabels[$id] ?? ('Meta Group #' . $id)), $config['tier_meta_group_ids']);
+    $lines = [
+        $config['mode'] === 'allow_list'
+            ? 'Operational allow-list mode is active. Items must match a selected operational category or advanced include before they flow into alliance analytics.'
+            : 'Allow-all mode is active. Published items stay visible unless blocked by the shared noise filters, tier toggles, or advanced exclusions.',
+        $operationalLabels !== []
+            ? 'Operational categories: ' . implode(', ', $operationalLabels) . '.'
+            : 'Operational categories: none selected.',
+        $tierNames !== []
+            ? 'Meta tiers enabled: ' . implode(', ', $tierNames) . '.'
+            : 'Meta tiers enabled: all tiers.',
+        $noiseLabels !== []
+            ? 'Noise filters enabled: ' . implode(', ', $noiseLabels) . '.'
+            : 'Noise filters enabled: none.',
+    ];
+
+    if ($config['include_group_ids'] !== [] || $config['include_market_group_ids'] !== []) {
+        $lines[] = 'Advanced includes are active for specific groups or market groups.';
+    }
+    if ($config['exclude_group_ids'] !== [] || $config['exclude_market_group_ids'] !== []) {
+        $lines[] = 'Advanced excludes are active for specific groups or market groups.';
+    }
     if ($config['include_type_ids'] !== []) {
         $lines[] = 'Explicit item includes: ' . number_format(count($config['include_type_ids'])) . '.';
     }
@@ -662,11 +1011,14 @@ function item_scope_view_model(): array
 {
     $config = item_scope_config();
     $catalog = item_scope_catalog();
+    $operationalDefinitions = item_scope_operational_definitions();
+    $noiseDefinitions = item_scope_noise_filter_definitions();
 
     $includeOverrides = item_scope_metadata_by_type_ids($config['include_type_ids']);
     $excludeOverrides = item_scope_metadata_by_type_ids($config['exclude_type_ids']);
     $publishedCount = 0;
     $inScopeCount = 0;
+    $metadataByType = [];
 
     try {
         $publishedTypeIds = db_ref_item_type_ids_published();
@@ -680,6 +1032,61 @@ function item_scope_view_model(): array
     } catch (Throwable) {
         $publishedCount = 0;
         $inScopeCount = 0;
+        $metadataByType = [];
+    }
+
+    $operationalRows = [];
+    foreach ($operationalDefinitions as $key => $definition) {
+        $matchedCount = 0;
+        foreach ($metadataByType as $metadata) {
+            if (item_scope_matches_operational_category($metadata, $key)) {
+                $matchedCount++;
+            }
+        }
+
+        $operationalRows[] = [
+            'key' => $key,
+            'label' => (string) ($definition['label'] ?? $key),
+            'description' => (string) ($definition['description'] ?? ''),
+            'selected' => in_array($key, $config['operational_category_keys'], true),
+            'default' => (bool) ($definition['default'] ?? false),
+            'type_count' => $matchedCount,
+        ];
+    }
+
+    $tierRows = [];
+    $tierCountById = array_column((array) ($catalog['meta_groups'] ?? []), 'type_count', 'meta_group_id');
+    foreach ((array) ($catalog['meta_groups'] ?? []) as $row) {
+        $metaGroupId = (int) ($row['meta_group_id'] ?? 0);
+        if ($metaGroupId <= 0) {
+            continue;
+        }
+
+        $tierRows[] = [
+            'meta_group_id' => $metaGroupId,
+            'meta_group_name' => (string) ($row['meta_group_name'] ?? ('Meta Group #' . $metaGroupId)),
+            'selected' => in_array($metaGroupId, $config['tier_meta_group_ids'], true),
+            'type_count' => (int) ($tierCountById[$metaGroupId] ?? 0),
+        ];
+    }
+
+    $noiseRows = [];
+    foreach ($noiseDefinitions as $key => $definition) {
+        $matchedCount = 0;
+        foreach ($metadataByType as $metadata) {
+            if (item_scope_matches_noise_filter($metadata, $key)) {
+                $matchedCount++;
+            }
+        }
+
+        $noiseRows[] = [
+            'key' => $key,
+            'label' => (string) ($definition['label'] ?? $key),
+            'description' => (string) ($definition['description'] ?? ''),
+            'selected' => in_array($key, $config['noise_filter_keys'], true),
+            'default' => (bool) ($definition['default'] ?? false),
+            'type_count' => $matchedCount,
+        ];
     }
 
     return [
@@ -691,6 +1098,9 @@ function item_scope_view_model(): array
             'in_scope_count' => $inScopeCount,
             'excluded_count' => max(0, $publishedCount - $inScopeCount),
         ],
+        'operational_rows' => $operationalRows,
+        'tier_rows' => $tierRows,
+        'noise_rows' => $noiseRows,
         'override_rows' => [
             'include' => array_values($includeOverrides),
             'exclude' => array_values($excludeOverrides),
@@ -7392,6 +7802,8 @@ function static_data_extract_reference_rows_from_jsonl_archive(string $archivePa
         'groups.jsonl' => 'groups',
         'invgroups.jsonl' => 'groups',
         'marketgroups.jsonl' => 'market_groups',
+        'metatypes.jsonl' => 'meta_types',
+        'invmetatypes.jsonl' => 'meta_types',
         'metagroups.jsonl' => 'meta_groups',
         'invmetagroups.jsonl' => 'meta_groups',
         'types.jsonl' => 'types',
@@ -7405,6 +7817,7 @@ function static_data_extract_reference_rows_from_jsonl_archive(string $archivePa
         'categories' => [],
         'groups' => [],
         'market_groups' => [],
+        'meta_types' => [],
         'meta_groups' => [],
         'types' => [],
     ];
@@ -7551,16 +7964,27 @@ function static_data_extract_reference_rows_from_jsonl_archive(string $archivePa
                 continue;
             }
 
+            if ($targetKey === 'meta_types') {
+                $typeId = (int) static_data_record_value($row, ['typeID', 'type_id']);
+                $metaGroupId = (int) static_data_record_value($row, ['metaGroupID', 'meta_group_id']);
+                if ($typeId > 0 && $metaGroupId > 0) {
+                    $records['meta_types'][$typeId] = $metaGroupId;
+                }
+                continue;
+            }
+
             if ($targetKey === 'types') {
                 $typeId = (int) static_data_record_value($row, ['typeID', 'type_id', '_key']);
                 $groupId = (int) static_data_record_value($row, ['groupID', 'group_id']);
                 $name = static_data_localized_text(static_data_record_value($row, ['typeName', 'name']));
                 if ($typeId > 0 && $groupId > 0 && $name !== null) {
+                    $categoryId = (int) static_data_record_value($row, ['categoryID', 'category_id'], 0);
                     $marketGroupId = (int) static_data_record_value($row, ['marketGroupID', 'market_group_id', '_key'], 0);
-                    $metaGroupId = (int) static_data_record_value($row, ['metaGroupID', 'meta_group_id'], 0);
+                    $metaGroupId = (int) static_data_record_value($row, ['metaGroupID', 'meta_group_id'], (int) ($records['meta_types'][$typeId] ?? 0));
                     $publishedRaw = static_data_record_value($row, ['published'], 0);
                     $records['types'][] = [
                         'type_id' => $typeId,
+                        'category_id' => $categoryId,
                         'group_id' => $groupId,
                         'market_group_id' => $marketGroupId > 0 ? $marketGroupId : null,
                         'meta_group_id' => $metaGroupId > 0 ? $metaGroupId : null,
@@ -7581,6 +8005,28 @@ function static_data_extract_reference_rows_from_jsonl_archive(string $archivePa
     if ($records['regions'] === [] || $records['constellations'] === [] || $records['systems'] === [] || $records['market_groups'] === [] || $records['types'] === []) {
         throw new RuntimeException('Static-data archive is missing one or more required JSONL datasets for import.');
     }
+
+    $groupCategoryById = [];
+    foreach ($records['groups'] as $groupRow) {
+        $groupId = (int) ($groupRow['group_id'] ?? 0);
+        $categoryId = (int) ($groupRow['category_id'] ?? 0);
+        if ($groupId > 0 && $categoryId > 0) {
+            $groupCategoryById[$groupId] = $categoryId;
+        }
+    }
+
+    foreach ($records['types'] as &$typeRow) {
+        $categoryId = (int) ($typeRow['category_id'] ?? 0);
+        if ($categoryId <= 0) {
+            $typeRow['category_id'] = (int) ($groupCategoryById[(int) ($typeRow['group_id'] ?? 0)] ?? 0);
+        }
+    }
+    unset($typeRow);
+
+    $records['types'] = array_values(array_filter(
+        $records['types'],
+        static fn (array $row): bool => (int) ($row['category_id'] ?? 0) > 0
+    ));
 
     return $records;
 }


### PR DESCRIPTION
### Motivation
- The item-scope system relied on raw SDE taxonomies and did not consistently surface `categoryID`, making operational filtering brittle for alliance logistics workflows.
- The goal was to fix the underlying metadata model so `categoryID` is loaded and available everywhere and to replace the low-level market-group-first UI with an opinionated, operational filter model (with hidden advanced controls).

### Description
- Persist `category_id` on `ref_item_types`, add schema/index support and a backfill/update path in `src/db.php`, and surface `category_id` in reference queries so metadata always includes `category_id` and `meta_group_id` where available (coalesced from group when necessary).
- Extend the static-data importer to extract `categoryID` and `metaGroupID` (including a small `meta_types` pass) and backfill `category_id` for `types` when missing, so reference data contains usable category metadata.
- Replace the item-scope evaluation with a centralized operational model in `src/functions.php` that: introduces curated operational categories (`Ships`, `Modules`, `Rigs`, `Ammo & Charges`, `Drones & Fighters`, `Fuel & Structures`, `Boosters`, optional `Industry`), tier filtering using `meta_group_id` (`metaGroupID`), shared noise filters, and keyword/market-group-aware clause matching; all in-scope checks now explicitly use `category_id` first and fall back to group/market-group only where needed.
- Rebuild the settings UI (`public/settings/index.php`) to present an alliance-focused control panel exposing operational category toggles, tier meta toggles, noise filters (defaults enabled), and a hidden Advanced mode for group/market-group and explicit item overrides; advanced mode preserves the finer-grained controls but is hidden by default.

### Testing
- Ran PHP syntax checks: `php -l src/functions.php`, `php -l src/db.php`, and `php -l public/settings/index.php`, all returned no syntax errors.
- Ran repository checks: `git diff --check` completed with no reported problems.
- Committed changes and verified file diffs with `git diff --stat` to ensure expected files were modified (schema, DB layer, static-data importer, item-scope logic, and settings UI).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf3e9a3dc832f873572a20860fb2d)