### PR TITLE
Show item icons in dashboard queues

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -284,8 +284,17 @@ $statusThemes = [
                         <?php else: ?>
                             <?php foreach ($rows as $index => $row): ?>
                                 <div class="intelligence-row group">
-                                    <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-white/8 bg-slate-900/88 text-sm font-semibold text-slate-100">
-                                        <?= htmlspecialchars(substr((string) ($row['module'] ?? '?'), 0, 2), ENT_QUOTES) ?>
+                                    <div class="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-white/8 bg-slate-900/88 text-sm font-semibold text-slate-100">
+                                        <?php if (!empty($row['image_url'])): ?>
+                                            <img
+                                                src="<?= htmlspecialchars((string) $row['image_url'], ENT_QUOTES) ?>"
+                                                alt="<?= htmlspecialchars((string) ($row['module'] ?? 'Item icon'), ENT_QUOTES) ?>"
+                                                class="h-full w-full object-contain p-1"
+                                                loading="lazy"
+                                            >
+                                        <?php else: ?>
+                                            <?= htmlspecialchars(substr((string) ($row['module'] ?? '?'), 0, 2), ENT_QUOTES) ?>
+                                        <?php endif; ?>
                                     </div>
                                     <div class="min-w-0 flex-1">
                                         <div class="flex flex-wrap items-start gap-3">
@@ -332,8 +341,17 @@ $statusThemes = [
             <?php else: ?>
                 <?php foreach ($rows as $index => $row): ?>
                     <div class="intelligence-row group">
-                        <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-orange-400/15 bg-orange-500/8 text-sm font-semibold text-orange-100">
-                            <?= htmlspecialchars(substr((string) ($row['module'] ?? '?'), 0, 2), ENT_QUOTES) ?>
+                        <div class="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-orange-400/15 bg-orange-500/8 text-sm font-semibold text-orange-100">
+                            <?php if (!empty($row['image_url'])): ?>
+                                <img
+                                    src="<?= htmlspecialchars((string) $row['image_url'], ENT_QUOTES) ?>"
+                                    alt="<?= htmlspecialchars((string) ($row['module'] ?? 'Item icon'), ENT_QUOTES) ?>"
+                                    class="h-full w-full object-contain p-1"
+                                    loading="lazy"
+                                >
+                            <?php else: ?>
+                                <?= htmlspecialchars(substr((string) ($row['module'] ?? '?'), 0, 2), ENT_QUOTES) ?>
+                            <?php endif; ?>
                         </div>
                         <div class="min-w-0 flex-1">
                             <div class="flex items-start justify-between gap-3">

--- a/src/functions.php
+++ b/src/functions.php
@@ -2600,21 +2600,21 @@ function dashboard_intelligence_data(): array
             ['label' => 'Overlap Coverage', 'value' => market_format_percentage($coveragePercent), 'context' => $rowCount > 0 ? ($inBothCount . ' of ' . $rowCount . ' items in both markets') : 'No market overlap data yet'],
         ],
         'priority_queues' => [
-            'opportunities' => array_map(static fn (array $row): array => [
-                'module' => $row['type_name'] !== '' ? $row['type_name'] : ('Type #' . $row['type_id']),
-                'signal' => (bool) ($row['missing_in_alliance'] ?? false) ? 'Import seed candidate' : sprintf('%+.1f%% vs hub', (float) ($row['deviation_percent'] ?? 0.0)),
-                'score' => (int) ($row['opportunity_score'] ?? 0),
-            ], array_slice(array_values(array_filter($opportunities, static fn (array $row): bool => (int) ($row['opportunity_score'] ?? 0) > 0)), 0, 5)),
-            'risks' => array_map(static fn (array $row): array => [
-                'module' => $row['type_name'] !== '' ? $row['type_name'] : ('Type #' . $row['type_id']),
-                'signal' => (bool) ($row['overpriced_in_alliance'] ?? false) ? sprintf('%+.1f%% overpriced', (float) ($row['deviation_percent'] ?? 0.0)) : 'Stock or freshness risk',
-                'score' => (int) ($row['risk_score'] ?? 0),
-            ], array_slice(array_values(array_filter($risks, static fn (array $row): bool => (int) ($row['risk_score'] ?? 0) > 0)), 0, 5)),
-            'missing_items' => array_map(static fn (array $row): array => [
-                'module' => $row['type_name'] !== '' ? $row['type_name'] : ('Type #' . $row['type_id']),
-                'signal' => 'Volume ' . (string) ($row['reference_total_sell_volume'] ?? 0) . ' · score ' . (string) ($row['opportunity_score'] ?? 0),
-                'score' => (int) ($row['opportunity_score'] ?? 0),
-            ], array_slice(array_values(array_filter($opportunities, static fn (array $row): bool => (bool) ($row['missing_in_alliance'] ?? false))), 0, 5)),
+            'opportunities' => array_map(static fn (array $row): array => dashboard_priority_queue_item(
+                $row,
+                (bool) ($row['missing_in_alliance'] ?? false) ? 'Import seed candidate' : sprintf('%+.1f%% vs hub', (float) ($row['deviation_percent'] ?? 0.0)),
+                (int) ($row['opportunity_score'] ?? 0)
+            ), array_slice(array_values(array_filter($opportunities, static fn (array $row): bool => (int) ($row['opportunity_score'] ?? 0) > 0)), 0, 5)),
+            'risks' => array_map(static fn (array $row): array => dashboard_priority_queue_item(
+                $row,
+                (bool) ($row['overpriced_in_alliance'] ?? false) ? sprintf('%+.1f%% overpriced', (float) ($row['deviation_percent'] ?? 0.0)) : 'Stock or freshness risk',
+                (int) ($row['risk_score'] ?? 0)
+            ), array_slice(array_values(array_filter($risks, static fn (array $row): bool => (int) ($row['risk_score'] ?? 0) > 0)), 0, 5)),
+            'missing_items' => array_map(static fn (array $row): array => dashboard_priority_queue_item(
+                $row,
+                'Volume ' . (string) ($row['reference_total_sell_volume'] ?? 0) . ' · score ' . (string) ($row['opportunity_score'] ?? 0),
+                (int) ($row['opportunity_score'] ?? 0)
+            ), array_slice(array_values(array_filter($opportunities, static fn (array $row): bool => (bool) ($row['missing_in_alliance'] ?? false))), 0, 5)),
         ],
         'health_panels' => [
             'alliance_freshness' => dashboard_sync_health_panel($allianceSync),
@@ -2634,6 +2634,19 @@ function dashboard_intelligence_data(): array
         'dependencies' => ['dashboard', 'market_compare', 'doctrine'],
         'lock_ttl' => 20,
     ]);
+}
+
+function dashboard_priority_queue_item(array $row, string $signal, int $score): array
+{
+    $typeId = max(0, (int) ($row['type_id'] ?? 0));
+
+    return [
+        'module' => $row['type_name'] !== '' ? $row['type_name'] : ('Type #' . $typeId),
+        'signal' => $signal,
+        'score' => max(0, $score),
+        'type_id' => $typeId > 0 ? $typeId : null,
+        'image_url' => $typeId > 0 ? killmail_entity_image_url('type', $typeId, 'icon', 64) : null,
+    ];
 }
 
 function current_alliance_market_status_data(): array


### PR DESCRIPTION
### Motivation
- Improve the dashboard intelligence queues by showing real item thumbnails instead of the two-letter placeholder while preserving the existing rounded badge styling.

### Description
- Add `dashboard_priority_queue_item()` in `src/functions.php` to centralize mapping for priority queue rows and include `type_id` and `image_url` (uses `killmail_entity_image_url`).
- Replace inline row shaping with calls to the new mapper for `opportunities`, `risks`, and `missing_items` in `dashboard_intelligence_data()`.
- Update `public/index.php` to render the EVE item icon inside the existing rounded thumbnail container with `object-contain p-1` and a lazy-loading `<img>`; fall back to the two-letter text if no image is available.
- Keep visual shape and accessibility (alt text) consistent with existing layout and styles.

### Testing
- Ran PHP syntax checks: `php -l public/index.php` succeeded. 
- Ran PHP syntax checks: `php -l src/functions.php` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf9a514c4832f96adb385bec3764c)