### PR TITLE
Ensure AI briefing scheduler auto-registers and defers during history syncs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ README.md
 
 - SupplyCore’s first local AI layer is intentionally **non-authoritative**. Doctrine calculations, market comparisons, killmail/loss signals, and readiness math remain deterministic and authoritative.
 - Ollama is used only to summarize compact precomputed doctrine facts into operator briefings. It does **not** run on page load; it runs in the background through the scheduler job `rebuild_ai_briefings`.
+- The scheduler now self-registers missing schedule rows, so `rebuild_ai_briefings` starts running automatically on fresh installs and after upgrades without requiring a manual save in Settings.
 - Required environment variables:
   - `OLLAMA_ENABLED=1`
   - `OLLAMA_URL=http://localhost:11434/api`
@@ -189,7 +190,7 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 - SupplyCore now separates cadences by workload:
   - **Fast ingestion**: `killmail_r2z2_sync`, `alliance_current_sync`, and `market_hub_current_sync` keep raw market and killmail inputs fresh.
   - **Materialized intelligence refresh (target cadence: every 5 minutes)**: `doctrine_intelligence_sync`, `market_comparison_summary_sync`, `loss_demand_summary_sync`, `dashboard_summary_sync`, and `current_state_refresh_sync` recompute heavy current-summary layers from raw tables, then publish the latest payloads into Redis for fast reads.
-  - **Local doctrine AI briefings (target cadence: every 5 minutes)**: `rebuild_ai_briefings` ranks the most important doctrine fits/groups first, generates concise Ollama summaries from compact deterministic facts, stores the latest result in MySQL, and refreshes the dashboard briefing panel.
+  - **Local doctrine AI briefings (target cadence: every 5 minutes)**: `rebuild_ai_briefings` ranks the most important doctrine fits/groups first, generates concise Ollama summaries from compact deterministic facts, stores the latest result in MySQL, refreshes the dashboard briefing panel, and skips that cycle when a history rebuild job is still running.
   - **Slow forecasting / AI**: `forecasting_ai_sync` derives slower-moving target-adjustment, anomaly, briefing, and explanation layers from the latest medium snapshot instead of raw minute-by-minute ingestion.
 - UI pages now read Redis first and fall back to `intelligence_snapshots` if Redis is unavailable; each intelligence surface also exposes its last computed timestamp and freshness state to operators.
 - The hub-history scheduler jobs (`market_hub_historical_sync` and `market_hub_local_history_sync`) rebuild `market_history_daily` from SupplyCore’s own raw hub-order snapshots stored in MySQL for the configured market hub, using the recent window controlled by `raw_order_snapshot_retention_days` unless a CLI override is supplied.

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -625,14 +625,18 @@ INSERT INTO doctrine_groups (group_name, description) VALUES
 ON DUPLICATE KEY UPDATE description = VALUES(description);
 
 INSERT INTO sync_schedules (job_key, enabled, interval_seconds, next_run_at, last_run_at, last_status, last_error, locked_until) VALUES
-    ('alliance_current_sync', 1, 60, NULL, NULL, NULL, NULL, NULL),
-    ('alliance_historical_sync', 1, 1800, NULL, NULL, NULL, NULL, NULL),
-    ('market_hub_current_sync', 1, 60, NULL, NULL, NULL, NULL, NULL),
-    ('current_state_refresh_sync', 1, 120, NULL, NULL, NULL, NULL, NULL),
-    ('market_hub_historical_sync', 1, 1800, NULL, NULL, NULL, NULL, NULL),
-    ('market_hub_local_history_sync', 1, 300, NULL, NULL, NULL, NULL, NULL),
-    ('doctrine_intelligence_sync', 1, 900, NULL, NULL, NULL, NULL, NULL),
-    ('forecasting_ai_sync', 1, 3600, NULL, NULL, NULL, NULL, NULL),
+    ('alliance_current_sync', 1, 60, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('alliance_historical_sync', 1, 1800, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('market_hub_current_sync', 1, 60, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('current_state_refresh_sync', 1, 300, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('market_hub_historical_sync', 1, 1800, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('market_hub_local_history_sync', 1, 300, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('doctrine_intelligence_sync', 1, 300, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('market_comparison_summary_sync', 1, 300, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('loss_demand_summary_sync', 1, 300, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('dashboard_summary_sync', 1, 300, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('rebuild_ai_briefings', 1, 300, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
+    ('forecasting_ai_sync', 1, 3600, UTC_TIMESTAMP(), NULL, NULL, NULL, NULL),
     ('killmail_r2z2_sync', 0, 60, NULL, NULL, NULL, NULL, NULL)
 ON DUPLICATE KEY UPDATE
     enabled = VALUES(enabled),

--- a/src/db.php
+++ b/src/db.php
@@ -1752,6 +1752,61 @@ function db_sync_schedule_fetch_by_job_keys(array $jobKeys): array
     );
 }
 
+function db_sync_schedule_running_job_keys(array $jobKeys): array
+{
+    $keys = array_values(array_filter(array_map(static fn (mixed $jobKey): string => trim((string) $jobKey), $jobKeys), static fn (string $jobKey): bool => $jobKey !== ''));
+    if ($keys === []) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($keys), '?'));
+    $rows = db_select(
+        "SELECT job_key
+         FROM sync_schedules
+         WHERE job_key IN ($placeholders)
+           AND enabled = 1
+           AND last_status = 'running'
+           AND locked_until IS NOT NULL
+           AND locked_until > UTC_TIMESTAMP()
+         ORDER BY job_key ASC",
+        $keys
+    );
+
+    return array_values(array_filter(array_map(
+        static fn (array $row): string => trim((string) ($row['job_key'] ?? '')),
+        $rows
+    ), static fn (string $jobKey): bool => $jobKey !== ''));
+}
+
+function db_sync_schedule_ensure_job(string $jobKey, int $enabled, int $intervalSeconds): bool
+{
+    $normalizedKey = trim($jobKey);
+    if ($normalizedKey === '') {
+        return false;
+    }
+
+    return db_execute(
+        'INSERT INTO sync_schedules (job_key, enabled, interval_seconds, next_run_at, last_run_at, last_status, last_error, locked_until)
+         VALUES (
+            ?,
+            ?,
+            ?,
+            CASE WHEN ? = 1 THEN UTC_TIMESTAMP() ELSE NULL END,
+            NULL,
+            NULL,
+            NULL,
+            NULL
+         )
+         ON DUPLICATE KEY UPDATE
+            next_run_at = CASE
+                WHEN enabled = 1 AND next_run_at IS NULL THEN UTC_TIMESTAMP()
+                ELSE next_run_at
+            END,
+            updated_at = CURRENT_TIMESTAMP',
+        [$normalizedKey, $enabled, $intervalSeconds, $enabled]
+    );
+}
+
 function db_sync_schedule_upsert(string $jobKey, int $enabled, int $intervalSeconds): bool
 {
     $normalizedKey = trim($jobKey);
@@ -1761,7 +1816,16 @@ function db_sync_schedule_upsert(string $jobKey, int $enabled, int $intervalSeco
 
     return db_execute(
         'INSERT INTO sync_schedules (job_key, enabled, interval_seconds, next_run_at, last_run_at, last_status, last_error, locked_until)
-         VALUES (?, ?, ?, NULL, NULL, NULL, NULL, NULL)
+         VALUES (
+            ?,
+            ?,
+            ?,
+            CASE WHEN ? = 1 THEN UTC_TIMESTAMP() ELSE NULL END,
+            NULL,
+            NULL,
+            NULL,
+            NULL
+         )
          ON DUPLICATE KEY UPDATE
             enabled = VALUES(enabled),
             interval_seconds = VALUES(interval_seconds),
@@ -1771,7 +1835,7 @@ function db_sync_schedule_upsert(string $jobKey, int $enabled, int $intervalSeco
             END,
             locked_until = CASE WHEN VALUES(enabled) = 1 THEN locked_until ELSE NULL END,
             updated_at = CURRENT_TIMESTAMP',
-        [$normalizedKey, $enabled, $intervalSeconds]
+        [$normalizedKey, $enabled, $intervalSeconds, $enabled]
     );
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -5615,6 +5615,22 @@ function scheduler_job_definitions(): array
             'timeout_seconds' => 180,
             'lock_ttl_seconds' => 300,
             'handler' => static function (): array {
+                $runningHistoryJobs = scheduler_ai_briefing_running_history_jobs();
+                if ($runningHistoryJobs !== []) {
+                    $historyJobLabels = array_map(
+                        static fn (string $jobKey): string => str_replace('_', ' ', $jobKey),
+                        $runningHistoryJobs
+                    );
+
+                    return sync_result_shape() + [
+                        'warnings' => ['AI briefing rebuild skipped while history sync is running: ' . implode(', ', $historyJobLabels) . '.'],
+                        'meta' => [
+                            'outcome_reason' => 'Doctrine AI briefings were deferred because a history sync job is still running.',
+                            'blocking_jobs' => $runningHistoryJobs,
+                        ],
+                    ];
+                }
+
                 return rebuild_ai_briefings_job_result('scheduler');
             },
         ],
@@ -5695,8 +5711,40 @@ function scheduler_job_summary_message(array $result): string
 
     return 'Processed ' . $rowsSeen . ' records, wrote ' . $rowsWritten . ' records.';
 }
+
+function scheduler_ensure_default_jobs_registered(): void
+{
+    foreach (data_sync_schedule_job_definitions() as $jobKey => $definition) {
+        db_sync_schedule_ensure_job(
+            $jobKey,
+            1,
+            (int) ($definition['default_interval_seconds'] ?? 300)
+        );
+    }
+}
+
+function scheduler_ai_briefing_blocking_job_keys(): array
+{
+    return [
+        'alliance_historical_sync',
+        'market_hub_historical_sync',
+        'market_hub_local_history_sync',
+    ];
+}
+
+function scheduler_ai_briefing_running_history_jobs(): array
+{
+    try {
+        return db_sync_schedule_running_job_keys(scheduler_ai_briefing_blocking_job_keys());
+    } catch (Throwable) {
+        return [];
+    }
+}
+
 function scheduler_due_jobs(): array
 {
+    scheduler_ensure_default_jobs_registered();
+
     $definitions = scheduler_job_definitions();
     $due = db_sync_schedule_fetch_due_jobs(20);
     $claimed = [];


### PR DESCRIPTION
### Motivation
- Ensure `rebuild_ai_briefings` runs on fresh installs/upgrades without manual settings changes by auto-registering missing schedule rows.
- Prevent AI briefing rebuilds from interfering with long-running history rebuilds by deferring when history jobs are active.
- Make schedule defaults and detection of running history jobs centralized and robust to avoid scattered schedule logic and edge cases.

### Description
- Added `db_sync_schedule_running_job_keys()` and `db_sync_schedule_ensure_job()` helpers in `src/db.php` to detect running jobs and auto-create/seed schedule rows with an initial `next_run_at` when enabled.
- Updated `db_sync_schedule_upsert()` to set `next_run_at` immediately for newly enabled schedules and to use the new ensure helper signature.
- Added `scheduler_ensure_default_jobs_registered()`, `scheduler_ai_briefing_blocking_job_keys()`, and `scheduler_ai_briefing_running_history_jobs()` in `src/functions.php` and call `scheduler_ensure_default_jobs_registered()` from `scheduler_due_jobs()` to guarantee schedule rows exist before claiming jobs.
- Modified the `rebuild_ai_briefings` job handler to return a skipped result with a warning and meta when any configured history job (e.g., `market_hub_local_history_sync`) is currently running.
- Seeded schema defaults in `database/schema.sql` so relevant jobs (including `rebuild_ai_briefings`) have an initial `next_run_at`, and updated `README.md` to document the self-registration and deferred behavior.

### Testing
- Ran PHP linter on modified files with `php -l src/db.php` and `php -l src/functions.php`, both returned no syntax errors. (success)
- Ran `php -l public/index.php` to validate public entrypoint syntax (success).
- Verified diffs and schema changes to ensure the `rebuild_ai_briefings` schedule is present and that the scheduler installs/registers missing jobs (manual inspection). (no runtime tests executed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb4d347134832f99e59d8517cb7676)