### PR TITLE
Add indexed normalized lookups for ref_item_types names

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -458,6 +458,7 @@ CREATE TABLE IF NOT EXISTS ref_item_types (
     market_group_id INT UNSIGNED DEFAULT NULL,
     meta_group_id INT UNSIGNED DEFAULT NULL,
     type_name VARCHAR(255) NOT NULL,
+    type_name_normalized VARCHAR(255) GENERATED ALWAYS AS (LOWER(type_name)) STORED,
     description TEXT DEFAULT NULL,
     published TINYINT(1) NOT NULL DEFAULT 0,
     volume DECIMAL(20,6) DEFAULT NULL,
@@ -467,6 +468,7 @@ CREATE TABLE IF NOT EXISTS ref_item_types (
     KEY idx_group_id (group_id),
     KEY idx_market_group_id (market_group_id),
     KEY idx_meta_group_id (meta_group_id),
+    KEY idx_type_name_normalized (type_name_normalized),
     KEY idx_published (published)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/src/db.php
+++ b/src/db.php
@@ -2909,13 +2909,14 @@ function db_ref_item_types_by_names(array $names): array
         return [];
     }
 
-    $placeholders = implode(',', array_fill(0, count($safeNames), '?'));
+    $normalizedNames = array_map(static fn (string $name): string => mb_strtolower($name), $safeNames);
+    $placeholders = implode(',', array_fill(0, count($normalizedNames), '?'));
 
     return db_select(
         "SELECT type_id, type_name, category_id, group_id, market_group_id, meta_group_id, description, published, volume
          FROM ref_item_types
-         WHERE LOWER(type_name) IN ($placeholders)",
-        array_map(static fn (string $name): string => mb_strtolower($name), $safeNames)
+         WHERE type_name_normalized IN ($placeholders)",
+        $normalizedNames
     );
 }
 
@@ -3071,6 +3072,16 @@ function db_column_exists(string $tableName, string $columnName): bool
     return $row !== null;
 }
 
+function db_index_exists(string $tableName, string $indexName): bool
+{
+    $row = db_select_one(
+        'SELECT 1 FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ? LIMIT 1',
+        [$tableName, $indexName]
+    );
+
+    return $row !== null;
+}
+
 function db_foreign_key_delete_rule(string $constraintName): ?string
 {
     $row = db_select_one(
@@ -3132,6 +3143,14 @@ function item_scope_db_ensure_schema(): void
     if (db_table_exists('ref_item_types') && !db_column_exists('ref_item_types', 'meta_group_id')) {
         db()->exec('ALTER TABLE ref_item_types ADD COLUMN meta_group_id INT UNSIGNED DEFAULT NULL AFTER market_group_id');
         db()->exec('ALTER TABLE ref_item_types ADD KEY idx_meta_group_id (meta_group_id)');
+    }
+
+    if (db_table_exists('ref_item_types') && !db_column_exists('ref_item_types', 'type_name_normalized')) {
+        db()->exec('ALTER TABLE ref_item_types ADD COLUMN type_name_normalized VARCHAR(255) GENERATED ALWAYS AS (LOWER(type_name)) STORED AFTER type_name');
+    }
+
+    if (db_table_exists('ref_item_types') && !db_index_exists('ref_item_types', 'idx_type_name_normalized')) {
+        db()->exec('ALTER TABLE ref_item_types ADD KEY idx_type_name_normalized (type_name_normalized)');
     }
 
     $ensured = true;


### PR DESCRIPTION
### Motivation

- Improve performance and indexability of case-insensitive exact-name lookups for item types currently using `LOWER(type_name)` in queries.
- Keep lookup logic centralized in `src/db.php` while avoiding full-text/locale changes to the DB collation.

### Description

- Add a stored generated column `type_name_normalized` and index `idx_type_name_normalized` to `ref_item_types` in `database/schema.sql` to store `LOWER(type_name)` for indexed comparisons.
- Update `db_ref_item_types_by_names()` in `src/db.php` to normalize input names in PHP and query `WHERE type_name_normalized IN (...)` instead of `LOWER(type_name)`.
- Add a helper `db_index_exists()` to `src/db.php` to detect existing indexes in `information_schema`.
- Extend `item_scope_db_ensure_schema()` in `src/db.php` to create the generated column and index on existing databases when missing so migrations are automatic at runtime.

### Testing

- Linted `src/db.php` with `php -l src/db.php` and confirmed no syntax errors (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc7f8ddaa0832f93d07ee47c80248e)