### PR TITLE
Make scheduler timeouts configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,13 @@ Cron must run with the same environment the app expects:
 
 - App config vars: `APP_ENV`, `APP_BASE_URL`, `APP_TIMEZONE`
 - Database vars: `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD`
+- Scheduler timeout vars (optional): `SCHEDULER_DEFAULT_TIMEOUT_SECONDS` for a global override, plus per-job overrides such as `SCHEDULER_TIMEOUT_MARKET_HUB_CURRENT_SYNC=480` when a single pipeline needs more runtime.
 - Pipeline source vars (when those pipelines are enabled):
   - `SUPPLYCORE_ALLIANCE_SOURCE_ID` (for `alliance-current` and `alliance-history`)
   - `SUPPLYCORE_HUB_SOURCE_ID` (for `hub-current`, `hub-history`, and hub snapshot-history generation)
 
 The canonical log path for the cron tick is `storage/logs/cron.log` (relative to app root).
+If logs show `Job exceeded timeout of ... seconds.`, raise the matching scheduler timeout environment variable and reload cron/PHP so new worker processes inherit it.
 Raw order snapshots are pruned according to `raw_order_snapshot_retention_days` from Settings → Data Sync.
 Daily history rows are built from those local snapshots for both the alliance market and the reference hub, so keep the current-sync and history schedules enabled together for continuous trend updates.
 

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -34,4 +34,7 @@ return [
         'model' => getenv('OLLAMA_MODEL') ?: 'qwen2.5:1.5b-instruct',
         'timeout' => max(1, (int) (getenv('OLLAMA_TIMEOUT') ?: 20)),
     ],
+    'scheduler' => [
+        'default_timeout_seconds' => max(30, (int) (getenv('SCHEDULER_DEFAULT_TIMEOUT_SECONDS') ?: 300)),
+    ],
 ];

--- a/src/functions.php
+++ b/src/functions.php
@@ -5513,6 +5513,34 @@ function scheduler_normalize_messages(array $messages): array
     return array_keys($normalized);
 }
 
+function scheduler_timeout_env_key(string $jobKey): string
+{
+    $normalizedKey = strtoupper((string) preg_replace('/[^A-Za-z0-9]+/', '_', $jobKey));
+
+    return 'SCHEDULER_TIMEOUT_' . trim($normalizedKey, '_');
+}
+
+function scheduler_job_timeout_seconds(string $jobKey, int $defaultSeconds = 300): int
+{
+    $fallback = max(30, min(3600, $defaultSeconds));
+    $configuredDefault = max(30, min(3600, (int) config('scheduler.default_timeout_seconds', $fallback)));
+    $envValue = getenv(scheduler_timeout_env_key($jobKey));
+
+    if ($envValue === false || trim((string) $envValue) === '') {
+        return $configuredDefault;
+    }
+
+    return max(30, min(3600, (int) $envValue));
+}
+
+function scheduler_job_lock_ttl_seconds(int $defaultSeconds, int $timeoutSeconds): int
+{
+    $baseLockTtl = max(30, min(3600, $defaultSeconds));
+    $timeoutBackedTtl = min(3600, max($baseLockTtl, $timeoutSeconds + 60));
+
+    return $timeoutBackedTtl;
+}
+
 function scheduler_job_definitions(): array
 {
     return [
@@ -5756,7 +5784,10 @@ function scheduler_due_jobs(): array
         }
 
         $jobKey = (string) ($job['job_key'] ?? '');
-        $lockTtl = (int) ($definitions[$jobKey]['lock_ttl_seconds'] ?? 300);
+        $defaultTimeout = (int) ($definitions[$jobKey]['timeout_seconds'] ?? 300);
+        $timeoutSeconds = scheduler_job_timeout_seconds($jobKey, $defaultTimeout);
+        $defaultLockTtl = (int) ($definitions[$jobKey]['lock_ttl_seconds'] ?? 300);
+        $lockTtl = scheduler_job_lock_ttl_seconds($defaultLockTtl, $timeoutSeconds);
         $claimedJob = db_sync_schedule_claim_job($scheduleId, $lockTtl);
         if ($claimedJob !== null) {
             $claimed[] = $claimedJob;
@@ -5805,7 +5836,7 @@ function scheduler_run_job(array $job): array
         ];
     }
 
-    $timeoutSeconds = max(30, min(3600, (int) ($definition['timeout_seconds'] ?? 300)));
+    $timeoutSeconds = scheduler_job_timeout_seconds($jobKey, (int) ($definition['timeout_seconds'] ?? 300));
     $startedAt = microtime(true);
 
     try {


### PR DESCRIPTION
### Motivation

- Jobs like `market_hub_current_sync` were hitting a hard timeout and needed a way to extend runtime without changing code for each environment. 
- The scheduler should allow a global default and per-job overrides and keep lock TTLs aligned with any extended runtime so long-running jobs are not re-claimed prematurely.

### Description

- Add a new `scheduler.default_timeout_seconds` config (read from `SCHEDULER_DEFAULT_TIMEOUT_SECONDS`) in `src/config/app.php` and document the new env vars in `README.md`.
- Add helpers `scheduler_timeout_env_key`, `scheduler_job_timeout_seconds`, and `scheduler_job_lock_ttl_seconds` in `src/functions.php` to compute an effective timeout per job (per-job env override wins, bounded to 30–3600s) and to compute a lock TTL that stays ahead of the timeout.
- Update scheduler flow to use the effective timeout in `scheduler_run_job` and to use the timeout-backed lock TTL when claiming jobs in `scheduler_due_jobs` so locks don't expire mid-run.
- Update `README.md` to document `SCHEDULER_DEFAULT_TIMEOUT_SECONDS` and per-job overrides like `SCHEDULER_TIMEOUT_MARKET_HUB_CURRENT_SYNC=480` and to instruct operators to reload cron/PHP after changing env vars.

### Testing

- Ran `php -l src/functions.php` which returned no syntax errors. 
- Ran `php -l src/config/app.php` which returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb50f58720832fb1ccca775a36b7b6)