### PR TITLE
Support Runpod async jobs: submit, poll status, and convert legacy /runsync URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ README.md
   - `Request Timeout (seconds)`
   - `Capability Tier` (`auto`, `small`, `medium`, or `large`)
 - When `Local Ollama` is selected, SupplyCore sends standard Ollama `/generate` requests to the configured API base URL.
-- When `Runpod Serverless` is selected, SupplyCore sends a bearer-authenticated JSON request to the saved Runpod endpoint using the configured model name and the centralized doctrine prompt payload.
+- When `Runpod Serverless` is selected, SupplyCore submits a bearer-authenticated async job to the saved Runpod endpoint, polls the companion `/status/<job-id>` endpoint until completion, and then validates the centralized doctrine prompt payload response.
+- Saved legacy `.../runsync` Runpod URLs are automatically converted to the async `.../run` flow before submission.
 - SupplyCore now uses a centralized AI capability strategy layer. By default it infers the tier from the configured model name (for example `1.5b` → `small`, `3b–8b` → `medium`, larger models → `large`), but operators can explicitly override the tier in Settings when needed.
 - The capability tier centrally controls prompt depth, enabled AI task types, how much snapshot/history context is included, the number of doctrine entities processed per background run, and how rich the dashboard briefing cards are.
 - Small tiers stay intentionally compact: short prompts, short structured outputs, top critical doctrines/groups only, no broad cross-doctrine reasoning, and no forecast-style commentary.

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -571,7 +571,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $selectedProvider === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
                             <?php endforeach; ?>
                         </select>
-                        <p class="text-xs text-muted">Use <span class="font-medium text-slate-100">Local Ollama</span> for your existing self-hosted API, or switch to <span class="font-medium text-slate-100">Runpod Serverless</span> to send prompt requests through a bearer-authenticated endpoint.</p>
+                        <p class="text-xs text-muted">Use <span class="font-medium text-slate-100">Local Ollama</span> for your existing self-hosted API, or switch to <span class="font-medium text-slate-100">Runpod Serverless</span> to submit bearer-authenticated async jobs and poll their status in the background.</p>
                     </label>
                     <label class="block space-y-2 md:col-span-2">
                         <span class="text-sm text-muted">Local Ollama API URL</span>
@@ -581,7 +581,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <label class="block space-y-2 md:col-span-2">
                         <span class="text-sm text-muted">Runpod Serverless Endpoint</span>
                         <input name="ollama_runpod_url" value="<?= htmlspecialchars($settingValues['ollama_runpod_url'] ?? ($ollamaConfig['runpod_url'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="https://api.runpod.ai/v2/.../run" />
-                        <p class="text-xs text-muted">Paste the full Runpod request URL, for example <span class="font-medium text-slate-100">https://api.runpod.ai/v2/58qz2qbho8h3f1/run</span>.</p>
+                        <p class="text-xs text-muted">Paste the full Runpod async request URL, for example <span class="font-medium text-slate-100">https://api.runpod.ai/v2/58qz2qbho8h3f1/run</span>. Existing <span class="font-medium text-slate-100">/runsync</span> URLs are converted automatically.</p>
                     </label>
                     <label class="block space-y-2 md:col-span-2">
                         <span class="text-sm text-muted">Runpod API Key</span>
@@ -613,7 +613,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 </div>
 
                 <div class="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3 text-sm text-muted">
-                    Configure either the local Ollama API or the Runpod serverless endpoint here, then manage cadence under <a href="/settings?section=data-sync" class="font-medium text-slate-100 hover:text-white">Settings → Data Sync</a> for the <span class="font-medium text-slate-100">rebuild_ai_briefings</span> scheduler job. Small tiers stay compact, medium tiers add explanation and deltas, and large tiers unlock richer operator briefings while still keeping deterministic calculations authoritative.
+                    Configure either the local Ollama API or the Runpod serverless endpoint here, then manage cadence under <a href="/settings?section=data-sync" class="font-medium text-slate-100 hover:text-white">Settings → Data Sync</a> for the <span class="font-medium text-slate-100">rebuild_ai_briefings</span> scheduler job. Runpod requests now submit asynchronously and poll for completion within the configured timeout window. Small tiers stay compact, medium tiers add explanation and deltas, and large tiers unlock richer operator briefings while still keeping deterministic calculations authoritative.
                 </div>
 
                 <button class="btn-primary">Save AI Briefing Settings</button>

--- a/src/functions.php
+++ b/src/functions.php
@@ -14178,17 +14178,7 @@ function supplycore_ai_ollama_generate_json(array $sourcePayload): array
     $schema = doctrine_ai_output_schema($strategy);
 
     if (($config['provider'] ?? 'local') === 'runpod') {
-        $response = http_post_json(
-            (string) ($config['runpod_url'] ?? ''),
-            ['Authorization: Bearer ' . (string) ($config['runpod_api_key'] ?? '')],
-            [
-                'input' => [
-                    'prompt' => supplycore_ai_runpod_prompt($config, $systemPrompt, $userPrompt, $schema),
-                ],
-            ],
-            (int) ($config['timeout'] ?? 20)
-        );
-        $decoded = supplycore_ai_decode_runpod_response($response);
+        $decoded = supplycore_ai_runpod_generate_json($config, $systemPrompt, $userPrompt, $schema);
 
         return doctrine_ai_validate_response($decoded, $strategy);
     }
@@ -14225,6 +14215,25 @@ function supplycore_ai_ollama_generate_json(array $sourcePayload): array
     return doctrine_ai_validate_response($decoded, $strategy);
 }
 
+function supplycore_ai_runpod_generate_json(array $config, string $systemPrompt, string $userPrompt, array $schema): array
+{
+    $headers = ['Authorization: Bearer ' . (string) ($config['runpod_api_key'] ?? '')];
+    $requestPayload = [
+        'input' => [
+            'prompt' => supplycore_ai_runpod_prompt($config, $systemPrompt, $userPrompt, $schema),
+        ],
+    ];
+    $response = http_post_json(
+        supplycore_ai_runpod_submit_url((string) ($config['runpod_url'] ?? '')),
+        $headers,
+        $requestPayload,
+        supplycore_ai_runpod_request_timeout($config)
+    );
+    $polledResponse = supplycore_ai_runpod_poll_until_complete($config, $headers, $response);
+
+    return supplycore_ai_decode_runpod_response($polledResponse);
+}
+
 function supplycore_ai_runpod_prompt(array $config, string $systemPrompt, string $userPrompt, array $schema): string
 {
     $schemaJson = json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
@@ -14245,6 +14254,109 @@ function supplycore_ai_runpod_prompt(array $config, string $systemPrompt, string
     ]));
 }
 
+function supplycore_ai_runpod_submit_url(string $url): string
+{
+    $normalized = rtrim(trim($url), '/');
+    if ($normalized === '') {
+        return '';
+    }
+
+    if (preg_match('#/runsync$#i', $normalized) === 1) {
+        return (string) preg_replace('#/runsync$#i', '/run', $normalized);
+    }
+
+    return $normalized;
+}
+
+function supplycore_ai_runpod_status_url(string $url, string $jobId): string
+{
+    $normalized = rtrim(trim($url), '/');
+    if ($normalized === '') {
+        throw new RuntimeException('Runpod endpoint is not configured.');
+    }
+
+    if (preg_match('#/(?:run|runsync)$#i', $normalized) === 1) {
+        return (string) preg_replace('#/(?:run|runsync)$#i', '/status/' . rawurlencode($jobId), $normalized);
+    }
+
+    return $normalized . '/status/' . rawurlencode($jobId);
+}
+
+function supplycore_ai_runpod_request_timeout(array $config): int
+{
+    $configuredTimeout = max(1, (int) ($config['timeout'] ?? 20));
+
+    return min(10, $configuredTimeout);
+}
+
+function supplycore_ai_runpod_poll_until_complete(array $config, array $headers, array $response): array
+{
+    $status = (int) ($response['status'] ?? 0);
+    $json = is_array($response['json'] ?? null) ? $response['json'] : [];
+    if ($status < 200 || $status >= 300) {
+        throw new RuntimeException('Runpod returned HTTP ' . $status . '.');
+    }
+
+    $jobStatus = supplycore_ai_runpod_job_status($json);
+    if (in_array($jobStatus, ['COMPLETED', 'SUCCESS'], true)) {
+        return $response;
+    }
+
+    if ($jobStatus === '' && supplycore_ai_runpod_response_has_output($json)) {
+        return $response;
+    }
+
+    if (in_array($jobStatus, ['FAILED', 'CANCELLED', 'TIMED_OUT'], true)) {
+        throw new RuntimeException('Runpod job failed with status: ' . $jobStatus . '.');
+    }
+
+    $jobId = trim((string) ($json['id'] ?? $json['job_id'] ?? ''));
+    if ($jobId === '') {
+        throw new RuntimeException('Runpod did not return a job ID for async polling.');
+    }
+
+    $deadline = microtime(true) + max(1, (int) ($config['timeout'] ?? 20));
+    $pollDelayMicroseconds = 750000;
+    $statusUrl = supplycore_ai_runpod_status_url((string) ($config['runpod_url'] ?? ''), $jobId);
+    $lastKnownStatus = $jobStatus !== '' ? $jobStatus : 'SUBMITTED';
+
+    while (microtime(true) < $deadline) {
+        usleep($pollDelayMicroseconds);
+
+        $statusResponse = http_get_json($statusUrl, $headers, supplycore_ai_runpod_request_timeout($config));
+        $statusCode = (int) ($statusResponse['status'] ?? 0);
+        $statusJson = is_array($statusResponse['json'] ?? null) ? $statusResponse['json'] : [];
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new RuntimeException('Runpod status returned HTTP ' . $statusCode . '.');
+        }
+
+        $lastKnownStatus = supplycore_ai_runpod_job_status($statusJson);
+        if (in_array($lastKnownStatus, ['COMPLETED', 'SUCCESS'], true)) {
+            return $statusResponse;
+        }
+
+        if ($lastKnownStatus === '' && supplycore_ai_runpod_response_has_output($statusJson)) {
+            return $statusResponse;
+        }
+
+        if (in_array($lastKnownStatus, ['FAILED', 'CANCELLED', 'TIMED_OUT'], true)) {
+            throw new RuntimeException('Runpod job failed with status: ' . $lastKnownStatus . '.');
+        }
+    }
+
+    throw new RuntimeException('Runpod job did not finish before timeout (last status: ' . $lastKnownStatus . ').');
+}
+
+function supplycore_ai_runpod_job_status(array $payload): string
+{
+    return strtoupper(trim((string) ($payload['status'] ?? '')));
+}
+
+function supplycore_ai_runpod_response_has_output(array $payload): bool
+{
+    return array_key_exists('output', $payload) || array_key_exists('response', $payload);
+}
+
 function supplycore_ai_decode_runpod_response(array $response): array
 {
     $status = (int) ($response['status'] ?? 0);
@@ -14253,7 +14365,7 @@ function supplycore_ai_decode_runpod_response(array $response): array
         throw new RuntimeException('Runpod returned HTTP ' . $status . '.');
     }
 
-    $jobStatus = strtoupper(trim((string) ($json['status'] ?? '')));
+    $jobStatus = supplycore_ai_runpod_job_status($json);
     if ($jobStatus !== '' && !in_array($jobStatus, ['COMPLETED', 'SUCCESS'], true)) {
         throw new RuntimeException('Runpod job did not complete synchronously (status: ' . $jobStatus . ').');
     }


### PR DESCRIPTION
### Motivation
- Move Runpod integration from a synchronous `/runsync` request model to an async job workflow to better handle longer-running model executions and improve reliability.
- Surface the async behavior in the UI so operators know requests are submitted and polled in the background.
- Provide compatibility for existing saved Runpod `.../runsync` endpoints by transparently converting them to the async `/run` flow.

### Description
- Added a new async Runpod flow by introducing `supplycore_ai_runpod_generate_json` which submits the job and polls until completion using `supplycore_ai_runpod_poll_until_complete`.
- Implemented helper functions `supplycore_ai_runpod_submit_url`, `supplycore_ai_runpod_status_url`, `supplycore_ai_runpod_request_timeout`, `supplycore_ai_runpod_job_status`, and `supplycore_ai_runpod_response_has_output` to normalize URLs, compute timeouts, and interpret Runpod responses.
- Updated `supplycore_ai_ollama_generate_json` to delegate Runpod requests to the new async generator and refactored response decoding to use `supplycore_ai_runpod_job_status`.
- Updated UI copy in `public/settings/index.php` and `README.md` to document async submission, polling behavior, and automatic conversion of `/runsync` URLs to `/run`.

### Testing
- Ran the project automated test suite using `phpunit` and static checks; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0752c8d0832fae76acbfac4468ce)