### PR TITLE
Add local Ollama AI briefing layer for doctrine (background jobs + UI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ README.md
    export REDIS_PORT=6379
    export REDIS_DATABASE=0
    export REDIS_PREFIX=supplycore
+   export OLLAMA_ENABLED=1
+   export OLLAMA_URL=http://localhost:11434/api
+   export OLLAMA_MODEL=qwen2.5:1.5b-instruct
+   export OLLAMA_TIMEOUT=20
    ```
 
 3. **Run with PHP built-in server (dev only)**
@@ -96,6 +100,18 @@ README.md
   - metadata/name resolution for alliance, corporation, character, type, system, region, and structure labels
 - Redis locks are used only as a lightweight coordination layer for scheduler runners and expensive cache recomputation. Database-backed locking remains the fallback path when Redis is disabled or unavailable.
 - You can configure Redis either through environment variables or through **Settings → Data Sync → Redis performance layer**.
+
+## Local Ollama AI Briefings
+
+- SupplyCore’s first local AI layer is intentionally **non-authoritative**. Doctrine calculations, market comparisons, killmail/loss signals, and readiness math remain deterministic and authoritative.
+- Ollama is used only to summarize compact precomputed doctrine facts into operator briefings. It does **not** run on page load; it runs in the background through the scheduler job `rebuild_ai_briefings`.
+- Required environment variables:
+  - `OLLAMA_ENABLED=1`
+  - `OLLAMA_URL=http://localhost:11434/api`
+  - `OLLAMA_MODEL=qwen2.5:1.5b-instruct`
+  - `OLLAMA_TIMEOUT=20`
+- The current-state AI briefing store lives in MySQL table `doctrine_ai_briefings`. Each row keeps the latest model name, operator-facing text, compact source payload, raw response JSON, and failure metadata for debugging/auditability.
+- If Ollama is unavailable or returns malformed JSON, SupplyCore logs the failure and stores a deterministic fallback briefing instead of blocking the rest of the app.
 
 ## Apache2 Deployment Notes
 
@@ -173,6 +189,7 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 - SupplyCore now separates cadences by workload:
   - **Fast ingestion**: `killmail_r2z2_sync`, `alliance_current_sync`, and `market_hub_current_sync` keep raw market and killmail inputs fresh.
   - **Materialized intelligence refresh (target cadence: every 5 minutes)**: `doctrine_intelligence_sync`, `market_comparison_summary_sync`, `loss_demand_summary_sync`, `dashboard_summary_sync`, and `current_state_refresh_sync` recompute heavy current-summary layers from raw tables, then publish the latest payloads into Redis for fast reads.
+  - **Local doctrine AI briefings (target cadence: every 5 minutes)**: `rebuild_ai_briefings` ranks the most important doctrine fits/groups first, generates concise Ollama summaries from compact deterministic facts, stores the latest result in MySQL, and refreshes the dashboard briefing panel.
   - **Slow forecasting / AI**: `forecasting_ai_sync` derives slower-moving target-adjustment, anomaly, briefing, and explanation layers from the latest medium snapshot instead of raw minute-by-minute ingestion.
 - UI pages now read Redis first and fall back to `intelligence_snapshots` if Redis is unavailable; each intelligence surface also exposes its last computed timestamp and freshness state to operators.
 - The hub-history scheduler jobs (`market_hub_historical_sync` and `market_hub_local_history_sync`) rebuild `market_history_daily` from SupplyCore’s own raw hub-order snapshots stored in MySQL for the configured market hub, using the recent window controlled by `raw_order_snapshot_retention_days` unless a CLI override is supplied.

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -131,6 +131,31 @@ CREATE TABLE IF NOT EXISTS intelligence_snapshots (
     KEY idx_snapshot_computed_at (computed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS doctrine_ai_briefings (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    entity_type ENUM('fit', 'group') NOT NULL,
+    entity_id INT UNSIGNED NOT NULL,
+    fit_id INT UNSIGNED DEFAULT NULL,
+    group_id INT UNSIGNED DEFAULT NULL,
+    generation_status ENUM('ready', 'fallback', 'failed') NOT NULL DEFAULT 'ready',
+    computed_at DATETIME DEFAULT NULL,
+    model_name VARCHAR(120) DEFAULT NULL,
+    headline VARCHAR(255) DEFAULT NULL,
+    summary TEXT DEFAULT NULL,
+    action_text TEXT DEFAULT NULL,
+    priority_level ENUM('low', 'medium', 'high', 'critical') NOT NULL DEFAULT 'medium',
+    source_payload_json LONGTEXT DEFAULT NULL,
+    response_json LONGTEXT DEFAULT NULL,
+    error_message VARCHAR(500) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_entity_briefing (entity_type, entity_id),
+    KEY idx_entity_status (entity_type, generation_status, priority_level),
+    KEY idx_computed_at (computed_at),
+    KEY idx_fit_id (fit_id),
+    KEY idx_group_id (group_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS killmail_events (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     sequence_id BIGINT UNSIGNED NOT NULL,

--- a/public/doctrine/fit.php
+++ b/public/doctrine/fit.php
@@ -218,6 +218,21 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Doctrine groups</p>
                         <p class="mt-2 font-semibold text-slate-100"><?= htmlspecialchars(implode(', ', (array) ($fit['group_names'] ?? [])) ?: 'Ungrouped', ENT_QUOTES) ?></p>
                     </div>
+                    <?php if (is_array($fit['ai_briefing'] ?? null)): ?>
+                        <?php $aiBriefing = (array) $fit['ai_briefing']; ?>
+                        <div class="rounded-[1.25rem] border border-violet-400/20 bg-violet-500/10 p-4">
+                            <div class="flex flex-wrap items-start justify-between gap-3">
+                                <div>
+                                    <p class="text-xs uppercase tracking-[0.16em] text-violet-100/80">AI notes</p>
+                                    <p class="mt-2 text-sm font-semibold text-white"><?= htmlspecialchars((string) ($aiBriefing['headline'] ?? 'Operational briefing'), ENT_QUOTES) ?></p>
+                                </div>
+                                <span class="badge <?= htmlspecialchars((string) ($aiBriefing['priority_tone'] ?? 'border-violet-400/20 bg-violet-500/10 text-violet-100'), ENT_QUOTES) ?>"><?= htmlspecialchars(strtoupper((string) ($aiBriefing['priority_level'] ?? 'medium')), ENT_QUOTES) ?></span>
+                            </div>
+                            <p class="mt-3 text-sm text-slate-200"><?= htmlspecialchars((string) ($aiBriefing['summary'] ?? ''), ENT_QUOTES) ?></p>
+                            <p class="mt-3 text-sm font-medium text-violet-50">Next action: <?= htmlspecialchars((string) ($aiBriefing['action_text'] ?? ''), ENT_QUOTES) ?></p>
+                            <p class="mt-2 text-xs text-violet-100/70">Generated <?= htmlspecialchars((string) ($aiBriefing['computed_relative'] ?? 'Unknown'), ENT_QUOTES) ?><?= (($aiBriefing['generation_status'] ?? 'ready') !== 'ready') ? ' · deterministic fallback' : '' ?></p>
+                        </div>
+                    <?php endif; ?>
                     <div class="surface-tertiary">
                         <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Complete fits available</p>
                         <p class="mt-2 font-semibold text-slate-100"><?= doctrine_format_quantity((int) ($supply['complete_fits_available'] ?? 0)) ?></p>

--- a/public/doctrine/group.php
+++ b/public/doctrine/group.php
@@ -116,6 +116,22 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 </div>
             </div>
 
+            <?php if (is_array($group['ai_briefing'] ?? null)): ?>
+                <?php $aiBriefing = (array) $group['ai_briefing']; ?>
+                <div class="mt-5 rounded-[1.4rem] border border-violet-400/20 bg-violet-500/10 p-4">
+                    <div class="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                            <p class="text-xs uppercase tracking-[0.16em] text-violet-100/80">AI notes</p>
+                            <h3 class="mt-2 text-lg font-semibold text-white"><?= htmlspecialchars((string) ($aiBriefing['headline'] ?? 'Operational briefing'), ENT_QUOTES) ?></h3>
+                        </div>
+                        <span class="badge <?= htmlspecialchars((string) ($aiBriefing['priority_tone'] ?? 'border-violet-400/20 bg-violet-500/10 text-violet-100'), ENT_QUOTES) ?>"><?= htmlspecialchars(strtoupper((string) ($aiBriefing['priority_level'] ?? 'medium')), ENT_QUOTES) ?></span>
+                    </div>
+                    <p class="mt-3 text-sm text-slate-200"><?= htmlspecialchars((string) ($aiBriefing['summary'] ?? ''), ENT_QUOTES) ?></p>
+                    <p class="mt-3 text-sm font-medium text-violet-50">Next action: <?= htmlspecialchars((string) ($aiBriefing['action_text'] ?? ''), ENT_QUOTES) ?></p>
+                    <p class="mt-2 text-xs text-violet-100/70">Generated <?= htmlspecialchars((string) ($aiBriefing['computed_relative'] ?? 'Unknown'), ENT_QUOTES) ?><?= (($aiBriefing['generation_status'] ?? 'ready') !== 'ready') ? ' · deterministic fallback' : '' ?></p>
+                </div>
+            <?php endif; ?>
+
             <?php if ($fits === []): ?>
                 <div class="surface-tertiary text-sm text-slate-400">No fits have been imported into this group yet.</div>
             <?php else: ?>

--- a/public/index.php
+++ b/public/index.php
@@ -312,6 +312,42 @@ $statusThemes = [
     </article>
 </section>
 
+<section class="mt-8">
+    <article class="surface-secondary">
+        <div class="section-header border-b border-white/8 pb-4">
+            <div>
+                <p class="eyebrow">AI-assisted briefings</p>
+                <h2 class="mt-2 section-title">Operational Briefings</h2>
+                <p class="mt-2 section-copy">Background-generated local AI summaries layered on top of deterministic doctrine metrics.</p>
+            </div>
+            <span class="badge border-violet-400/20 bg-violet-500/10 text-violet-100">Background only</span>
+        </div>
+        <div class="mt-5 grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+            <?php foreach ((array) ($intel['ai_briefings'] ?? []) as $briefing): ?>
+                <a href="<?= htmlspecialchars((string) ($briefing['href'] ?? '/doctrine'), ENT_QUOTES) ?>" class="block rounded-[1.3rem] border border-white/8 bg-white/[0.03] p-4 transition hover:bg-white/[0.05]">
+                    <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                            <p class="truncate text-sm font-semibold text-slate-100"><?= htmlspecialchars((string) ($briefing['entity_name'] ?? 'Doctrine briefing'), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-slate-500"><?= htmlspecialchars((string) ($briefing['context_name'] ?? ucfirst((string) ($briefing['entity_type'] ?? 'doctrine'))), ENT_QUOTES) ?></p>
+                        </div>
+                        <span class="badge <?= htmlspecialchars((string) ($briefing['priority_tone'] ?? 'border-slate-400/15 bg-slate-500/10 text-slate-200'), ENT_QUOTES) ?>"><?= htmlspecialchars(strtoupper((string) ($briefing['priority_level'] ?? 'medium')), ENT_QUOTES) ?></span>
+                    </div>
+                    <p class="mt-4 text-base font-semibold text-white"><?= htmlspecialchars((string) ($briefing['headline'] ?? 'Briefing unavailable'), ENT_QUOTES) ?></p>
+                    <p class="mt-2 text-sm text-slate-300"><?= htmlspecialchars((string) ($briefing['summary'] ?? ''), ENT_QUOTES) ?></p>
+                    <div class="mt-4 rounded-2xl border border-white/8 bg-slate-950/60 px-3 py-3">
+                        <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Recommended action</p>
+                        <p class="mt-2 text-sm text-slate-100"><?= htmlspecialchars((string) ($briefing['action_text'] ?? ''), ENT_QUOTES) ?></p>
+                    </div>
+                    <p class="mt-3 text-xs text-slate-500">Updated <?= htmlspecialchars((string) ($briefing['computed_relative'] ?? 'Unknown'), ENT_QUOTES) ?><?= (($briefing['generation_status'] ?? 'ready') !== 'ready') ? ' · deterministic fallback' : '' ?></p>
+                </a>
+            <?php endforeach; ?>
+            <?php if (((array) ($intel['ai_briefings'] ?? [])) === []): ?>
+                <div class="surface-tertiary text-sm text-slate-400 lg:col-span-2 xl:col-span-3">No doctrine AI briefings are available yet. Run the background AI briefing job after doctrine intelligence refreshes.</div>
+            <?php endif; ?>
+        </div>
+    </article>
+</section>
+
 <section class="mt-8 grid gap-5 xl:grid-cols-3">
     <article class="surface-primary xl:col-span-2">
         <div class="section-header border-b border-white/8 pb-4">

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -28,4 +28,10 @@ return [
         'read_timeout' => (float) (getenv('REDIS_READ_TIMEOUT') ?: 1.5),
         'lock_enabled' => (getenv('REDIS_LOCK_ENABLED') ?: '1') === '1',
     ],
+    'ollama' => [
+        'enabled' => (getenv('OLLAMA_ENABLED') ?: '0') === '1',
+        'url' => rtrim(getenv('OLLAMA_URL') ?: 'http://localhost:11434/api', '/'),
+        'model' => getenv('OLLAMA_MODEL') ?: 'qwen2.5:1.5b-instruct',
+        'timeout' => max(1, (int) (getenv('OLLAMA_TIMEOUT') ?: 20)),
+    ],
 ];

--- a/src/db.php
+++ b/src/db.php
@@ -3476,6 +3476,144 @@ function db_doctrine_fit_snapshot_insert(array $row): int
     return (int) db()->lastInsertId();
 }
 
+function db_doctrine_ai_briefing_get(string $entityType, int $entityId): ?array
+{
+    $normalizedType = in_array($entityType, ['fit', 'group'], true) ? $entityType : '';
+    $safeEntityId = max(0, $entityId);
+    if ($normalizedType === '' || $safeEntityId <= 0) {
+        return null;
+    }
+
+    return db_select_one(
+        'SELECT *
+         FROM doctrine_ai_briefings
+         WHERE entity_type = ? AND entity_id = ?
+         LIMIT 1',
+        [$normalizedType, $safeEntityId]
+    );
+}
+
+function db_doctrine_ai_briefings_get_many(array $targets): array
+{
+    $normalized = [];
+
+    foreach ($targets as $target) {
+        if (!is_array($target)) {
+            continue;
+        }
+
+        $entityType = in_array((string) ($target['entity_type'] ?? ''), ['fit', 'group'], true)
+            ? (string) $target['entity_type']
+            : '';
+        $entityId = max(0, (int) ($target['entity_id'] ?? 0));
+        if ($entityType === '' || $entityId <= 0) {
+            continue;
+        }
+
+        $normalized[$entityType . ':' . $entityId] = [$entityType, $entityId];
+    }
+
+    if ($normalized === []) {
+        return [];
+    }
+
+    $clauses = [];
+    $params = [];
+    foreach (array_values($normalized) as [$entityType, $entityId]) {
+        $clauses[] = '(entity_type = ? AND entity_id = ?)';
+        $params[] = $entityType;
+        $params[] = $entityId;
+    }
+
+    return db_select(
+        'SELECT *
+         FROM doctrine_ai_briefings
+         WHERE ' . implode(' OR ', $clauses),
+        $params
+    );
+}
+
+function db_doctrine_ai_briefings_top(int $limit = 6): array
+{
+    $safeLimit = max(1, min(20, $limit));
+
+    return db_select(
+        "SELECT *
+         FROM doctrine_ai_briefings
+         WHERE generation_status IN ('ready', 'fallback')
+         ORDER BY
+            FIELD(priority_level, 'critical', 'high', 'medium', 'low'),
+            computed_at DESC,
+            updated_at DESC
+         LIMIT {$safeLimit}"
+    );
+}
+
+function db_doctrine_ai_briefing_upsert(array $row): bool
+{
+    $entityType = in_array((string) ($row['entity_type'] ?? ''), ['fit', 'group'], true)
+        ? (string) $row['entity_type']
+        : '';
+    $entityId = max(0, (int) ($row['entity_id'] ?? 0));
+    if ($entityType === '' || $entityId <= 0) {
+        return false;
+    }
+
+    $fitId = $entityType === 'fit' ? $entityId : null;
+    $groupId = $entityType === 'group' ? $entityId : null;
+
+    return db_execute(
+        'INSERT INTO doctrine_ai_briefings (
+            entity_type,
+            entity_id,
+            fit_id,
+            group_id,
+            generation_status,
+            computed_at,
+            model_name,
+            headline,
+            summary,
+            action_text,
+            priority_level,
+            source_payload_json,
+            response_json,
+            error_message
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+            fit_id = VALUES(fit_id),
+            group_id = VALUES(group_id),
+            generation_status = VALUES(generation_status),
+            computed_at = VALUES(computed_at),
+            model_name = VALUES(model_name),
+            headline = VALUES(headline),
+            summary = VALUES(summary),
+            action_text = VALUES(action_text),
+            priority_level = VALUES(priority_level),
+            source_payload_json = VALUES(source_payload_json),
+            response_json = VALUES(response_json),
+            error_message = VALUES(error_message),
+            updated_at = CURRENT_TIMESTAMP',
+        [
+            $entityType,
+            $entityId,
+            $fitId,
+            $groupId,
+            mb_substr(trim((string) ($row['generation_status'] ?? 'ready')), 0, 32),
+            (string) ($row['computed_at'] ?? gmdate('Y-m-d H:i:s')),
+            ($row['model_name'] ?? null) !== null ? mb_substr(trim((string) $row['model_name']), 0, 120) : null,
+            ($row['headline'] ?? null) !== null ? mb_substr(trim((string) $row['headline']), 0, 255) : null,
+            ($row['summary'] ?? null) !== null ? trim((string) $row['summary']) : null,
+            ($row['action_text'] ?? null) !== null ? trim((string) $row['action_text']) : null,
+            in_array((string) ($row['priority_level'] ?? 'medium'), ['low', 'medium', 'high', 'critical'], true)
+                ? (string) $row['priority_level']
+                : 'medium',
+            ($row['source_payload_json'] ?? null) !== null ? (string) $row['source_payload_json'] : null,
+            ($row['response_json'] ?? null) !== null ? (string) $row['response_json'] : null,
+            ($row['error_message'] ?? null) !== null ? mb_substr(trim((string) $row['error_message']), 0, 500) : null,
+        ]
+    );
+}
+
 function db_doctrine_fit_replace_items(int $fitId, array $items): void
 {
     db_execute('DELETE FROM doctrine_fit_items WHERE doctrine_fit_id = ?', [$fitId]);

--- a/src/functions.php
+++ b/src/functions.php
@@ -2025,6 +2025,13 @@ function data_sync_schedule_job_definitions(): array
             'default_interval_seconds' => 300,
             'label' => 'Dashboard Summary Batch',
         ],
+        'rebuild_ai_briefings' => [
+            'enabled_key' => 'rebuild_ai_briefings_enabled',
+            'interval_value_key' => 'rebuild_ai_briefings_interval_value',
+            'interval_unit_key' => 'rebuild_ai_briefings_interval_unit',
+            'default_interval_seconds' => 300,
+            'label' => 'Doctrine AI Briefings',
+        ],
         'forecasting_ai_sync' => [
             'enabled_key' => 'forecasting_ai_sync_enabled',
             'interval_value_key' => 'forecasting_ai_sync_interval_value',
@@ -2450,6 +2457,7 @@ function dashboard_intelligence_data_build(): array
     $doctrine = doctrine_groups_overview_data();
     $lossDemand = loss_demand_snapshot_payload();
     $lossDemandTop = array_slice((array) ($lossDemand['top_rows'] ?? []), 0, 5);
+    $aiBriefings = doctrine_ai_dashboard_briefings(6);
 
     $atRiskDoctrines = array_slice(array_values((array) ($doctrine['not_ready_fits'] ?? [])), 0, 5);
     if ($atRiskDoctrines === []) {
@@ -2499,6 +2507,7 @@ function dashboard_intelligence_data_build(): array
         'top_loss_demand_items' => $lossDemandTop,
         'top_comparison_signals' => array_slice($risks, 0, 5),
         'doctrine_readiness_rollups' => array_slice((array) ($doctrine['groups'] ?? []), 0, 8),
+        'ai_briefings' => $aiBriefings,
     ];
 }
 
@@ -5602,6 +5611,13 @@ function scheduler_job_definitions(): array
                 return dashboard_refresh_summary_job_result('scheduler');
             },
         ],
+        'rebuild_ai_briefings' => [
+            'timeout_seconds' => 180,
+            'lock_ttl_seconds' => 300,
+            'handler' => static function (): array {
+                return rebuild_ai_briefings_job_result('scheduler');
+            },
+        ],
         'forecasting_ai_sync' => [
             'timeout_seconds' => 180,
             'lock_ttl_seconds' => 300,
@@ -5633,6 +5649,7 @@ function scheduler_job_type(string $jobKey): string
         'market_comparison_summary_sync' => 'sync.market_summary',
         'loss_demand_summary_sync' => 'sync.loss_demand',
         'dashboard_summary_sync' => 'sync.dashboard',
+        'rebuild_ai_briefings' => 'sync.doctrine_ai',
         'forecasting_ai_sync' => 'sync.forecasting',
         'killmail_r2z2_sync' => 'sync.killmail',
         default => 'sync.generic',
@@ -6034,6 +6051,39 @@ function http_post_form(string $url, array $headers, array $formData): array
         CURLOPT_POSTFIELDS => http_build_query($formData),
         CURLOPT_HTTPHEADER => $headers,
         CURLOPT_TIMEOUT => 25,
+    ]);
+
+    $response = curl_exec($ch);
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $error = curl_error($ch);
+    curl_close($ch);
+
+    if ($response === false) {
+        throw new RuntimeException('HTTP request failed: ' . $error);
+    }
+
+    $decoded = json_decode($response, true);
+    if (!is_array($decoded)) {
+        throw new RuntimeException('Invalid JSON response from ' . $url);
+    }
+
+    return ['status' => $status, 'json' => $decoded];
+}
+
+function http_post_json(string $url, array $headers, array $payload, int $timeoutSeconds = 25): array
+{
+    $jsonPayload = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    if (!is_string($jsonPayload)) {
+        throw new RuntimeException('Unable to encode JSON payload for ' . $url);
+    }
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POST => true,
+        CURLOPT_POSTFIELDS => $jsonPayload,
+        CURLOPT_HTTPHEADER => array_merge(['Content-Type: application/json'], $headers),
+        CURLOPT_TIMEOUT => max(1, $timeoutSeconds),
     ]);
 
     $response = curl_exec($ch);
@@ -12530,6 +12580,7 @@ function doctrine_refresh_trigger_job_keys(): array
         'market_comparison_summary_sync',
         'loss_demand_summary_sync',
         'dashboard_summary_sync',
+        'rebuild_ai_briefings',
     ];
 }
 
@@ -12702,6 +12753,21 @@ function doctrine_groups_overview_data(): array
     $snapshot = doctrine_operational_snapshot();
     $groups = $snapshot['groups'] ?? [];
     $fits = $snapshot['fits'] ?? [];
+    $briefingMap = doctrine_ai_briefings_fetch_map(array_merge(
+        array_map(static fn (array $group): array => ['entity_type' => 'group', 'entity_id' => (int) ($group['id'] ?? 0)], $groups),
+        array_map(static fn (array $fit): array => ['entity_type' => 'fit', 'entity_id' => (int) ($fit['id'] ?? 0)], $fits)
+    ));
+
+    foreach ($groups as &$group) {
+        $group['ai_briefing'] = $briefingMap['group:' . (int) ($group['id'] ?? 0)] ?? null;
+    }
+    unset($group);
+
+    foreach ($fits as &$fit) {
+        $fit['ai_briefing'] = $briefingMap['fit:' . (int) ($fit['id'] ?? 0)] ?? null;
+    }
+    unset($fit);
+
     $notReadyFits = array_values(array_filter($fits, static fn (array $fit): bool => (($fit['supply']['readiness_state'] ?? 'market_ready') !== 'market_ready')));
     $pressureFits = array_values(array_filter($fits, static fn (array $fit): bool => (($fit['supply']['resupply_pressure_state'] ?? 'stable') !== 'stable')));
     usort($notReadyFits, static fn (array $a, array $b): int => ((float) (($b['supply']['driver_scores']['total'] ?? 0.0)) <=> (float) (($a['supply']['driver_scores']['total'] ?? 0.0))) ?: ((int) (($b['supply']['gap_to_target_fit_count'] ?? 0)) <=> (int) (($a['supply']['gap_to_target_fit_count'] ?? 0))));
@@ -12741,7 +12807,18 @@ function doctrine_group_detail_data(int $groupId): array
     $groups = $snapshot['groups'] ?? [];
     foreach ($groups as $group) {
         if ((int) ($group['id'] ?? 0) === $groupId) {
-            return ['group' => $group, 'fits' => (array) ($group['fits'] ?? []), 'freshness' => $snapshot['_freshness'] ?? doctrine_snapshot_metadata()];
+            $fits = array_values((array) ($group['fits'] ?? []));
+            $briefingMap = doctrine_ai_briefings_fetch_map(array_merge(
+                [['entity_type' => 'group', 'entity_id' => $groupId]],
+                array_map(static fn (array $fit): array => ['entity_type' => 'fit', 'entity_id' => (int) ($fit['id'] ?? 0)], $fits)
+            ));
+            $group['ai_briefing'] = $briefingMap['group:' . $groupId] ?? null;
+            foreach ($fits as &$fit) {
+                $fit['ai_briefing'] = $briefingMap['fit:' . (int) ($fit['id'] ?? 0)] ?? null;
+            }
+            unset($fit);
+
+            return ['group' => $group, 'fits' => $fits, 'freshness' => $snapshot['_freshness'] ?? doctrine_snapshot_metadata()];
         }
     }
 
@@ -12809,6 +12886,7 @@ function doctrine_fit_detail_view_model(int $fitId): array
         $fit['ship_image_url'] = doctrine_ship_image_url(isset($fit['ship_type_id']) ? (int) $fit['ship_type_id'] : null, 256);
         $fit['supply'] = $supply;
         $fit['snapshot_history'] = $history;
+        $fit['ai_briefing'] = doctrine_ai_briefing_get('fit', $fitId);
 
         return [
             'fit' => $fit,
@@ -12827,4 +12905,683 @@ function doctrine_fit_detail_view_model(int $fitId): array
         'dependencies' => ['doctrine', 'market_compare', 'killmail_overview'],
         'lock_ttl' => 20,
     ]);
+}
+
+function supplycore_ai_ollama_config(): array
+{
+    return [
+        'enabled' => (bool) config('ollama.enabled', false),
+        'url' => rtrim((string) config('ollama.url', 'http://localhost:11434/api'), '/'),
+        'model' => trim((string) config('ollama.model', 'qwen2.5:1.5b-instruct')),
+        'timeout' => max(1, (int) config('ollama.timeout', 20)),
+    ];
+}
+
+function supplycore_ai_ollama_enabled(): bool
+{
+    $config = supplycore_ai_ollama_config();
+
+    return $config['enabled'] === true && $config['url'] !== '' && $config['model'] !== '';
+}
+
+function supplycore_ai_log(string $event, array $payload = []): void
+{
+    try {
+        error_log('[supplycore.ai] ' . json_encode([
+            'event' => $event,
+            'ts' => gmdate(DATE_ATOM),
+        ] + $payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+    } catch (Throwable) {
+        error_log('[supplycore.ai] ' . $event);
+    }
+}
+
+function supplycore_ai_priority_rank(string $priority): int
+{
+    return match ($priority) {
+        'critical' => 4,
+        'high' => 3,
+        'medium' => 2,
+        default => 1,
+    };
+}
+
+function supplycore_ai_priority_tone(string $priority): string
+{
+    return match ($priority) {
+        'critical' => 'border-rose-400/20 bg-rose-500/10 text-rose-200',
+        'high' => 'border-amber-400/20 bg-amber-500/10 text-amber-100',
+        'medium' => 'border-sky-400/20 bg-sky-500/10 text-sky-100',
+        default => 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100',
+    };
+}
+
+function doctrine_ai_cache_key(string $entityType, int $entityId): string
+{
+    return 'doctrine_ai_briefing:' . $entityType . ':' . max(0, $entityId);
+}
+
+function doctrine_ai_briefing_normalize_row(?array $row): ?array
+{
+    if (!is_array($row)) {
+        return null;
+    }
+
+    $responseJson = json_decode((string) ($row['response_json'] ?? ''), true);
+    $sourcePayload = json_decode((string) ($row['source_payload_json'] ?? ''), true);
+    $priority = in_array((string) ($row['priority_level'] ?? 'medium'), ['low', 'medium', 'high', 'critical'], true)
+        ? (string) $row['priority_level']
+        : 'medium';
+
+    return [
+        'entity_type' => (string) ($row['entity_type'] ?? ''),
+        'entity_id' => (int) ($row['entity_id'] ?? 0),
+        'fit_id' => isset($row['fit_id']) ? (int) $row['fit_id'] : null,
+        'group_id' => isset($row['group_id']) ? (int) $row['group_id'] : null,
+        'generation_status' => (string) ($row['generation_status'] ?? 'ready'),
+        'computed_at' => ($row['computed_at'] ?? null) !== null ? (string) $row['computed_at'] : null,
+        'computed_relative' => supplycore_relative_datetime(($row['computed_at'] ?? null) !== null ? (string) $row['computed_at'] : null),
+        'model_name' => ($row['model_name'] ?? null) !== null ? (string) $row['model_name'] : null,
+        'headline' => trim((string) ($row['headline'] ?? '')),
+        'summary' => trim((string) ($row['summary'] ?? '')),
+        'action_text' => trim((string) ($row['action_text'] ?? '')),
+        'priority_level' => $priority,
+        'priority_rank' => supplycore_ai_priority_rank($priority),
+        'priority_tone' => supplycore_ai_priority_tone($priority),
+        'source_payload' => is_array($sourcePayload) ? $sourcePayload : [],
+        'response_json' => is_array($responseJson) ? $responseJson : [],
+        'error_message' => ($row['error_message'] ?? null) !== null ? (string) $row['error_message'] : null,
+        'updated_at' => ($row['updated_at'] ?? null) !== null ? (string) $row['updated_at'] : null,
+    ];
+}
+
+function doctrine_ai_briefing_get(string $entityType, int $entityId): ?array
+{
+    $normalizedType = in_array($entityType, ['fit', 'group'], true) ? $entityType : '';
+    $safeEntityId = max(0, $entityId);
+    if ($normalizedType === '' || $safeEntityId <= 0) {
+        return null;
+    }
+
+    $cached = supplycore_redis_get_json(doctrine_ai_cache_key($normalizedType, $safeEntityId));
+    if (is_array($cached)) {
+        return doctrine_ai_briefing_normalize_row($cached);
+    }
+
+    try {
+        $row = db_doctrine_ai_briefing_get($normalizedType, $safeEntityId);
+    } catch (Throwable) {
+        $row = null;
+    }
+
+    if (!is_array($row)) {
+        return null;
+    }
+
+    supplycore_redis_set_json(doctrine_ai_cache_key($normalizedType, $safeEntityId), $row, 300);
+
+    return doctrine_ai_briefing_normalize_row($row);
+}
+
+function doctrine_ai_briefings_fetch_map(array $targets): array
+{
+    $normalizedTargets = [];
+    $cacheKeys = [];
+
+    foreach ($targets as $target) {
+        if (!is_array($target)) {
+            continue;
+        }
+
+        $entityType = in_array((string) ($target['entity_type'] ?? ''), ['fit', 'group'], true)
+            ? (string) $target['entity_type']
+            : '';
+        $entityId = max(0, (int) ($target['entity_id'] ?? 0));
+        if ($entityType === '' || $entityId <= 0) {
+            continue;
+        }
+
+        $key = $entityType . ':' . $entityId;
+        $normalizedTargets[$key] = ['entity_type' => $entityType, 'entity_id' => $entityId];
+        $cacheKeys[$key] = doctrine_ai_cache_key($entityType, $entityId);
+    }
+
+    if ($normalizedTargets === []) {
+        return [];
+    }
+
+    $map = [];
+    $cacheKeyEntries = array_values($cacheKeys);
+    $cachedRows = supplycore_redis_enabled() ? supplycore_redis_mget($cacheKeyEntries) : [];
+    $targetKeys = array_keys($cacheKeys);
+    foreach ($cacheKeyEntries as $index => $cacheKey) {
+        $key = $targetKeys[$index] ?? null;
+        if (!is_string($key)) {
+            continue;
+        }
+        $cachedPayload = $cachedRows[$index] ?? null;
+        if (!is_string($cachedPayload) || $cachedPayload === '') {
+            continue;
+        }
+
+        $decoded = json_decode($cachedPayload, true);
+        if (!is_array($decoded)) {
+            continue;
+        }
+
+        $map[$key] = doctrine_ai_briefing_normalize_row($decoded);
+    }
+
+    $missingTargets = [];
+    foreach ($normalizedTargets as $key => $target) {
+        if (!array_key_exists($key, $map)) {
+            $missingTargets[] = $target;
+        }
+    }
+
+    if ($missingTargets !== []) {
+        try {
+            foreach (db_doctrine_ai_briefings_get_many($missingTargets) as $row) {
+                $key = (string) ($row['entity_type'] ?? '') . ':' . (int) ($row['entity_id'] ?? 0);
+                $map[$key] = doctrine_ai_briefing_normalize_row($row);
+                supplycore_redis_set_json(doctrine_ai_cache_key((string) ($row['entity_type'] ?? ''), (int) ($row['entity_id'] ?? 0)), $row, 300);
+            }
+        } catch (Throwable) {
+        }
+    }
+
+    return array_filter($map, static fn (mixed $value): bool => is_array($value));
+}
+
+function doctrine_ai_recent_change_summary_for_group(array $group): string
+{
+    $parts = [];
+    $fitGapCount = max(0, (int) ($group['fit_gap_count'] ?? 0));
+    $pressureFitCount = max(0, (int) ($group['pressure_fit_count'] ?? 0));
+    $trendingDownFits = max(0, (int) ($group['trending_down_fit_count'] ?? 0));
+
+    if ($fitGapCount > 0) {
+        $parts[] = doctrine_format_quantity($fitGapCount) . ' fits are currently below target coverage.';
+    }
+    if ($pressureFitCount > 0) {
+        $parts[] = doctrine_format_quantity($pressureFitCount) . ' fits show non-stable resupply pressure.';
+    }
+    if ($trendingDownFits > 0) {
+        $parts[] = doctrine_format_quantity($trendingDownFits) . ' fits are trending down.';
+    }
+
+    return $parts !== [] ? implode(' ', $parts) : 'No material group-level change is currently flagged by deterministic signals.';
+}
+
+function doctrine_ai_previous_recommendation_fact(?array $briefing): ?array
+{
+    if (!is_array($briefing)) {
+        return null;
+    }
+
+    $action = trim((string) ($briefing['action_text'] ?? ''));
+    $priority = trim((string) ($briefing['priority_level'] ?? ''));
+    if ($action === '' && $priority === '') {
+        return null;
+    }
+
+    return [
+        'priority' => $priority !== '' ? $priority : null,
+        'action' => $action !== '' ? $action : null,
+        'computed_at' => ($briefing['computed_at'] ?? null) !== null ? (string) $briefing['computed_at'] : null,
+    ];
+}
+
+function doctrine_ai_source_payload_for_fit(array $fit, ?array $previousBriefing = null): array
+{
+    $supply = is_array($fit['supply'] ?? null) ? $fit['supply'] : [];
+    $recentChange = is_array($fit['snapshot_change'] ?? null)
+        ? (string) (($fit['snapshot_change']['summary'] ?? '') ?: 'No prior doctrine snapshot change is available.')
+        : 'No prior doctrine snapshot change is available.';
+
+    return [
+        'entity_type' => 'fit',
+        'entity_id' => (int) ($fit['id'] ?? 0),
+        'name' => trim((string) ($fit['fit_name'] ?? ('Fit #' . (int) ($fit['id'] ?? 0)))),
+        'group_name' => implode(', ', (array) ($fit['group_names'] ?? [])),
+        'readiness_state' => (string) ($supply['readiness_label'] ?? $supply['status_label'] ?? 'Market ready'),
+        'resupply_pressure' => (string) ($supply['resupply_pressure_label'] ?? 'Stable'),
+        'complete_fits' => (int) ($supply['complete_fits_available'] ?? 0),
+        'target_fits' => (int) ($supply['recommended_target_fit_count'] ?? 0),
+        'fit_gap' => (int) ($supply['gap_to_target_fit_count'] ?? 0),
+        'bottleneck_item' => ($supply['bottleneck_item_name'] ?? null) !== null ? (string) $supply['bottleneck_item_name'] : null,
+        'bottleneck_quantity' => (int) ($supply['bottleneck_quantity'] ?? 0),
+        'loss_24h' => max((int) ($supply['recent_hull_losses_24h'] ?? 0), (int) ($supply['recent_item_fit_losses_24h'] ?? 0)),
+        'loss_7d' => max((int) ($supply['recent_hull_losses_7d'] ?? 0), (int) ($supply['recent_item_fit_losses_7d'] ?? 0)),
+        'depletion_signal' => (string) ($supply['depletion_state'] ?? 'stable'),
+        'recent_change_summary' => $recentChange,
+        'current_recommendation' => (string) ($supply['recommendation_text'] ?? ''),
+        'previous_recommendation' => doctrine_ai_previous_recommendation_fact($previousBriefing),
+    ];
+}
+
+function doctrine_ai_source_payload_for_group(array $group, ?array $previousBriefing = null): array
+{
+    $fits = array_values((array) ($group['fits'] ?? []));
+    $loss24h = 0;
+    $loss7d = 0;
+    $topBottleneckItem = null;
+    $topBottleneckQty = 0;
+    $topScore = -1.0;
+    $depletionSignal = 'stable';
+
+    foreach ($fits as $fit) {
+        $supply = is_array($fit['supply'] ?? null) ? $fit['supply'] : [];
+        $loss24h = max($loss24h, max((int) ($supply['recent_hull_losses_24h'] ?? 0), (int) ($supply['recent_item_fit_losses_24h'] ?? 0)));
+        $loss7d = max($loss7d, max((int) ($supply['recent_hull_losses_7d'] ?? 0), (int) ($supply['recent_item_fit_losses_7d'] ?? 0)));
+        $score = (float) (($supply['driver_scores']['total'] ?? 0.0));
+        if ($score > $topScore) {
+            $topScore = $score;
+            $topBottleneckItem = ($supply['bottleneck_item_name'] ?? null) !== null ? (string) $supply['bottleneck_item_name'] : null;
+            $topBottleneckQty = (int) ($supply['bottleneck_quantity'] ?? 0);
+            $depletionSignal = (string) ($supply['depletion_state'] ?? 'stable');
+        }
+    }
+
+    return [
+        'entity_type' => 'group',
+        'entity_id' => (int) ($group['id'] ?? 0),
+        'name' => trim((string) ($group['group_name'] ?? ('Group #' . (int) ($group['id'] ?? 0)))),
+        'readiness_state' => (string) ($group['status_label'] ?? 'Market ready'),
+        'resupply_pressure' => (string) ($group['pressure_label'] ?? 'Stable'),
+        'complete_fits' => (int) ($group['complete_fits_available'] ?? 0),
+        'target_fits' => (int) ($group['target_fit_count'] ?? 0),
+        'fit_gap' => (int) ($group['fit_gap_count'] ?? 0),
+        'bottleneck_item' => $topBottleneckItem,
+        'bottleneck_quantity' => $topBottleneckQty,
+        'loss_24h' => $loss24h,
+        'loss_7d' => $loss7d,
+        'depletion_signal' => $depletionSignal,
+        'recent_change_summary' => doctrine_ai_recent_change_summary_for_group($group),
+        'current_recommendation' => (string) ($group['combined_status_label'] ?? ''),
+        'previous_recommendation' => doctrine_ai_previous_recommendation_fact($previousBriefing),
+    ];
+}
+
+function doctrine_ai_system_prompt(): string
+{
+    return 'You are an alliance logistics analyst. Use only the provided facts. Do not invent data. Keep output concise and operational. Return JSON only.';
+}
+
+function doctrine_ai_output_schema(): array
+{
+    return [
+        'type' => 'object',
+        'required' => ['headline', 'summary', 'action', 'priority'],
+        'properties' => [
+            'headline' => ['type' => 'string'],
+            'summary' => ['type' => 'string'],
+            'action' => ['type' => 'string'],
+            'priority' => ['type' => 'string', 'enum' => ['low', 'medium', 'high', 'critical']],
+        ],
+        'additionalProperties' => false,
+    ];
+}
+
+function doctrine_ai_user_prompt(array $sourcePayload): string
+{
+    return "Summarize this doctrine logistics state.\nFacts:\n"
+        . json_encode($sourcePayload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+}
+
+function doctrine_ai_validate_response(array $response): array
+{
+    $headline = trim((string) ($response['headline'] ?? ''));
+    $summary = trim((string) ($response['summary'] ?? ''));
+    $action = trim((string) ($response['action'] ?? ''));
+    $priority = trim((string) ($response['priority'] ?? ''));
+
+    if ($headline === '' || $summary === '' || $action === '') {
+        throw new RuntimeException('AI response is missing one or more required fields.');
+    }
+
+    if (!in_array($priority, ['low', 'medium', 'high', 'critical'], true)) {
+        throw new RuntimeException('AI response priority is invalid.');
+    }
+
+    return [
+        'headline' => mb_substr($headline, 0, 255),
+        'summary' => mb_substr($summary, 0, 1200),
+        'action' => mb_substr($action, 0, 1200),
+        'priority' => $priority,
+    ];
+}
+
+function doctrine_ai_fallback_response(array $sourcePayload, string $reason): array
+{
+    $gap = max(0, (int) ($sourcePayload['fit_gap'] ?? 0));
+    $pressure = (string) ($sourcePayload['resupply_pressure'] ?? 'Stable');
+    $readiness = (string) ($sourcePayload['readiness_state'] ?? 'Market ready');
+    $name = trim((string) ($sourcePayload['name'] ?? 'Doctrine item'));
+    $bottleneckItem = trim((string) ($sourcePayload['bottleneck_item'] ?? ''));
+
+    $priority = 'low';
+    if ($gap >= 3 || str_contains(mb_strtolower($pressure), 'urgent') || str_contains(mb_strtolower($readiness), 'critical')) {
+        $priority = 'critical';
+    } elseif ($gap > 0 || str_contains(mb_strtolower($pressure), 'soon')) {
+        $priority = 'high';
+    } elseif (str_contains(mb_strtolower($pressure), 'elevated')) {
+        $priority = 'medium';
+    }
+
+    return [
+        'headline' => $name . ': ' . ($gap > 0 ? doctrine_format_quantity($gap) . ' fit gap' : $pressure),
+        'summary' => trim($readiness . ' with ' . $pressure . '. ' . ($bottleneckItem !== '' ? ('Primary bottleneck remains ' . $bottleneckItem . '.') : 'Use deterministic doctrine metrics for precise quantities.')),
+        'action' => $gap > 0
+            ? 'Prioritize the current bottleneck and close the remaining fit gap before the next doctrine review.'
+            : 'Monitor this doctrine state in the next background refresh and verify deterministic stock numbers before acting.',
+        'priority' => $priority,
+        '_fallback_reason' => $reason,
+    ];
+}
+
+function supplycore_ai_ollama_generate_json(array $sourcePayload): array
+{
+    $config = supplycore_ai_ollama_config();
+    if ($config['enabled'] !== true) {
+        throw new RuntimeException('Ollama integration is disabled.');
+    }
+
+    $endpoint = $config['url'] . '/generate';
+    $requestPayload = [
+        'model' => $config['model'],
+        'stream' => false,
+        'system' => doctrine_ai_system_prompt(),
+        'prompt' => doctrine_ai_user_prompt($sourcePayload),
+        'format' => doctrine_ai_output_schema(),
+        'options' => [
+            'temperature' => 0.1,
+        ],
+    ];
+
+    $response = http_post_json($endpoint, [], $requestPayload, $config['timeout']);
+    $status = (int) ($response['status'] ?? 0);
+    $json = is_array($response['json'] ?? null) ? $response['json'] : [];
+    if ($status < 200 || $status >= 300) {
+        throw new RuntimeException('Ollama returned HTTP ' . $status . '.');
+    }
+
+    $rawModelResponse = trim((string) ($json['response'] ?? ''));
+    if ($rawModelResponse === '') {
+        throw new RuntimeException('Ollama returned an empty response payload.');
+    }
+
+    $decoded = json_decode($rawModelResponse, true);
+    if (!is_array($decoded)) {
+        throw new RuntimeException('Ollama returned malformed JSON content.');
+    }
+
+    return doctrine_ai_validate_response($decoded);
+}
+
+function doctrine_ai_store_briefing(array $sourcePayload, array $briefing, string $status, ?string $errorMessage = null): bool
+{
+    $entityType = (string) ($sourcePayload['entity_type'] ?? '');
+    $entityId = max(0, (int) ($sourcePayload['entity_id'] ?? 0));
+    if (!in_array($entityType, ['fit', 'group'], true) || $entityId <= 0) {
+        return false;
+    }
+
+    $modelName = $status === 'ready' ? (string) supplycore_ai_ollama_config()['model'] : 'deterministic-fallback';
+    $sourcePayloadJson = json_encode($sourcePayload, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    $responseJson = json_encode($briefing, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    $row = [
+        'entity_type' => $entityType,
+        'entity_id' => $entityId,
+        'generation_status' => $status,
+        'computed_at' => gmdate('Y-m-d H:i:s'),
+        'model_name' => $modelName,
+        'headline' => (string) ($briefing['headline'] ?? ''),
+        'summary' => (string) ($briefing['summary'] ?? ''),
+        'action_text' => (string) ($briefing['action'] ?? ''),
+        'priority_level' => (string) ($briefing['priority'] ?? 'medium'),
+        'source_payload_json' => is_string($sourcePayloadJson) ? $sourcePayloadJson : null,
+        'response_json' => is_string($responseJson) ? $responseJson : null,
+        'error_message' => $errorMessage,
+    ];
+
+    $saved = db_doctrine_ai_briefing_upsert($row);
+    if ($saved) {
+        $dbRow = db_doctrine_ai_briefing_get($entityType, $entityId);
+        if (is_array($dbRow)) {
+            supplycore_redis_set_json(doctrine_ai_cache_key($entityType, $entityId), $dbRow, 300);
+        }
+    }
+
+    return $saved;
+}
+
+function doctrine_ai_candidate_score(array $entity, string $entityType): float
+{
+    if ($entityType === 'fit') {
+        $supply = is_array($entity['supply'] ?? null) ? $entity['supply'] : [];
+        $priority = (float) (($supply['driver_scores']['total'] ?? 0.0));
+        $gap = (int) ($supply['gap_to_target_fit_count'] ?? 0);
+        $pressureWeight = match ((string) ($supply['resupply_pressure_state'] ?? 'stable')) {
+            'urgent_resupply' => 40,
+            'resupply_soon' => 24,
+            'elevated' => 10,
+            default => 0,
+        };
+        $readinessWeight = match ((string) ($supply['readiness_state'] ?? 'market_ready')) {
+            'critical_gap' => 35,
+            'partial_gap' => 18,
+            default => 0,
+        };
+
+        return $priority + ($gap * 12) + $pressureWeight + $readinessWeight;
+    }
+
+    $gap = (int) ($entity['fit_gap_count'] ?? 0);
+    $pressureWeight = match ((string) ($entity['pressure_state'] ?? 'stable')) {
+        'urgent_resupply' => 40,
+        'resupply_soon' => 24,
+        'elevated' => 10,
+        default => 0,
+    };
+    $readinessWeight = match ((string) ($entity['status'] ?? 'market_ready')) {
+        'critical_gap' => 35,
+        'partial_gap' => 18,
+        default => 0,
+    };
+
+    return ($gap * 14) + $pressureWeight + $readinessWeight + ((int) ($entity['pressure_fit_count'] ?? 0) * 3);
+}
+
+function doctrine_ai_select_candidates(array $snapshot, int $limit = 8): array
+{
+    $candidates = [];
+
+    foreach ((array) ($snapshot['fits'] ?? []) as $fit) {
+        $fitId = (int) ($fit['id'] ?? 0);
+        if ($fitId <= 0) {
+            continue;
+        }
+
+        $score = doctrine_ai_candidate_score($fit, 'fit');
+        if ($score <= 0) {
+            continue;
+        }
+
+        $candidates[] = [
+            'entity_type' => 'fit',
+            'entity_id' => $fitId,
+            'score' => $score,
+            'entity' => $fit,
+        ];
+    }
+
+    foreach ((array) ($snapshot['groups'] ?? []) as $group) {
+        $groupId = (int) ($group['id'] ?? 0);
+        if ($groupId <= 0) {
+            continue;
+        }
+
+        $score = doctrine_ai_candidate_score($group, 'group');
+        if ($score <= 0) {
+            continue;
+        }
+
+        $candidates[] = [
+            'entity_type' => 'group',
+            'entity_id' => $groupId,
+            'score' => $score,
+            'entity' => $group,
+        ];
+    }
+
+    usort($candidates, static function (array $a, array $b): int {
+        return ((float) ($b['score'] ?? 0.0) <=> (float) ($a['score'] ?? 0.0))
+            ?: strcmp((string) ($a['entity_type'] ?? ''), (string) ($b['entity_type'] ?? ''))
+            ?: ((int) ($a['entity_id'] ?? 0) <=> (int) ($b['entity_id'] ?? 0));
+    });
+
+    return array_slice($candidates, 0, max(1, min(20, $limit)));
+}
+
+function rebuild_ai_briefings_job_result(string $reason = 'manual'): array
+{
+    $snapshot = doctrine_snapshot_cache_payload();
+    if ($snapshot === null) {
+        $snapshot = doctrine_refresh_intelligence($reason . ':bootstrap');
+    }
+
+    $config = supplycore_ai_ollama_config();
+    if ($config['enabled'] !== true) {
+        return sync_result_shape() + [
+            'rows_seen' => 0,
+            'rows_written' => 0,
+            'warnings' => ['Ollama integration is disabled.'],
+            'meta' => [
+                'outcome_reason' => 'AI briefing rebuild skipped because OLLAMA_ENABLED is disabled.',
+            ],
+        ];
+    }
+
+    $candidates = doctrine_ai_select_candidates($snapshot, 8);
+    $processed = 0;
+    $written = 0;
+    $fallbacks = 0;
+
+    foreach ($candidates as $candidate) {
+        $entityType = (string) ($candidate['entity_type'] ?? '');
+        $entityId = (int) ($candidate['entity_id'] ?? 0);
+        $entity = is_array($candidate['entity'] ?? null) ? $candidate['entity'] : [];
+        if (!in_array($entityType, ['fit', 'group'], true) || $entityId <= 0 || $entity === []) {
+            continue;
+        }
+
+        $processed++;
+        $previousBriefing = doctrine_ai_briefing_get($entityType, $entityId);
+        $sourcePayload = $entityType === 'fit'
+            ? doctrine_ai_source_payload_for_fit($entity, $previousBriefing)
+            : doctrine_ai_source_payload_for_group($entity, $previousBriefing);
+
+        supplycore_ai_log('briefing.attempt', [
+            'entity_type' => $entityType,
+            'entity_id' => $entityId,
+            'reason' => $reason,
+            'model' => $config['model'],
+        ]);
+
+        try {
+            $briefing = supplycore_ai_ollama_generate_json($sourcePayload);
+            doctrine_ai_store_briefing($sourcePayload, $briefing, 'ready');
+            $written++;
+            supplycore_ai_log('briefing.success', [
+                'entity_type' => $entityType,
+                'entity_id' => $entityId,
+                'priority' => (string) ($briefing['priority'] ?? 'medium'),
+            ]);
+        } catch (Throwable $exception) {
+            $fallbacks++;
+            $fallback = doctrine_ai_fallback_response($sourcePayload, $exception->getMessage());
+            doctrine_ai_store_briefing($sourcePayload, $fallback, 'fallback', $exception->getMessage());
+            supplycore_ai_log('briefing.failure', [
+                'entity_type' => $entityType,
+                'entity_id' => $entityId,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    dashboard_refresh_summary($reason . ':ai-briefings');
+    supplycore_cache_bust(['dashboard', 'doctrine']);
+
+    return sync_result_shape() + [
+        'rows_seen' => $processed,
+        'rows_written' => $written + $fallbacks,
+        'cursor' => 'doctrine_ai_briefings:' . gmdate('Y-m-d H:i:s'),
+        'checksum' => sync_checksum([
+            'processed' => $processed,
+            'written' => $written,
+            'fallbacks' => $fallbacks,
+            'reason' => $reason,
+            'model' => $config['model'],
+        ]),
+        'meta' => [
+            'outcome_reason' => 'Doctrine AI briefings were rebuilt in the background from compact deterministic doctrine facts.',
+            'processed_candidates' => $processed,
+            'fallback_count' => $fallbacks,
+            'model_name' => $config['model'],
+        ],
+    ];
+}
+
+function doctrine_ai_dashboard_briefings(int $limit = 6): array
+{
+    try {
+        $rows = db_doctrine_ai_briefings_top($limit);
+    } catch (Throwable) {
+        $rows = [];
+    }
+
+    $briefings = [];
+    foreach ($rows as $row) {
+        $normalized = doctrine_ai_briefing_normalize_row($row);
+        if ($normalized !== null) {
+            $briefings[] = $normalized;
+        }
+    }
+
+    if ($briefings === []) {
+        return [];
+    }
+
+    $snapshot = doctrine_snapshot_cache_payload();
+    $fitsById = [];
+    foreach ((array) ($snapshot['fits'] ?? []) as $fit) {
+        $fitsById[(int) ($fit['id'] ?? 0)] = $fit;
+    }
+    $groupsById = [];
+    foreach ((array) ($snapshot['groups'] ?? []) as $group) {
+        $groupsById[(int) ($group['id'] ?? 0)] = $group;
+    }
+
+    foreach ($briefings as &$briefing) {
+        if (($briefing['entity_type'] ?? '') === 'fit') {
+            $fit = $fitsById[(int) ($briefing['entity_id'] ?? 0)] ?? [];
+            $briefing['entity_name'] = (string) ($fit['fit_name'] ?? ('Fit #' . (int) ($briefing['entity_id'] ?? 0)));
+            $briefing['context_name'] = implode(', ', (array) ($fit['group_names'] ?? []));
+            $briefing['href'] = '/doctrine/fit?fit_id=' . (int) ($briefing['entity_id'] ?? 0);
+        } else {
+            $group = $groupsById[(int) ($briefing['entity_id'] ?? 0)] ?? [];
+            $briefing['entity_name'] = (string) ($group['group_name'] ?? ('Group #' . (int) ($briefing['entity_id'] ?? 0)));
+            $briefing['context_name'] = doctrine_format_quantity((int) ($group['fit_count'] ?? 0)) . ' fits';
+            $briefing['href'] = '/doctrine/group?group_id=' . (int) ($briefing['entity_id'] ?? 0);
+        }
+    }
+    unset($briefing);
+
+    usort($briefings, static function (array $a, array $b): int {
+        return ((int) ($b['priority_rank'] ?? 0) <=> (int) ($a['priority_rank'] ?? 0))
+            ?: strcmp((string) ($b['computed_at'] ?? ''), (string) ($a['computed_at'] ?? ''));
+    });
+
+    return array_slice($briefings, 0, $limit);
 }


### PR DESCRIPTION
### Motivation
- Provide a safe, local AI summarization layer on top of deterministic doctrine intelligence using an on-host Ollama service, while keeping deterministic calculations authoritative. 
- Run AI generation only in background jobs and persist results for auditability, fast reads, and resilient fallbacks.

### Description
- Configuration: added environment-driven settings `OLLAMA_ENABLED`, `OLLAMA_URL`, `OLLAMA_MODEL`, and `OLLAMA_TIMEOUT` surfaced via `src/config/app.php` and accessed through `supplycore_ai_ollama_config()`/`supplycore_ai_ollama_enabled()` helpers. 
- Persistence and DB helpers: added `doctrine_ai_briefings` table to `database/schema.sql` and DB wrappers `db_doctrine_ai_briefing_get`, `db_doctrine_ai_briefings_get_many`, `db_doctrine_ai_briefings_top`, and `db_doctrine_ai_briefing_upsert` in `src/db.php` for audit-friendly storage and retrieval. 
- Ollama client + helpers: added a lightweight `http_post_json()` helper and a modular Ollama generation flow in `src/functions.php` implementing non-streaming requests, structured JSON output mode, `system` + `prompt` support, low-temperature deterministic options, strict JSON schema expectations, and robust parsing/error handling. 
- Doctrine payloads, prompting, validation & fallback: implemented compact doctrine payload builders for fits/groups, strict system/user prompt templates, JSON output schema, response validation, deterministic fallback generation, and logging (`supplycore_ai_log`) in `src/functions.php`. 
- Background job and scheduler: added a prioritized `rebuild_ai_briefings` scheduler job and candidate selection logic that processes highest-priority fits/groups first and stores either model results or deterministic fallbacks (no Ollama calls on page load). Scheduler wiring added to job definitions and trigger keys. 
- UI integration: surfaced stored briefings (read-only) via Redis-backed reads into dashboard payload (`ai_briefings`) and added compact AI notes blocks to doctrine group and fit pages plus an Operational Briefings panel on the dashboard; UI never calls Ollama directly. 
- Observability & caching: stored full `source_payload_json` and `response_json` in DB rows, log AI attempts/failures, and optionally cached latest briefings in Redis for fast delivery. 
- Documentation: updated `README.md` with environment variables, product rule (AI non-authoritative), and brief scheduling/ops notes.

### Testing
- Syntax checks: ran `php -l` on modified files (`src/config/app.php`, `src/db.php`, `src/functions.php`, `public/index.php`, `public/doctrine/group.php`, `public/doctrine/fit.php`) and received no syntax errors. (succeeded)
- Runtime config check: executed `php -r "require 'src/bootstrap.php'; echo json_encode(supplycore_ai_ollama_config(), JSON_UNESCAPED_SLASHES), PHP_EOL;"` to confirm config shape and defaults; output shown (Ollama disabled by default in this env). (succeeded)
- Integration notes: background job `rebuild_ai_briefings` is registered with scheduler and will run only when `OLLAMA_ENABLED=1` and appropriate scheduler row is enabled; DB migration adds `doctrine_ai_briefings` for storage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb443137b0832f991741b691ca715c)