### PR TITLE
Compact doctrine impact summary and aggregation

### DIFF
--- a/public/killmail-intelligence/view.php
+++ b/public/killmail-intelligence/view.php
@@ -173,126 +173,115 @@ include __DIR__ . '/../../src/views/partials/header.php';
         <div class="flex flex-wrap items-start justify-between gap-4">
             <div>
                 <p class="text-xs uppercase tracking-[0.2em] text-emerald-200/80">Doctrine impact</p>
-                <h2 class="mt-1 text-xl font-semibold text-slate-50">Normalized doctrine fit match</h2>
-                <p class="mt-2 max-w-4xl text-sm text-muted">Victim-side hull and stored loss items are matched by <span class="font-medium text-slate-200">type_id</span> against normalized doctrine fit items. Durable components drive the primary signal; consumables only appear as supporting context.</p>
+                <h2 class="mt-1 text-xl font-semibold text-slate-50">Compact doctrine match summary</h2>
+                <p class="mt-2 max-w-4xl text-sm text-muted">Victim-side hull and stored loss items are matched by <span class="font-medium text-slate-200">type_id</span> against normalized doctrine fit items. Durable overlaps are condensed into an operator-focused summary; full fit-level detail remains available on demand.</p>
             </div>
             <div class="flex flex-wrap gap-2">
                 <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= htmlspecialchars((string) ($doctrineImpact['tone'] ?? 'border-slate-500/40 bg-slate-500/10 text-slate-300'), ENT_QUOTES) ?>">
                     <?= htmlspecialchars((string) ($doctrineImpact['label'] ?? 'No doctrine impact'), ENT_QUOTES) ?>
                 </span>
-                <?php if (($doctrineImpact['matched'] ?? false) && is_array($doctrineImpact['severity'] ?? null)): ?>
+                <?php if (is_array($doctrineImpact['severity'] ?? null)): ?>
                     <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= htmlspecialchars((string) (($doctrineImpact['severity']['tone'] ?? 'border-slate-500/40 bg-slate-500/10 text-slate-300')), ENT_QUOTES) ?>">
-                        Severity <?= htmlspecialchars((string) ($doctrineImpact['severity']['label'] ?? 'Low'), ENT_QUOTES) ?>
+                        Severity <?= htmlspecialchars((string) ($doctrineImpact['severity']['label'] ?? 'Weak'), ENT_QUOTES) ?>
                     </span>
                 <?php endif; ?>
             </div>
         </div>
 
-        <div class="mt-6 grid gap-4 md:grid-cols-4">
-            <article class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Doctrine groups</p>
-                <p class="mt-2 text-2xl font-semibold text-slate-50"><?= number_format((int) ($doctrineImpact['matched_group_count'] ?? 0)) ?></p>
-                <p class="mt-2 text-sm text-muted">Groups touched by at least one durable victim-side doctrine item.</p>
-            </article>
-            <article class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Doctrine fits</p>
-                <p class="mt-2 text-2xl font-semibold text-slate-50"><?= number_format((int) ($doctrineImpact['matched_fit_count'] ?? 0)) ?></p>
-                <p class="mt-2 text-sm text-muted">Normalized fits intersecting the victim hull or stored durable loss items.</p>
-            </article>
-            <article class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Matched lines</p>
-                <p class="mt-2 text-2xl font-semibold text-slate-50"><?= number_format((int) ($doctrineImpact['matched_line_count'] ?? 0)) ?></p>
-                <p class="mt-2 text-sm text-muted">Distinct durable doctrine item type_ids found on the victim-side loss.</p>
-            </article>
-            <article class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Consumable overlaps</p>
-                <p class="mt-2 text-2xl font-semibold text-slate-50"><?= number_format((int) ($doctrineImpact['supporting_consumable_count'] ?? 0)) ?></p>
-                <p class="mt-2 text-sm text-muted">Secondary-only overlaps excluded from the primary doctrine-impact signal.</p>
-            </article>
-        </div>
-
-        <div class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)]">
+        <div class="mt-6 grid gap-4 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.85fr)]">
             <article class="surface-secondary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Summary</p>
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Doctrine impact summary</p>
                 <p class="mt-3 text-sm text-slate-200"><?= htmlspecialchars((string) ($doctrineImpact['context'] ?? 'Doctrine impact context unavailable.'), ENT_QUOTES) ?></p>
 
-                <?php if (((array) ($doctrineImpact['matched_item_names'] ?? [])) !== []): ?>
-                    <div class="mt-4">
-                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Matched doctrine items</p>
-                        <div class="mt-3 flex flex-wrap gap-2">
-                            <?php foreach ((array) ($doctrineImpact['matched_item_names'] ?? []) as $itemName): ?>
-                                <span class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-100"><?= htmlspecialchars((string) $itemName, ENT_QUOTES) ?></span>
+                <div class="mt-4 grid gap-3 sm:grid-cols-3">
+                    <div class="surface-tertiary">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Severity</p>
+                        <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($doctrineImpact['severity']['label'] ?? 'Weak'), ENT_QUOTES) ?></p>
+                        <p class="mt-1 text-xs text-muted">Immediate doctrine relevance.</p>
+                    </div>
+                    <div class="surface-tertiary">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Groups affected</p>
+                        <p class="mt-2 text-lg font-semibold text-slate-50"><?= number_format((int) ($doctrineImpact['matched_group_count'] ?? 0)) ?></p>
+                        <p class="mt-1 text-xs text-muted">Distinct doctrine groups touched.</p>
+                    </div>
+                    <div class="surface-tertiary">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Meaningful items</p>
+                        <p class="mt-2 text-lg font-semibold text-slate-50"><?= number_format((int) ($doctrineImpact['meaningful_item_count'] ?? ($doctrineImpact['matched_item_count'] ?? 0))) ?></p>
+                        <p class="mt-1 text-xs text-muted">Unique durable items after overlap collapse.</p>
+                    </div>
+                </div>
+
+                <div class="mt-5">
+                    <div class="flex items-center justify-between gap-3">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Impacted doctrine groups</p>
+                        <?php if ((int) ($doctrineImpact['matched_fit_count'] ?? 0) > 0): ?>
+                            <span class="text-xs text-muted"><?= number_format((int) ($doctrineImpact['matched_fit_count'] ?? 0)) ?> unique fit<?= ((int) ($doctrineImpact['matched_fit_count'] ?? 0)) === 1 ? '' : 's' ?> behind summary</span>
+                        <?php endif; ?>
+                    </div>
+
+                    <?php if (((array) ($doctrineImpact['matched_groups'] ?? [])) === []): ?>
+                        <div class="mt-3 rounded-xl border border-dashed border-border bg-black/20 px-4 py-5 text-sm text-slate-400">
+                            No durable doctrine groups matched this victim-side loss.
+                        </div>
+                    <?php else: ?>
+                        <div class="mt-3 space-y-2">
+                            <?php foreach ((array) ($doctrineImpact['matched_groups'] ?? []) as $group): ?>
+                                <div class="surface-tertiary">
+                                    <div class="flex flex-wrap items-start justify-between gap-3">
+                                        <div>
+                                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($group['group_name'] ?? 'Doctrine group'), ENT_QUOTES) ?></p>
+                                            <?php if (((array) ($group['preview_item_names'] ?? [])) !== []): ?>
+                                                <p class="mt-1 text-xs text-muted"><?= htmlspecialchars(implode(', ', (array) ($group['preview_item_names'] ?? [])), ENT_QUOTES) ?></p>
+                                            <?php else: ?>
+                                                <p class="mt-1 text-xs text-muted">No durable item preview available.</p>
+                                            <?php endif; ?>
+                                        </div>
+                                        <div class="flex flex-wrap items-center gap-2 text-xs">
+                                            <span class="rounded-full border border-border bg-black/20 px-2 py-0.5 text-slate-300"><?= number_format((int) ($group['matched_item_count'] ?? 0)) ?> item<?= ((int) ($group['matched_item_count'] ?? 0)) === 1 ? '' : 's' ?></span>
+                                            <?php if (is_array($group['confidence'] ?? null)): ?>
+                                                <span class="rounded-full border px-2 py-0.5 <?= htmlspecialchars((string) ($group['confidence']['tone'] ?? 'border-slate-500/40 bg-slate-500/10 text-slate-300'), ENT_QUOTES) ?>"><?= htmlspecialchars((string) ($group['confidence']['label'] ?? 'Low'), ENT_QUOTES) ?> confidence</span>
+                                            <?php endif; ?>
+                                        </div>
+                                    </div>
+                                </div>
                             <?php endforeach; ?>
                         </div>
-                    </div>
-                <?php endif; ?>
+                    <?php endif; ?>
+                </div>
+            </article>
 
-                <?php if (((array) ($doctrineImpact['matched_groups'] ?? [])) === []): ?>
+            <article class="surface-secondary">
+                <div class="flex items-center justify-between gap-3">
+                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Key matching items</p>
+                    <?php if ((int) ($doctrineImpact['supporting_consumable_count'] ?? 0) > 0): ?>
+                        <span class="text-xs text-muted"><?= number_format((int) ($doctrineImpact['supporting_consumable_count'] ?? 0)) ?> consumable overlap<?= ((int) ($doctrineImpact['supporting_consumable_count'] ?? 0)) === 1 ? '' : 's' ?> hidden in details</span>
+                    <?php endif; ?>
+                </div>
+
+                <?php if (((array) ($doctrineImpact['top_matched_items'] ?? [])) === []): ?>
                     <div class="mt-4 rounded-xl border border-dashed border-border bg-black/20 px-4 py-5 text-sm text-slate-400">
-                        No durable doctrine groups matched this victim-side loss.
+                        No meaningful durable doctrine items were identified for summary display.
                     </div>
                 <?php else: ?>
-                    <div class="mt-4 space-y-3">
-                        <?php foreach ((array) ($doctrineImpact['matched_groups'] ?? []) as $group): ?>
+                    <div class="mt-4 space-y-2">
+                        <?php foreach ((array) ($doctrineImpact['top_matched_items'] ?? []) as $matchedItem): ?>
                             <div class="surface-tertiary">
                                 <div class="flex flex-wrap items-start justify-between gap-3">
                                     <div>
-                                        <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($group['group_name'] ?? 'Doctrine group'), ENT_QUOTES) ?></p>
-                                        <p class="mt-1 text-xs text-muted"><?= htmlspecialchars(implode(', ', (array) ($group['fit_names'] ?? [])), ENT_QUOTES) ?></p>
+                                        <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($matchedItem['item_name'] ?? 'Unknown item'), ENT_QUOTES) ?></p>
+                                        <p class="mt-1 text-xs text-muted">
+                                            <?= number_format((int) ($matchedItem['group_count'] ?? 0)) ?> group<?= ((int) ($matchedItem['group_count'] ?? 0)) === 1 ? '' : 's' ?>
+                                            <?php if ((int) ($matchedItem['fit_count'] ?? 0) > 0): ?>
+                                                · <?= number_format((int) ($matchedItem['fit_count'] ?? 0)) ?> fit<?= ((int) ($matchedItem['fit_count'] ?? 0)) === 1 ? '' : 's' ?>
+                                            <?php endif; ?>
+                                            <?php if ((string) ($matchedItem['victim_state_label'] ?? '') !== ''): ?>
+                                                · <?= htmlspecialchars((string) ($matchedItem['victim_state_label'] ?? ''), ENT_QUOTES) ?>
+                                            <?php endif; ?>
+                                        </p>
                                     </div>
-                                    <span class="rounded-full border border-border bg-black/20 px-2 py-0.5 text-xs text-slate-300"><?= number_format(count((array) ($group['matched_item_names'] ?? []))) ?> items</span>
-                                </div>
-                                <?php if (((array) ($group['matched_item_names'] ?? [])) !== []): ?>
-                                    <p class="mt-3 text-sm text-slate-300"><?= htmlspecialchars(implode(', ', (array) ($group['matched_item_names'] ?? [])), ENT_QUOTES) ?></p>
-                                <?php endif; ?>
-                            </div>
-                        <?php endforeach; ?>
-                    </div>
-                <?php endif; ?>
-            </article>
-
-            <article class="surface-secondary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Matched doctrine fits</p>
-                <?php if (((array) ($doctrineImpact['matched_fits'] ?? [])) === []): ?>
-                    <div class="mt-4 rounded-xl border border-dashed border-border bg-black/20 px-4 py-5 text-sm text-slate-400">
-                        No normalized doctrine fits currently intersect this victim-side loss.
-                    </div>
-                <?php else: ?>
-                    <div class="mt-4 space-y-3">
-                        <?php foreach ((array) ($doctrineImpact['matched_fits'] ?? []) as $fit): ?>
-                            <div class="surface-tertiary">
-                                <div class="flex items-start gap-3">
-                                    <?php if ((string) ($fit['ship_image_url'] ?? '') !== ''): ?>
-                                        <img src="<?= htmlspecialchars((string) $fit['ship_image_url'], ENT_QUOTES) ?>" alt="" class="h-12 w-12 rounded-xl bg-black/20 object-cover">
+                                    <?php if ((bool) ($matchedItem['is_hull'] ?? false)): ?>
+                                        <span class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-100">Hull match</span>
                                     <?php endif; ?>
-                                    <div class="min-w-0 flex-1">
-                                        <div class="flex flex-wrap items-start justify-between gap-3">
-                                            <div>
-                                                <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($fit['fit_name'] ?? 'Doctrine fit'), ENT_QUOTES) ?></p>
-                                                <p class="mt-1 text-xs text-muted"><?= htmlspecialchars(implode(', ', (array) ($fit['group_names'] ?? [])) ?: (string) ($fit['ship_name'] ?? ''), ENT_QUOTES) ?></p>
-                                            </div>
-                                            <div class="flex flex-wrap gap-2 text-xs">
-                                                <span class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-emerald-100"><?= number_format((int) ($fit['matched_primary_line_count'] ?? 0)) ?> durable</span>
-                                                <?php if ((int) ($fit['matched_secondary_line_count'] ?? 0) > 0): ?>
-                                                    <span class="rounded-full border border-border bg-black/20 px-2 py-0.5 text-slate-300"><?= number_format((int) ($fit['matched_secondary_line_count'] ?? 0)) ?> consumable</span>
-                                                <?php endif; ?>
-                                            </div>
-                                        </div>
-
-                                        <?php if (((array) ($fit['matched_primary_items'] ?? [])) !== []): ?>
-                                            <div class="mt-3 flex flex-wrap gap-2">
-                                                <?php foreach ((array) ($fit['matched_primary_items'] ?? []) as $matchedItem): ?>
-                                                    <span class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-100">
-                                                        <?= htmlspecialchars((string) ($matchedItem['item_name'] ?? 'Unknown item'), ENT_QUOTES) ?>
-                                                    </span>
-                                                <?php endforeach; ?>
-                                            </div>
-                                        <?php endif; ?>
-
-                                        <?php if (((array) ($fit['matched_secondary_items'] ?? [])) !== []): ?>
-                                            <p class="mt-3 text-xs text-muted">Supporting consumables: <?= htmlspecialchars(implode(', ', array_map(static fn (array $row): string => (string) ($row['item_name'] ?? ''), (array) ($fit['matched_secondary_items'] ?? []))), ENT_QUOTES) ?></p>
-                                        <?php endif; ?>
-                                    </div>
                                 </div>
                             </div>
                         <?php endforeach; ?>
@@ -302,26 +291,109 @@ include __DIR__ . '/../../src/views/partials/header.php';
         </div>
 
         <details class="mt-6 surface-secondary">
-            <summary class="cursor-pointer list-none text-sm font-medium text-slate-100">Doctrine impact debug trace</summary>
-            <?php $doctrineDebug = $doctrineImpact['debug'] ?? []; ?>
-            <div class="mt-4 grid gap-4 md:grid-cols-2">
-                <div class="surface-tertiary">
-                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Victim-side type_ids considered</p>
-                    <p class="mt-2 break-words font-mono text-xs text-slate-300"><?= htmlspecialchars(implode(', ', array_map('strval', (array) ($doctrineDebug['victim_item_type_ids_considered'] ?? []))) ?: 'None', ENT_QUOTES) ?></p>
-                    <p class="mt-3 text-xs uppercase tracking-[0.15em] text-muted">Durable type_ids considered</p>
-                    <p class="mt-2 break-words font-mono text-xs text-slate-300"><?= htmlspecialchars(implode(', ', array_map('strval', (array) ($doctrineDebug['victim_durable_type_ids_considered'] ?? []))) ?: 'None', ENT_QUOTES) ?></p>
-                    <p class="mt-3 text-xs uppercase tracking-[0.15em] text-muted">Consumable type_ids considered</p>
-                    <p class="mt-2 break-words font-mono text-xs text-slate-300"><?= htmlspecialchars(implode(', ', array_map('strval', (array) ($doctrineDebug['victim_consumable_type_ids_considered'] ?? []))) ?: 'None', ENT_QUOTES) ?></p>
+            <summary class="cursor-pointer list-none text-sm font-medium text-slate-100">Expanded doctrine match details</summary>
+            <div class="mt-4 space-y-4">
+                <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                    <article class="surface-tertiary">
+                        <div class="flex items-center justify-between gap-3">
+                            <p class="text-xs uppercase tracking-[0.15em] text-muted">Fit-level matches</p>
+                            <span class="text-xs text-muted"><?= number_format((int) ($doctrineImpact['matched_fit_count'] ?? 0)) ?> fit<?= ((int) ($doctrineImpact['matched_fit_count'] ?? 0)) === 1 ? '' : 's' ?></span>
+                        </div>
+                        <?php if (((array) ($doctrineImpact['matched_fits'] ?? [])) === []): ?>
+                            <div class="mt-4 rounded-xl border border-dashed border-border bg-black/20 px-4 py-5 text-sm text-slate-400">
+                                No normalized doctrine fits currently intersect this victim-side loss.
+                            </div>
+                        <?php else: ?>
+                            <div class="mt-4 space-y-3">
+                                <?php foreach ((array) ($doctrineImpact['matched_fits'] ?? []) as $fit): ?>
+                                    <div class="rounded-xl border border-border bg-black/20 p-4">
+                                        <div class="flex items-start gap-3">
+                                            <?php if ((string) ($fit['ship_image_url'] ?? '') !== ''): ?>
+                                                <img src="<?= htmlspecialchars((string) $fit['ship_image_url'], ENT_QUOTES) ?>" alt="" class="h-10 w-10 rounded-xl bg-black/20 object-cover">
+                                            <?php endif; ?>
+                                            <div class="min-w-0 flex-1">
+                                                <div class="flex flex-wrap items-start justify-between gap-3">
+                                                    <div>
+                                                        <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($fit['fit_name'] ?? 'Doctrine fit'), ENT_QUOTES) ?></p>
+                                                        <p class="mt-1 text-xs text-muted"><?= htmlspecialchars(implode(', ', (array) ($fit['group_names'] ?? [])) ?: (string) ($fit['ship_name'] ?? ''), ENT_QUOTES) ?></p>
+                                                    </div>
+                                                    <div class="flex flex-wrap gap-2 text-xs">
+                                                        <span class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-emerald-100"><?= number_format((int) ($fit['matched_primary_line_count'] ?? 0)) ?> durable</span>
+                                                        <?php if ((int) ($fit['matched_secondary_line_count'] ?? 0) > 0): ?>
+                                                            <span class="rounded-full border border-border bg-black/20 px-2 py-0.5 text-slate-300"><?= number_format((int) ($fit['matched_secondary_line_count'] ?? 0)) ?> consumable</span>
+                                                        <?php endif; ?>
+                                                    </div>
+                                                </div>
+
+                                                <?php if (((array) ($fit['matched_primary_items'] ?? [])) !== []): ?>
+                                                    <p class="mt-3 text-sm text-slate-300"><?= htmlspecialchars(implode(', ', array_map(static fn (array $row): string => (string) ($row['item_name'] ?? ''), (array) ($fit['matched_primary_items'] ?? []))), ENT_QUOTES) ?></p>
+                                                <?php endif; ?>
+
+                                                <?php if (((array) ($fit['matched_secondary_items'] ?? [])) !== []): ?>
+                                                    <p class="mt-3 text-xs text-muted">Supporting consumables: <?= htmlspecialchars(implode(', ', array_map(static fn (array $row): string => (string) ($row['item_name'] ?? ''), (array) ($fit['matched_secondary_items'] ?? []))), ENT_QUOTES) ?></p>
+                                                <?php endif; ?>
+                                            </div>
+                                        </div>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif; ?>
+                    </article>
+
+                    <article class="surface-tertiary">
+                        <p class="text-xs uppercase tracking-[0.15em] text-muted">All matched durable items</p>
+                        <?php if (((array) ($doctrineImpact['matched_items'] ?? [])) === []): ?>
+                            <div class="mt-4 rounded-xl border border-dashed border-border bg-black/20 px-4 py-5 text-sm text-slate-400">
+                                No durable doctrine items matched this loss.
+                            </div>
+                        <?php else: ?>
+                            <div class="mt-4 space-y-2">
+                                <?php foreach ((array) ($doctrineImpact['matched_items'] ?? []) as $matchedItem): ?>
+                                    <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+                                        <div class="flex flex-wrap items-start justify-between gap-3">
+                                            <div>
+                                                <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($matchedItem['item_name'] ?? 'Unknown item'), ENT_QUOTES) ?></p>
+                                                <p class="mt-1 text-xs text-muted"><?= htmlspecialchars(implode(', ', (array) ($matchedItem['group_names'] ?? [])) ?: 'No doctrine groups recorded', ENT_QUOTES) ?></p>
+                                            </div>
+                                            <div class="flex flex-wrap gap-2 text-xs">
+                                                <span class="rounded-full border border-border bg-black/20 px-2 py-0.5 text-slate-300"><?= number_format((int) ($matchedItem['group_count'] ?? 0)) ?> group<?= ((int) ($matchedItem['group_count'] ?? 0)) === 1 ? '' : 's' ?></span>
+                                                <?php if ((bool) ($matchedItem['is_generic_overlap'] ?? false)): ?>
+                                                    <span class="rounded-full border border-slate-500/30 bg-slate-500/10 px-2 py-0.5 text-slate-300">Generic overlap</span>
+                                                <?php endif; ?>
+                                            </div>
+                                        </div>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif; ?>
+                    </article>
                 </div>
+
                 <div class="surface-tertiary">
-                    <p class="text-xs uppercase tracking-[0.15em] text-muted">Doctrine durable type_ids considered</p>
-                    <p class="mt-2 break-words font-mono text-xs text-slate-300"><?= htmlspecialchars(implode(', ', array_map('strval', (array) ($doctrineDebug['doctrine_item_type_ids_considered'] ?? []))) ?: 'None', ENT_QUOTES) ?></p>
-                    <p class="mt-3 text-xs uppercase tracking-[0.15em] text-muted">Intersection</p>
-                    <p class="mt-2 text-sm text-slate-200"><?= htmlspecialchars((string) number_format((int) ($doctrineDebug['intersection_count'] ?? 0)), ENT_QUOTES) ?> durable · <?= htmlspecialchars((string) number_format((int) ($doctrineDebug['secondary_intersection_count'] ?? 0)), ENT_QUOTES) ?> consumable</p>
-                    <?php if ((string) ($doctrineDebug['no_match_reason'] ?? '') !== ''): ?>
-                        <p class="mt-3 text-xs uppercase tracking-[0.15em] text-muted">No-match reason</p>
-                        <p class="mt-2 text-sm text-slate-300"><?= htmlspecialchars((string) ($doctrineDebug['no_match_reason'] ?? ''), ENT_QUOTES) ?></p>
-                    <?php endif; ?>
+                    <p class="text-sm font-medium text-slate-100">Doctrine impact debug trace</p>
+                    <?php $doctrineDebug = $doctrineImpact['debug'] ?? []; ?>
+                    <div class="mt-4 grid gap-4 md:grid-cols-2">
+                        <div class="rounded-xl border border-border bg-black/20 p-4">
+                            <p class="text-xs uppercase tracking-[0.15em] text-muted">Victim-side type_ids considered</p>
+                            <p class="mt-2 break-words font-mono text-xs text-slate-300"><?= htmlspecialchars(implode(', ', array_map('strval', (array) ($doctrineDebug['victim_item_type_ids_considered'] ?? []))) ?: 'None', ENT_QUOTES) ?></p>
+                            <p class="mt-3 text-xs uppercase tracking-[0.15em] text-muted">Durable type_ids considered</p>
+                            <p class="mt-2 break-words font-mono text-xs text-slate-300"><?= htmlspecialchars(implode(', ', array_map('strval', (array) ($doctrineDebug['victim_durable_type_ids_considered'] ?? []))) ?: 'None', ENT_QUOTES) ?></p>
+                            <p class="mt-3 text-xs uppercase tracking-[0.15em] text-muted">Consumable type_ids considered</p>
+                            <p class="mt-2 break-words font-mono text-xs text-slate-300"><?= htmlspecialchars(implode(', ', array_map('strval', (array) ($doctrineDebug['victim_consumable_type_ids_considered'] ?? []))) ?: 'None', ENT_QUOTES) ?></p>
+                        </div>
+                        <div class="rounded-xl border border-border bg-black/20 p-4">
+                            <p class="text-xs uppercase tracking-[0.15em] text-muted">Doctrine durable type_ids considered</p>
+                            <p class="mt-2 break-words font-mono text-xs text-slate-300"><?= htmlspecialchars(implode(', ', array_map('strval', (array) ($doctrineDebug['doctrine_item_type_ids_considered'] ?? []))) ?: 'None', ENT_QUOTES) ?></p>
+                            <p class="mt-3 text-xs uppercase tracking-[0.15em] text-muted">Intersection</p>
+                            <p class="mt-2 text-sm text-slate-200"><?= htmlspecialchars((string) number_format((int) ($doctrineDebug['intersection_count'] ?? 0)), ENT_QUOTES) ?> durable · <?= htmlspecialchars((string) number_format((int) ($doctrineDebug['secondary_intersection_count'] ?? 0)), ENT_QUOTES) ?> consumable</p>
+                            <p class="mt-3 text-xs uppercase tracking-[0.15em] text-muted">Meaningful durable type_ids</p>
+                            <p class="mt-2 break-words font-mono text-xs text-slate-300"><?= htmlspecialchars(implode(', ', array_map('strval', (array) ($doctrineDebug['meaningful_item_type_ids'] ?? []))) ?: 'None', ENT_QUOTES) ?></p>
+                            <?php if ((string) ($doctrineDebug['no_match_reason'] ?? '') !== ''): ?>
+                                <p class="mt-3 text-xs uppercase tracking-[0.15em] text-muted">No-match reason</p>
+                                <p class="mt-2 text-sm text-slate-300"><?= htmlspecialchars((string) ($doctrineDebug['no_match_reason'] ?? ''), ENT_QUOTES) ?></p>
+                            <?php endif; ?>
+                        </div>
+                    </div>
                 </div>
             </div>
         </details>

--- a/src/functions.php
+++ b/src/functions.php
@@ -3564,21 +3564,51 @@ function killmail_loss_item_groups(array $items, array $resolvedEntities = []): 
     return $groups;
 }
 
-function killmail_doctrine_impact_severity(int $matchedFitCount, int $matchedPrimaryLineCount, bool $matchedHull): array
+
+function killmail_doctrine_impact_confidence(int $matchedItemCount, int $matchedFitCount, bool $matchedHull): array
 {
-    $score = $matchedPrimaryLineCount + ($matchedHull ? 2 : 0) + max(0, $matchedFitCount - 1);
+    $score = $matchedItemCount + min(2, max(0, $matchedFitCount - 1)) + ($matchedHull ? 1 : 0);
     $level = 'low';
     $label = 'Low';
     $tone = 'border-sky-500/40 bg-sky-500/10 text-sky-100';
 
-    if ($score >= 6) {
+    if ($score >= 5) {
         $level = 'high';
         $label = 'High';
-        $tone = 'border-red-500/40 bg-red-500/10 text-red-100';
+        $tone = 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100';
     } elseif ($score >= 3) {
         $level = 'medium';
         $label = 'Medium';
         $tone = 'border-amber-500/40 bg-amber-500/10 text-amber-100';
+    }
+
+    return [
+        'level' => $level,
+        'label' => $label,
+        'tone' => $tone,
+        'score' => $score,
+    ];
+}
+
+function killmail_doctrine_impact_severity(int $matchedGroupCount, int $matchedMeaningfulItemCount, bool $matchedHull): array
+{
+    $score = ($matchedGroupCount * 2) + $matchedMeaningfulItemCount + ($matchedHull ? 2 : 0);
+    $level = 'weak';
+    $label = 'Weak';
+    $tone = 'border-sky-500/40 bg-sky-500/10 text-sky-100';
+
+    if ($score >= 9) {
+        $level = 'strong';
+        $label = 'Strong';
+        $tone = 'border-red-500/40 bg-red-500/10 text-red-100';
+    } elseif ($score >= 6) {
+        $level = 'likely';
+        $label = 'Likely';
+        $tone = 'border-amber-500/40 bg-amber-500/10 text-amber-100';
+    } elseif ($score >= 3) {
+        $level = 'possible';
+        $label = 'Possible';
+        $tone = 'border-cyan-500/40 bg-cyan-500/10 text-cyan-100';
     }
 
     return [
@@ -3800,13 +3830,18 @@ function killmail_doctrine_impact(array $event, array $items, array $resolvedEnt
         }
     }
 
-    $matchedFits = [];
+    $matchedFitsById = [];
     $matchedGroups = [];
-    $matchedItemNames = [];
     $matchedPrimaryTypeIds = [];
     $matchedSecondaryTypeIds = [];
+    $matchedItemsByTypeId = [];
 
     foreach ((array) ($catalog['fits'] ?? []) as $fit) {
+        $fitId = (int) ($fit['id'] ?? 0);
+        if ($fitId <= 0) {
+            continue;
+        }
+
         $fitPrimaryIntersection = array_values(array_intersect(
             array_keys($primaryVictimTypeIds),
             (array) ($fit['durable_type_ids'] ?? [])
@@ -3822,45 +3857,82 @@ function killmail_doctrine_impact(array $event, array $items, array $resolvedEnt
         $matchedPrimaryItems = [];
         foreach ($fitPrimaryIntersection as $typeId) {
             $typeId = (int) $typeId;
+            if ($typeId <= 0) {
+                continue;
+            }
+
             $matchedPrimaryTypeIds[$typeId] = true;
             $fitItem = (array) (($fit['durable_items_by_type_id'][$typeId] ?? []));
             $victimItem = (array) ($victimRowsByTypeId[$typeId] ?? []);
-            $itemName = (string) (($fitItem['item_name'] ?? null) ?: ($victimItem['item_name'] ?? ('Type #' . $typeId)));
-            $matchedItemNames[$itemName] = true;
-            $matchedPrimaryItems[] = [
+            $itemName = trim((string) (($fitItem['item_name'] ?? null) ?: ($victimItem['item_name'] ?? ('Type #' . $typeId))));
+            $slotCategory = (string) ($fitItem['slot_category'] ?? '');
+            $matchedPrimaryItems[$typeId] = [
                 'type_id' => $typeId,
-                'item_name' => $itemName,
-                'slot_category' => (string) ($fitItem['slot_category'] ?? ''),
+                'item_name' => $itemName !== '' ? $itemName : ('Type #' . $typeId),
+                'slot_category' => $slotCategory,
                 'victim_state_label' => (string) ($victimItem['state_label'] ?? ''),
+                'is_hull' => $typeId === $victimShipTypeId,
             ];
         }
 
         $matchedSecondaryItems = [];
         foreach ($fitSecondaryIntersection as $typeId) {
             $typeId = (int) $typeId;
+            if ($typeId <= 0) {
+                continue;
+            }
+
             $matchedSecondaryTypeIds[$typeId] = true;
             $fitItem = (array) (($fit['consumable_items_by_type_id'][$typeId] ?? []));
             $victimItem = (array) ($victimRowsByTypeId[$typeId] ?? []);
-            $matchedSecondaryItems[] = [
+            $matchedSecondaryItems[$typeId] = [
                 'type_id' => $typeId,
                 'item_name' => (string) (($fitItem['item_name'] ?? null) ?: ($victimItem['item_name'] ?? ('Type #' . $typeId))),
                 'victim_state_label' => (string) ($victimItem['state_label'] ?? ''),
             ];
         }
 
-        $matchedFits[] = [
-            'id' => (int) ($fit['id'] ?? 0),
+        ksort($matchedPrimaryItems);
+        ksort($matchedSecondaryItems);
+
+        $matchedFitsById[$fitId] = [
+            'id' => $fitId,
             'fit_name' => (string) ($fit['fit_name'] ?? 'Doctrine fit'),
             'ship_name' => (string) (($fit['ship_name'] ?? '') !== '' ? $fit['ship_name'] : ($fit['fit_name'] ?? 'Doctrine fit')),
             'ship_image_url' => $fit['ship_image_url'] ?? null,
-            'group_names' => array_values((array) ($fit['group_names'] ?? [])),
-            'matched_primary_items' => $matchedPrimaryItems,
-            'matched_secondary_items' => $matchedSecondaryItems,
+            'group_names' => array_values(array_filter(array_map(static fn ($value): string => trim((string) $value), (array) ($fit['group_names'] ?? [])), static fn (string $value): bool => $value !== '')),
+            'matched_primary_items' => array_values($matchedPrimaryItems),
+            'matched_secondary_items' => array_values($matchedSecondaryItems),
             'matched_primary_line_count' => count($matchedPrimaryItems),
             'matched_secondary_line_count' => count($matchedSecondaryItems),
         ];
 
-        foreach ((array) ($fit['group_names'] ?? []) as $groupName) {
+        $fitGroupNames = $matchedFitsById[$fitId]['group_names'];
+        if ($fitGroupNames === []) {
+            $fitGroupNames = ['Ungrouped'];
+            $matchedFitsById[$fitId]['group_names'] = $fitGroupNames;
+        }
+
+        foreach ($matchedPrimaryItems as $typeId => $matchedItem) {
+            $typeId = (int) $typeId;
+            $matchedItemsByTypeId[$typeId] ??= [
+                'type_id' => $typeId,
+                'item_name' => (string) ($matchedItem['item_name'] ?? ('Type #' . $typeId)),
+                'slot_category' => (string) ($matchedItem['slot_category'] ?? ''),
+                'victim_state_label' => (string) ($matchedItem['victim_state_label'] ?? ''),
+                'is_hull' => (bool) ($matchedItem['is_hull'] ?? false),
+                'fit_ids' => [],
+                'fit_names' => [],
+                'group_names' => [],
+            ];
+            $matchedItemsByTypeId[$typeId]['fit_ids'][$fitId] = true;
+            $matchedItemsByTypeId[$typeId]['fit_names'][(string) ($matchedFitsById[$fitId]['fit_name'] ?? 'Doctrine fit')] = true;
+            foreach ($fitGroupNames as $groupName) {
+                $matchedItemsByTypeId[$typeId]['group_names'][$groupName] = true;
+            }
+        }
+
+        foreach ($fitGroupNames as $groupName) {
             $normalizedGroup = trim((string) $groupName);
             if ($normalizedGroup === '') {
                 continue;
@@ -3868,16 +3940,31 @@ function killmail_doctrine_impact(array $event, array $items, array $resolvedEnt
 
             $matchedGroups[$normalizedGroup] ??= [
                 'group_name' => $normalizedGroup,
+                'fit_ids' => [],
                 'fit_names' => [],
+                'matched_item_type_ids' => [],
                 'matched_item_names' => [],
+                'matched_secondary_type_ids' => [],
+                'matched_secondary_item_names' => [],
+                'matched_hull' => false,
             ];
-            $matchedGroups[$normalizedGroup]['fit_names'][(string) ($fit['fit_name'] ?? 'Doctrine fit')] = true;
-            foreach ($matchedPrimaryItems as $matchedItem) {
+            $matchedGroups[$normalizedGroup]['fit_ids'][$fitId] = true;
+            $matchedGroups[$normalizedGroup]['fit_names'][(string) ($matchedFitsById[$fitId]['fit_name'] ?? 'Doctrine fit')] = true;
+            foreach ($matchedPrimaryItems as $typeId => $matchedItem) {
+                $matchedGroups[$normalizedGroup]['matched_item_type_ids'][(int) $typeId] = true;
                 $matchedGroups[$normalizedGroup]['matched_item_names'][(string) ($matchedItem['item_name'] ?? '')] = true;
+                if ((bool) ($matchedItem['is_hull'] ?? false)) {
+                    $matchedGroups[$normalizedGroup]['matched_hull'] = true;
+                }
+            }
+            foreach ($matchedSecondaryItems as $typeId => $matchedItem) {
+                $matchedGroups[$normalizedGroup]['matched_secondary_type_ids'][(int) $typeId] = true;
+                $matchedGroups[$normalizedGroup]['matched_secondary_item_names'][(string) ($matchedItem['item_name'] ?? '')] = true;
             }
         }
     }
 
+    $matchedFits = array_values($matchedFitsById);
     usort($matchedFits, static function (array $a, array $b): int {
         return ((int) ($b['matched_primary_line_count'] ?? 0) <=> (int) ($a['matched_primary_line_count'] ?? 0))
             ?: ((int) ($b['matched_secondary_line_count'] ?? 0) <=> (int) ($a['matched_secondary_line_count'] ?? 0))
@@ -3888,21 +3975,82 @@ function killmail_doctrine_impact(array $event, array $items, array $resolvedEnt
     $matchedSecondaryTypeIds = array_values(array_map('intval', array_keys($matchedSecondaryTypeIds)));
     sort($matchedPrimaryTypeIds);
     sort($matchedSecondaryTypeIds);
-    $matchedItemNames = array_values(array_keys($matchedItemNames));
-    natcasesort($matchedItemNames);
+
+    $matchedItemRows = array_values(array_map(static function (array $item): array {
+        $item['fit_count'] = count((array) ($item['fit_ids'] ?? []));
+        $item['group_count'] = count((array) ($item['group_names'] ?? []));
+        $slotCategory = strtolower(trim((string) ($item['slot_category'] ?? '')));
+        $genericPenalty = in_array($slotCategory, ['low', 'mid', 'high', 'subsystem', 'service'], true) ? 1 : 0;
+        $item['is_generic_overlap'] = !$item['is_hull'] && $genericPenalty > 0 && ($item['group_count'] >= 2 || $item['fit_count'] >= 3);
+        $item['signal_score'] = ($item['is_hull'] ? 100 : 0)
+            + ($item['group_count'] * 6)
+            + min(3, $item['fit_count'])
+            + ($slotCategory === 'rig' ? 2 : 0)
+            + ($slotCategory === 'drone' ? 1 : 0)
+            - $genericPenalty;
+        $item['fit_names'] = array_values(array_keys((array) ($item['fit_names'] ?? [])));
+        sort($item['fit_names']);
+        $item['group_names'] = array_values(array_keys((array) ($item['group_names'] ?? [])));
+        sort($item['group_names']);
+        unset($item['fit_ids']);
+
+        return $item;
+    }, $matchedItemsByTypeId));
+
+    usort($matchedItemRows, static function (array $a, array $b): int {
+        return ((int) ($b['signal_score'] ?? 0) <=> (int) ($a['signal_score'] ?? 0))
+            ?: ((int) ($b['group_count'] ?? 0) <=> (int) ($a['group_count'] ?? 0))
+            ?: ((int) ($b['fit_count'] ?? 0) <=> (int) ($a['fit_count'] ?? 0))
+            ?: strcasecmp((string) ($a['item_name'] ?? ''), (string) ($b['item_name'] ?? ''));
+    });
+
+    $meaningfulItemRows = array_values(array_filter($matchedItemRows, static fn (array $item): bool => !((bool) ($item['is_generic_overlap'] ?? false))));
+    if ($meaningfulItemRows === []) {
+        $meaningfulItemRows = $matchedItemRows;
+    }
+
+    $topMatchedItemRows = array_slice($meaningfulItemRows, 0, 5);
 
     $matchedGroupRows = array_values(array_map(static function (array $group): array {
+        $fitCount = count((array) ($group['fit_ids'] ?? []));
+        $itemCount = count((array) ($group['matched_item_type_ids'] ?? []));
+        $confidence = killmail_doctrine_impact_confidence($itemCount, $fitCount, (bool) ($group['matched_hull'] ?? false));
         $group['fit_names'] = array_values(array_keys((array) ($group['fit_names'] ?? [])));
         sort($group['fit_names']);
-        $group['matched_item_names'] = array_values(array_keys((array) ($group['matched_item_names'] ?? [])));
+        $group['matched_item_names'] = array_values(array_filter(array_keys((array) ($group['matched_item_names'] ?? [])), static fn (string $value): bool => trim($value) !== ''));
         natcasesort($group['matched_item_names']);
+        $group['matched_item_names'] = array_values($group['matched_item_names']);
+        $group['matched_secondary_item_names'] = array_values(array_filter(array_keys((array) ($group['matched_secondary_item_names'] ?? [])), static fn (string $value): bool => trim($value) !== ''));
+        natcasesort($group['matched_secondary_item_names']);
+        $group['matched_secondary_item_names'] = array_values($group['matched_secondary_item_names']);
+        $group['fit_count'] = $fitCount;
+        $group['matched_item_count'] = $itemCount;
+        $group['matched_secondary_count'] = count((array) ($group['matched_secondary_type_ids'] ?? []));
+        $group['confidence'] = $confidence;
+        $group['preview_item_names'] = array_slice($group['matched_item_names'], 0, 3);
+        unset($group['fit_ids'], $group['matched_item_type_ids'], $group['matched_secondary_type_ids'], $group['matched_hull']);
 
         return $group;
     }, $matchedGroups));
-    usort($matchedGroupRows, static fn (array $a, array $b): int => strcasecmp((string) ($a['group_name'] ?? ''), (string) ($b['group_name'] ?? '')));
+    usort($matchedGroupRows, static function (array $a, array $b): int {
+        return ((int) (($b['confidence']['score'] ?? 0)) <=> (int) (($a['confidence']['score'] ?? 0)))
+            ?: ((int) ($b['matched_item_count'] ?? 0) <=> (int) ($a['matched_item_count'] ?? 0))
+            ?: strcasecmp((string) ($a['group_name'] ?? ''), (string) ($b['group_name'] ?? ''));
+    });
 
-    $severity = killmail_doctrine_impact_severity(count($matchedFits), count($matchedPrimaryTypeIds), in_array($victimShipTypeId, $matchedPrimaryTypeIds, true));
     $matched = $matchedPrimaryTypeIds !== [];
+    $meaningfulItemCount = count($meaningfulItemRows);
+    $severity = killmail_doctrine_impact_severity(count($matchedGroupRows), $meaningfulItemCount, in_array($victimShipTypeId, $matchedPrimaryTypeIds, true));
+    $topItemNames = array_values(array_map(static fn (array $item): string => (string) ($item['item_name'] ?? ''), $topMatchedItemRows));
+    $context = $matched
+        ? ('Doctrine signal is ' . strtolower((string) ($severity['label'] ?? 'weak'))
+            . ': ' . number_format(count($matchedGroupRows)) . ' doctrine group' . (count($matchedGroupRows) === 1 ? '' : 's')
+            . ' affected by ' . number_format($meaningfulItemCount) . ' meaningful durable item' . ($meaningfulItemCount === 1 ? '' : 's') . '.')
+        : 'No durable doctrine fit item type_ids intersected the victim-side hull and stored loss items.';
+    if (!$matched && $matchedSecondaryTypeIds !== []) {
+        $context .= ' Secondary consumable-only overlaps were detected, but they do not drive the primary doctrine-impact signal.';
+    }
+
     $debug = [
         'sequence_id' => (int) ($event['sequence_id'] ?? 0),
         'victim_item_type_ids_considered' => $candidateTypeIds,
@@ -3915,6 +4063,8 @@ function killmail_doctrine_impact(array $event, array $items, array $resolvedEnt
         'secondary_intersection_count' => count($matchedSecondaryTypeIds),
         'matched_fit_ids' => array_values(array_map(static fn (array $fit): int => (int) ($fit['id'] ?? 0), $matchedFits)),
         'matched_group_names' => array_values(array_map(static fn (array $group): string => (string) ($group['group_name'] ?? ''), $matchedGroupRows)),
+        'meaningful_item_type_ids' => array_values(array_map(static fn (array $item): int => (int) ($item['type_id'] ?? 0), $meaningfulItemRows)),
+        'top_item_type_ids' => array_values(array_map(static fn (array $item): int => (int) ($item['type_id'] ?? 0), $topMatchedItemRows)),
         'no_match_reason' => $matched
             ? null
             : match (true) {
@@ -3927,14 +4077,6 @@ function killmail_doctrine_impact(array $event, array $items, array $resolvedEnt
     ];
     killmail_doctrine_impact_log_debug($debug);
 
-    $context = $matched
-        ? ('Matched ' . number_format(count($matchedPrimaryTypeIds)) . ' durable doctrine item type' . (count($matchedPrimaryTypeIds) === 1 ? '' : 's')
-            . ' across ' . number_format(count($matchedFits)) . ' doctrine fit' . (count($matchedFits) === 1 ? '' : 's') . '.')
-        : 'No durable doctrine fit item type_ids intersected the victim-side hull and stored loss items.';
-    if (!$matched && $matchedSecondaryTypeIds !== []) {
-        $context .= ' Secondary consumable-only overlaps were detected, but they do not drive the primary doctrine-impact signal.';
-    }
-
     return [
         'matched' => $matched,
         'label' => $matched ? 'Doctrine impact detected' : 'No doctrine impact',
@@ -3945,7 +4087,10 @@ function killmail_doctrine_impact(array $event, array $items, array $resolvedEnt
         'severity' => $severity,
         'matched_groups' => $matchedGroupRows,
         'matched_fits' => $matchedFits,
-        'matched_item_names' => array_values($matchedItemNames),
+        'matched_items' => $matchedItemRows,
+        'matched_item_names' => $topItemNames,
+        'top_matched_items' => $topMatchedItemRows,
+        'meaningful_item_count' => $meaningfulItemCount,
         'matched_item_count' => count($matchedPrimaryTypeIds),
         'matched_fit_count' => count($matchedFits),
         'matched_group_count' => count($matchedGroupRows),


### PR DESCRIPTION
### Motivation
- The existing doctrine impact UI listed many duplicated fits and repeated module overlaps, producing noisy, low-signal output that consumed screen space. 
- The goal is to present a compact, decision-oriented summary that highlights whether doctrine matters, which groups are affected, and which durable items are relevant while preserving full debug/detail visibility behind a toggle.

### Description
- Deduplicated fit matches by fit ID and collapsed per-fit durable overlaps into a group-centric aggregation with per-group preview, matched item count, and a computed confidence score; logic implemented in `src/functions.php`.
- Built a unique matched durable-item index, computed a signal-ranking (`signal_score`) and generic-overlap heuristics, and surfaced only the top matched items (limit 5) while exposing the full ranked list in details; changes in `src/functions.php` return `matched_items`, `top_matched_items`, and `meaningful_item_count` for the view.
- Reworked severity/confidence scoring with new `killmail_doctrine_impact_confidence` and a `weak/possible/likely/strong` top-line `killmail_doctrine_impact_severity` to drive the UI indicators in `src/functions.php`.
- Replaced the verbose doctrine UI with a compact summary block that shows severity, groups affected, meaningful item count, a compact impacted-group list, key matching items, and an expandable details section containing fit-level matches, full matched items, consumables, and debug trace in `public/killmail-intelligence/view.php`.

### Testing
- Ran PHP syntax checks `php -l src/functions.php` which returned no syntax errors. 
- Ran PHP syntax checks `php -l public/killmail-intelligence/view.php` which returned no syntax errors. 
- Verified the refactored view renders summary, top items, and expands to show fit-level matches and debug trace in the details section (manual UI verification steps exercised during development).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb1b1c34c0832fbb330c264cffb6db)