### PR TITLE
Fix static data import transaction handling

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -1959,18 +1959,15 @@ function db_static_data_import_state_upsert(
 function db_reference_data_truncate_all(): void
 {
     item_scope_db_ensure_schema();
-
-    db_transaction(static function (): void {
-        db_execute('TRUNCATE TABLE ref_item_types');
-        db_execute('TRUNCATE TABLE ref_meta_groups');
-        db_execute('TRUNCATE TABLE ref_item_groups');
-        db_execute('TRUNCATE TABLE ref_item_categories');
-        db_execute('TRUNCATE TABLE ref_market_groups');
-        db_execute('TRUNCATE TABLE ref_npc_stations');
-        db_execute('TRUNCATE TABLE ref_systems');
-        db_execute('TRUNCATE TABLE ref_constellations');
-        db_execute('TRUNCATE TABLE ref_regions');
-    });
+    db_execute('TRUNCATE TABLE ref_item_types');
+    db_execute('TRUNCATE TABLE ref_meta_groups');
+    db_execute('TRUNCATE TABLE ref_item_groups');
+    db_execute('TRUNCATE TABLE ref_item_categories');
+    db_execute('TRUNCATE TABLE ref_market_groups');
+    db_execute('TRUNCATE TABLE ref_npc_stations');
+    db_execute('TRUNCATE TABLE ref_systems');
+    db_execute('TRUNCATE TABLE ref_constellations');
+    db_execute('TRUNCATE TABLE ref_regions');
 }
 
 function db_ref_regions_bulk_upsert(array $rows, ?int $chunkSize = null): int

--- a/src/functions.php
+++ b/src/functions.php
@@ -9219,11 +9219,11 @@ function static_data_import_reference_data(string $requestedMode = 'auto', bool 
         $metaGroups = $dataset['meta_groups'];
         $types = $dataset['types'];
 
-        $rowsWritten = db_transaction(static function () use ($mode, $regions, $constellations, $systems, $stations, $categories, $groups, $marketGroups, $metaGroups, $types): int {
-            if ($mode === 'full') {
-                db_reference_data_truncate_all();
-            }
+        if ($mode === 'full') {
+            db_reference_data_truncate_all();
+        }
 
+        $rowsWritten = db_transaction(static function () use ($regions, $constellations, $systems, $stations, $categories, $groups, $marketGroups, $metaGroups, $types): int {
             $written = 0;
             $written += db_ref_regions_bulk_upsert($regions);
             $written += db_ref_constellations_bulk_upsert($constellations);


### PR DESCRIPTION
### Motivation

- The static data importer failed with "There is no active transaction" because `TRUNCATE` (which implicitly commits in MySQL) was executed inside the import transaction and later caused the transaction helper to attempt commit/rollback on a non-active transaction.

### Description

- Moved the full-refresh truncation step out of the wrapped import transaction by calling `db_reference_data_truncate_all()` before entering the `db_transaction()` block in `static_data_import_reference_data` (`src/functions.php`).
- Simplified `db_reference_data_truncate_all()` in `src/db.php` to execute `TRUNCATE` statements directly rather than wrapping them in `db_transaction()`, avoiding implicit-commit issues with MySQL `TRUNCATE`.
- Kept the subsequent dataset bulk-upserts inside `db_transaction()` so imported rows are still written transactionally after the truncate/reset.

### Testing

- Verified PHP syntax for the modified files with `php -l src/functions.php`, `php -l src/db.php`, and `php -l bin/static_data_import.php`, and all checks passed.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb8ab05e00832fabaf4d081b828579)