### PR TITLE
Dispatch async scheduler jobs to background PHP workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,13 +203,13 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 ### Scheduling model
 
 - Cron is **timer-only**: it triggers `bin/cron_tick.php` once per minute.
-- The scheduler (`bin/cron_tick.php`) decides which jobs are due and dispatches `bin/sync_runner.php`.
+- The scheduler (`bin/cron_tick.php`) decides which jobs are due, runs standard jobs inline, and dispatches async-capable AI jobs to `bin/scheduler_job_runner.php` background workers so long-polling providers do not block the rest of the queue.
 - Interval and enable/disable controls are configured in **Settings → Data Sync** (`/settings?section=data-sync`) via scheduler rows in `sync_schedules`.
 - SupplyCore now separates cadences by workload:
   - **Fast ingestion**: `killmail_r2z2_sync`, `alliance_current_sync`, and `market_hub_current_sync` keep raw market and killmail inputs fresh.
   - **Materialized intelligence refresh (target cadence: every 5 minutes)**: `doctrine_intelligence_sync`, `market_comparison_summary_sync`, `loss_demand_summary_sync`, `dashboard_summary_sync`, and `current_state_refresh_sync` recompute heavy current-summary layers from raw tables, then publish the latest payloads into Redis for fast reads.
-  - **Doctrine AI briefings (target cadence: every 5 minutes)**: `rebuild_ai_briefings` ranks doctrine fits/groups through the centralized capability-tier strategy, scales prompt/context richness and batch size to the configured model, stores the latest result in MySQL, refreshes the dashboard briefing panel, and skips that cycle when a history rebuild job is still running.
-  - **Slow forecasting / AI**: `forecasting_ai_sync` derives slower-moving target-adjustment, anomaly, briefing, and explanation layers from the latest medium snapshot instead of raw minute-by-minute ingestion.
+  - **Doctrine AI briefings (target cadence: every 5 minutes)**: `rebuild_ai_briefings` ranks doctrine fits/groups through the centralized capability-tier strategy, scales prompt/context richness and batch size to the configured model, stores the latest result in MySQL, refreshes the dashboard briefing panel, skips that cycle when a history rebuild job is still running, and now continues in a background worker after the scheduler claims it.
+  - **Slow forecasting / AI**: `forecasting_ai_sync` derives slower-moving target-adjustment, anomaly, briefing, and explanation layers from the latest medium snapshot instead of raw minute-by-minute ingestion, and it also continues in its own background worker after dispatch.
 - UI pages now read Redis first and fall back to `intelligence_snapshots` if Redis is unavailable; each intelligence surface also exposes its last computed timestamp and freshness state to operators.
 - The hub-history scheduler jobs (`market_hub_historical_sync` and `market_hub_local_history_sync`) rebuild `market_history_daily` from SupplyCore’s own raw hub-order snapshots stored in MySQL for the configured market hub, using the recent window controlled by `raw_order_snapshot_retention_days` unless a CLI override is supplied.
 - **Trend Snippets** on the dashboard depend on that first-party snapshot history generation.

--- a/bin/scheduler_job_runner.php
+++ b/bin/scheduler_job_runner.php
@@ -1,0 +1,89 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+function scheduler_job_runner_output(string $event, array $payload = [], $stream = STDOUT): void
+{
+    $line = ['event' => $event, 'ts' => gmdate(DATE_ATOM)] + $payload;
+    fwrite($stream, json_encode($line, JSON_UNESCAPED_SLASHES) . PHP_EOL);
+}
+
+function scheduler_job_runner_parse_options(): int
+{
+    $options = getopt('', ['schedule-id:']);
+    $scheduleId = (int) ($options['schedule-id'] ?? 0);
+    if ($scheduleId <= 0) {
+        throw new InvalidArgumentException('Argument --schedule-id must be a positive integer.');
+    }
+
+    return $scheduleId;
+}
+
+function scheduler_job_runner_main(): int
+{
+    $scheduleId = scheduler_job_runner_parse_options();
+    $job = db_sync_schedule_fetch_by_id($scheduleId);
+    if ($job === null) {
+        throw new RuntimeException('No scheduler job found for schedule ID ' . $scheduleId . '.');
+    }
+
+    $jobKey = trim((string) ($job['job_key'] ?? 'unknown_job'));
+    $jobType = scheduler_job_type($jobKey);
+    $status = trim((string) ($job['last_status'] ?? ''));
+    $lockedUntil = trim((string) ($job['locked_until'] ?? ''));
+
+    if ($status !== 'running' || $lockedUntil === '') {
+        throw new RuntimeException('Scheduler job "' . $jobKey . '" is no longer claimed for background execution.');
+    }
+
+    scheduler_job_runner_output('job.background.started', [
+        'job_id' => $scheduleId,
+        'job' => $jobKey,
+        'job_type' => $jobType,
+        'scheduled_for' => (string) ($job['next_run_at'] ?? ''),
+        'locked_until' => $lockedUntil,
+    ]);
+
+    $result = scheduler_run_job($job);
+    $resultStatus = (string) ($result['status'] ?? 'failed');
+
+    scheduler_job_runner_output(
+        $resultStatus === 'failed' ? 'job.background.failed' : 'job.background.completed',
+        [
+            'job_id' => (int) ($result['job_id'] ?? $scheduleId),
+            'job' => (string) ($result['job_key'] ?? $jobKey),
+            'job_type' => (string) ($result['job_type'] ?? $jobType),
+            'scheduled_for' => (string) ($result['scheduled_for'] ?? ''),
+            'actual_start_time' => (string) ($result['started_at'] ?? ''),
+            'finish_time' => (string) ($result['finished_at'] ?? ''),
+            'duration_ms' => (int) ($result['duration_ms'] ?? 0),
+            'status' => $resultStatus,
+            'summary' => (string) ($result['summary'] ?? ''),
+            'error' => $resultStatus === 'failed' ? (string) ($result['error'] ?? '') : null,
+        ]
+    );
+
+    $meta = is_array($result['meta'] ?? null) ? $result['meta'] : [];
+    if ($meta !== []) {
+        scheduler_job_runner_output('job.background.outcome', [
+            'job_id' => (int) ($result['job_id'] ?? $scheduleId),
+            'job' => (string) ($result['job_key'] ?? $jobKey),
+            'status' => $resultStatus,
+        ] + $meta);
+    }
+
+    return $resultStatus === 'failed' ? 1 : 0;
+}
+
+try {
+    exit(scheduler_job_runner_main());
+} catch (Throwable $exception) {
+    scheduler_job_runner_output('job.background.scheduler_error', [
+        'error' => $exception->getMessage(),
+    ], STDERR);
+
+    exit(1);
+}

--- a/src/db.php
+++ b/src/db.php
@@ -1752,6 +1752,23 @@ function db_sync_schedule_fetch_by_job_keys(array $jobKeys): array
     );
 }
 
+function db_sync_schedule_fetch_by_id(int $scheduleId): ?array
+{
+    if ($scheduleId <= 0) {
+        return null;
+    }
+
+    $row = db_select_one(
+        'SELECT id, job_key, enabled, interval_seconds, next_run_at, last_run_at, last_status, last_error, locked_until
+         FROM sync_schedules
+         WHERE id = ?
+         LIMIT 1',
+        [$scheduleId]
+    );
+
+    return $row !== [] ? $row : null;
+}
+
 function db_sync_schedule_running_job_keys(array $jobKeys): array
 {
     $keys = array_values(array_filter(array_map(static fn (mixed $jobKey): string => trim((string) $jobKey), $jobKeys), static fn (string $jobKey): bool => $jobKey !== ''));

--- a/src/functions.php
+++ b/src/functions.php
@@ -5766,6 +5766,107 @@ function scheduler_job_lock_ttl_seconds(int $defaultSeconds, int $timeoutSeconds
     return $timeoutBackedTtl;
 }
 
+function scheduler_job_runner_script_path(): string
+{
+    return dirname(__DIR__) . '/bin/scheduler_job_runner.php';
+}
+
+function scheduler_cron_log_path(): string
+{
+    return dirname(__DIR__) . '/storage/logs/cron.log';
+}
+
+function scheduler_job_runs_in_background(string $jobKey): bool
+{
+    $definitions = scheduler_job_definitions();
+    $definition = $definitions[$jobKey] ?? null;
+
+    return ($definition['execution'] ?? 'inline') === 'background';
+}
+
+function scheduler_dispatch_background_job(array $job): array
+{
+    $scheduleId = (int) ($job['id'] ?? 0);
+    $jobKey = trim((string) ($job['job_key'] ?? ''));
+    $jobType = scheduler_job_type($jobKey);
+    $scheduledFor = (string) ($job['next_run_at'] ?? '');
+    $startedAt = gmdate(DATE_ATOM);
+
+    if ($scheduleId <= 0 || $jobKey === '') {
+        throw new RuntimeException('Background scheduler dispatch requires a valid claimed job.');
+    }
+
+    $phpBinary = PHP_BINARY !== '' ? PHP_BINARY : 'php';
+    $scriptPath = scheduler_job_runner_script_path();
+    $logPath = scheduler_cron_log_path();
+    $command = sprintf(
+        '%s %s --schedule-id=%d >> %s 2>&1 &',
+        escapeshellarg($phpBinary),
+        escapeshellarg($scriptPath),
+        $scheduleId,
+        escapeshellarg($logPath)
+    );
+
+    exec($command, $output, $exitCode);
+    if ($exitCode !== 0) {
+        throw new RuntimeException('Failed to dispatch background job "' . $jobKey . '".');
+    }
+
+    return [
+        'job_id' => $scheduleId,
+        'job_key' => $jobKey,
+        'job_type' => $jobType,
+        'scheduled_for' => $scheduledFor,
+        'started_at' => $startedAt,
+        'finished_at' => null,
+        'duration_ms' => 0,
+        'status' => 'dispatched',
+        'error' => null,
+        'rows_seen' => 0,
+        'rows_written' => 0,
+        'warnings' => [],
+        'meta' => [
+            'execution' => 'background',
+            'outcome_reason' => 'Job was dispatched to a background PHP worker so other due jobs can continue immediately.',
+        ],
+        'summary' => 'Dispatched to a background worker.',
+    ];
+}
+
+function scheduler_background_dispatch_failure_result(array $job, Throwable $exception): array
+{
+    $jobKey = trim((string) ($job['job_key'] ?? ''));
+    $scheduleId = (int) ($job['id'] ?? 0);
+    $jobType = scheduler_job_type($jobKey);
+    $scheduledFor = (string) ($job['next_run_at'] ?? '');
+    $datasetKey = scheduler_job_dataset_key($jobKey !== '' ? $jobKey : 'unknown');
+    $message = scheduler_normalize_error_message($exception->getMessage());
+
+    mark_sync_failure($datasetKey, 'incremental', $message);
+    if ($scheduleId > 0) {
+        db_sync_schedule_mark_failure($scheduleId, $message);
+    }
+
+    return [
+        'job_id' => $scheduleId,
+        'job_key' => $jobKey,
+        'job_type' => $jobType,
+        'scheduled_for' => $scheduledFor,
+        'started_at' => gmdate(DATE_ATOM),
+        'finished_at' => gmdate(DATE_ATOM),
+        'duration_ms' => 0,
+        'status' => 'failed',
+        'error' => $message,
+        'rows_seen' => 0,
+        'rows_written' => 0,
+        'warnings' => [],
+        'meta' => [
+            'execution' => 'background',
+        ],
+        'summary' => $message,
+    ];
+}
+
 function scheduler_job_definitions(): array
 {
     return [
@@ -5867,6 +5968,7 @@ function scheduler_job_definitions(): array
         'rebuild_ai_briefings' => [
             'timeout_seconds' => 180,
             'lock_ttl_seconds' => 300,
+            'execution' => 'background',
             'handler' => static function (): array {
                 $runningHistoryJobs = scheduler_ai_briefing_running_history_jobs();
                 if ($runningHistoryJobs !== []) {
@@ -5890,6 +5992,7 @@ function scheduler_job_definitions(): array
         'forecasting_ai_sync' => [
             'timeout_seconds' => 180,
             'lock_ttl_seconds' => 300,
+            'execution' => 'background',
             'handler' => static function (): array {
                 return supplycore_refresh_forecasting_snapshot_job_result('scheduler');
             },
@@ -6149,6 +6252,7 @@ function cron_tick_run(?callable $logger = null): array
     $results = [];
     $successCount = 0;
     $failureCount = 0;
+    $dispatchedCount = 0;
 
     foreach ($jobs as $job) {
         $jobId = (int) ($job['id'] ?? 0);
@@ -6165,11 +6269,22 @@ function cron_tick_run(?callable $logger = null): array
             ]);
         }
 
-        $result = scheduler_run_job($job);
+        try {
+            $result = scheduler_job_runs_in_background($jobKey)
+                ? scheduler_dispatch_background_job($job)
+                : scheduler_run_job($job);
+        } catch (Throwable $exception) {
+            $result = scheduler_background_dispatch_failure_result($job, $exception);
+        }
         $results[] = $result;
 
         if ($logger !== null) {
-            $jobEvent = ($result['status'] ?? 'failed') === 'failed' ? 'job.failed' : 'job.completed';
+            $resultStatus = (string) ($result['status'] ?? 'failed');
+            $jobEvent = match ($resultStatus) {
+                'failed' => 'job.failed',
+                'dispatched' => 'job.dispatched',
+                default => 'job.completed',
+            };
             $logger($jobEvent, [
                 'job_id' => (int) ($result['job_id'] ?? $jobId),
                 'job' => (string) ($result['job_key'] ?? $jobKey),
@@ -6204,6 +6319,11 @@ function cron_tick_run(?callable $logger = null): array
             continue;
         }
 
+        if ($jobStatus === 'dispatched') {
+            $dispatchedCount++;
+            continue;
+        }
+
         if ($jobStatus === 'failed') {
             $failureCount++;
         }
@@ -6215,6 +6335,7 @@ function cron_tick_run(?callable $logger = null): array
         'jobs_processed' => count($results),
         'jobs_succeeded' => $successCount,
         'jobs_failed' => $failureCount,
+        'jobs_dispatched' => $dispatchedCount,
         'results' => $results,
     ];
 }


### PR DESCRIPTION
### Motivation
- Long-polling / async AI jobs can block the per-minute scheduler tick and delay other due jobs, causing responses to take minutes instead of returning quickly.
- We need async-capable jobs to continue running while allowing the scheduler to immediately proceed to other work.

### Description
- Add `db_sync_schedule_fetch_by_id` in `src/db.php` to safely reload a claimed schedule row by ID for background workers.  
- Add background dispatch helpers in `src/functions.php`: `scheduler_job_runs_in_background`, `scheduler_dispatch_background_job`, and a failure helper so the scheduler can `exec()` off long-running jobs and produce a `dispatched` result.  
- Mark `rebuild_ai_briefings` and `forecasting_ai_sync` with `'execution' => 'background'` in `scheduler_job_definitions()` so they are dispatched instead of run inline.  
- Add a new CLI worker `bin/scheduler_job_runner.php` that validates the claimed schedule row and runs `scheduler_run_job()` from the background process while emitting structured start/completion/failure events.  
- Update `cron_tick` accounting and README notes to include `jobs_dispatched` and document the new background dispatch behavior.

### Testing
- Ran PHP syntax checks: `php -l src/functions.php`, `php -l src/db.php`, `php -l bin/scheduler_job_runner.php`, and `php -l bin/cron_tick.php`, all succeeded.  
- Verified scheduler flow handles dispatch exceptions by converting them into a failed sync result and marking schedule failure via `db_sync_schedule_mark_failure`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0d161118832f9ddbe42ce98046f5)