### PR TITLE
Refactor intelligence scheduling cadences (fast/medium/slow) and snapshot-backed doctrine

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 - Cron is **timer-only**: it triggers `bin/cron_tick.php` once per minute.
 - The scheduler (`bin/cron_tick.php`) decides which jobs are due and dispatches `bin/sync_runner.php`.
 - Interval and enable/disable controls are configured in **Settings → Data Sync** (`/settings?section=data-sync`) via scheduler rows in `sync_schedules`.
+- SupplyCore now separates cadences by workload:
+  - **Fast ingestion**: `killmail_r2z2_sync`, `alliance_current_sync`, `market_hub_current_sync`, and `current_state_refresh_sync` keep raw data and lightweight current-state views fresh.
+  - **Medium intelligence**: `doctrine_intelligence_sync` recomputes snapshot-backed readiness, shortages, opportunities, loss pressure, depletion, and dashboard-facing doctrine summaries on a steadier batch cadence.
+  - **Slow forecasting / AI**: `forecasting_ai_sync` derives slower-moving target-adjustment, anomaly, briefing, and explanation layers from the latest medium snapshot instead of raw minute-by-minute ingestion.
 - The hub-history scheduler jobs (`market_hub_historical_sync` and `market_hub_local_history_sync`) rebuild `market_history_daily` from SupplyCore’s own raw hub-order snapshots stored in MySQL for the configured market hub, using the recent window controlled by `raw_order_snapshot_retention_days` unless a CLI override is supplied.
 - **Trend Snippets** on the dashboard depend on that first-party snapshot history generation.
 - The **Run now** button in Settings → Data Sync includes the Hub Snapshot History job, forces the selected enabled schedule due immediately, and executes one scheduler tick.
@@ -289,7 +293,8 @@ Configure ingestion + tracked alliances/corporations at:
 - Doctrine recalculation persists fit-level history in `doctrine_fit_snapshots`.
 - Each recalculation stores complete-fit availability, target fits, fit gap, bottleneck item, loss pressure, depletion, readiness state, recommendation, and the driver scores behind the decision.
 - The doctrine UI uses those snapshots to explain recommendation changes, target deltas, bottleneck swaps, and trend direction over time.
-- Intended recalculation triggers are doctrine fit changes, market sync completion, killmail sync completion, and the optional scheduler job `doctrine_intelligence_sync`.
+- High-level recommendations are now intentionally **snapshot-based**: fast ingestion updates raw data quickly, while `doctrine_intelligence_sync` refreshes the stable doctrine snapshot on its own medium cadence.
+- Slow forecasting (`forecasting_ai_sync`) reads from the latest stored doctrine snapshot so heavier recommendation explanations and anomaly-style summaries do not thrash on every minute tick.
 
 
 ## Architecture Guidelines

--- a/bin/sync_runner.php
+++ b/bin/sync_runner.php
@@ -212,10 +212,6 @@ function sync_runner_dispatch_job(string $jobKey, int $sourceId, string $runMode
     if ($jobKey === 'alliance-current') {
         $datasetKey = sync_dataset_key_alliance_structure_orders_current($sourceId);
         $result = sync_alliance_structure_orders($sourceId, $runMode);
-        try {
-            doctrine_refresh_intelligence('sync-runner:alliance-current');
-        } catch (Throwable) {
-        }
 
         return $result + ['dataset_key' => $datasetKey];
     }
@@ -230,10 +226,6 @@ function sync_runner_dispatch_job(string $jobKey, int $sourceId, string $runMode
     if ($jobKey === 'killmail-r2z2') {
         $datasetKey = sync_dataset_key_killmail_r2z2_stream();
         $result = sync_killmail_r2z2_stream($runMode);
-        try {
-            doctrine_refresh_intelligence('sync-runner:killmail-r2z2');
-        } catch (Throwable) {
-        }
 
         return $result + ['dataset_key' => $datasetKey];
     }
@@ -246,10 +238,6 @@ function sync_runner_dispatch_job(string $jobKey, int $sourceId, string $runMode
 
         $datasetKey = sync_dataset_key_market_hub_current_orders($hubRef);
         $result = sync_market_hub_current_orders($hubRef, $runMode);
-        try {
-            doctrine_refresh_intelligence('sync-runner:hub-current');
-        } catch (Throwable) {
-        }
 
         return $result + ['dataset_key' => $datasetKey];
     }
@@ -262,10 +250,6 @@ function sync_runner_dispatch_job(string $jobKey, int $sourceId, string $runMode
 
         $datasetKey = sync_dataset_key_market_hub_local_history_daily($hubRef);
         $result = sync_market_hub_local_history($hubRef, $runMode, $windowDays);
-        try {
-            doctrine_refresh_intelligence('sync-runner:market-hub-local-history');
-        } catch (Throwable) {
-        }
 
         return $result + ['dataset_key' => $datasetKey];
     }

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -580,12 +580,14 @@ INSERT INTO doctrine_groups (group_name, description) VALUES
 ON DUPLICATE KEY UPDATE description = VALUES(description);
 
 INSERT INTO sync_schedules (job_key, enabled, interval_seconds, next_run_at, last_run_at, last_status, last_error, locked_until) VALUES
-    ('alliance_current_sync', 1, 300, NULL, NULL, NULL, NULL, NULL),
+    ('alliance_current_sync', 1, 60, NULL, NULL, NULL, NULL, NULL),
     ('alliance_historical_sync', 1, 1800, NULL, NULL, NULL, NULL, NULL),
-    ('market_hub_current_sync', 1, 300, NULL, NULL, NULL, NULL, NULL),
+    ('market_hub_current_sync', 1, 60, NULL, NULL, NULL, NULL, NULL),
+    ('current_state_refresh_sync', 1, 120, NULL, NULL, NULL, NULL, NULL),
     ('market_hub_historical_sync', 1, 1800, NULL, NULL, NULL, NULL, NULL),
     ('market_hub_local_history_sync', 1, 300, NULL, NULL, NULL, NULL, NULL),
-    ('doctrine_intelligence_sync', 0, 1800, NULL, NULL, NULL, NULL, NULL),
+    ('doctrine_intelligence_sync', 1, 900, NULL, NULL, NULL, NULL, NULL),
+    ('forecasting_ai_sync', 1, 3600, NULL, NULL, NULL, NULL, NULL),
     ('killmail_r2z2_sync', 0, 60, NULL, NULL, NULL, NULL, NULL)
 ON DUPLICATE KEY UPDATE
     enabled = VALUES(enabled),

--- a/src/functions.php
+++ b/src/functions.php
@@ -1916,7 +1916,7 @@ function data_sync_schedule_job_definitions(): array
             'enabled_key' => 'alliance_current_sync_enabled',
             'interval_value_key' => 'alliance_current_sync_interval_value',
             'interval_unit_key' => 'alliance_current_sync_interval_unit',
-            'default_interval_seconds' => 300,
+            'default_interval_seconds' => 60,
             'label' => 'Alliance Current',
         ],
         'alliance_historical_sync' => [
@@ -1930,8 +1930,15 @@ function data_sync_schedule_job_definitions(): array
             'enabled_key' => 'market_hub_current_sync_enabled',
             'interval_value_key' => 'market_hub_current_sync_interval_value',
             'interval_unit_key' => 'market_hub_current_sync_interval_unit',
-            'default_interval_seconds' => 300,
+            'default_interval_seconds' => 60,
             'label' => 'Hub Current',
+        ],
+        'current_state_refresh_sync' => [
+            'enabled_key' => 'current_state_refresh_sync_enabled',
+            'interval_value_key' => 'current_state_refresh_sync_interval_value',
+            'interval_unit_key' => 'current_state_refresh_sync_interval_unit',
+            'default_interval_seconds' => 120,
+            'label' => 'Current-State Refresh',
         ],
         'market_hub_historical_sync' => [
             'enabled_key' => 'market_hub_historical_sync_enabled',
@@ -1951,8 +1958,15 @@ function data_sync_schedule_job_definitions(): array
             'enabled_key' => 'doctrine_intelligence_sync_enabled',
             'interval_value_key' => 'doctrine_intelligence_sync_interval_value',
             'interval_unit_key' => 'doctrine_intelligence_sync_interval_unit',
-            'default_interval_seconds' => 1800,
-            'label' => 'Doctrine Intelligence',
+            'default_interval_seconds' => 900,
+            'label' => 'Medium Intelligence Batch',
+        ],
+        'forecasting_ai_sync' => [
+            'enabled_key' => 'forecasting_ai_sync_enabled',
+            'interval_value_key' => 'forecasting_ai_sync_interval_value',
+            'interval_unit_key' => 'forecasting_ai_sync_interval_unit',
+            'default_interval_seconds' => 3600,
+            'label' => 'Forecasting / AI Batch',
         ],
         'killmail_r2z2_sync' => [
             'enabled_key' => 'killmail_r2z2_sync_enabled',
@@ -4693,22 +4707,25 @@ function scheduler_job_definitions(): array
                 return sync_market_hub_current_orders($hubRef, 'incremental');
             },
         ],
+        'current_state_refresh_sync' => [
+            'timeout_seconds' => 90,
+            'lock_ttl_seconds' => 180,
+            'handler' => static function (): array {
+                return supplycore_refresh_current_state_cache('scheduler');
+            },
+        ],
         'doctrine_intelligence_sync' => [
             'timeout_seconds' => 180,
             'lock_ttl_seconds' => 300,
             'handler' => static function (): array {
-                $snapshot = doctrine_refresh_intelligence('scheduler');
-                $fitCount = count((array) ($snapshot['fits'] ?? []));
-
-                return sync_result_shape() + [
-                    'rows_seen' => $fitCount,
-                    'rows_written' => $fitCount,
-                    'cursor' => 'doctrine_snapshot:' . gmdate('Y-m-d H:i:s'),
-                    'checksum' => sync_checksum(['fit_count' => $fitCount, 'finished_at' => gmdate(DATE_ATOM)]),
-                    'meta' => [
-                        'outcome_reason' => 'Doctrine intelligence refreshed from cached market, killmail, and fit data.',
-                    ],
-                ];
+                return doctrine_refresh_intelligence_job_result('scheduler');
+            },
+        ],
+        'forecasting_ai_sync' => [
+            'timeout_seconds' => 180,
+            'lock_ttl_seconds' => 300,
+            'handler' => static function (): array {
+                return supplycore_refresh_forecasting_snapshot_job_result('scheduler');
             },
         ],
         'killmail_r2z2_sync' => [
@@ -4729,9 +4746,10 @@ function scheduler_job_definitions(): array
 function scheduler_job_type(string $jobKey): string
 {
     return match ($jobKey) {
-        'alliance_current_sync', 'market_hub_current_sync' => 'sync.current',
+        'alliance_current_sync', 'market_hub_current_sync', 'current_state_refresh_sync' => 'sync.current',
         'alliance_historical_sync', 'market_hub_historical_sync', 'market_hub_local_history_sync' => 'sync.history',
         'doctrine_intelligence_sync' => 'sync.doctrine',
+        'forecasting_ai_sync' => 'sync.forecasting',
         'killmail_r2z2_sync' => 'sync.killmail',
         default => 'sync.generic',
     };
@@ -4891,13 +4909,6 @@ function scheduler_run_job(array $job): array
             'meta' => is_array($syncResult['meta'] ?? null) ? $syncResult['meta'] : [],
         ];
         $result['summary'] = scheduler_job_summary_message($result);
-
-        if ($status === 'success' && in_array($jobKey, doctrine_refresh_trigger_job_keys(), true) && $jobKey !== 'doctrine_intelligence_sync') {
-            try {
-                doctrine_refresh_intelligence('scheduler:' . $jobKey);
-            } catch (Throwable) {
-            }
-        }
 
         return $result;
     } catch (Throwable $exception) {
@@ -10820,16 +10831,106 @@ function doctrine_operational_snapshot_build(bool $persistSnapshots = false, str
 function doctrine_operational_snapshot(): array
 {
     return supplycore_cache_aside('doctrine', ['operational-snapshot'], supplycore_cache_ttl('doctrine_summary'), static function (): array {
-        return doctrine_operational_snapshot_build(false, 'cached-read');
+        $snapshot = doctrine_snapshot_cache_payload();
+        if ($snapshot !== null) {
+            return $snapshot;
+        }
+
+        return doctrine_operational_snapshot_build(false, 'cached-read-fallback');
     }, [
         'dependencies' => ['doctrine', 'market_compare', 'killmail_overview'],
         'lock_ttl' => 20,
     ]);
 }
 
+function doctrine_snapshot_setting_key(): string
+{
+    return 'doctrine_intelligence_snapshot_v1';
+}
+
+function doctrine_snapshot_metadata_setting_key(): string
+{
+    return 'doctrine_intelligence_snapshot_meta_v1';
+}
+
+function doctrine_snapshot_cache_payload(): ?array
+{
+    $raw = trim((string) get_setting(doctrine_snapshot_setting_key(), ''));
+    if ($raw === '') {
+        return null;
+    }
+
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        return null;
+    }
+
+    return [
+        'groups' => array_values((array) ($decoded['groups'] ?? [])),
+        'fits' => array_values((array) ($decoded['fits'] ?? [])),
+        'ungrouped_fits' => array_values((array) ($decoded['ungrouped_fits'] ?? [])),
+        'top_missing_items' => array_values((array) ($decoded['top_missing_items'] ?? [])),
+        'global_layer' => is_array($decoded['global_layer'] ?? null)
+            ? $decoded['global_layer']
+            : ['rows' => [], 'top_restock_items' => []],
+    ];
+}
+
+function doctrine_snapshot_metadata(): array
+{
+    $raw = trim((string) get_setting(doctrine_snapshot_metadata_setting_key(), ''));
+    if ($raw === '') {
+        return [];
+    }
+
+    $decoded = json_decode($raw, true);
+
+    return is_array($decoded) ? $decoded : [];
+}
+
+function doctrine_store_snapshot(array $snapshot, string $reason): bool
+{
+    $meta = [
+        'generated_at' => gmdate(DATE_ATOM),
+        'reason' => $reason,
+        'fit_count' => count((array) ($snapshot['fits'] ?? [])),
+        'group_count' => count((array) ($snapshot['groups'] ?? [])),
+        'top_missing_count' => count((array) ($snapshot['top_missing_items'] ?? [])),
+    ];
+
+    return save_settings([
+        doctrine_snapshot_setting_key() => json_encode($snapshot, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+        doctrine_snapshot_metadata_setting_key() => json_encode($meta, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+    ]);
+}
+
+function doctrine_refresh_intelligence_job_result(string $reason = 'manual'): array
+{
+    $snapshot = doctrine_refresh_intelligence($reason);
+    $fitCount = count((array) ($snapshot['fits'] ?? []));
+    $meta = doctrine_snapshot_metadata();
+
+    return sync_result_shape() + [
+        'rows_seen' => $fitCount,
+        'rows_written' => $fitCount,
+        'cursor' => 'doctrine_snapshot:' . gmdate('Y-m-d H:i:s'),
+        'checksum' => sync_checksum([
+            'fit_count' => $fitCount,
+            'generated_at' => (string) ($meta['generated_at'] ?? gmdate(DATE_ATOM)),
+            'reason' => $reason,
+        ]),
+        'meta' => [
+            'outcome_reason' => 'Medium intelligence snapshot refreshed from the latest ingested market, killmail, and doctrine data.',
+            'snapshot_generated_at' => (string) ($meta['generated_at'] ?? ''),
+            'snapshot_reason' => (string) ($meta['reason'] ?? $reason),
+        ],
+    ];
+}
+
 function doctrine_refresh_intelligence(string $reason = 'manual'): array
 {
     $snapshot = doctrine_operational_snapshot_build(true, $reason);
+    doctrine_store_snapshot($snapshot, $reason);
     supplycore_cache_bust(['doctrine', 'dashboard']);
 
     return $snapshot;
@@ -10837,12 +10938,171 @@ function doctrine_refresh_intelligence(string $reason = 'manual'): array
 
 function doctrine_refresh_trigger_job_keys(): array
 {
+    return ['doctrine_intelligence_sync'];
+}
+
+function supplycore_refresh_current_state_cache(string $reason = 'manual'): array
+{
+    supplycore_cache_bust(['dashboard', 'market_compare']);
+
+    $context = market_comparison_context();
+    $outcomes = market_comparison_outcomes();
+    $dashboard = dashboard_intelligence_data();
+    $rows = count((array) ($outcomes['rows'] ?? []));
+    $queues = count((array) ($dashboard['priority_queues']['opportunities'] ?? []))
+        + count((array) ($dashboard['priority_queues']['risks'] ?? []))
+        + count((array) ($dashboard['priority_queues']['missing_items'] ?? []));
+
+    return sync_result_shape() + [
+        'rows_seen' => $rows,
+        'rows_written' => $queues,
+        'cursor' => 'current_state:' . gmdate('Y-m-d H:i:s'),
+        'checksum' => sync_checksum([
+            'reason' => $reason,
+            'reference_hub' => (string) ($context['reference_hub'] ?? ''),
+            'rows' => $rows,
+            'queues' => $queues,
+        ]),
+        'meta' => [
+            'outcome_reason' => 'Fast current-state cache refresh completed without recalculating higher-level recommendations.',
+        ],
+    ];
+}
+
+function supplycore_forecasting_snapshot_setting_key(): string
+{
+    return 'supplycore_forecasting_snapshot_v1';
+}
+
+function supplycore_forecasting_snapshot_metadata_setting_key(): string
+{
+    return 'supplycore_forecasting_snapshot_meta_v1';
+}
+
+function supplycore_forecasting_snapshot(): array
+{
+    $raw = trim((string) get_setting(supplycore_forecasting_snapshot_setting_key(), ''));
+    if ($raw === '') {
+        return [];
+    }
+
+    $decoded = json_decode($raw, true);
+
+    return is_array($decoded) ? $decoded : [];
+}
+
+function supplycore_forecasting_snapshot_store(array $snapshot, string $reason): bool
+{
+    $meta = [
+        'generated_at' => gmdate(DATE_ATOM),
+        'reason' => $reason,
+        'forecast_count' => count((array) ($snapshot['forecast_rows'] ?? [])),
+        'anomaly_count' => count((array) ($snapshot['anomalies'] ?? [])),
+    ];
+
+    return save_settings([
+        supplycore_forecasting_snapshot_setting_key() => json_encode($snapshot, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+        supplycore_forecasting_snapshot_metadata_setting_key() => json_encode($meta, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+    ]);
+}
+
+function supplycore_forecasting_snapshot_build(string $reason = 'manual'): array
+{
+    $snapshot = doctrine_snapshot_cache_payload();
+    if ($snapshot === null) {
+        $snapshot = doctrine_refresh_intelligence($reason . ':bootstrap');
+    }
+
+    $fits = array_values((array) ($snapshot['fits'] ?? []));
+    $forecastRows = [];
+    $anomalies = [];
+    $briefings = [];
+    $explanations = [];
+
+    foreach ($fits as $fit) {
+        $fitId = (int) ($fit['id'] ?? 0);
+        $fitName = trim((string) ($fit['fit_name'] ?? ('Fit #' . $fitId)));
+        $supply = is_array($fit['supply'] ?? null) ? $fit['supply'] : [];
+        $gap = max(0, (int) ($supply['gap_to_target_fit_count'] ?? 0));
+        $target = max(0, (int) ($supply['recommended_target_fit_count'] ?? 0));
+        $losses7d = max((int) ($supply['recent_hull_losses_7d'] ?? 0), (int) ($supply['recent_item_fit_losses_7d'] ?? 0));
+        $depletionState = (string) ($supply['depletion_state'] ?? 'stable');
+        $totalScore = (float) (($supply['driver_scores']['total'] ?? 0.0));
+        $restockGap = (float) ($supply['restock_gap_isk'] ?? 0.0);
+        $pressureIndex = round(($gap * 12) + ($losses7d * 4) + ($depletionState === 'draining' ? 15 : 0) + min(35, $totalScore * 0.4), 2);
+
+        $forecastRows[] = [
+            'fit_id' => $fitId,
+            'fit_name' => $fitName,
+            'target_fits' => $target,
+            'fit_gap' => $gap,
+            'losses_7d' => $losses7d,
+            'depletion_state' => $depletionState,
+            'pressure_index' => $pressureIndex,
+            'restock_gap_isk' => $restockGap,
+            'recommended_action' => (string) ($supply['recommendation_text'] ?? 'Observe'),
+        ];
+
+        if ($gap >= 3 || $totalScore >= 70.0 || $depletionState === 'draining') {
+            $anomalies[] = [
+                'fit_id' => $fitId,
+                'fit_name' => $fitName,
+                'signal' => $depletionState === 'draining'
+                    ? 'Depletion is draining faster than the doctrine buffer.'
+                    : ($gap >= 3 ? 'Doctrine target gap has widened materially.' : 'Recommendation pressure score spiked above the normal threshold.'),
+            ];
+        }
+
+        if ($gap > 0 || $restockGap > 0.0) {
+            $briefings[] = [
+                'fit_id' => $fitId,
+                'fit_name' => $fitName,
+                'briefing' => $fitName . ' needs ' . doctrine_format_quantity($gap) . ' more fit'
+                    . ($gap === 1 ? '' : 's')
+                    . ' to reach target, with ' . market_format_isk($restockGap) . ' estimated hub spend.',
+            ];
+        }
+
+        $explanations[] = [
+            'fit_id' => $fitId,
+            'fit_name' => $fitName,
+            'recommendation_code' => (string) ($supply['recommendation_code'] ?? 'observe'),
+            'recommendation_text' => (string) ($supply['recommendation_text'] ?? 'Observe'),
+            'recommendation_explanation' => (string) ($supply['recommendation_explanation'] ?? 'No explanation available.'),
+        ];
+    }
+
+    usort($forecastRows, static fn (array $a, array $b): int => ((float) ($b['pressure_index'] ?? 0.0) <=> (float) ($a['pressure_index'] ?? 0.0)) ?: strcasecmp((string) ($a['fit_name'] ?? ''), (string) ($b['fit_name'] ?? '')));
+    usort($anomalies, static fn (array $a, array $b): int => strcasecmp((string) ($a['fit_name'] ?? ''), (string) ($b['fit_name'] ?? '')));
+    usort($briefings, static fn (array $a, array $b): int => strcasecmp((string) ($a['fit_name'] ?? ''), (string) ($b['fit_name'] ?? '')));
+
     return [
-        'alliance_current_sync',
-        'market_hub_current_sync',
-        'market_hub_local_history_sync',
-        'killmail_r2z2_sync',
-        'doctrine_intelligence_sync',
+        'generated_at' => gmdate(DATE_ATOM),
+        'reason' => $reason,
+        'forecast_rows' => array_slice($forecastRows, 0, 12),
+        'anomalies' => array_slice($anomalies, 0, 12),
+        'briefings' => array_slice($briefings, 0, 8),
+        'recommendation_explanations' => array_slice($explanations, 0, 20),
+    ];
+}
+
+function supplycore_refresh_forecasting_snapshot_job_result(string $reason = 'manual'): array
+{
+    $snapshot = supplycore_forecasting_snapshot_build($reason);
+    supplycore_forecasting_snapshot_store($snapshot, $reason);
+
+    return sync_result_shape() + [
+        'rows_seen' => count((array) ($snapshot['forecast_rows'] ?? [])),
+        'rows_written' => count((array) ($snapshot['briefings'] ?? [])) + count((array) ($snapshot['anomalies'] ?? [])),
+        'cursor' => 'forecasting_snapshot:' . gmdate('Y-m-d H:i:s'),
+        'checksum' => sync_checksum([
+            'generated_at' => (string) ($snapshot['generated_at'] ?? gmdate(DATE_ATOM)),
+            'reason' => $reason,
+            'forecast_rows' => count((array) ($snapshot['forecast_rows'] ?? [])),
+        ]),
+        'meta' => [
+            'outcome_reason' => 'Slow forecasting batch refreshed target-adjustment, anomaly, briefing, and recommendation-explanation views from the latest medium snapshot.',
+        ],
     ];
 }
 


### PR DESCRIPTION
### Motivation
- Killmail and market ingestion can be frequent but recomputing high-level intelligence every minute is expensive and noisy.  
- Split work into multiple cadences so ingestion stays fast while heavier analysis runs in steadier, explainable batches.  
- Preserve responsiveness for raw syncs and stabilize recommendation outputs via snapshotting.  

### Description
- Introduce explicit cadence tiers and new jobs in `data_sync_schedule_job_definitions()`: added `current_state_refresh_sync` (fast lightweight refresh) and `forecasting_ai_sync` (slow forecasting/AI batch), and relabeled `doctrine_intelligence_sync` as a medium-intelligence batch with a shorter default than before; adjusted default intervals for `alliance_current_sync` and `market_hub_current_sync` to a fast cadence.  
- Decoupled ingestion from intelligence recomputation by removing eager `doctrine_refresh_intelligence()` calls from `bin/sync_runner.php` so ingestion jobs (`killmail_r2z2_sync`, `alliance_current_sync`, `market_hub_current_sync`) do not trigger full recompute on every run.  
- Implemented snapshot-backed doctrine intelligence: functions to store/load a serialized doctrine snapshot in settings (`doctrine_intelligence_snapshot_v1` and metadata), `doctrine_store_snapshot()`, `doctrine_snapshot_cache_payload()`, and a job-result wrapper `doctrine_refresh_intelligence_job_result()` that persists the medium snapshot and returns `sync_result_shape()` metadata.  
- Added lightweight current-state refresh (`supplycore_refresh_current_state_cache()`) and forecasting/AI snapshot builder and persister (`supplycore_forecasting_snapshot_build()`, `supplycore_forecasting_snapshot_store()`, `supplycore_refresh_forecasting_snapshot_job_result()`), and switched scheduler handlers to return those job-results.  
- Persisted snapshot JSON safely using `JSON_INVALID_UTF8_SUBSTITUTE` and added DB schema defaults for the new schedules in `database/schema.sql`.  
- Documented the new cadence model and snapshot behavior in `README.md`.  

### Testing
- Verified PHP syntax with `php -l src/functions.php` and `php -l bin/sync_runner.php`, both succeeded.  
- Ran `git diff --check` to ensure no whitespace errors, which reported no issues.  
- Exercised job-definition introspection via `php -r "require 'src/bootstrap.php'; echo implode(PHP_EOL, array_keys(data_sync_schedule_job_definitions())) . PHP_EOL;"` and `php -r "require 'src/bootstrap.php'; echo implode(PHP_EOL, array_keys(scheduler_job_definitions())) . PHP_EOL;"`, both returned the expected job keys.  
- No automated unit tests exist for these flows; changes are limited to scheduler definitions, handler wiring, snapshot persistence helpers, and README docs and passed static checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb0618293c832f94a595af1f307a5f)