### PR TITLE
Add generated date columns and indexes for history and killmail queries

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -172,6 +172,7 @@ CREATE TABLE IF NOT EXISTS killmail_events (
     victim_ship_type_id INT UNSIGNED DEFAULT NULL,
     zkb_json LONGTEXT NOT NULL,
     raw_killmail_json LONGTEXT NOT NULL,
+    effective_killmail_at DATETIME GENERATED ALWAYS AS (COALESCE(killmail_time, created_at)) STORED,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     UNIQUE KEY unique_sequence_id (sequence_id),
@@ -180,6 +181,8 @@ CREATE TABLE IF NOT EXISTS killmail_events (
     KEY idx_victim_alliance (victim_alliance_id),
     KEY idx_victim_corporation (victim_corporation_id),
     KEY idx_victim_ship_type (victim_ship_type_id),
+    KEY idx_killmail_effective_ship (effective_killmail_at, victim_ship_type_id),
+    KEY idx_killmail_ship_effective (victim_ship_type_id, effective_killmail_at),
     KEY idx_system_region (solar_system_id, region_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -293,10 +296,12 @@ CREATE TABLE IF NOT EXISTS market_orders_history (
     issued DATETIME NOT NULL,
     expires DATETIME NOT NULL,
     observed_at DATETIME NOT NULL,
+    observed_date DATE GENERATED ALWAYS AS (DATE(observed_at)) STORED,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY unique_source_order_observed (source_type, source_id, order_id, observed_at),
     KEY idx_market_orders_history_type_observed (source_type, source_id, type_id, observed_at),
-    KEY idx_market_orders_history_observed (source_type, source_id, observed_at)
+    KEY idx_market_orders_history_observed (source_type, source_id, observed_at),
+    KEY idx_market_orders_history_source_date_type (source_type, source_id, observed_date, type_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS market_history_daily (

--- a/src/db.php
+++ b/src/db.php
@@ -1284,7 +1284,7 @@ function db_market_orders_history_stock_health_series(
 
     return db_select(
         "SELECT
-            DATE(moh.observed_at) AS observed_date,
+            moh.observed_date,
             moh.type_id,
             rit.type_name,
             SUM(CASE WHEN moh.is_buy_order = 0 THEN moh.volume_remain ELSE 0 END) AS sell_volume,
@@ -1298,8 +1298,8 @@ function db_market_orders_history_stock_health_series(
          LEFT JOIN ref_item_types rit ON rit.type_id = moh.type_id
          WHERE moh.source_type = ?
            AND moh.source_id = ?
-           AND DATE(moh.observed_at) BETWEEN ? AND ?{$typeFilterSql}
-         GROUP BY DATE(moh.observed_at), moh.type_id, rit.type_name
+           AND moh.observed_date BETWEEN ? AND ?{$typeFilterSql}
+         GROUP BY moh.observed_date, moh.type_id, rit.type_name
          ORDER BY observed_date ASC, moh.type_id ASC",
         $params
     );
@@ -2810,13 +2810,13 @@ function db_killmail_tracked_recent_hull_losses(array $hullTypeIds, int $hours =
     return db_select(
         "SELECT
             e.victim_ship_type_id AS type_id,
-            SUM(CASE WHEN COALESCE(e.killmail_time, e.created_at) >= (UTC_TIMESTAMP() - INTERVAL 24 HOUR) THEN 1 ELSE 0 END) AS losses_24h,
-            SUM(CASE WHEN COALESCE(e.killmail_time, e.created_at) >= (UTC_TIMESTAMP() - INTERVAL 7 DAY) THEN 1 ELSE 0 END) AS losses_7d,
+            SUM(CASE WHEN e.effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL 24 HOUR) THEN 1 ELSE 0 END) AS losses_24h,
+            SUM(CASE WHEN e.effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL 7 DAY) THEN 1 ELSE 0 END) AS losses_7d,
             COUNT(*) AS losses_window,
-            MAX(COALESCE(e.killmail_time, e.created_at)) AS latest_loss_at
+            MAX(e.effective_killmail_at) AS latest_loss_at
          FROM killmail_events e
          WHERE {$matchSql}
-           AND COALESCE(e.killmail_time, e.created_at) >= (UTC_TIMESTAMP() - INTERVAL {$safeHours} HOUR)
+           AND e.effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL {$safeHours} HOUR)
            AND e.victim_ship_type_id IN ({$placeholders})
          GROUP BY e.victim_ship_type_id",
         $normalizedTypeIds
@@ -2845,17 +2845,17 @@ function db_killmail_tracked_recent_item_losses(array $typeIds, int $hours = 24 
     return db_select(
         "SELECT
             i.item_type_id AS type_id,
-            SUM(CASE WHEN COALESCE(e.killmail_time, e.created_at) >= (UTC_TIMESTAMP() - INTERVAL 24 HOUR) THEN {$quantitySql} ELSE 0 END) AS quantity_24h,
-            SUM(CASE WHEN COALESCE(e.killmail_time, e.created_at) >= (UTC_TIMESTAMP() - INTERVAL 7 DAY) THEN {$quantitySql} ELSE 0 END) AS quantity_7d,
+            SUM(CASE WHEN e.effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL 24 HOUR) THEN {$quantitySql} ELSE 0 END) AS quantity_24h,
+            SUM(CASE WHEN e.effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL 7 DAY) THEN {$quantitySql} ELSE 0 END) AS quantity_7d,
             SUM({$quantitySql}) AS quantity_window,
-            COUNT(DISTINCT CASE WHEN COALESCE(e.killmail_time, e.created_at) >= (UTC_TIMESTAMP() - INTERVAL 24 HOUR) THEN e.sequence_id END) AS losses_24h,
-            COUNT(DISTINCT CASE WHEN COALESCE(e.killmail_time, e.created_at) >= (UTC_TIMESTAMP() - INTERVAL 7 DAY) THEN e.sequence_id END) AS losses_7d,
+            COUNT(DISTINCT CASE WHEN e.effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL 24 HOUR) THEN e.sequence_id END) AS losses_24h,
+            COUNT(DISTINCT CASE WHEN e.effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL 7 DAY) THEN e.sequence_id END) AS losses_7d,
             COUNT(DISTINCT e.sequence_id) AS losses_window,
-            MAX(COALESCE(e.killmail_time, e.created_at)) AS latest_loss_at
+            MAX(e.effective_killmail_at) AS latest_loss_at
          FROM killmail_items i
          INNER JOIN killmail_events e ON e.sequence_id = i.sequence_id
          WHERE {$matchSql}
-           AND COALESCE(e.killmail_time, e.created_at) >= (UTC_TIMESTAMP() - INTERVAL {$safeHours} HOUR)
+           AND e.effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL {$safeHours} HOUR)
            AND i.item_type_id IN ({$placeholders})
          GROUP BY i.item_type_id",
         $normalizedTypeIds


### PR DESCRIPTION
### Motivation

- Improve query performance for market-history and tracked-loss queries by enabling indexed datetime comparisons instead of wrapping base datetime columns in `DATE(...)` or `COALESCE(...)` expressions.
- Provide stable, persisted helper columns that reflect the time expressions used by DB helpers so WHERE/GROUP BY clauses can use indexed fields without moving date math into application code.

### Description

- Add a stored generated column `effective_killmail_at` to `killmail_events` defined as `COALESCE(killmail_time, created_at)` and add composite indexes `(effective_killmail_at, victim_ship_type_id)` and `(victim_ship_type_id, effective_killmail_at)` to support tracked-loss lookups.
- Add a stored generated column `observed_date` to `market_orders_history` defined as `DATE(observed_at)` and add a composite index `(source_type, source_id, observed_date, type_id)` to support daily stock-health filtering and grouping.
- Update DB helper functions to filter and group on the generated columns instead of wrapping base datetime fields, specifically `db_market_orders_history_stock_health_series`, `db_killmail_tracked_recent_hull_losses`, and `db_killmail_tracked_recent_item_losses` so SQL date math remains in queries but compares directly against indexed columns.

### Testing

- `php -l src/db.php` was run and reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc79193c98832fbb0fa4a2d9d3aa37)