### PR TITLE
Add Runpod serverless AI briefing provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,18 +97,23 @@ README.md
 - Redis locks are used only as a lightweight coordination layer for scheduler runners and expensive cache recomputation. Database-backed locking remains the fallback path when Redis is disabled or unavailable.
 - You can configure Redis either through environment variables or through **Settings → Data Sync → Redis performance layer**.
 
-## Local Ollama AI Briefings
+## AI Briefings
 
-- SupplyCore’s first local AI layer is intentionally **non-authoritative**. Doctrine calculations, market comparisons, killmail/loss signals, and readiness math remain deterministic and authoritative.
-- Ollama is used only to summarize compact precomputed doctrine facts into operator briefings. It does **not** run on page load; it runs in the background through the scheduler job `rebuild_ai_briefings`.
+- SupplyCore’s AI briefing layer is intentionally **non-authoritative**. Doctrine calculations, market comparisons, killmail/loss signals, and readiness math remain deterministic and authoritative.
+- The configured provider is used only to summarize compact precomputed doctrine facts into operator briefings. It does **not** run on page load; it runs in the background through the scheduler job `rebuild_ai_briefings`.
 - The scheduler now self-registers missing schedule rows, so `rebuild_ai_briefings` starts running automatically on fresh installs and after upgrades without requiring a manual save in Settings.
-- Configure Ollama in **Settings → AI Briefings** (`/settings?section=ai-briefings`):
-  - `Enable local Ollama doctrine briefings`
-  - `Ollama API URL` (for example `http://localhost:11434/api`)
+- Configure AI briefing connectivity in **Settings → AI Briefings** (`/settings?section=ai-briefings`):
+  - `Enable AI doctrine briefings`
+  - `AI Provider` (`Local Ollama` or `Runpod Serverless`)
+  - `Local Ollama API URL` (for example `http://localhost:11434/api`)
+  - `Runpod Serverless Endpoint` (for example `https://api.runpod.ai/v2/<endpoint-id>/run`)
+  - `Runpod API Key`
   - `Model Name` (for example `qwen2.5:1.5b-instruct`)
   - `Request Timeout (seconds)`
   - `Capability Tier` (`auto`, `small`, `medium`, or `large`)
-- SupplyCore now uses a centralized AI capability strategy layer. By default it infers the tier from the configured model name (for example `1.5b` → `small`, `3b–8b` → `medium`, larger local models → `large`), but operators can explicitly override the tier in Settings when needed.
+- When `Local Ollama` is selected, SupplyCore sends standard Ollama `/generate` requests to the configured API base URL.
+- When `Runpod Serverless` is selected, SupplyCore sends a bearer-authenticated JSON request to the saved Runpod endpoint using the configured model name and the centralized doctrine prompt payload.
+- SupplyCore now uses a centralized AI capability strategy layer. By default it infers the tier from the configured model name (for example `1.5b` → `small`, `3b–8b` → `medium`, larger models → `large`), but operators can explicitly override the tier in Settings when needed.
 - The capability tier centrally controls prompt depth, enabled AI task types, how much snapshot/history context is included, the number of doctrine entities processed per background run, and how rich the dashboard briefing cards are.
 - Small tiers stay intentionally compact: short prompts, short structured outputs, top critical doctrines/groups only, no broad cross-doctrine reasoning, and no forecast-style commentary.
 - Medium tiers add explanation-oriented outputs: richer summaries, previous-vs-current recommendation context, bounded cross-signal reasoning, and larger batch sizes.
@@ -202,7 +207,7 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 - SupplyCore now separates cadences by workload:
   - **Fast ingestion**: `killmail_r2z2_sync`, `alliance_current_sync`, and `market_hub_current_sync` keep raw market and killmail inputs fresh.
   - **Materialized intelligence refresh (target cadence: every 5 minutes)**: `doctrine_intelligence_sync`, `market_comparison_summary_sync`, `loss_demand_summary_sync`, `dashboard_summary_sync`, and `current_state_refresh_sync` recompute heavy current-summary layers from raw tables, then publish the latest payloads into Redis for fast reads.
-  - **Local doctrine AI briefings (target cadence: every 5 minutes)**: `rebuild_ai_briefings` ranks doctrine fits/groups through the centralized capability-tier strategy, scales prompt/context richness and batch size to the configured Ollama model, stores the latest result in MySQL, refreshes the dashboard briefing panel, and skips that cycle when a history rebuild job is still running.
+  - **Doctrine AI briefings (target cadence: every 5 minutes)**: `rebuild_ai_briefings` ranks doctrine fits/groups through the centralized capability-tier strategy, scales prompt/context richness and batch size to the configured model, stores the latest result in MySQL, refreshes the dashboard briefing panel, and skips that cycle when a history rebuild job is still running.
   - **Slow forecasting / AI**: `forecasting_ai_sync` derives slower-moving target-adjustment, anomaly, briefing, and explanation layers from the latest medium snapshot instead of raw minute-by-minute ingestion.
 - UI pages now read Redis first and fall back to `intelligence_snapshots` if Redis is unavailable; each intelligence surface also exposes its last computed timestamp and freshness state to operators.
 - The hub-history scheduler jobs (`market_hub_historical_sync` and `market_hub_local_history_sync`) rebuild `market_history_daily` from SupplyCore’s own raw hub-order snapshots stored in MySQL for the configured market hub, using the recent window controlled by `raw_order_snapshot_retention_days` unless a CLI override is supplied.

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -223,7 +223,7 @@ $trackedCorporations = [];
 $killmailStatus = null;
 $itemScope = item_scope_view_model();
 $ollamaConfig = supplycore_ai_ollama_config();
-$ollamaAvailable = supplycore_ai_ollama_available();
+$ollamaStatus = supplycore_ai_status_summary();
 if ($dbStatus['ok']) {
     try {
         $trackedAlliances = db_killmail_tracked_alliances_active();
@@ -527,12 +527,12 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <div class="rounded-2xl border border-white/8 bg-white/[0.03] p-4">
                         <p class="text-xs uppercase tracking-[0.16em] text-muted">Configured Mode</p>
                         <p class="mt-2 text-2xl font-semibold text-slate-50"><?= ($ollamaConfig['enabled'] ?? false) ? 'Enabled' : 'Fallback only' ?></p>
-                        <p class="mt-1 text-sm text-muted">Doctrine briefings use the saved endpoint and model below.</p>
+                        <p class="mt-1 text-sm text-muted">Provider: <?= htmlspecialchars(ollama_provider_options()[(string) ($ollamaConfig['provider'] ?? 'local')] ?? 'Local Ollama', ENT_QUOTES) ?>.</p>
                     </div>
-                    <div class="rounded-2xl border <?= $ollamaAvailable ? 'border-emerald-500/20 bg-emerald-500/10' : 'border-amber-500/20 bg-amber-500/10' ?> p-4">
-                        <p class="text-xs uppercase tracking-[0.16em] <?= $ollamaAvailable ? 'text-emerald-200/80' : 'text-amber-200/80' ?>">Reachability</p>
-                        <p class="mt-2 text-2xl font-semibold <?= $ollamaAvailable ? 'text-emerald-100' : 'text-amber-100' ?>"><?= $ollamaAvailable ? 'Ollama reachable' : 'Ollama not reachable' ?></p>
-                        <p class="mt-1 text-sm <?= $ollamaAvailable ? 'text-emerald-100/70' : 'text-amber-100/70' ?>">Status is checked against the configured Ollama API endpoint.</p>
+                    <div class="rounded-2xl border <?= ($ollamaStatus['ok'] ?? false) ? 'border-emerald-500/20 bg-emerald-500/10' : 'border-amber-500/20 bg-amber-500/10' ?> p-4">
+                        <p class="text-xs uppercase tracking-[0.16em] <?= ($ollamaStatus['ok'] ?? false) ? 'text-emerald-200/80' : 'text-amber-200/80' ?>">Connection Status</p>
+                        <p class="mt-2 text-2xl font-semibold <?= ($ollamaStatus['ok'] ?? false) ? 'text-emerald-100' : 'text-amber-100' ?>"><?= htmlspecialchars((string) ($ollamaStatus['label'] ?? 'Not configured'), ENT_QUOTES) ?></p>
+                        <p class="mt-1 text-sm <?= ($ollamaStatus['ok'] ?? false) ? 'text-emerald-100/70' : 'text-amber-100/70' ?>"><?= htmlspecialchars((string) ($ollamaStatus['description'] ?? ''), ENT_QUOTES) ?></p>
                     </div>
                     <div class="rounded-2xl border border-sky-500/20 bg-sky-500/10 p-4">
                         <p class="text-xs uppercase tracking-[0.16em] text-sky-200/80">Scheduler Behavior</p>
@@ -557,16 +557,40 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <input type="hidden" name="ollama_enabled" value="0">
                     <input type="checkbox" name="ollama_enabled" value="1" <?= ($settingValues['ollama_enabled'] ?? '0') === '1' ? 'checked' : '' ?> class="mt-1 size-4 rounded border-border bg-black">
                     <span>
-                        <span class="block text-sm font-medium text-slate-100">Enable local Ollama doctrine briefings</span>
+                        <span class="block text-sm font-medium text-slate-100">Enable AI doctrine briefings</span>
                         <span class="mt-1 block text-xs text-muted">Turn this off to force deterministic fallback summaries while still keeping briefing records populated.</span>
                     </span>
                 </label>
 
                 <div class="grid gap-4 md:grid-cols-2">
                     <label class="block space-y-2 md:col-span-2">
-                        <span class="text-sm text-muted">Ollama API URL</span>
+                        <span class="text-sm text-muted">AI Provider</span>
+                        <select name="ollama_provider" class="w-full field-input">
+                            <?php $selectedProvider = (string) ($settingValues['ollama_provider'] ?? ($ollamaConfig['provider'] ?? 'local')); ?>
+                            <?php foreach (ollama_provider_options() as $value => $label): ?>
+                                <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $selectedProvider === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <p class="text-xs text-muted">Use <span class="font-medium text-slate-100">Local Ollama</span> for your existing self-hosted API, or switch to <span class="font-medium text-slate-100">Runpod Serverless</span> to send prompt requests through a bearer-authenticated endpoint.</p>
+                    </label>
+                    <label class="block space-y-2 md:col-span-2">
+                        <span class="text-sm text-muted">Local Ollama API URL</span>
                         <input name="ollama_url" value="<?= htmlspecialchars($settingValues['ollama_url'] ?? ($ollamaConfig['url'] ?? 'http://localhost:11434/api'), ENT_QUOTES) ?>" class="w-full field-input" />
                         <p class="text-xs text-muted">Use the API base URL, for example <span class="font-medium text-slate-100">http://localhost:11434/api</span>.</p>
+                    </label>
+                    <label class="block space-y-2 md:col-span-2">
+                        <span class="text-sm text-muted">Runpod Serverless Endpoint</span>
+                        <input name="ollama_runpod_url" value="<?= htmlspecialchars($settingValues['ollama_runpod_url'] ?? ($ollamaConfig['runpod_url'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="https://api.runpod.ai/v2/.../run" />
+                        <p class="text-xs text-muted">Paste the full Runpod request URL, for example <span class="font-medium text-slate-100">https://api.runpod.ai/v2/58qz2qbho8h3f1/run</span>.</p>
+                    </label>
+                    <label class="block space-y-2 md:col-span-2">
+                        <span class="text-sm text-muted">Runpod API Key</span>
+                        <input name="ollama_runpod_api_key" type="password" value="<?= htmlspecialchars($settingValues['ollama_runpod_api_key'] ?? ($ollamaConfig['runpod_api_key'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="Bearer token for the Runpod endpoint" />
+                        <?php if (($ollamaConfig['runpod_api_key_masked'] ?? '') !== ''): ?>
+                            <p class="text-xs text-muted">Saved key preview: <span class="font-medium text-slate-100"><?= htmlspecialchars((string) $ollamaConfig['runpod_api_key_masked'], ENT_QUOTES) ?></span>.</p>
+                        <?php else: ?>
+                            <p class="text-xs text-muted">Stored only when you save settings. Leave blank if you are staying on the local provider.</p>
+                        <?php endif; ?>
                     </label>
                     <label class="block space-y-2">
                         <span class="text-sm text-muted">Model Name</span>
@@ -589,7 +613,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 </div>
 
                 <div class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm text-muted">
-                    Configure the local AI endpoint here, then manage cadence under <a href="/settings?section=data-sync" class="font-medium text-slate-100 hover:text-white">Settings → Data Sync</a> for the <span class="font-medium text-slate-100">rebuild_ai_briefings</span> scheduler job. Small tiers stay compact, medium tiers add explanation and deltas, and large tiers unlock richer operator briefings while still keeping deterministic calculations authoritative.
+                    Configure either the local Ollama API or the Runpod serverless endpoint here, then manage cadence under <a href="/settings?section=data-sync" class="font-medium text-slate-100 hover:text-white">Settings → Data Sync</a> for the <span class="font-medium text-slate-100">rebuild_ai_briefings</span> scheduler job. Small tiers stay compact, medium tiers add explanation and deltas, and large tiers unlock richer operator briefings while still keeping deterministic calculations authoritative.
                 </div>
 
                 <button class="btn-primary">Save AI Briefing Settings</button>

--- a/src/functions.php
+++ b/src/functions.php
@@ -131,7 +131,7 @@ function setting_sections(): array
         'general' => ['title' => 'General Settings', 'description' => 'Core application behavior and preferences.'],
         'trading-stations' => ['title' => 'Trading Stations', 'description' => 'Configure your reference market hub and operational trading destination.'],
         'item-scope' => ['title' => 'Item Scope', 'description' => 'Control which item classes are operationally relevant across market, doctrine, and loss-demand analytics.'],
-        'ai-briefings' => ['title' => 'AI Briefings', 'description' => 'Configure the local Ollama endpoint used for doctrine briefing summaries.'],
+        'ai-briefings' => ['title' => 'AI Briefings', 'description' => 'Configure either a local Ollama endpoint or a Runpod serverless endpoint for doctrine briefing summaries.'],
         'esi-login' => ['title' => 'ESI Login', 'description' => 'Configure EVE SSO credentials and callback behavior.'],
         'data-sync' => ['title' => 'Data Sync', 'description' => 'Control database import and incremental update policies.'],
         'killmail-intelligence' => ['title' => 'Killmail Intelligence', 'description' => 'Manage zKillboard stream ingestion, tracked entities, and demand prediction foundation.'],
@@ -219,16 +219,36 @@ function ai_briefing_setting_defaults(): array
 {
     return [
         'ollama_enabled' => '0',
+        'ollama_provider' => 'local',
         'ollama_url' => 'http://localhost:11434/api',
         'ollama_model' => 'qwen2.5:1.5b-instruct',
         'ollama_timeout' => '20',
         'ollama_capability_tier' => 'auto',
+        'ollama_runpod_url' => '',
+        'ollama_runpod_api_key' => '',
     ];
 }
 
 function ai_briefing_setting_keys(): array
 {
     return array_keys(ai_briefing_setting_defaults());
+}
+
+function ollama_provider_options(): array
+{
+    return [
+        'local' => 'Local Ollama',
+        'runpod' => 'Runpod Serverless',
+    ];
+}
+
+function sanitize_ollama_provider(mixed $value): string
+{
+    $provider = mb_strtolower(trim((string) $value));
+
+    return array_key_exists($provider, ollama_provider_options())
+        ? $provider
+        : ai_briefing_setting_defaults()['ollama_provider'];
 }
 
 function sanitize_ollama_url(?string $value): string
@@ -273,14 +293,36 @@ function sanitize_ollama_capability_tier(mixed $value): string
         : ai_briefing_setting_defaults()['ollama_capability_tier'];
 }
 
+function sanitize_ollama_runpod_url(?string $value): string
+{
+    $url = rtrim(trim((string) $value), '/');
+    if ($url === '') {
+        return '';
+    }
+
+    if (!preg_match('/^https?:\/\/.+/i', $url)) {
+        return '';
+    }
+
+    return mb_substr($url, 0, 255);
+}
+
+function sanitize_ollama_runpod_api_key(?string $value): string
+{
+    return mb_substr(trim((string) $value), 0, 255);
+}
+
 function ai_briefing_settings_from_request(array $request): array
 {
     return [
         'ollama_enabled' => sanitize_enabled_flag($request['ollama_enabled'] ?? null),
+        'ollama_provider' => sanitize_ollama_provider($request['ollama_provider'] ?? null),
         'ollama_url' => sanitize_ollama_url($request['ollama_url'] ?? null),
         'ollama_model' => sanitize_ollama_model($request['ollama_model'] ?? null),
         'ollama_timeout' => sanitize_ollama_timeout($request['ollama_timeout'] ?? null),
         'ollama_capability_tier' => sanitize_ollama_capability_tier($request['ollama_capability_tier'] ?? null),
+        'ollama_runpod_url' => sanitize_ollama_runpod_url($request['ollama_runpod_url'] ?? null),
+        'ollama_runpod_api_key' => sanitize_ollama_runpod_api_key($request['ollama_runpod_api_key'] ?? null),
     ];
 }
 
@@ -13234,13 +13276,17 @@ function supplycore_ai_ollama_config(): array
 
     $defaults = ai_briefing_setting_defaults();
     $settings = get_settings(ai_briefing_setting_keys());
+    $provider = sanitize_ollama_provider($settings['ollama_provider'] ?? $defaults['ollama_provider']);
 
     $config = [
         'enabled' => (($settings['ollama_enabled'] ?? $defaults['ollama_enabled']) === '1'),
+        'provider' => $provider,
         'url' => sanitize_ollama_url($settings['ollama_url'] ?? $defaults['ollama_url']),
         'model' => sanitize_ollama_model($settings['ollama_model'] ?? $defaults['ollama_model']),
         'timeout' => max(1, (int) sanitize_ollama_timeout($settings['ollama_timeout'] ?? $defaults['ollama_timeout'])),
         'capability_override' => sanitize_ollama_capability_tier($settings['ollama_capability_tier'] ?? $defaults['ollama_capability_tier']),
+        'runpod_url' => sanitize_ollama_runpod_url($settings['ollama_runpod_url'] ?? $defaults['ollama_runpod_url']),
+        'runpod_api_key' => sanitize_ollama_runpod_api_key($settings['ollama_runpod_api_key'] ?? $defaults['ollama_runpod_api_key']),
     ];
 
     $inferredTier = supplycore_ai_infer_model_capability_tier((string) ($config['model'] ?? ''));
@@ -13251,14 +13297,33 @@ function supplycore_ai_ollama_config(): array
 
     return [
         'enabled' => (bool) ($config['enabled'] ?? false),
+        'provider' => (string) ($config['provider'] ?? $defaults['ollama_provider']),
         'url' => (string) ($config['url'] ?? $defaults['ollama_url']),
         'model' => (string) ($config['model'] ?? $defaults['ollama_model']),
         'timeout' => max(1, (int) ($config['timeout'] ?? (int) $defaults['ollama_timeout'])),
         'capability_override' => (string) ($config['capability_override'] ?? 'auto'),
+        'runpod_url' => (string) ($config['runpod_url'] ?? ''),
+        'runpod_api_key' => (string) ($config['runpod_api_key'] ?? ''),
+        'runpod_api_key_masked' => supplycore_mask_secret((string) ($config['runpod_api_key'] ?? '')),
         'inferred_tier' => $inferredTier,
         'capability_tier' => $effectiveTier,
         'strategy' => $strategy,
     ];
+}
+
+function supplycore_mask_secret(string $value): string
+{
+    $trimmed = trim($value);
+    if ($trimmed === '') {
+        return '';
+    }
+
+    $length = mb_strlen($trimmed);
+    if ($length <= 8) {
+        return str_repeat('•', $length);
+    }
+
+    return mb_substr($trimmed, 0, 4) . str_repeat('•', max(4, $length - 8)) . mb_substr($trimmed, -4);
 }
 
 function supplycore_ai_infer_model_capacity_billions(string $model): ?float
@@ -13421,7 +13486,15 @@ function supplycore_ai_ollama_enabled(): bool
 {
     $config = supplycore_ai_ollama_config();
 
-    return $config['enabled'] === true && $config['url'] !== '' && $config['model'] !== '';
+    if ($config['enabled'] !== true || $config['model'] === '') {
+        return false;
+    }
+
+    if (($config['provider'] ?? 'local') === 'runpod') {
+        return ($config['runpod_url'] ?? '') !== '' && ($config['runpod_api_key'] ?? '') !== '';
+    }
+
+    return ($config['url'] ?? '') !== '';
 }
 
 function supplycore_ai_ollama_available(): bool
@@ -13434,11 +13507,19 @@ function supplycore_ai_ollama_available(): bool
     }
 
     $cacheKey = implode('|', [
+        (string) ($config['provider'] ?? 'local'),
         (string) ($config['url'] ?? ''),
+        (string) ($config['runpod_url'] ?? ''),
         (string) ($config['model'] ?? ''),
         (string) ($config['timeout'] ?? 20),
     ]);
     if (array_key_exists($cacheKey, $availability)) {
+        return $availability[$cacheKey];
+    }
+
+    if (($config['provider'] ?? 'local') === 'runpod') {
+        $availability[$cacheKey] = ($config['runpod_url'] ?? '') !== '' && ($config['runpod_api_key'] ?? '') !== '';
+
         return $availability[$cacheKey];
     }
 
@@ -13454,6 +13535,29 @@ function supplycore_ai_ollama_available(): bool
     }
 
     return $availability[$cacheKey];
+}
+
+function supplycore_ai_status_summary(): array
+{
+    $config = supplycore_ai_ollama_config();
+    $provider = (string) ($config['provider'] ?? 'local');
+    $available = supplycore_ai_ollama_available();
+
+    if ($provider === 'runpod') {
+        return [
+            'ok' => $available,
+            'label' => $available ? 'Runpod configured' : 'Runpod incomplete',
+            'description' => $available
+                ? 'Runpod serverless endpoint and API key are saved for AI briefing requests.'
+                : 'Save both the Runpod endpoint and API key to enable serverless AI briefings.',
+        ];
+    }
+
+    return [
+        'ok' => $available,
+        'label' => $available ? 'Ollama reachable' : 'Ollama not reachable',
+        'description' => 'Status is checked against the configured local Ollama API endpoint.',
+    ];
 }
 
 function supplycore_ai_log(string $event, array $payload = []): void
@@ -14069,13 +14173,33 @@ function supplycore_ai_ollama_generate_json(array $sourcePayload): array
         throw new RuntimeException('Ollama integration is disabled.');
     }
 
+    $systemPrompt = doctrine_ai_system_prompt($strategy, $sourcePayload);
+    $userPrompt = doctrine_ai_user_prompt($sourcePayload, $strategy);
+    $schema = doctrine_ai_output_schema($strategy);
+
+    if (($config['provider'] ?? 'local') === 'runpod') {
+        $response = http_post_json(
+            (string) ($config['runpod_url'] ?? ''),
+            ['Authorization: Bearer ' . (string) ($config['runpod_api_key'] ?? '')],
+            [
+                'input' => [
+                    'prompt' => supplycore_ai_runpod_prompt($config, $systemPrompt, $userPrompt, $schema),
+                ],
+            ],
+            (int) ($config['timeout'] ?? 20)
+        );
+        $decoded = supplycore_ai_decode_runpod_response($response);
+
+        return doctrine_ai_validate_response($decoded, $strategy);
+    }
+
     $endpoint = $config['url'] . '/generate';
     $requestPayload = [
         'model' => $config['model'],
         'stream' => false,
-        'system' => doctrine_ai_system_prompt($strategy, $sourcePayload),
-        'prompt' => doctrine_ai_user_prompt($sourcePayload, $strategy),
-        'format' => doctrine_ai_output_schema($strategy),
+        'system' => $systemPrompt,
+        'prompt' => $userPrompt,
+        'format' => $schema,
         'options' => [
             'temperature' => 0.1,
         ],
@@ -14099,6 +14223,88 @@ function supplycore_ai_ollama_generate_json(array $sourcePayload): array
     }
 
     return doctrine_ai_validate_response($decoded, $strategy);
+}
+
+function supplycore_ai_runpod_prompt(array $config, string $systemPrompt, string $userPrompt, array $schema): string
+{
+    $schemaJson = json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    if (!is_string($schemaJson)) {
+        $schemaJson = '{}';
+    }
+
+    return trim(implode("\n\n", [
+        'You are using the model "' . (string) ($config['model'] ?? '') . '" through a Runpod serverless endpoint.',
+        'SYSTEM INSTRUCTIONS',
+        $systemPrompt,
+        'USER REQUEST',
+        $userPrompt,
+        'OUTPUT REQUIREMENTS',
+        'Return JSON only. Do not include markdown fences or any commentary outside the JSON object.',
+        'The JSON object must match this schema exactly:',
+        $schemaJson,
+    ]));
+}
+
+function supplycore_ai_decode_runpod_response(array $response): array
+{
+    $status = (int) ($response['status'] ?? 0);
+    $json = is_array($response['json'] ?? null) ? $response['json'] : [];
+    if ($status < 200 || $status >= 300) {
+        throw new RuntimeException('Runpod returned HTTP ' . $status . '.');
+    }
+
+    $jobStatus = strtoupper(trim((string) ($json['status'] ?? '')));
+    if ($jobStatus !== '' && !in_array($jobStatus, ['COMPLETED', 'SUCCESS'], true)) {
+        throw new RuntimeException('Runpod job did not complete synchronously (status: ' . $jobStatus . ').');
+    }
+
+    $candidates = [
+        $json['output']['response'] ?? null,
+        $json['output']['text'] ?? null,
+        $json['output'][0]['response'] ?? null,
+        $json['output'][0]['text'] ?? null,
+        $json['response'] ?? null,
+        $json['output'] ?? null,
+    ];
+
+    foreach ($candidates as $candidate) {
+        if (is_array($candidate)) {
+            if ($candidate !== [] && array_keys($candidate) !== range(0, count($candidate) - 1)) {
+                return $candidate;
+            }
+
+            $candidate = json_encode($candidate, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        }
+
+        $decoded = supplycore_ai_decode_json_string((string) $candidate);
+        if (is_array($decoded)) {
+            return $decoded;
+        }
+    }
+
+    throw new RuntimeException('Runpod returned an unsupported response payload.');
+}
+
+function supplycore_ai_decode_json_string(string $value): ?array
+{
+    $trimmed = trim($value);
+    if ($trimmed === '') {
+        return null;
+    }
+
+    $decoded = json_decode($trimmed, true);
+    if (is_array($decoded)) {
+        return $decoded;
+    }
+
+    if (preg_match('/\{.*\}/s', $trimmed, $matches) === 1) {
+        $decoded = json_decode((string) $matches[0], true);
+        if (is_array($decoded)) {
+            return $decoded;
+        }
+    }
+
+    return null;
 }
 
 function doctrine_ai_store_briefing(array $sourcePayload, array $briefing, string $status, ?string $errorMessage = null): bool


### PR DESCRIPTION
### Motivation
- Provide an alternative serverless AI provider so operators can send doctrine briefing prompts to Runpod while keeping the existing local Ollama integration available.
- Keep AI wiring centralized and settings-driven so background scheduler jobs and the rest of the app remain provider-agnostic.

### Description
- Added new AI briefing settings keys and sanitizers: `ollama_provider`, `ollama_runpod_url`, and `ollama_runpod_api_key`, plus `ollama_provider` options and validation helpers in `src/functions.php`.
- Extended `supplycore_ai_ollama_config()` to include provider and Runpod fields, added secret masking via `supplycore_mask_secret()`, and implemented provider-aware enablement and availability checks with `supplycore_ai_status_summary()`.
- Updated generation flow in `supplycore_ai_ollama_generate_json()` to preserve the existing local Ollama `/generate` call and to send a bearer-authenticated Runpod request when `provider === 'runpod'`, using a JSON body of the shape `{'input': {'prompt': '...'}}` and decoding Runpod output with `supplycore_ai_decode_runpod_response()` and `supplycore_ai_decode_json_string()`.
- Updated the Settings UI (`public/settings/index.php`) to expose `AI Provider` selection, `Local Ollama API URL`, `Runpod Serverless Endpoint`, and `Runpod API Key` (masked preview), and adjusted status messaging to be provider-aware.
- Documented the new provider options and Runpod usage in `README.md` and left the deterministic fallback behavior unchanged for scheduler jobs.

### Testing
- Ran PHP syntax checks: `php -l src/functions.php`, `php -l public/settings/index.php`, and `php -l bin/ai_briefing_debug.php`, all succeeded with no syntax errors.
- Ran repository validation: `git diff --check` returned clean results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc01483284832fa73fb01c9026073b)