### PR TITLE
Static-data importer: manifest-based build detection and cURL fetch fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ SupplyCore includes a local reference-data pipeline for EVE static data exports.
 
 ### What it does
 
-- Checks the current upstream static-data build from `static_data_source_url`
+- Checks the current upstream static-data build from `static_data_source_url` and, for the official CCP archive, uses the companion `static-data/tranquility/latest.jsonl` manifest for build detection
 - Compares upstream build metadata with `static_data_import_state.imported_build_id`
 - Downloads and caches the static package in `storage/static-data/`
 - Supports official CCP JSONL ZIP payloads (`.zip`); default source is `eve-online-static-data-latest-jsonl.zip`

--- a/src/functions.php
+++ b/src/functions.php
@@ -5494,6 +5494,119 @@ function static_data_default_source_url(): string
     return 'https://developers.eveonline.com/static-data/eve-online-static-data-latest-jsonl.zip';
 }
 
+function static_data_manifest_url_for_source(string $sourceUrl): ?string
+{
+    $host = mb_strtolower((string) parse_url($sourceUrl, PHP_URL_HOST));
+    $path = (string) parse_url($sourceUrl, PHP_URL_PATH);
+
+    if ($host !== 'developers.eveonline.com') {
+        return null;
+    }
+
+    if (!str_starts_with($path, '/static-data/')) {
+        return null;
+    }
+
+    return 'https://developers.eveonline.com/static-data/tranquility/latest.jsonl';
+}
+
+function static_data_fetch_text_payload(string $url, int $timeoutSeconds = 30): string
+{
+    if (!function_exists('curl_init')) {
+        throw new RuntimeException('PHP cURL extension is required to fetch static-data payloads.');
+    }
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_TIMEOUT => $timeoutSeconds,
+        CURLOPT_HTTPHEADER => [
+            'Accept: application/json, text/plain, */*',
+            'User-Agent: SupplyCore/1.0',
+        ],
+    ]);
+
+    $payload = curl_exec($ch);
+    $error = curl_error($ch);
+    $status = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    curl_close($ch);
+
+    if (!is_string($payload) || $payload === '' || $status >= 400) {
+        throw new RuntimeException('Unable to fetch static-data payload from source URL.' . ($error !== '' ? ' ' . $error : ''));
+    }
+
+    return $payload;
+}
+
+function static_data_fetch_binary_payload(string $url, int $timeoutSeconds = 120): string
+{
+    if (!function_exists('curl_init')) {
+        throw new RuntimeException('PHP cURL extension is required to download static-data archives.');
+    }
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_CONNECTTIMEOUT => 15,
+        CURLOPT_TIMEOUT => $timeoutSeconds,
+        CURLOPT_HTTPHEADER => [
+            'Accept: application/zip, application/octet-stream, */*',
+            'User-Agent: SupplyCore/1.0',
+        ],
+    ]);
+
+    $payload = curl_exec($ch);
+    $error = curl_error($ch);
+    $status = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    curl_close($ch);
+
+    if (!is_string($payload) || $payload === '' || $status >= 400) {
+        throw new RuntimeException('Failed to download static-data package.' . ($error !== '' ? ' ' . $error : ''));
+    }
+
+    return $payload;
+}
+
+function static_data_build_info_from_manifest(string $manifestUrl): ?array
+{
+    $payload = static_data_fetch_text_payload($manifestUrl);
+
+    foreach (preg_split("/(?:\r\n|\n|\r)/", $payload) as $line) {
+        $line = trim((string) $line);
+        if ($line === '') {
+            continue;
+        }
+
+        try {
+            $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            continue;
+        }
+
+        if (!is_array($row)) {
+            continue;
+        }
+
+        $buildNumber = trim((string) ($row['buildNumber'] ?? $row['build_number'] ?? ''));
+        $releaseDate = trim((string) ($row['releaseDate'] ?? $row['release_date'] ?? ''));
+        if ($buildNumber === '' && $releaseDate === '') {
+            continue;
+        }
+
+        return [
+            'build_id' => $buildNumber !== '' ? $buildNumber : sha1($manifestUrl . '|' . $releaseDate),
+            'etag' => null,
+            'last_modified' => $releaseDate !== '' ? $releaseDate : null,
+            'manifest_url' => $manifestUrl,
+        ];
+    }
+
+    return null;
+}
+
 function sync_watermark(string $datasetKey): ?string
 {
     $state = db_sync_state_get($datasetKey);
@@ -8773,9 +8886,69 @@ function static_data_import_mode(string $requestedMode = 'auto'): string
 
 function static_data_fetch_remote_build_info(string $sourceUrl): array
 {
-    $headers = @get_headers($sourceUrl, true);
+    $manifestUrl = static_data_manifest_url_for_source($sourceUrl);
+    if ($manifestUrl !== null) {
+        try {
+            $manifestInfo = static_data_build_info_from_manifest($manifestUrl);
+            if ($manifestInfo !== null) {
+                return $manifestInfo;
+            }
+        } catch (Throwable) {
+            // Fall back to archive headers for non-standard mirrors or manifest fetch failures.
+        }
+    }
+
+    if (!function_exists('get_headers')) {
+        throw new RuntimeException('Unable to fetch static-data metadata from source URL.');
+    }
+
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'HEAD',
+            'timeout' => 30,
+            'ignore_errors' => true,
+            'header' => "User-Agent: SupplyCore/1.0\r\nAccept: */*\r\n",
+        ],
+    ]);
+    $headers = @get_headers($sourceUrl, true, $context);
+    if ($headers === false && function_exists('curl_init')) {
+        $ch = curl_init($sourceUrl);
+        curl_setopt_array($ch, [
+            CURLOPT_NOBODY => true,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_CONNECTTIMEOUT => 10,
+            CURLOPT_TIMEOUT => 30,
+            CURLOPT_HTTPHEADER => ['Accept: */*', 'User-Agent: SupplyCore/1.0'],
+        ]);
+        $rawHeaders = curl_exec($ch);
+        $status = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        curl_close($ch);
+
+        if (is_string($rawHeaders) && $rawHeaders !== '' && $status > 0 && $status < 400) {
+            $headers = [];
+            foreach (preg_split("/(?:\r\n|\n|\r)/", trim($rawHeaders)) as $line) {
+                if (!str_contains($line, ':')) {
+                    continue;
+                }
+
+                [$name, $value] = array_map('trim', explode(':', $line, 2));
+                if ($name === '') {
+                    continue;
+                }
+
+                if (isset($headers[$name])) {
+                    $headers[$name] = array_merge((array) $headers[$name], [$value]);
+                } else {
+                    $headers[$name] = $value;
+                }
+            }
+        }
+    }
+
     if ($headers === false) {
-        throw new RuntimeException('Unable to fetch static-data headers from source URL.');
+        throw new RuntimeException('Unable to fetch static-data metadata from source URL.');
     }
 
     $lastModified = '';
@@ -8825,12 +8998,7 @@ function static_data_ensure_local_jsonl_archive(string $sourceUrl, string $build
     }
 
     if (!is_file($paths['archive_path'])) {
-        $context = stream_context_create(['http' => ['timeout' => 120]]);
-        $payload = @file_get_contents($sourceUrl, false, $context);
-        if ($payload === false) {
-            throw new RuntimeException('Failed to download static-data package.');
-        }
-
+        $payload = static_data_fetch_binary_payload($sourceUrl);
         if (file_put_contents($paths['archive_path'], $payload) === false) {
             throw new RuntimeException('Failed to write static-data archive to local storage.');
         }


### PR DESCRIPTION
### Motivation

- Make the static-data import resilient when PHP stream-based HTTP helpers fail against CCP endpoints and when header inspection of the ZIP URL is unreliable.
- Ensure the importer can detect the official build id for the CCP archive even when the ZIP endpoint does not provide reliable headers.

### Description

- Added `static_data_manifest_url_for_source()` and `static_data_build_info_from_manifest()` to detect official build metadata from CCP's `static-data/tranquility/latest.jsonl` manifest.
- Replaced fragile PHP stream downloads with cURL-backed helpers `static_data_fetch_text_payload()` and `static_data_fetch_binary_payload()` and switched archive download to use the binary fetcher in `static_data_ensure_local_jsonl_archive()`.
- Added a fallback path that attempts HEAD via `get_headers()` and, if necessary, a cURL HEAD request to gather archive metadata when the manifest is not applicable.
- Documented the manifest-based detection behavior in the README static-data import section.

### Testing

- Ran `php -l src/functions.php` to confirm no syntax errors, which succeeded.
- Executed `static_data_fetch_remote_build_info()` against the official CCP URL to validate manifest lookup, which returned the expected `build_id` and timestamps successfully.
- Ran `static_data_ensure_local_jsonl_archive()` to download the archive and verified the file exists and its size (example: `storage/static-data/3261822.jsonl.zip`, ~83MB), which succeeded.
- Ran `static_data_extract_reference_rows_from_jsonl_archive()` to parse the downloaded archive and verified dataset row counts for `regions`, `constellations`, `systems`, `stations`, `categories`, `groups`, `market_groups`, `meta_groups`, and `types`, which succeeded; full end-to-end import into MySQL could not be executed because `db_connection_status()` returned connection refused in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb8c54707c832fbbf4fd9bc6cd4645)