### PR TITLE
Add AI Briefings settings and Ollama integration UI with availability checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,6 @@ README.md
    export REDIS_PORT=6379
    export REDIS_DATABASE=0
    export REDIS_PREFIX=supplycore
-   export OLLAMA_ENABLED=1
-   export OLLAMA_URL=http://localhost:11434/api
-   export OLLAMA_MODEL=qwen2.5:1.5b-instruct
-   export OLLAMA_TIMEOUT=20
    ```
 
 3. **Run with PHP built-in server (dev only)**
@@ -106,14 +102,14 @@ README.md
 - SupplyCore’s first local AI layer is intentionally **non-authoritative**. Doctrine calculations, market comparisons, killmail/loss signals, and readiness math remain deterministic and authoritative.
 - Ollama is used only to summarize compact precomputed doctrine facts into operator briefings. It does **not** run on page load; it runs in the background through the scheduler job `rebuild_ai_briefings`.
 - The scheduler now self-registers missing schedule rows, so `rebuild_ai_briefings` starts running automatically on fresh installs and after upgrades without requiring a manual save in Settings.
-- Required environment variables:
-  - `OLLAMA_ENABLED=1`
-  - `OLLAMA_URL=http://localhost:11434/api`
-  - `OLLAMA_MODEL=qwen2.5:1.5b-instruct`
-  - `OLLAMA_TIMEOUT=20`
+- Configure Ollama in **Settings → AI Briefings** (`/settings?section=ai-briefings`):
+  - `Enable local Ollama doctrine briefings`
+  - `Ollama API URL` (for example `http://localhost:11434/api`)
+  - `Model Name` (for example `qwen2.5:1.5b-instruct`)
+  - `Request Timeout (seconds)`
 - The current-state AI briefing store lives in MySQL table `doctrine_ai_briefings`. Each row keeps the latest model name, operator-facing text, compact source payload, raw response JSON, and failure metadata for debugging/auditability.
 - If Ollama is unavailable or returns malformed JSON, SupplyCore logs the failure and stores a deterministic fallback briefing instead of blocking the rest of the app.
-- If `OLLAMA_ENABLED=0`, the background briefing job still stores deterministic fallback briefings so the dashboard briefing panel remains populated while AI connectivity is being debugged.
+- If the AI Briefings section is disabled, the background briefing job still stores deterministic fallback briefings so the dashboard briefing panel remains populated while AI connectivity is being debugged.
 - Use the AI briefing debug CLI to exercise the pipeline on demand:
   ```bash
   php bin/ai_briefing_debug.php

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -617,6 +617,10 @@ INSERT INTO app_settings (setting_key, setting_value) VALUES
     ('esi_client_secret', 'eat_iasVmhqov40Ud568JVAyctOErv5E6AgV_3S6eiZ'),
     ('esi_callback_url', 'http://192.168.178.47/callback'),
     ('esi_scopes', 'publicData esi-location.read_location.v1 esi-search.search_structures.v1 esi-universe.read_structures.v1 esi-markets.structure_markets.v1'),
+    ('ollama_enabled', '0'),
+    ('ollama_url', 'http://localhost:11434/api'),
+    ('ollama_model', 'qwen2.5:1.5b-instruct'),
+    ('ollama_timeout', '20'),
     ('doctrine.default_group', 'SupplyCore Doctrine')
 ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value);
 

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -54,6 +54,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
             break;
 
+        case 'ai-briefings':
+            $saved = save_settings(ai_briefing_settings_from_request($_POST));
+            break;
+
         case 'esi-login':
             $saved = save_settings([
                 'esi_client_id' => trim($_POST['esi_client_id'] ?? ''),
@@ -145,6 +149,7 @@ $settingValues = get_settings([
     'market_station_id',
     'alliance_station_id',
     ...item_scope_setting_keys(),
+    ...ai_briefing_setting_keys(),
     'esi_client_id',
     'esi_client_secret',
     'esi_callback_url',
@@ -217,6 +222,8 @@ $trackedAlliances = [];
 $trackedCorporations = [];
 $killmailStatus = null;
 $itemScope = item_scope_view_model();
+$ollamaConfig = supplycore_ai_ollama_config();
+$ollamaAvailable = supplycore_ai_ollama_available();
 if ($dbStatus['ok']) {
     try {
         $trackedAlliances = db_killmail_tracked_alliances_active();
@@ -511,6 +518,60 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     });
                 })();
             </script>
+        <?php elseif ($section === 'ai-briefings'): ?>
+            <form class="mt-6 space-y-6" method="post">
+                <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
+                <input type="hidden" name="section" value="ai-briefings">
+
+                <div class="grid gap-4 md:grid-cols-3">
+                    <div class="rounded-2xl border border-white/8 bg-white/[0.03] p-4">
+                        <p class="text-xs uppercase tracking-[0.16em] text-muted">Configured Mode</p>
+                        <p class="mt-2 text-2xl font-semibold text-slate-50"><?= ($ollamaConfig['enabled'] ?? false) ? 'Enabled' : 'Fallback only' ?></p>
+                        <p class="mt-1 text-sm text-muted">Doctrine briefings use the saved endpoint and model below.</p>
+                    </div>
+                    <div class="rounded-2xl border <?= $ollamaAvailable ? 'border-emerald-500/20 bg-emerald-500/10' : 'border-amber-500/20 bg-amber-500/10' ?> p-4">
+                        <p class="text-xs uppercase tracking-[0.16em] <?= $ollamaAvailable ? 'text-emerald-200/80' : 'text-amber-200/80' ?>">Reachability</p>
+                        <p class="mt-2 text-2xl font-semibold <?= $ollamaAvailable ? 'text-emerald-100' : 'text-amber-100' ?>"><?= $ollamaAvailable ? 'Ollama reachable' : 'Ollama not reachable' ?></p>
+                        <p class="mt-1 text-sm <?= $ollamaAvailable ? 'text-emerald-100/70' : 'text-amber-100/70' ?>">Status is checked against the configured Ollama API endpoint.</p>
+                    </div>
+                    <div class="rounded-2xl border border-sky-500/20 bg-sky-500/10 p-4">
+                        <p class="text-xs uppercase tracking-[0.16em] text-sky-200/80">Scheduler Behavior</p>
+                        <p class="mt-2 text-2xl font-semibold text-sky-100">Non-blocking</p>
+                        <p class="mt-1 text-sm text-sky-100/70">Disabled or unreachable AI falls back to deterministic summaries instead of blocking the job.</p>
+                    </div>
+                </div>
+
+                <label class="flex items-start gap-3 rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3">
+                    <input type="hidden" name="ollama_enabled" value="0">
+                    <input type="checkbox" name="ollama_enabled" value="1" <?= ($settingValues['ollama_enabled'] ?? '0') === '1' ? 'checked' : '' ?> class="mt-1 size-4 rounded border-border bg-black">
+                    <span>
+                        <span class="block text-sm font-medium text-slate-100">Enable local Ollama doctrine briefings</span>
+                        <span class="mt-1 block text-xs text-muted">Turn this off to force deterministic fallback summaries while still keeping briefing records populated.</span>
+                    </span>
+                </label>
+
+                <div class="grid gap-4 md:grid-cols-2">
+                    <label class="block space-y-2 md:col-span-2">
+                        <span class="text-sm text-muted">Ollama API URL</span>
+                        <input name="ollama_url" value="<?= htmlspecialchars($settingValues['ollama_url'] ?? ($ollamaConfig['url'] ?? 'http://localhost:11434/api'), ENT_QUOTES) ?>" class="w-full field-input" />
+                        <p class="text-xs text-muted">Use the API base URL, for example <span class="font-medium text-slate-100">http://localhost:11434/api</span>.</p>
+                    </label>
+                    <label class="block space-y-2">
+                        <span class="text-sm text-muted">Model Name</span>
+                        <input name="ollama_model" value="<?= htmlspecialchars($settingValues['ollama_model'] ?? ($ollamaConfig['model'] ?? 'qwen2.5:1.5b-instruct'), ENT_QUOTES) ?>" class="w-full field-input" />
+                    </label>
+                    <label class="block space-y-2">
+                        <span class="text-sm text-muted">Request Timeout (seconds)</span>
+                        <input type="number" min="1" max="300" step="1" name="ollama_timeout" value="<?= htmlspecialchars($settingValues['ollama_timeout'] ?? (string) ($ollamaConfig['timeout'] ?? 20), ENT_QUOTES) ?>" class="w-full field-input" />
+                    </label>
+                </div>
+
+                <div class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm text-muted">
+                    Configure the local AI endpoint here, then manage cadence under <a href="/settings?section=data-sync" class="font-medium text-slate-100 hover:text-white">Settings → Data Sync</a> for the <span class="font-medium text-slate-100">rebuild_ai_briefings</span> scheduler job.
+                </div>
+
+                <button class="btn-primary">Save AI Briefing Settings</button>
+            </form>
         <?php elseif ($section === 'item-scope'): ?>
             <?php
                 $itemScopeConfig = $itemScope['config'] ?? item_scope_default_config();

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -28,12 +28,6 @@ return [
         'read_timeout' => (float) (getenv('REDIS_READ_TIMEOUT') ?: 1.5),
         'lock_enabled' => (getenv('REDIS_LOCK_ENABLED') ?: '1') === '1',
     ],
-    'ollama' => [
-        'enabled' => (getenv('OLLAMA_ENABLED') ?: '0') === '1',
-        'url' => rtrim(getenv('OLLAMA_URL') ?: 'http://localhost:11434/api', '/'),
-        'model' => getenv('OLLAMA_MODEL') ?: 'qwen2.5:1.5b-instruct',
-        'timeout' => max(1, (int) (getenv('OLLAMA_TIMEOUT') ?: 20)),
-    ],
     'scheduler' => [
         'default_timeout_seconds' => max(30, (int) (getenv('SCHEDULER_DEFAULT_TIMEOUT_SECONDS') ?: 300)),
     ],

--- a/src/functions.php
+++ b/src/functions.php
@@ -131,6 +131,7 @@ function setting_sections(): array
         'general' => ['title' => 'General Settings', 'description' => 'Core application behavior and preferences.'],
         'trading-stations' => ['title' => 'Trading Stations', 'description' => 'Configure your reference market hub and operational trading destination.'],
         'item-scope' => ['title' => 'Item Scope', 'description' => 'Control which item classes are operationally relevant across market, doctrine, and loss-demand analytics.'],
+        'ai-briefings' => ['title' => 'AI Briefings', 'description' => 'Configure the local Ollama endpoint used for doctrine briefing summaries.'],
         'esi-login' => ['title' => 'ESI Login', 'description' => 'Configure EVE SSO credentials and callback behavior.'],
         'data-sync' => ['title' => 'Data Sync', 'description' => 'Control database import and incremental update policies.'],
         'killmail-intelligence' => ['title' => 'Killmail Intelligence', 'description' => 'Manage zKillboard stream ingestion, tracked entities, and demand prediction foundation.'],
@@ -211,6 +212,64 @@ function item_scope_setting_keys(): array
         'item_scope_exclude_meta_group_ids',
         'item_scope_include_type_ids',
         'item_scope_exclude_type_ids',
+    ];
+}
+
+function ai_briefing_setting_defaults(): array
+{
+    return [
+        'ollama_enabled' => '0',
+        'ollama_url' => 'http://localhost:11434/api',
+        'ollama_model' => 'qwen2.5:1.5b-instruct',
+        'ollama_timeout' => '20',
+    ];
+}
+
+function ai_briefing_setting_keys(): array
+{
+    return array_keys(ai_briefing_setting_defaults());
+}
+
+function sanitize_ollama_url(?string $value): string
+{
+    $url = rtrim(trim((string) $value), '/');
+
+    if ($url === '') {
+        return ai_briefing_setting_defaults()['ollama_url'];
+    }
+
+    if (!preg_match('/^https?:\/\/.+/i', $url)) {
+        return ai_briefing_setting_defaults()['ollama_url'];
+    }
+
+    return mb_substr($url, 0, 255);
+}
+
+function sanitize_ollama_model(?string $value): string
+{
+    $model = trim((string) $value);
+
+    if ($model === '') {
+        return ai_briefing_setting_defaults()['ollama_model'];
+    }
+
+    return mb_substr($model, 0, 120);
+}
+
+function sanitize_ollama_timeout(mixed $value): string
+{
+    $timeout = max(1, min(300, (int) $value));
+
+    return (string) $timeout;
+}
+
+function ai_briefing_settings_from_request(array $request): array
+{
+    return [
+        'ollama_enabled' => sanitize_enabled_flag($request['ollama_enabled'] ?? null),
+        'ollama_url' => sanitize_ollama_url($request['ollama_url'] ?? null),
+        'ollama_model' => sanitize_ollama_model($request['ollama_model'] ?? null),
+        'ollama_timeout' => sanitize_ollama_timeout($request['ollama_timeout'] ?? null),
     ];
 }
 
@@ -6182,14 +6241,14 @@ function http_post_json(string $url, array $headers, array $payload, int $timeou
     return ['status' => $status, 'json' => $decoded];
 }
 
-function http_get_json(string $url, array $headers = []): array
+function http_get_json(string $url, array $headers = [], int $timeoutSeconds = 25): array
 {
     $ch = curl_init($url);
     $responseHeaders = [];
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_HTTPHEADER => $headers,
-        CURLOPT_TIMEOUT => 25,
+        CURLOPT_TIMEOUT => max(1, $timeoutSeconds),
         CURLOPT_HEADERFUNCTION => static function ($curl, string $headerLine) use (&$responseHeaders): int {
             $trimmed = trim($headerLine);
             if ($trimmed === '' || !str_contains($trimmed, ':')) {
@@ -12988,11 +13047,27 @@ function doctrine_fit_detail_view_model(int $fitId): array
 
 function supplycore_ai_ollama_config(): array
 {
+    static $config = null;
+
+    if (is_array($config)) {
+        return $config;
+    }
+
+    $defaults = ai_briefing_setting_defaults();
+    $settings = get_settings(ai_briefing_setting_keys());
+
+    $config = [
+        'enabled' => (($settings['ollama_enabled'] ?? $defaults['ollama_enabled']) === '1'),
+        'url' => sanitize_ollama_url($settings['ollama_url'] ?? $defaults['ollama_url']),
+        'model' => sanitize_ollama_model($settings['ollama_model'] ?? $defaults['ollama_model']),
+        'timeout' => max(1, (int) sanitize_ollama_timeout($settings['ollama_timeout'] ?? $defaults['ollama_timeout'])),
+    ];
+
     return [
-        'enabled' => (bool) config('ollama.enabled', false),
-        'url' => rtrim((string) config('ollama.url', 'http://localhost:11434/api'), '/'),
-        'model' => trim((string) config('ollama.model', 'qwen2.5:1.5b-instruct')),
-        'timeout' => max(1, (int) config('ollama.timeout', 20)),
+        'enabled' => (bool) ($config['enabled'] ?? false),
+        'url' => (string) ($config['url'] ?? $defaults['ollama_url']),
+        'model' => (string) ($config['model'] ?? $defaults['ollama_model']),
+        'timeout' => max(1, (int) ($config['timeout'] ?? (int) $defaults['ollama_timeout'])),
     ];
 }
 
@@ -13001,6 +13076,38 @@ function supplycore_ai_ollama_enabled(): bool
     $config = supplycore_ai_ollama_config();
 
     return $config['enabled'] === true && $config['url'] !== '' && $config['model'] !== '';
+}
+
+function supplycore_ai_ollama_available(): bool
+{
+    static $availability = [];
+
+    $config = supplycore_ai_ollama_config();
+    if (!supplycore_ai_ollama_enabled()) {
+        return false;
+    }
+
+    $cacheKey = implode('|', [
+        (string) ($config['url'] ?? ''),
+        (string) ($config['model'] ?? ''),
+        (string) ($config['timeout'] ?? 20),
+    ]);
+    if (array_key_exists($cacheKey, $availability)) {
+        return $availability[$cacheKey];
+    }
+
+    $endpoint = rtrim((string) ($config['url'] ?? ''), '/') . '/tags';
+
+    try {
+        $response = http_get_json($endpoint, [], max(1, (int) ($config['timeout'] ?? 20)));
+        $status = (int) ($response['status'] ?? 0);
+        $json = is_array($response['json'] ?? null) ? $response['json'] : [];
+        $availability[$cacheKey] = $status >= 200 && $status < 300 && is_array($json['models'] ?? null);
+    } catch (Throwable) {
+        $availability[$cacheKey] = false;
+    }
+
+    return $availability[$cacheKey];
 }
 
 function supplycore_ai_log(string $event, array $payload = []): void
@@ -13626,7 +13733,7 @@ function doctrine_ai_debug_preview(?string $entityType = null, ?int $entityId = 
 
     return [
         'config' => supplycore_ai_ollama_config() + [
-            'available' => supplycore_ai_ollama_enabled(),
+            'available' => supplycore_ai_ollama_available(),
         ],
         'selected_candidate' => [
             'entity_type' => $resolvedEntityType,


### PR DESCRIPTION
### Motivation
- Introduce a configurable, non-blocking local AI layer for doctrine briefings using Ollama and surface controls in the web UI instead of relying solely on environment variables.
- Allow runtime configuration and reachability checks so scheduler jobs can fall back to deterministic briefings when the AI endpoint is disabled or unreachable.

### Description
- Added database defaults for Ollama settings (`ollama_enabled`, `ollama_url`, `ollama_model`, `ollama_timeout`) in `database/schema.sql` so installs get sane defaults.
- Replaced the env-based Ollama block in `src/config/app.php` and introduced DB-backed runtime configuration via `supplycore_ai_ollama_config()` plus an availability probe `supplycore_ai_ollama_available()` in `src/functions.php`.
- Added setting keys, sanitizers, and request handlers (`ai_briefing_setting_defaults`, `ai_briefing_setting_keys`, `sanitize_ollama_*`, `ai_briefing_settings_from_request`) and wired them into `public/settings/index.php` to render and persist the new `AI Briefings` settings page and form.
- Tied the UI and logic together by adding reachability UI, making the scheduler behavior explicit, and wiring the `doctrine_ai_debug_preview` view to use the new availability check; also updated `http_get_json()` to accept a configurable timeout.
- Updated `README.md` to document configuring Ollama via `Settings → AI Briefings` instead of required environment variables and clarified fallback behavior.

### Testing
- No automated tests were included or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb53721cc8832f994c601077c0ee6b)