### PR TITLE
Add adaptive local AI capability tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ README.md
   - `Ollama API URL` (for example `http://localhost:11434/api`)
   - `Model Name` (for example `qwen2.5:1.5b-instruct`)
   - `Request Timeout (seconds)`
+  - `Capability Tier` (`auto`, `small`, `medium`, or `large`)
+- SupplyCore now uses a centralized AI capability strategy layer. By default it infers the tier from the configured model name (for example `1.5b` → `small`, `3b–8b` → `medium`, larger local models → `large`), but operators can explicitly override the tier in Settings when needed.
+- The capability tier centrally controls prompt depth, enabled AI task types, how much snapshot/history context is included, the number of doctrine entities processed per background run, and how rich the dashboard briefing cards are.
+- Small tiers stay intentionally compact: short prompts, short structured outputs, top critical doctrines/groups only, no broad cross-doctrine reasoning, and no forecast-style commentary.
+- Medium tiers add explanation-oriented outputs: richer summaries, previous-vs-current recommendation context, bounded cross-signal reasoning, and larger batch sizes.
+- Large tiers unlock richer operator-facing sections: broader doctrine coverage, deeper explanations of pressure/bottlenecks, bounded use of local snapshot history, and limited forecast-style commentary grounded only in SupplyCore’s stored deterministic history.
 - The current-state AI briefing store lives in MySQL table `doctrine_ai_briefings`. Each row keeps the latest model name, operator-facing text, compact source payload, raw response JSON, and failure metadata for debugging/auditability.
 - If Ollama is unavailable or returns malformed JSON, SupplyCore logs the failure and stores a deterministic fallback briefing instead of blocking the rest of the app.
 - If the AI Briefings section is disabled, the background briefing job still stores deterministic fallback briefings so the dashboard briefing panel remains populated while AI connectivity is being debugged.
@@ -196,7 +202,7 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 - SupplyCore now separates cadences by workload:
   - **Fast ingestion**: `killmail_r2z2_sync`, `alliance_current_sync`, and `market_hub_current_sync` keep raw market and killmail inputs fresh.
   - **Materialized intelligence refresh (target cadence: every 5 minutes)**: `doctrine_intelligence_sync`, `market_comparison_summary_sync`, `loss_demand_summary_sync`, `dashboard_summary_sync`, and `current_state_refresh_sync` recompute heavy current-summary layers from raw tables, then publish the latest payloads into Redis for fast reads.
-  - **Local doctrine AI briefings (target cadence: every 5 minutes)**: `rebuild_ai_briefings` ranks the most important doctrine fits/groups first, generates concise Ollama summaries from compact deterministic facts, stores the latest result in MySQL, refreshes the dashboard briefing panel, and skips that cycle when a history rebuild job is still running.
+  - **Local doctrine AI briefings (target cadence: every 5 minutes)**: `rebuild_ai_briefings` ranks doctrine fits/groups through the centralized capability-tier strategy, scales prompt/context richness and batch size to the configured Ollama model, stores the latest result in MySQL, refreshes the dashboard briefing panel, and skips that cycle when a history rebuild job is still running.
   - **Slow forecasting / AI**: `forecasting_ai_sync` derives slower-moving target-adjustment, anomaly, briefing, and explanation layers from the latest medium snapshot instead of raw minute-by-minute ingestion.
 - UI pages now read Redis first and fall back to `intelligence_snapshots` if Redis is unavailable; each intelligence surface also exposes its last computed timestamp and freshness state to operators.
 - The hub-history scheduler jobs (`market_hub_historical_sync` and `market_hub_local_history_sync`) rebuild `market_history_daily` from SupplyCore’s own raw hub-order snapshots stored in MySQL for the configured market hub, using the recent window controlled by `raw_order_snapshot_retention_days` unless a CLI override is supplied.

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -621,6 +621,7 @@ INSERT INTO app_settings (setting_key, setting_value) VALUES
     ('ollama_url', 'http://localhost:11434/api'),
     ('ollama_model', 'qwen2.5:1.5b-instruct'),
     ('ollama_timeout', '20'),
+    ('ollama_capability_tier', 'auto'),
     ('doctrine.default_group', 'SupplyCore Doctrine')
 ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value);
 

--- a/public/index.php
+++ b/public/index.php
@@ -334,10 +334,28 @@ $statusThemes = [
                     </div>
                     <p class="mt-4 text-base font-semibold text-white"><?= htmlspecialchars((string) ($briefing['headline'] ?? 'Briefing unavailable'), ENT_QUOTES) ?></p>
                     <p class="mt-2 text-sm text-slate-300"><?= htmlspecialchars((string) ($briefing['summary'] ?? ''), ENT_QUOTES) ?></p>
+                    <?php if (trim((string) ($briefing['explanation_text'] ?? '')) !== ''): ?>
+                        <div class="mt-4 rounded-2xl border border-white/8 bg-white/[0.02] px-3 py-3">
+                            <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Why this changed</p>
+                            <p class="mt-2 text-sm text-slate-200"><?= htmlspecialchars((string) ($briefing['explanation_text'] ?? ''), ENT_QUOTES) ?></p>
+                        </div>
+                    <?php endif; ?>
                     <div class="mt-4 rounded-2xl border border-white/8 bg-slate-950/60 px-3 py-3">
                         <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Recommended action</p>
                         <p class="mt-2 text-sm text-slate-100"><?= htmlspecialchars((string) ($briefing['action_text'] ?? ''), ENT_QUOTES) ?></p>
                     </div>
+                    <?php if (trim((string) ($briefing['operator_briefing'] ?? '')) !== ''): ?>
+                        <div class="mt-4 rounded-2xl border border-violet-400/15 bg-violet-500/5 px-3 py-3">
+                            <p class="text-xs uppercase tracking-[0.16em] text-violet-200/70">Operator briefing</p>
+                            <p class="mt-2 text-sm text-violet-50"><?= htmlspecialchars((string) ($briefing['operator_briefing'] ?? ''), ENT_QUOTES) ?></p>
+                        </div>
+                    <?php endif; ?>
+                    <?php if (trim((string) ($briefing['trend_interpretation'] ?? '')) !== ''): ?>
+                        <div class="mt-4 rounded-2xl border border-sky-400/15 bg-sky-500/5 px-3 py-3">
+                            <p class="text-xs uppercase tracking-[0.16em] text-sky-200/70">Trend interpretation</p>
+                            <p class="mt-2 text-sm text-sky-50"><?= htmlspecialchars((string) ($briefing['trend_interpretation'] ?? ''), ENT_QUOTES) ?></p>
+                        </div>
+                    <?php endif; ?>
                     <p class="mt-3 text-xs text-slate-500">Updated <?= htmlspecialchars((string) ($briefing['computed_relative'] ?? 'Unknown'), ENT_QUOTES) ?><?= (($briefing['generation_status'] ?? 'ready') !== 'ready') ? ' · deterministic fallback' : '' ?></p>
                 </a>
             <?php endforeach; ?>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -539,6 +539,18 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <p class="mt-2 text-2xl font-semibold text-sky-100">Non-blocking</p>
                         <p class="mt-1 text-sm text-sky-100/70">Disabled or unreachable AI falls back to deterministic summaries instead of blocking the job.</p>
                     </div>
+                    <div class="rounded-2xl border border-violet-500/20 bg-violet-500/10 p-4 md:col-span-3">
+                        <p class="text-xs uppercase tracking-[0.16em] text-violet-200/80">Capability Tier</p>
+                        <div class="mt-2 flex flex-wrap items-center gap-3">
+                            <p class="text-2xl font-semibold text-violet-50"><?= htmlspecialchars(strtoupper((string) ($ollamaConfig['capability_tier'] ?? 'small')), ENT_QUOTES) ?></p>
+                            <span class="badge border-violet-300/20 bg-violet-400/10 text-violet-100">
+                                <?= (($ollamaConfig['capability_override'] ?? 'auto') === 'auto')
+                                    ? ('auto from model: ' . htmlspecialchars((string) ($ollamaConfig['inferred_tier'] ?? 'small'), ENT_QUOTES))
+                                    : ('manual override: ' . htmlspecialchars((string) ($ollamaConfig['capability_override'] ?? 'small'), ENT_QUOTES)) ?>
+                            </span>
+                        </div>
+                        <p class="mt-2 text-sm text-violet-100/75">Candidate batching, prompt depth, enabled tasks, and dashboard richness all scale from this centralized AI strategy.</p>
+                    </div>
                 </div>
 
                 <label class="flex items-start gap-3 rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3">
@@ -564,10 +576,20 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <span class="text-sm text-muted">Request Timeout (seconds)</span>
                         <input type="number" min="1" max="300" step="1" name="ollama_timeout" value="<?= htmlspecialchars($settingValues['ollama_timeout'] ?? (string) ($ollamaConfig['timeout'] ?? 20), ENT_QUOTES) ?>" class="w-full field-input" />
                     </label>
+                    <label class="block space-y-2 md:col-span-2">
+                        <span class="text-sm text-muted">Capability Tier</span>
+                        <select name="ollama_capability_tier" class="w-full field-input">
+                            <?php $selectedTier = (string) ($settingValues['ollama_capability_tier'] ?? ($ollamaConfig['capability_override'] ?? 'auto')); ?>
+                            <?php foreach (['auto' => 'Auto-detect from model', 'small' => 'Small', 'medium' => 'Medium', 'large' => 'Large'] as $value => $label): ?>
+                                <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $selectedTier === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <p class="text-xs text-muted">Leave this on auto to infer capability from the configured model name, or pin a tier if the model naming does not include parameter size.</p>
+                    </label>
                 </div>
 
                 <div class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm text-muted">
-                    Configure the local AI endpoint here, then manage cadence under <a href="/settings?section=data-sync" class="font-medium text-slate-100 hover:text-white">Settings → Data Sync</a> for the <span class="font-medium text-slate-100">rebuild_ai_briefings</span> scheduler job.
+                    Configure the local AI endpoint here, then manage cadence under <a href="/settings?section=data-sync" class="font-medium text-slate-100 hover:text-white">Settings → Data Sync</a> for the <span class="font-medium text-slate-100">rebuild_ai_briefings</span> scheduler job. Small tiers stay compact, medium tiers add explanation and deltas, and large tiers unlock richer operator briefings while still keeping deterministic calculations authoritative.
                 </div>
 
                 <button class="btn-primary">Save AI Briefing Settings</button>

--- a/src/functions.php
+++ b/src/functions.php
@@ -222,6 +222,7 @@ function ai_briefing_setting_defaults(): array
         'ollama_url' => 'http://localhost:11434/api',
         'ollama_model' => 'qwen2.5:1.5b-instruct',
         'ollama_timeout' => '20',
+        'ollama_capability_tier' => 'auto',
     ];
 }
 
@@ -263,6 +264,15 @@ function sanitize_ollama_timeout(mixed $value): string
     return (string) $timeout;
 }
 
+function sanitize_ollama_capability_tier(mixed $value): string
+{
+    $tier = mb_strtolower(trim((string) $value));
+
+    return in_array($tier, ['auto', 'small', 'medium', 'large'], true)
+        ? $tier
+        : ai_briefing_setting_defaults()['ollama_capability_tier'];
+}
+
 function ai_briefing_settings_from_request(array $request): array
 {
     return [
@@ -270,6 +280,7 @@ function ai_briefing_settings_from_request(array $request): array
         'ollama_url' => sanitize_ollama_url($request['ollama_url'] ?? null),
         'ollama_model' => sanitize_ollama_model($request['ollama_model'] ?? null),
         'ollama_timeout' => sanitize_ollama_timeout($request['ollama_timeout'] ?? null),
+        'ollama_capability_tier' => sanitize_ollama_capability_tier($request['ollama_capability_tier'] ?? null),
     ];
 }
 
@@ -13229,14 +13240,181 @@ function supplycore_ai_ollama_config(): array
         'url' => sanitize_ollama_url($settings['ollama_url'] ?? $defaults['ollama_url']),
         'model' => sanitize_ollama_model($settings['ollama_model'] ?? $defaults['ollama_model']),
         'timeout' => max(1, (int) sanitize_ollama_timeout($settings['ollama_timeout'] ?? $defaults['ollama_timeout'])),
+        'capability_override' => sanitize_ollama_capability_tier($settings['ollama_capability_tier'] ?? $defaults['ollama_capability_tier']),
     ];
+
+    $inferredTier = supplycore_ai_infer_model_capability_tier((string) ($config['model'] ?? ''));
+    $effectiveTier = ($config['capability_override'] ?? 'auto') !== 'auto'
+        ? (string) $config['capability_override']
+        : $inferredTier;
+    $strategy = supplycore_ai_capability_strategy($effectiveTier);
 
     return [
         'enabled' => (bool) ($config['enabled'] ?? false),
         'url' => (string) ($config['url'] ?? $defaults['ollama_url']),
         'model' => (string) ($config['model'] ?? $defaults['ollama_model']),
         'timeout' => max(1, (int) ($config['timeout'] ?? (int) $defaults['ollama_timeout'])),
+        'capability_override' => (string) ($config['capability_override'] ?? 'auto'),
+        'inferred_tier' => $inferredTier,
+        'capability_tier' => $effectiveTier,
+        'strategy' => $strategy,
     ];
+}
+
+function supplycore_ai_infer_model_capacity_billions(string $model): ?float
+{
+    $normalized = mb_strtolower(trim($model));
+    if ($normalized === '') {
+        return null;
+    }
+
+    if (preg_match('/(?:^|[:\-_ ])(\d+(?:\.\d+)?)\s*b(?:[^a-z0-9]|$)/i', $normalized, $matches) === 1) {
+        return max(0.0, (float) $matches[1]);
+    }
+
+    if (preg_match('/(\d+(?:\.\d+)?)\s*b\b/i', $normalized, $matches) === 1) {
+        return max(0.0, (float) $matches[1]);
+    }
+
+    return null;
+}
+
+function supplycore_ai_infer_model_capability_tier(string $model): string
+{
+    $billions = supplycore_ai_infer_model_capacity_billions($model);
+    if ($billions !== null) {
+        if ($billions < 3.0) {
+            return 'small';
+        }
+
+        if ($billions <= 8.0) {
+            return 'medium';
+        }
+
+        return 'large';
+    }
+
+    $normalized = mb_strtolower(trim($model));
+    if ($normalized === '') {
+        return 'small';
+    }
+
+    if (str_contains($normalized, '1.5b') || str_contains($normalized, '2b')) {
+        return 'small';
+    }
+
+    if (str_contains($normalized, '3b') || str_contains($normalized, '7b') || str_contains($normalized, '8b')) {
+        return 'medium';
+    }
+
+    return 'medium';
+}
+
+function supplycore_ai_capability_strategy(string $tier): array
+{
+    $normalizedTier = in_array($tier, ['small', 'medium', 'large'], true) ? $tier : 'small';
+
+    $base = [
+        'tier' => $normalizedTier,
+        'background_only' => true,
+        'strict_json' => true,
+        'authoritative_source' => 'deterministic',
+        'candidate_limit' => 5,
+        'dashboard_limit' => 3,
+        'history_limit' => 0,
+        'group_history_fit_limit' => 0,
+        'prompt_style' => 'compact',
+        'prompt_max_chars' => 1600,
+        'summary_max_chars' => 240,
+        'action_max_chars' => 220,
+        'explanation_max_chars' => 0,
+        'operator_briefing_max_chars' => 0,
+        'trend_max_chars' => 0,
+        'task_labels' => [
+            'fit' => 'doctrine fit briefing',
+            'group' => 'doctrine group briefing',
+        ],
+        'enabled_tasks' => [
+            'fit_briefing',
+            'group_briefing',
+            'dashboard_critical_note',
+        ],
+        'include_previous_recommendation' => false,
+        'include_snapshot_delta' => false,
+        'include_cross_signal_reasoning' => false,
+        'include_historical_context' => false,
+        'include_operator_briefing' => false,
+        'include_trend_interpretation' => false,
+        'forecast_language' => 'avoid',
+    ];
+
+    return match ($normalizedTier) {
+        'medium' => $base + [
+            'candidate_limit' => 12,
+            'dashboard_limit' => 6,
+            'history_limit' => 2,
+            'group_history_fit_limit' => 2,
+            'prompt_style' => 'balanced',
+            'prompt_max_chars' => 3200,
+            'summary_max_chars' => 420,
+            'action_max_chars' => 320,
+            'explanation_max_chars' => 260,
+            'enabled_tasks' => [
+                'fit_briefing',
+                'group_briefing',
+                'dashboard_critical_note',
+                'recommendation_change_explanation',
+                'doctrine_pressure_summary',
+                'prioritized_restock_note',
+            ],
+            'include_previous_recommendation' => true,
+            'include_snapshot_delta' => true,
+            'include_cross_signal_reasoning' => true,
+            'forecast_language' => 'minimal',
+        ],
+        'large' => $base + [
+            'candidate_limit' => 20,
+            'dashboard_limit' => 8,
+            'history_limit' => 4,
+            'group_history_fit_limit' => 3,
+            'prompt_style' => 'rich',
+            'prompt_max_chars' => 5200,
+            'summary_max_chars' => 600,
+            'action_max_chars' => 420,
+            'explanation_max_chars' => 360,
+            'operator_briefing_max_chars' => 360,
+            'trend_max_chars' => 320,
+            'enabled_tasks' => [
+                'fit_briefing',
+                'group_briefing',
+                'dashboard_critical_note',
+                'recommendation_change_explanation',
+                'doctrine_pressure_summary',
+                'prioritized_restock_note',
+                'top_doctrine_risk_briefing',
+                'market_doctrine_synthesis',
+                'operator_guidance',
+                'limited_forecast_commentary',
+            ],
+            'include_previous_recommendation' => true,
+            'include_snapshot_delta' => true,
+            'include_cross_signal_reasoning' => true,
+            'include_historical_context' => true,
+            'include_operator_briefing' => true,
+            'include_trend_interpretation' => true,
+            'forecast_language' => 'bounded',
+        ],
+        default => $base,
+    };
+}
+
+function supplycore_ai_strategy(): array
+{
+    $config = supplycore_ai_ollama_config();
+
+    return is_array($config['strategy'] ?? null)
+        ? $config['strategy']
+        : supplycore_ai_capability_strategy((string) ($config['capability_tier'] ?? 'small'));
 }
 
 function supplycore_ai_ollama_enabled(): bool
@@ -13339,9 +13517,13 @@ function doctrine_ai_briefing_normalize_row(?array $row): ?array
         'headline' => trim((string) ($row['headline'] ?? '')),
         'summary' => trim((string) ($row['summary'] ?? '')),
         'action_text' => trim((string) ($row['action_text'] ?? '')),
+        'explanation_text' => trim((string) ($responseJson['explanation'] ?? '')),
+        'operator_briefing' => trim((string) ($responseJson['operator_briefing'] ?? '')),
+        'trend_interpretation' => trim((string) ($responseJson['trend_interpretation'] ?? '')),
         'priority_level' => $priority,
         'priority_rank' => supplycore_ai_priority_rank($priority),
         'priority_tone' => supplycore_ai_priority_tone($priority),
+        'capability_tier' => (string) (($sourcePayload['capability']['tier'] ?? $sourcePayload['capability_tier'] ?? 'small')),
         'source_payload' => is_array($sourcePayload) ? $sourcePayload : [],
         'response_json' => is_array($responseJson) ? $responseJson : [],
         'error_message' => ($row['error_message'] ?? null) !== null ? (string) $row['error_message'] : null,
@@ -13486,14 +13668,81 @@ function doctrine_ai_previous_recommendation_fact(?array $briefing): ?array
     ];
 }
 
-function doctrine_ai_source_payload_for_fit(array $fit, ?array $previousBriefing = null): array
+function doctrine_ai_history_context_for_fit(int $fitId, int $limit = 0): array
 {
+    $safeFitId = max(0, $fitId);
+    $safeLimit = max(0, min(6, $limit));
+    if ($safeFitId <= 0 || $safeLimit <= 0) {
+        return [];
+    }
+
+    try {
+        $rows = db_doctrine_fit_snapshot_history($safeFitId, $safeLimit + 1);
+    } catch (Throwable) {
+        return [];
+    }
+
+    $history = [];
+    foreach (array_slice($rows, 0, $safeLimit) as $row) {
+        $history[] = [
+            'snapshot_time' => (string) ($row['snapshot_time'] ?? ''),
+            'ready_fits' => (int) ($row['complete_fits_available'] ?? 0),
+            'target_fits' => (int) ($row['target_fit_count'] ?? 0),
+            'fit_gap' => (int) ($row['fit_gap_count'] ?? 0),
+            'readiness_state' => (string) ($row['readiness_state'] ?? ''),
+            'pressure_state' => (string) ($row['resupply_pressure_state'] ?? ''),
+            'loss_24h' => (int) ($row['recent_hull_losses_24h'] ?? 0),
+            'loss_7d' => (int) ($row['recent_hull_losses_7d'] ?? 0),
+            'restock_gap_isk' => (float) ($row['restock_gap_isk'] ?? 0.0),
+            'bottleneck_item' => ($row['bottleneck_item_name'] ?? null) !== null ? (string) $row['bottleneck_item_name'] : null,
+        ];
+    }
+
+    return $history;
+}
+
+function doctrine_ai_history_context_for_group(array $group, int $historyLimit = 0, int $fitLimit = 0): array
+{
+    $safeHistoryLimit = max(0, min(4, $historyLimit));
+    $safeFitLimit = max(0, min(4, $fitLimit));
+    if ($safeHistoryLimit <= 0 || $safeFitLimit <= 0) {
+        return [];
+    }
+
+    $fits = array_values((array) ($group['fits'] ?? []));
+    usort($fits, static function (array $a, array $b): int {
+        $aSupply = is_array($a['supply'] ?? null) ? $a['supply'] : [];
+        $bSupply = is_array($b['supply'] ?? null) ? $b['supply'] : [];
+
+        return ((float) ($bSupply['driver_scores']['total'] ?? 0.0) <=> (float) ($aSupply['driver_scores']['total'] ?? 0.0))
+            ?: ((int) ($a['id'] ?? 0) <=> (int) ($b['id'] ?? 0));
+    });
+
+    $history = [];
+    foreach (array_slice($fits, 0, $safeFitLimit) as $fit) {
+        $fitId = (int) ($fit['id'] ?? 0);
+        if ($fitId <= 0) {
+            continue;
+        }
+
+        $history[] = [
+            'fit_name' => (string) ($fit['fit_name'] ?? ('Fit #' . $fitId)),
+            'history' => doctrine_ai_history_context_for_fit($fitId, $safeHistoryLimit),
+        ];
+    }
+
+    return array_values(array_filter($history, static fn (array $row): bool => $row['history'] !== []));
+}
+
+function doctrine_ai_source_payload_for_fit(array $fit, ?array $previousBriefing = null, ?array $strategy = null): array
+{
+    $resolvedStrategy = is_array($strategy) ? $strategy : supplycore_ai_strategy();
     $supply = is_array($fit['supply'] ?? null) ? $fit['supply'] : [];
     $recentChange = is_array($fit['snapshot_change'] ?? null)
         ? (string) (($fit['snapshot_change']['summary'] ?? '') ?: 'No prior doctrine snapshot change is available.')
         : 'No prior doctrine snapshot change is available.';
 
-    return [
+    $payload = [
         'entity_type' => 'fit',
         'entity_id' => (int) ($fit['id'] ?? 0),
         'name' => trim((string) ($fit['fit_name'] ?? ('Fit #' . (int) ($fit['id'] ?? 0)))),
@@ -13508,14 +13757,38 @@ function doctrine_ai_source_payload_for_fit(array $fit, ?array $previousBriefing
         'loss_24h' => max((int) ($supply['recent_hull_losses_24h'] ?? 0), (int) ($supply['recent_item_fit_losses_24h'] ?? 0)),
         'loss_7d' => max((int) ($supply['recent_hull_losses_7d'] ?? 0), (int) ($supply['recent_item_fit_losses_7d'] ?? 0)),
         'depletion_signal' => (string) ($supply['depletion_state'] ?? 'stable'),
-        'recent_change_summary' => $recentChange,
         'current_recommendation' => (string) ($supply['recommendation_text'] ?? ''),
-        'previous_recommendation' => doctrine_ai_previous_recommendation_fact($previousBriefing),
+        'capability' => [
+            'tier' => (string) ($resolvedStrategy['tier'] ?? 'small'),
+            'prompt_style' => (string) ($resolvedStrategy['prompt_style'] ?? 'compact'),
+            'enabled_tasks' => array_values((array) ($resolvedStrategy['enabled_tasks'] ?? [])),
+        ],
+        'signals' => [
+            'restock_gap_isk' => (float) ($supply['restock_gap_isk'] ?? 0.0),
+            'market_price_label' => (string) ($supply['market_price_status_label'] ?? ''),
+            'readiness_code' => (string) ($supply['readiness_code'] ?? ''),
+            'pressure_code' => (string) ($supply['resupply_pressure_code'] ?? ''),
+        ],
     ];
+
+    if (($resolvedStrategy['include_snapshot_delta'] ?? false) === true) {
+        $payload['recent_change_summary'] = $recentChange;
+    }
+
+    if (($resolvedStrategy['include_previous_recommendation'] ?? false) === true) {
+        $payload['previous_recommendation'] = doctrine_ai_previous_recommendation_fact($previousBriefing);
+    }
+
+    if (($resolvedStrategy['include_historical_context'] ?? false) === true) {
+        $payload['history'] = doctrine_ai_history_context_for_fit((int) ($fit['id'] ?? 0), (int) ($resolvedStrategy['history_limit'] ?? 0));
+    }
+
+    return $payload;
 }
 
-function doctrine_ai_source_payload_for_group(array $group, ?array $previousBriefing = null): array
+function doctrine_ai_source_payload_for_group(array $group, ?array $previousBriefing = null, ?array $strategy = null): array
 {
+    $resolvedStrategy = is_array($strategy) ? $strategy : supplycore_ai_strategy();
     $fits = array_values((array) ($group['fits'] ?? []));
     $loss24h = 0;
     $loss7d = 0;
@@ -13523,11 +13796,17 @@ function doctrine_ai_source_payload_for_group(array $group, ?array $previousBrie
     $topBottleneckQty = 0;
     $topScore = -1.0;
     $depletionSignal = 'stable';
+    $restockGapIsk = 0.0;
+    $criticalFitCount = 0;
 
     foreach ($fits as $fit) {
         $supply = is_array($fit['supply'] ?? null) ? $fit['supply'] : [];
         $loss24h = max($loss24h, max((int) ($supply['recent_hull_losses_24h'] ?? 0), (int) ($supply['recent_item_fit_losses_24h'] ?? 0)));
         $loss7d = max($loss7d, max((int) ($supply['recent_hull_losses_7d'] ?? 0), (int) ($supply['recent_item_fit_losses_7d'] ?? 0)));
+        $restockGapIsk += (float) ($supply['restock_gap_isk'] ?? 0.0);
+        if ((string) ($supply['readiness_state'] ?? '') === 'critical_gap') {
+            $criticalFitCount++;
+        }
         $score = (float) (($supply['driver_scores']['total'] ?? 0.0));
         if ($score > $topScore) {
             $topScore = $score;
@@ -13537,7 +13816,7 @@ function doctrine_ai_source_payload_for_group(array $group, ?array $previousBrie
         }
     }
 
-    return [
+    $payload = [
         'entity_type' => 'group',
         'entity_id' => (int) ($group['id'] ?? 0),
         'name' => trim((string) ($group['group_name'] ?? ('Group #' . (int) ($group['id'] ?? 0)))),
@@ -13551,39 +13830,139 @@ function doctrine_ai_source_payload_for_group(array $group, ?array $previousBrie
         'loss_24h' => $loss24h,
         'loss_7d' => $loss7d,
         'depletion_signal' => $depletionSignal,
-        'recent_change_summary' => doctrine_ai_recent_change_summary_for_group($group),
         'current_recommendation' => (string) ($group['combined_status_label'] ?? ''),
-        'previous_recommendation' => doctrine_ai_previous_recommendation_fact($previousBriefing),
+        'capability' => [
+            'tier' => (string) ($resolvedStrategy['tier'] ?? 'small'),
+            'prompt_style' => (string) ($resolvedStrategy['prompt_style'] ?? 'compact'),
+            'enabled_tasks' => array_values((array) ($resolvedStrategy['enabled_tasks'] ?? [])),
+        ],
+        'signals' => [
+            'fit_count' => (int) ($group['fit_count'] ?? count($fits)),
+            'critical_fit_count' => $criticalFitCount,
+            'pressure_fit_count' => (int) ($group['pressure_fit_count'] ?? 0),
+            'trending_down_fit_count' => (int) ($group['trending_down_fit_count'] ?? 0),
+            'restock_gap_isk' => $restockGapIsk,
+        ],
     ];
+
+    if (($resolvedStrategy['include_snapshot_delta'] ?? false) === true) {
+        $payload['recent_change_summary'] = doctrine_ai_recent_change_summary_for_group($group);
+    }
+
+    if (($resolvedStrategy['include_previous_recommendation'] ?? false) === true) {
+        $payload['previous_recommendation'] = doctrine_ai_previous_recommendation_fact($previousBriefing);
+    }
+
+    if (($resolvedStrategy['include_historical_context'] ?? false) === true) {
+        $payload['history'] = doctrine_ai_history_context_for_group(
+            $group,
+            (int) ($resolvedStrategy['history_limit'] ?? 0),
+            (int) ($resolvedStrategy['group_history_fit_limit'] ?? 0)
+        );
+    }
+
+    return $payload;
 }
 
-function doctrine_ai_system_prompt(): string
+function doctrine_ai_system_prompt(array $strategy, array $sourcePayload): string
 {
-    return 'You are an alliance logistics analyst. Use only the provided facts. Do not invent data. Keep output concise and operational. Return JSON only.';
+    $taskLabel = (string) (($strategy['task_labels'][(string) ($sourcePayload['entity_type'] ?? '')] ?? 'doctrine briefing'));
+    $instructions = [
+        'You are an alliance logistics analyst.',
+        'Use only the provided deterministic facts.',
+        'Deterministic doctrine, market, loss, and readiness calculations remain authoritative.',
+        'Do not invent data, market states, or history.',
+        'Return JSON only.',
+        'Generate a ' . $taskLabel . ' that matches the configured model capability tier: ' . (string) ($strategy['tier'] ?? 'small') . '.',
+    ];
+
+    if (($strategy['include_cross_signal_reasoning'] ?? false) === true) {
+        $instructions[] = 'You may compare readiness, losses, depletion, and bottlenecks when the facts explicitly support it.';
+    } else {
+        $instructions[] = 'Avoid broad cross-doctrine reasoning; stay tightly scoped to the provided entity facts.';
+    }
+
+    $forecastLanguage = (string) ($strategy['forecast_language'] ?? 'avoid');
+    if ($forecastLanguage === 'avoid') {
+        $instructions[] = 'Avoid forecasting language beyond simple summary and prioritization.';
+    } elseif ($forecastLanguage === 'minimal') {
+        $instructions[] = 'Keep forward-looking language limited to near-term operator prioritization grounded in provided deltas.';
+    } else {
+        $instructions[] = 'Any forward-looking note must be limited, conditional, and grounded only in provided snapshot/history facts.';
+    }
+
+    return implode(' ', $instructions);
 }
 
-function doctrine_ai_output_schema(): array
+function doctrine_ai_output_schema(array $strategy): array
 {
+    $properties = [
+        'headline' => ['type' => 'string'],
+        'summary' => ['type' => 'string'],
+        'action' => ['type' => 'string'],
+        'priority' => ['type' => 'string', 'enum' => ['low', 'medium', 'high', 'critical']],
+    ];
+
+    if (($strategy['explanation_max_chars'] ?? 0) > 0) {
+        $properties['explanation'] = ['type' => 'string'];
+    }
+
+    if (($strategy['include_operator_briefing'] ?? false) === true) {
+        $properties['operator_briefing'] = ['type' => 'string'];
+    }
+
+    if (($strategy['include_trend_interpretation'] ?? false) === true) {
+        $properties['trend_interpretation'] = ['type' => 'string'];
+    }
+
     return [
         'type' => 'object',
         'required' => ['headline', 'summary', 'action', 'priority'],
-        'properties' => [
-            'headline' => ['type' => 'string'],
-            'summary' => ['type' => 'string'],
-            'action' => ['type' => 'string'],
-            'priority' => ['type' => 'string', 'enum' => ['low', 'medium', 'high', 'critical']],
-        ],
+        'properties' => $properties,
         'additionalProperties' => false,
     ];
 }
 
-function doctrine_ai_user_prompt(array $sourcePayload): string
+function doctrine_ai_prompt_source_payload(array $sourcePayload, array $strategy): array
 {
-    return "Summarize this doctrine logistics state.\nFacts:\n"
-        . json_encode($sourcePayload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    $payload = $sourcePayload;
+
+    if (($strategy['tier'] ?? 'small') === 'small') {
+        unset($payload['history'], $payload['previous_recommendation']);
+    }
+
+    return $payload;
 }
 
-function doctrine_ai_validate_response(array $response): array
+function doctrine_ai_user_prompt(array $sourcePayload, array $strategy): string
+{
+    $facts = doctrine_ai_prompt_source_payload($sourcePayload, $strategy);
+    $prompt = [
+        'Task: Summarize this doctrine logistics state using the configured capability tier.',
+        'Rules:',
+        '- Keep the response operational and bounded.',
+        '- Use only facts from the payload.',
+        '- Deterministic values remain the source of truth.',
+    ];
+
+    if (($strategy['tier'] ?? 'small') === 'small') {
+        $prompt[] = '- Keep prompts and outputs short. Focus on the top critical item only.';
+    } elseif (($strategy['tier'] ?? 'small') === 'medium') {
+        $prompt[] = '- Explain key deltas and prioritize the clearest next action.';
+    } else {
+        $prompt[] = '- Include a richer explanation of why priorities changed, plus bounded operator guidance.';
+    }
+
+    $prompt[] = 'Facts:';
+    $prompt[] = json_encode($facts, (($strategy['prompt_style'] ?? 'compact') === 'compact' ? 0 : JSON_PRETTY_PRINT) | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+
+    $rendered = implode("\n", $prompt);
+    $maxChars = max(800, (int) ($strategy['prompt_max_chars'] ?? 1600));
+
+    return mb_substr($rendered, 0, $maxChars);
+}
+
+function doctrine_ai_validate_response(array $response, array $strategy): array
 {
     $headline = trim((string) ($response['headline'] ?? ''));
     $summary = trim((string) ($response['summary'] ?? ''));
@@ -13600,14 +13979,18 @@ function doctrine_ai_validate_response(array $response): array
 
     return [
         'headline' => mb_substr($headline, 0, 255),
-        'summary' => mb_substr($summary, 0, 1200),
-        'action' => mb_substr($action, 0, 1200),
+        'summary' => mb_substr($summary, 0, max(120, (int) ($strategy['summary_max_chars'] ?? 240))),
+        'action' => mb_substr($action, 0, max(120, (int) ($strategy['action_max_chars'] ?? 220))),
+        'explanation' => mb_substr(trim((string) ($response['explanation'] ?? '')), 0, max(0, (int) ($strategy['explanation_max_chars'] ?? 0))),
+        'operator_briefing' => mb_substr(trim((string) ($response['operator_briefing'] ?? '')), 0, max(0, (int) ($strategy['operator_briefing_max_chars'] ?? 0))),
+        'trend_interpretation' => mb_substr(trim((string) ($response['trend_interpretation'] ?? '')), 0, max(0, (int) ($strategy['trend_max_chars'] ?? 0))),
         'priority' => $priority,
     ];
 }
 
-function doctrine_ai_fallback_response(array $sourcePayload, string $reason): array
+function doctrine_ai_fallback_response(array $sourcePayload, string $reason, ?array $strategy = null): array
 {
+    $resolvedStrategy = is_array($strategy) ? $strategy : supplycore_ai_strategy();
     $gap = max(0, (int) ($sourcePayload['fit_gap'] ?? 0));
     $pressure = (string) ($sourcePayload['resupply_pressure'] ?? 'Stable');
     $readiness = (string) ($sourcePayload['readiness_state'] ?? 'Market ready');
@@ -13623,7 +14006,7 @@ function doctrine_ai_fallback_response(array $sourcePayload, string $reason): ar
         $priority = 'medium';
     }
 
-    return [
+    $response = [
         'headline' => $name . ': ' . ($gap > 0 ? doctrine_format_quantity($gap) . ' fit gap' : $pressure),
         'summary' => trim($readiness . ' with ' . $pressure . '. ' . ($bottleneckItem !== '' ? ('Primary bottleneck remains ' . $bottleneckItem . '.') : 'Use deterministic doctrine metrics for precise quantities.')),
         'action' => $gap > 0
@@ -13632,11 +14015,30 @@ function doctrine_ai_fallback_response(array $sourcePayload, string $reason): ar
         'priority' => $priority,
         '_fallback_reason' => $reason,
     ];
+
+    if (($resolvedStrategy['explanation_max_chars'] ?? 0) > 0) {
+        $response['explanation'] = ($sourcePayload['recent_change_summary'] ?? null) !== null
+            ? (string) $sourcePayload['recent_change_summary']
+            : 'No higher-order explanation is available because the deterministic fallback path was used.';
+    }
+
+    if (($resolvedStrategy['include_operator_briefing'] ?? false) === true) {
+        $response['operator_briefing'] = 'Keep AI guidance secondary to the current doctrine snapshot, market totals, and loss indicators shown in SupplyCore.';
+    }
+
+    if (($resolvedStrategy['include_trend_interpretation'] ?? false) === true) {
+        $response['trend_interpretation'] = ($sourcePayload['history'] ?? []) !== []
+            ? 'Recent stored snapshot history is available; review the deterministic trend rows before making forecast-oriented decisions.'
+            : 'Trend interpretation is limited until more local snapshot history is available.';
+    }
+
+    return $response;
 }
 
 function doctrine_ai_generate_briefing_result(array $sourcePayload): array
 {
     $config = supplycore_ai_ollama_config();
+    $strategy = supplycore_ai_strategy();
 
     try {
         $briefing = supplycore_ai_ollama_generate_json($sourcePayload);
@@ -13648,7 +14050,7 @@ function doctrine_ai_generate_briefing_result(array $sourcePayload): array
             'model_name' => (string) ($config['model'] ?? ''),
         ];
     } catch (Throwable $exception) {
-        $fallback = doctrine_ai_fallback_response($sourcePayload, $exception->getMessage());
+        $fallback = doctrine_ai_fallback_response($sourcePayload, $exception->getMessage(), $strategy);
 
         return [
             'status' => 'fallback',
@@ -13662,6 +14064,7 @@ function doctrine_ai_generate_briefing_result(array $sourcePayload): array
 function supplycore_ai_ollama_generate_json(array $sourcePayload): array
 {
     $config = supplycore_ai_ollama_config();
+    $strategy = supplycore_ai_strategy();
     if ($config['enabled'] !== true) {
         throw new RuntimeException('Ollama integration is disabled.');
     }
@@ -13670,9 +14073,9 @@ function supplycore_ai_ollama_generate_json(array $sourcePayload): array
     $requestPayload = [
         'model' => $config['model'],
         'stream' => false,
-        'system' => doctrine_ai_system_prompt(),
-        'prompt' => doctrine_ai_user_prompt($sourcePayload),
-        'format' => doctrine_ai_output_schema(),
+        'system' => doctrine_ai_system_prompt($strategy, $sourcePayload),
+        'prompt' => doctrine_ai_user_prompt($sourcePayload, $strategy),
+        'format' => doctrine_ai_output_schema($strategy),
         'options' => [
             'temperature' => 0.1,
         ],
@@ -13695,7 +14098,7 @@ function supplycore_ai_ollama_generate_json(array $sourcePayload): array
         throw new RuntimeException('Ollama returned malformed JSON content.');
     }
 
-    return doctrine_ai_validate_response($decoded);
+    return doctrine_ai_validate_response($decoded, $strategy);
 }
 
 function doctrine_ai_store_briefing(array $sourcePayload, array $briefing, string $status, ?string $errorMessage = null): bool
@@ -13883,7 +14286,8 @@ function doctrine_ai_debug_preview(?string $entityType = null, ?int $entityId = 
         $snapshot = doctrine_refresh_intelligence('ai-debug');
     }
 
-    $candidateLimit = max(1, min(20, $limit));
+    $strategy = supplycore_ai_strategy();
+    $candidateLimit = max(1, min((int) ($strategy['candidate_limit'] ?? 8), $limit));
     $candidates = doctrine_ai_select_candidates($snapshot, $candidateLimit);
     $selectedCandidate = doctrine_ai_find_candidate($snapshot, $entityType, $entityId, max($candidateLimit, 8));
     if (!is_array($selectedCandidate)) {
@@ -13895,8 +14299,8 @@ function doctrine_ai_debug_preview(?string $entityType = null, ?int $entityId = 
     $entity = is_array($selectedCandidate['entity'] ?? null) ? $selectedCandidate['entity'] : [];
     $previousBriefing = doctrine_ai_briefing_get($resolvedEntityType, $resolvedEntityId);
     $sourcePayload = $resolvedEntityType === 'fit'
-        ? doctrine_ai_source_payload_for_fit($entity, $previousBriefing)
-        : doctrine_ai_source_payload_for_group($entity, $previousBriefing);
+        ? doctrine_ai_source_payload_for_fit($entity, $previousBriefing, $strategy)
+        : doctrine_ai_source_payload_for_group($entity, $previousBriefing, $strategy);
     $generation = doctrine_ai_generate_briefing_result($sourcePayload);
 
     return [
@@ -13931,7 +14335,8 @@ function rebuild_ai_briefings_job_result(string $reason = 'manual'): array
     }
 
     $config = supplycore_ai_ollama_config();
-    $candidates = doctrine_ai_select_candidates($snapshot, 8);
+    $strategy = supplycore_ai_strategy();
+    $candidates = doctrine_ai_select_candidates($snapshot, (int) ($strategy['candidate_limit'] ?? 8));
     $processed = 0;
     $written = 0;
     $fallbacks = 0;
@@ -13952,14 +14357,15 @@ function rebuild_ai_briefings_job_result(string $reason = 'manual'): array
         $processed++;
         $previousBriefing = doctrine_ai_briefing_get($entityType, $entityId);
         $sourcePayload = $entityType === 'fit'
-            ? doctrine_ai_source_payload_for_fit($entity, $previousBriefing)
-            : doctrine_ai_source_payload_for_group($entity, $previousBriefing);
+            ? doctrine_ai_source_payload_for_fit($entity, $previousBriefing, $strategy)
+            : doctrine_ai_source_payload_for_group($entity, $previousBriefing, $strategy);
 
         supplycore_ai_log('briefing.attempt', [
             'entity_type' => $entityType,
             'entity_id' => $entityId,
             'reason' => $reason,
             'model' => $config['model'],
+            'capability_tier' => (string) ($config['capability_tier'] ?? 'small'),
         ]);
 
         $generation = doctrine_ai_generate_briefing_result($sourcePayload);
@@ -13999,20 +14405,26 @@ function rebuild_ai_briefings_job_result(string $reason = 'manual'): array
             'fallbacks' => $fallbacks,
             'reason' => $reason,
             'model' => $config['model'],
+            'tier' => $config['capability_tier'] ?? 'small',
         ]),
         'meta' => [
-            'outcome_reason' => 'Doctrine AI briefings were rebuilt in the background from compact deterministic doctrine facts.',
+            'outcome_reason' => 'Doctrine AI briefings were rebuilt in the background using a centralized capability tier strategy over deterministic doctrine facts.',
             'processed_candidates' => $processed,
             'fallback_count' => $fallbacks,
             'model_name' => $config['model'],
+            'capability_tier' => $config['capability_tier'] ?? 'small',
+            'candidate_limit' => (int) ($strategy['candidate_limit'] ?? 0),
         ],
     ];
 }
 
 function doctrine_ai_dashboard_briefings(int $limit = 6): array
 {
+    $strategy = supplycore_ai_strategy();
+    $resolvedLimit = max(1, min((int) ($strategy['dashboard_limit'] ?? $limit), $limit));
+
     try {
-        $rows = db_doctrine_ai_briefings_top($limit);
+        $rows = db_doctrine_ai_briefings_top($resolvedLimit);
     } catch (Throwable) {
         $rows = [];
     }
@@ -14059,5 +14471,5 @@ function doctrine_ai_dashboard_briefings(int $limit = 6): array
             ?: strcmp((string) ($b['computed_at'] ?? ''), (string) ($a['computed_at'] ?? ''));
     });
 
-    return array_slice($briefings, 0, $limit);
+    return array_slice($briefings, 0, $resolvedLimit);
 }


### PR DESCRIPTION
### Motivation

- Introduce a central, configuration-driven AI capability tier so local Ollama models can scale SupplyCore’s AI behavior (short/light outputs on small models, richer prompts/context on larger models). 
- Keep deterministic doctrine/market math authoritative while letting AI produce richer operator briefings only when model capacity allows.

### Description

- Added a saved `ollama_capability_tier` setting with `auto|small|medium|large` plus model-size inference and an effective-tier resolution in `supplycore_ai_ollama_config()`. 
- Implemented a central strategy generator `supplycore_ai_capability_strategy()` and accessor `supplycore_ai_strategy()` that control batching (`candidate_limit`), prompt depth/length, enabled tasks, history inclusion, and output richness per tier. 
- Made the doctrine AI pipeline capability-aware: source payloads (`doctrine_ai_source_payload_for_fit` / `..._for_group`) now include tier/signals, bounded history helpers were added, prompts/system instructions/schema are strategy-driven, response validation supports richer fields (`explanation`, `operator_briefing`, `trend_interpretation`) when enabled, and deterministic fallback responses remain authoritative. 
- Scaled background job and UI behavior from the single strategy: `rebuild_ai_briefings` uses tier `candidate_limit`, dashboard cards respect `dashboard_limit`, Settings UI exposes capability tier selection and shows effective tier, README and DB seed (`app_settings`) updated with the new default `ollama_capability_tier`. 

### Testing

- Ran PHP syntax checks which succeeded: `php -l src/functions.php` (OK). 
- Ran PHP syntax checks which succeeded: `php -l public/settings/index.php` (OK). 
- Ran PHP syntax checks which succeeded: `php -l public/index.php` (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb9999d398832f9dbc40dd6827b19d)