### PR TITLE
HTML-first bulk doctrine fit importer and fit overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository establishes a clean architecture that can scale from an initial 
 - ESI cache tables (`esi_cache_namespaces`, `esi_cache_entries`) for structured `cache.esi.*` namespaces
 - Incremental sync state tables (`sync_state`, `sync_runs`) for watermark/cursor tracking and run observability
 - Reusable entity metadata cache for human-readable killmail, market, and analytics surfaces
-- Doctrine fit import workflow with EFT/BuyAll parsing, item-name cache, doctrine group pages, alliance-vs-hub market mapping, and background-refreshed materialized intelligence snapshots
+- HTML-first doctrine fit import workflow for Winter Coalition fit pages, BuyAll/EFT normalization, bulk preview/save controls, fit-overview bulk management, item-name cache, doctrine group pages, alliance-vs-hub market mapping, and background-refreshed materialized intelligence snapshots
 - Materialized intelligence storage (`intelligence_snapshots`) for doctrine fit/group summaries, market comparison summaries, loss-demand summaries, and dashboard payloads
 - Redis delivery cache for the latest precomputed intelligence payloads with MySQL materialized-summary fallback
 - Secure CSRF-protected settings forms
@@ -33,7 +33,7 @@ This repository establishes a clean architecture that can scale from an initial 
 public/
   index.php                 # Dashboard
   settings/index.php        # Modular settings controller/view
-  doctrine/                 # Doctrine groups, import, and fit detail pages
+  doctrine/                 # Doctrine groups, bulk import, fit overview, and fit detail pages
   .htaccess                 # Apache rewrite rules
 src/
   bootstrap.php             # Session + shared bootstrap

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -522,14 +522,31 @@ CREATE TABLE IF NOT EXISTS doctrine_fits (
     fit_name VARCHAR(190) NOT NULL,
     ship_name VARCHAR(255) NOT NULL,
     ship_type_id INT UNSIGNED DEFAULT NULL,
+    source_type ENUM('html', 'eft', 'buyall', 'manual') NOT NULL DEFAULT 'manual',
     source_format ENUM('eft', 'buyall') NOT NULL,
+    source_reference VARCHAR(255) DEFAULT NULL,
+    notes TEXT DEFAULT NULL,
     import_body LONGTEXT NOT NULL,
+    raw_html LONGTEXT DEFAULT NULL,
+    raw_buyall LONGTEXT DEFAULT NULL,
+    raw_eft LONGTEXT DEFAULT NULL,
+    metadata_json LONGTEXT DEFAULT NULL,
+    parse_warnings_json LONGTEXT DEFAULT NULL,
+    parse_status ENUM('ready', 'review') NOT NULL DEFAULT 'ready',
+    review_status ENUM('clean', 'needs_review', 'reparse_requested') NOT NULL DEFAULT 'clean',
+    conflict_state ENUM('none', 'duplicate_name', 'duplicate_items', 'version_conflict', 'source_mismatch') NOT NULL DEFAULT 'none',
+    fingerprint_hash CHAR(64) DEFAULT NULL,
+    warning_count INT UNSIGNED NOT NULL DEFAULT 0,
     item_count INT UNSIGNED NOT NULL DEFAULT 0,
     unresolved_count INT UNSIGNED NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     KEY idx_doctrine_group_id (doctrine_group_id),
     KEY idx_ship_type_id (ship_type_id),
+    KEY idx_source_type (source_type),
+    KEY idx_parse_status (parse_status, review_status),
+    KEY idx_conflict_state (conflict_state),
+    KEY idx_fingerprint_hash (fingerprint_hash),
     CONSTRAINT fk_doctrine_fits_group FOREIGN KEY (doctrine_group_id) REFERENCES doctrine_groups(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -548,6 +565,7 @@ CREATE TABLE IF NOT EXISTS doctrine_fit_items (
     doctrine_fit_id INT UNSIGNED NOT NULL,
     line_number SMALLINT UNSIGNED NOT NULL DEFAULT 0,
     slot_category VARCHAR(80) NOT NULL DEFAULT 'Items',
+    source_role VARCHAR(80) NOT NULL DEFAULT 'fit',
     item_name VARCHAR(255) NOT NULL,
     type_id INT UNSIGNED DEFAULT NULL,
     quantity INT UNSIGNED NOT NULL DEFAULT 1,
@@ -558,6 +576,7 @@ CREATE TABLE IF NOT EXISTS doctrine_fit_items (
     KEY idx_doctrine_fit_id (doctrine_fit_id),
     KEY idx_type_id (type_id),
     KEY idx_slot_category (slot_category),
+    KEY idx_source_role (source_role),
     CONSTRAINT fk_doctrine_fit_items_fit FOREIGN KEY (doctrine_fit_id) REFERENCES doctrine_fits(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/public/doctrine/fit.php
+++ b/public/doctrine/fit.php
@@ -218,6 +218,30 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Doctrine groups</p>
                         <p class="mt-2 font-semibold text-slate-100"><?= htmlspecialchars(implode(', ', (array) ($fit['group_names'] ?? [])) ?: 'Ungrouped', ENT_QUOTES) ?></p>
                     </div>
+                    <div class="surface-tertiary">
+                        <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Import status</p>
+                        <p class="mt-2 font-semibold text-slate-100"><?= htmlspecialchars((string) ($fit['readiness_status'] ?? 'Ready'), ENT_QUOTES) ?></p>
+                        <p class="mt-1 text-xs text-slate-500">Source <?= htmlspecialchars(strtoupper((string) ($fit['source_type'] ?? 'manual')), ENT_QUOTES) ?> · warnings <?= (int) ($fit['warning_count'] ?? 0) ?> · unresolved <?= (int) ($fit['unresolved_count'] ?? 0) ?></p>
+                        <?php if (($fit['conflict_state'] ?? 'none') !== 'none'): ?>
+                            <p class="mt-2 text-xs text-fuchsia-100">Conflict: <?= htmlspecialchars((string) ($fit['conflict_state'] ?? ''), ENT_QUOTES) ?></p>
+                        <?php endif; ?>
+                    </div>
+                    <?php if (!empty($fit['notes'])): ?>
+                        <div class="surface-tertiary">
+                            <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Fitting notes</p>
+                            <p class="mt-2 whitespace-pre-wrap text-sm text-slate-300"><?= htmlspecialchars((string) ($fit['notes'] ?? ''), ENT_QUOTES) ?></p>
+                        </div>
+                    <?php endif; ?>
+                    <?php if ((array) ($fit['parse_warnings'] ?? []) !== []): ?>
+                        <div class="rounded-[1.25rem] border border-amber-400/20 bg-amber-500/10 p-4">
+                            <p class="text-xs uppercase tracking-[0.16em] text-amber-100/80">Parse warnings</p>
+                            <ul class="mt-3 space-y-2 text-sm text-amber-100">
+                                <?php foreach ((array) ($fit['parse_warnings'] ?? []) as $warning): ?>
+                                    <li class="rounded-xl border border-amber-400/15 bg-black/10 px-3 py-2"><?= htmlspecialchars((string) $warning, ENT_QUOTES) ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        </div>
+                    <?php endif; ?>
                     <?php if (is_array($fit['ai_briefing'] ?? null)): ?>
                         <?php $aiBriefing = (array) $fit['ai_briefing']; ?>
                         <div class="rounded-[1.25rem] border border-violet-400/20 bg-violet-500/10 p-4">
@@ -471,6 +495,21 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <?php endforeach; ?>
                 </div>
             <?php endif; ?>
+
+            <div class="mt-8 grid gap-4 xl:grid-cols-3">
+                <section class="surface-tertiary">
+                    <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Raw Buy All</p>
+                    <pre class="mt-3 overflow-x-auto whitespace-pre-wrap text-xs text-slate-300"><?= htmlspecialchars((string) ($fit['raw_buyall'] ?? 'Unavailable'), ENT_QUOTES) ?></pre>
+                </section>
+                <section class="surface-tertiary">
+                    <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Raw EFT</p>
+                    <pre class="mt-3 overflow-x-auto whitespace-pre-wrap text-xs text-slate-300"><?= htmlspecialchars((string) ($fit['raw_eft'] ?? 'Unavailable'), ENT_QUOTES) ?></pre>
+                </section>
+                <section class="surface-tertiary">
+                    <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Source metadata</p>
+                    <pre class="mt-3 overflow-x-auto whitespace-pre-wrap text-xs text-slate-300"><?= htmlspecialchars(json_encode((array) ($fit['metadata'] ?? []), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE) ?: '{}', ENT_QUOTES) ?></pre>
+                </section>
+            </div>
         </article>
     </section>
 <?php endif; ?>

--- a/public/doctrine/fits.php
+++ b/public/doctrine/fits.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Doctrine Fit Overview';
+$errorMessage = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_csrf($_POST['_token'] ?? null)) {
+        http_response_code(419);
+        exit('Invalid CSRF token');
+    }
+
+    $fitIds = array_values(array_unique(array_filter(array_map('intval', (array) ($_POST['fit_ids'] ?? [])), static fn (int $id): bool => $id > 0)));
+    $bulkAction = (string) ($_POST['bulk_action'] ?? '');
+    $selectedGroupIds = array_values(array_unique(array_filter(array_map('intval', (array) ($_POST['bulk_group_ids'] ?? [])), static fn (int $id): bool => $id > 0)));
+    $bulkNotes = trim((string) ($_POST['bulk_notes'] ?? ''));
+
+    try {
+        if ($fitIds === [] && $bulkAction !== '') {
+            throw new RuntimeException('Select at least one fit before running a bulk action.');
+        }
+
+        switch ($bulkAction) {
+            case 'delete':
+                db_doctrine_fit_bulk_delete($fitIds);
+                doctrine_schedule_intelligence_refresh('fit-bulk-delete');
+                flash('success', 'Deleted ' . count($fitIds) . ' doctrine fits.');
+                break;
+            case 'assign_groups':
+                db_doctrine_fit_bulk_assign_groups($fitIds, $selectedGroupIds, false);
+                doctrine_schedule_intelligence_refresh('fit-bulk-assign-groups');
+                flash('success', 'Assigned groups to ' . count($fitIds) . ' doctrine fits.');
+                break;
+            case 'replace_groups':
+                db_doctrine_fit_bulk_assign_groups($fitIds, $selectedGroupIds, true);
+                doctrine_schedule_intelligence_refresh('fit-bulk-replace-groups');
+                flash('success', 'Replaced doctrine group memberships for ' . count($fitIds) . ' fits.');
+                break;
+            case 'remove_groups':
+                db_doctrine_fit_bulk_remove_groups($fitIds, $selectedGroupIds);
+                doctrine_schedule_intelligence_refresh('fit-bulk-remove-groups');
+                flash('success', 'Removed selected doctrine groups from ' . count($fitIds) . ' fits.');
+                break;
+            case 'mark_review':
+                db_doctrine_fit_bulk_update_metadata($fitIds, ['parse_status' => 'review', 'review_status' => 'needs_review']);
+                flash('success', 'Marked ' . count($fitIds) . ' fits for review.');
+                break;
+            case 'mark_reparse':
+                db_doctrine_fit_bulk_update_metadata($fitIds, ['parse_status' => 'review', 'review_status' => 'reparse_requested']);
+                flash('success', 'Marked ' . count($fitIds) . ' fits for reparse.');
+                break;
+            case 'append_notes':
+                if ($bulkNotes === '') {
+                    throw new RuntimeException('Enter a note before using the bulk metadata update.');
+                }
+                db_doctrine_fit_bulk_update_metadata($fitIds, ['notes' => $bulkNotes]);
+                flash('success', 'Updated notes for ' . count($fitIds) . ' fits.');
+                break;
+        }
+
+        if ($bulkAction !== '') {
+            header('Location: /doctrine/fits?' . http_build_query($_GET));
+            exit;
+        }
+    } catch (Throwable $exception) {
+        $errorMessage = $exception->getMessage();
+    }
+}
+
+$data = doctrine_fit_overview_data($_GET);
+$fits = (array) ($data['fits'] ?? []);
+$filters = (array) ($data['filters'] ?? []);
+$sort = (string) ($data['sort'] ?? 'updated_desc');
+$groupOptions = (array) ($data['groups'] ?? []);
+$summary = (array) ($data['summary'] ?? []);
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+    <article class="surface-secondary"><p class="eyebrow">Imported fits</p><p class="mt-3 text-3xl metric-value"><?= (int) ($summary['total'] ?? 0) ?></p><p class="mt-2 text-sm text-slate-400">Searchable doctrine-fit registry.</p></article>
+    <article class="surface-secondary"><p class="eyebrow">Needs review</p><p class="mt-3 text-3xl metric-value text-amber-200"><?= (int) ($summary['review'] ?? 0) ?></p><p class="mt-2 text-sm text-slate-400">Rows carrying warnings, mismatches, or explicit review flags.</p></article>
+    <article class="surface-secondary"><p class="eyebrow">Unresolved</p><p class="mt-3 text-3xl metric-value text-rose-200"><?= (int) ($summary['unresolved'] ?? 0) ?></p><p class="mt-2 text-sm text-slate-400">Fits with unresolved hull or item names.</p></article>
+    <article class="surface-secondary"><p class="eyebrow">Conflicts</p><p class="mt-3 text-3xl metric-value text-fuchsia-200"><?= (int) ($summary['conflicts'] ?? 0) ?></p><p class="mt-2 text-sm text-slate-400">Potential duplicates, version drift, or source mismatches.</p></article>
+</section>
+
+<section class="mt-8 surface-secondary">
+    <div class="section-header">
+        <div>
+            <p class="eyebrow">Fit management surface</p>
+            <h2 class="mt-2 section-title">Doctrine fit overview</h2>
+            <p class="mt-2 text-sm text-slate-400">Filter and operate on large batches of imported doctrine fits without dropping into one-by-one edits.</p>
+        </div>
+        <a href="/doctrine/import" class="btn-primary">Open bulk importer</a>
+    </div>
+
+    <?php if ($errorMessage !== null): ?>
+        <div class="mb-5 rounded-2xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100"><?= htmlspecialchars($errorMessage, ENT_QUOTES) ?></div>
+    <?php endif; ?>
+
+    <form method="get" class="grid gap-4 rounded-[1.4rem] border border-white/8 bg-white/[0.03] p-4 md:grid-cols-3 xl:grid-cols-6">
+        <label class="block xl:col-span-2">
+            <span class="mb-2 block field-label">Search</span>
+            <input type="text" name="q" class="field-input" value="<?= htmlspecialchars((string) ($filters['search'] ?? ''), ENT_QUOTES) ?>" placeholder="Fit name, hull, note, source file">
+        </label>
+        <label class="block">
+            <span class="mb-2 block field-label">Doctrine group</span>
+            <select name="group_id" class="field-input">
+                <option value="0">All groups</option>
+                <?php foreach ($groupOptions as $group): ?>
+                    <option value="<?= (int) ($group['id'] ?? 0) ?>" <?= (int) ($filters['group_id'] ?? 0) === (int) ($group['id'] ?? 0) ? 'selected' : '' ?>><?= htmlspecialchars((string) ($group['group_name'] ?? ''), ENT_QUOTES) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label class="block">
+            <span class="mb-2 block field-label">Source type</span>
+            <select name="source_type" class="field-input">
+                <?php foreach (['' => 'All', 'html' => 'HTML', 'eft' => 'EFT', 'buyall' => 'BuyAll', 'manual' => 'Manual'] as $value => $label): ?>
+                    <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= (string) ($filters['source_type'] ?? '') === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label class="block">
+            <span class="mb-2 block field-label">Parse status</span>
+            <select name="parse_status" class="field-input">
+                <?php foreach (['' => 'All', 'ready' => 'Ready', 'review' => 'Review'] as $value => $label): ?>
+                    <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= (string) ($filters['parse_status'] ?? '') === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label class="block">
+            <span class="mb-2 block field-label">Conflict state</span>
+            <select name="conflict_state" class="field-input">
+                <?php foreach (['' => 'All', 'has_conflict' => 'Any conflict', 'duplicate_name' => 'Duplicate name', 'duplicate_items' => 'Duplicate items', 'version_conflict' => 'Version conflict', 'source_mismatch' => 'Source mismatch'] as $value => $label): ?>
+                    <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= (string) ($filters['conflict_state'] ?? '') === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label class="block">
+            <span class="mb-2 block field-label">Hull</span>
+            <input type="text" name="hull" class="field-input" value="<?= htmlspecialchars((string) ($filters['hull'] ?? ''), ENT_QUOTES) ?>" placeholder="Hull filter">
+        </label>
+        <label class="flex items-end gap-3">
+            <input type="checkbox" name="unresolved_only" value="1" <?= !empty($filters['unresolved_only']) ? 'checked' : '' ?>>
+            <span class="text-sm text-slate-300">Unresolved only</span>
+        </label>
+        <label class="block">
+            <span class="mb-2 block field-label">Sort</span>
+            <select name="sort" class="field-input">
+                <?php foreach (['updated_desc' => 'Last updated', 'fit_name_asc' => 'Fit name', 'hull_asc' => 'Hull', 'groups_desc' => 'Group count', 'items_desc' => 'Item count', 'warnings_desc' => 'Warnings', 'status_asc' => 'Status'] as $value => $label): ?>
+                    <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $sort === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <div class="flex items-end gap-3 xl:col-span-2">
+            <button type="submit" class="btn-primary">Apply filters</button>
+            <a href="/doctrine/fits" class="btn-secondary">Reset</a>
+        </div>
+    </form>
+
+    <form method="post" class="mt-6 space-y-4">
+        <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
+
+        <div class="grid gap-4 rounded-[1.4rem] border border-white/8 bg-white/[0.03] p-4 xl:grid-cols-[minmax(220px,0.7fr)_minmax(220px,0.7fr)_minmax(220px,1fr)_auto]">
+            <label class="block">
+                <span class="mb-2 block field-label">Bulk action</span>
+                <select name="bulk_action" class="field-input">
+                    <option value="">Choose action</option>
+                    <option value="delete">Bulk delete selected fits</option>
+                    <option value="assign_groups">Bulk assign doctrine groups</option>
+                    <option value="replace_groups">Bulk move/replace doctrine groups</option>
+                    <option value="remove_groups">Bulk remove doctrine groups</option>
+                    <option value="append_notes">Bulk edit metadata notes</option>
+                    <option value="mark_review">Bulk mark fits for review</option>
+                    <option value="mark_reparse">Bulk mark fits for reparse</option>
+                </select>
+            </label>
+            <label class="block">
+                <span class="mb-2 block field-label">Doctrine groups</span>
+                <select name="bulk_group_ids[]" multiple class="field-input min-h-[8rem]">
+                    <?php foreach ($groupOptions as $group): ?>
+                        <option value="<?= (int) ($group['id'] ?? 0) ?>"><?= htmlspecialchars((string) ($group['group_name'] ?? ''), ENT_QUOTES) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="block">
+                <span class="mb-2 block field-label">Metadata note</span>
+                <textarea name="bulk_notes" class="field-input" style="min-height: 8rem;" placeholder="Use for practical bulk metadata edits such as reviewer notes or next-step instructions."></textarea>
+            </label>
+            <div class="flex items-end">
+                <button type="submit" class="btn-primary">Run bulk action</button>
+            </div>
+        </div>
+
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-white/10 text-sm text-slate-200">
+                <thead>
+                    <tr class="text-left text-xs uppercase tracking-[0.16em] text-slate-500">
+                        <th class="px-3 py-3"><input type="checkbox" onclick="document.querySelectorAll('input[name=&quot;fit_ids[]&quot;]').forEach((el)=>el.checked=this.checked)"></th>
+                        <th class="px-3 py-3">Fit</th>
+                        <th class="px-3 py-3">Hull</th>
+                        <th class="px-3 py-3">Groups</th>
+                        <th class="px-3 py-3">Items</th>
+                        <th class="px-3 py-3">Source</th>
+                        <th class="px-3 py-3">Status</th>
+                        <th class="px-3 py-3">Updated</th>
+                        <th class="px-3 py-3">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-white/5 align-top">
+                    <?php foreach ($fits as $fit): ?>
+                        <tr>
+                            <td class="px-3 py-4"><input type="checkbox" name="fit_ids[]" value="<?= (int) ($fit['id'] ?? 0) ?>"></td>
+                            <td class="px-3 py-4">
+                                <p class="font-semibold text-white"><?= htmlspecialchars((string) ($fit['fit_name'] ?? ''), ENT_QUOTES) ?></p>
+                                <p class="mt-1 text-xs text-slate-500">#<?= (int) ($fit['id'] ?? 0) ?><?= !empty($fit['source_reference']) ? ' · ' . htmlspecialchars((string) $fit['source_reference'], ENT_QUOTES) : '' ?></p>
+                            </td>
+                            <td class="px-3 py-4"><?= htmlspecialchars((string) ($fit['ship_name'] ?? ''), ENT_QUOTES) ?></td>
+                            <td class="px-3 py-4">
+                                <div class="flex flex-wrap gap-2">
+                                    <?php foreach ((array) ($fit['group_names'] ?? []) as $groupName): ?>
+                                        <span class="badge border-white/10 bg-white/[0.04] text-slate-200"><?= htmlspecialchars((string) $groupName, ENT_QUOTES) ?></span>
+                                    <?php endforeach; ?>
+                                    <?php if ((array) ($fit['group_names'] ?? []) === []): ?>
+                                        <span class="text-xs text-slate-500">Ungrouped</span>
+                                    <?php endif; ?>
+                                </div>
+                            </td>
+                            <td class="px-3 py-4 text-xs text-slate-400">
+                                <p><?= (int) ($fit['item_count'] ?? 0) ?> declared</p>
+                                <p><?= (int) ($fit['normalized_item_rows'] ?? 0) ?> stored</p>
+                                <p><?= (int) ($fit['group_count'] ?? 0) ?> groups</p>
+                            </td>
+                            <td class="px-3 py-4">
+                                <span class="badge border-sky-400/20 bg-sky-500/10 text-sky-100"><?= htmlspecialchars((string) ($fit['source_type'] ?? 'manual'), ENT_QUOTES) ?></span>
+                            </td>
+                            <td class="px-3 py-4">
+                                <div class="space-y-2">
+                                    <span class="badge <?= (($fit['parse_status'] ?? 'ready') === 'ready') ? 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100' : 'border-amber-400/20 bg-amber-500/10 text-amber-100' ?>"><?= htmlspecialchars((string) ($fit['readiness_status'] ?? 'Ready'), ENT_QUOTES) ?></span>
+                                    <?php if (((int) ($fit['warning_count'] ?? 0)) > 0): ?>
+                                        <p class="text-xs text-amber-100"><?= (int) ($fit['warning_count'] ?? 0) ?> warnings</p>
+                                    <?php endif; ?>
+                                    <?php if (((int) ($fit['unresolved_count'] ?? 0)) > 0): ?>
+                                        <p class="text-xs text-rose-100"><?= (int) ($fit['unresolved_count'] ?? 0) ?> unresolved</p>
+                                    <?php endif; ?>
+                                    <?php if (($fit['conflict_state'] ?? 'none') !== 'none'): ?>
+                                        <p class="text-xs text-fuchsia-100"><?= htmlspecialchars((string) ($fit['conflict_state'] ?? ''), ENT_QUOTES) ?></p>
+                                    <?php endif; ?>
+                                </div>
+                            </td>
+                            <td class="px-3 py-4 text-xs text-slate-400"><?= htmlspecialchars((string) ($fit['updated_at'] ?? ''), ENT_QUOTES) ?></td>
+                            <td class="px-3 py-4">
+                                <div class="flex flex-wrap gap-2">
+                                    <a href="/doctrine/fit?fit_id=<?= (int) ($fit['id'] ?? 0) ?>" class="btn-secondary">Inspect</a>
+                                </div>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                    <?php if ($fits === []): ?>
+                        <tr><td colspan="9" class="px-3 py-8 text-center text-sm text-slate-400">No doctrine fits matched the current filters.</td></tr>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+    </form>
+</section>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/doctrine/import.php
+++ b/public/doctrine/import.php
@@ -4,27 +4,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../src/bootstrap.php';
 
-$title = 'Import Doctrine Fit';
-$groupOptions = doctrine_group_options();
-$defaultGroupId = max(0, (int) ($_GET['group_id'] ?? 0));
-if ($defaultGroupId <= 0 && $groupOptions !== []) {
-    $defaultGroupId = (int) ($groupOptions[0]['id'] ?? 0);
-}
-
-$formValues = [
-    'group_ids' => $defaultGroupId > 0 ? [$defaultGroupId] : [],
-    'new_group_name' => '',
-    'new_group_description' => '',
-    'fit_payload' => '',
-    'fit_name' => '',
-    'ship_name' => '',
-    'source_format' => 'buyall',
-    'import_body' => '',
-    'item_lines_text' => '',
-    'hull_stock_tracked' => '1',
-];
-$previewDraft = null;
+$title = 'Bulk Doctrine Import';
 $errorMessage = null;
+$saveResult = null;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!validate_csrf($_POST['_token'] ?? null)) {
@@ -32,229 +14,285 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit('Invalid CSRF token');
     }
 
-    $formValues = [
-        'group_ids' => array_values(array_map('intval', (array) ($_POST['group_ids'] ?? []))),
-        'new_group_name' => (string) ($_POST['new_group_name'] ?? ''),
-        'new_group_description' => (string) ($_POST['new_group_description'] ?? ''),
-        'fit_payload' => (string) ($_POST['fit_payload'] ?? ''),
-        'fit_name' => (string) ($_POST['fit_name'] ?? ''),
-        'ship_name' => (string) ($_POST['ship_name'] ?? ''),
-        'source_format' => (string) ($_POST['source_format'] ?? 'buyall'),
-        'import_body' => (string) ($_POST['import_body'] ?? ''),
-        'item_lines_text' => (string) ($_POST['item_lines_text'] ?? ''),
-        'hull_stock_tracked' => in_array((string) ($_POST['hull_stock_tracked'] ?? '0'), ['1', 'true', 'on', 'yes'], true) ? '1' : '0',
-    ];
+    $action = (string) ($_POST['action'] ?? 'preview');
 
-    if (($_POST['action'] ?? 'preview') === 'save') {
-        $result = doctrine_import_fit_from_request($_POST);
-        if (($result['ok'] ?? false) === true) {
-            flash('success', (string) ($result['message'] ?? 'Doctrine fit imported successfully.'));
-            header('Location: /doctrine/fit?fit_id=' . (int) ($result['fit_id'] ?? 0));
+    try {
+        if ($action === 'preview') {
+            $preview = doctrine_bulk_import_build_preview();
+            doctrine_bulk_import_preview_store($preview);
+            flash('success', 'Import preview built for ' . (int) ($preview['counts']['total'] ?? 0) . ' fits.');
+            header('Location: /doctrine/import');
             exit;
         }
 
-        $errorMessage = (string) ($result['message'] ?? 'Doctrine import failed.');
-        $previewDraft = $result['draft'] ?? null;
-    } else {
-        try {
-            $previewDraft = doctrine_build_draft_from_import_request($_POST);
-            $formValues['fit_name'] = (string) ($previewDraft['fit']['fit_name'] ?? '');
-            $formValues['ship_name'] = (string) ($previewDraft['fit']['ship_name'] ?? '');
-            $formValues['source_format'] = (string) ($previewDraft['fit']['source_format'] ?? 'buyall');
-            $formValues['import_body'] = (string) ($previewDraft['fit']['import_body'] ?? $formValues['fit_payload']);
-            $formValues['item_lines_text'] = (string) ($previewDraft['item_lines_text'] ?? '');
-            $formValues['group_ids'] = (array) ($previewDraft['group_ids'] ?? $formValues['group_ids']);
-            $formValues['hull_stock_tracked'] = !empty($previewDraft['hull_is_stock_tracked']) ? '1' : '0';
-        } catch (Throwable $exception) {
-            $errorMessage = $exception->getMessage();
+        if ($action === 'save_preview') {
+            $saveResult = doctrine_bulk_import_save_from_request($_POST);
+            if (($saveResult['ok'] ?? false) === true) {
+                $results = (array) ($saveResult['results'] ?? []);
+                flash('success', sprintf(
+                    'Bulk import complete. %d created · %d updated · %d flagged for review · %d skipped.',
+                    (int) ($results['created'] ?? 0),
+                    (int) ($results['updated'] ?? 0),
+                    (int) ($results['review'] ?? 0),
+                    (int) ($results['skipped'] ?? 0)
+                ));
+                header('Location: /doctrine/fits');
+                exit;
+            }
+
+            $errorMessage = (string) ($saveResult['message'] ?? 'Bulk import failed.');
         }
+
+        if ($action === 'clear_preview') {
+            doctrine_bulk_import_preview_clear();
+            flash('success', 'Bulk import preview cleared.');
+            header('Location: /doctrine/import');
+            exit;
+        }
+    } catch (Throwable $exception) {
+        $errorMessage = $exception->getMessage();
     }
 }
 
+$preview = doctrine_bulk_import_preview_fetch();
+$groupOptions = doctrine_group_options();
+$summary = (array) (($preview['counts'] ?? []));
+$rows = (array) (($preview['rows'] ?? []));
+
 include __DIR__ . '/../../src/views/partials/header.php';
 ?>
-<section class="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+<section class="grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(360px,1.05fr)]">
     <article class="surface-secondary">
         <div class="section-header">
             <div>
-                <p class="eyebrow">Doctrine ingest</p>
-                <h2 class="mt-2 section-title">Import alliance fitting payload</h2>
-                <p class="mt-2 text-sm text-slate-400">Stage the fit first, then confirm the resolved hull, doctrine groups, and normalized item lines before anything is saved.</p>
+                <p class="eyebrow">HTML-first doctrine ingest</p>
+                <h2 class="mt-2 section-title">Bulk Winter Coalition fit importer</h2>
+                <p class="mt-2 text-sm text-slate-400">Upload Winter Coalition fit HTML pages as the primary source. SupplyCore pulls fit title, hull, doctrine memberships, notes, Buy All payloads, visible items, and EFT fallbacks into a single bulk preview before save.</p>
             </div>
-            <span class="badge border-emerald-400/20 bg-emerald-500/10 text-emerald-100">Two-step import</span>
+            <span class="badge border-cyan-400/20 bg-cyan-500/10 text-cyan-100">Bulk control surface</span>
         </div>
 
         <?php if ($errorMessage !== null): ?>
             <div class="mb-5 rounded-2xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100"><?= htmlspecialchars($errorMessage, ENT_QUOTES) ?></div>
         <?php endif; ?>
 
-        <form method="post" class="space-y-4">
+        <form method="post" enctype="multipart/form-data" class="space-y-5">
             <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
             <input type="hidden" name="action" value="preview">
+
             <div class="grid gap-4 md:grid-cols-2">
-                <div>
-                    <span class="mb-2 block field-label">Doctrine groups</span>
-                    <div class="space-y-2 rounded-[1.2rem] border border-white/8 bg-slate-950/50 p-4">
-                        <?php foreach ($groupOptions as $group): ?>
-                            <?php $groupId = (int) ($group['id'] ?? 0); ?>
-                            <label class="flex items-start gap-3 text-sm text-slate-300">
-                                <input type="checkbox" name="group_ids[]" value="<?= $groupId ?>" class="mt-1" <?= in_array($groupId, (array) $formValues['group_ids'], true) ? 'checked' : '' ?>>
-                                <span>
-                                    <span class="font-medium text-slate-100"><?= htmlspecialchars((string) ($group['group_name'] ?? ''), ENT_QUOTES) ?></span>
-                                    <span class="mt-1 block text-xs text-slate-500"><?= htmlspecialchars((string) ($group['description'] ?? 'Doctrine group'), ENT_QUOTES) ?></span>
-                                </span>
-                            </label>
-                        <?php endforeach; ?>
-                    </div>
+                <label class="block">
+                    <span class="mb-2 block field-label">Winter Coalition HTML pages</span>
+                    <input type="file" name="html_files[]" accept=".html,.htm,text/html" multiple class="field-input py-3">
+                    <span class="mt-2 block text-xs text-slate-500">Upload one or many doctrine fit pages. HTML is treated as the source of truth for title, groups, notes, and Buy All metadata.</span>
+                </label>
+                <label class="block">
+                    <span class="mb-2 block field-label">Optional EFT fallback files</span>
+                    <input type="file" name="eft_files[]" accept=".txt,.eft,text/plain" multiple class="field-input py-3">
+                    <span class="mt-2 block text-xs text-slate-500">Fallback EFT files are matched by filename or fit name and used to validate hull identity when HTML metadata is incomplete.</span>
+                </label>
+            </div>
+
+            <div class="grid gap-3 md:grid-cols-3">
+                <div class="surface-tertiary">
+                    <p class="text-xs uppercase tracking-[0.16em] text-slate-500">1 · Upload</p>
+                    <p class="mt-2 text-sm text-slate-200">HTML pages, plus optional EFT fallback files.</p>
                 </div>
-                <div class="space-y-4">
-                    <label class="block">
-                        <span class="mb-2 block field-label">New group name</span>
-                        <input type="text" name="new_group_name" class="field-input" maxlength="190" value="<?= htmlspecialchars((string) $formValues['new_group_name'], ENT_QUOTES) ?>" placeholder="Optional new doctrine group">
-                    </label>
-                    <label class="block">
-                        <span class="mb-2 block field-label">New group description</span>
-                        <input type="text" name="new_group_description" class="field-input" maxlength="1000" value="<?= htmlspecialchars((string) $formValues['new_group_description'], ENT_QUOTES) ?>" placeholder="Operational note for the new doctrine group">
-                    </label>
+                <div class="surface-tertiary">
+                    <p class="text-xs uppercase tracking-[0.16em] text-slate-500">2 · Preview</p>
+                    <p class="mt-2 text-sm text-slate-200">Review conflicts, detected groups, unresolved names, and duplicate signals before anything is written.</p>
+                </div>
+                <div class="surface-tertiary">
+                    <p class="text-xs uppercase tracking-[0.16em] text-slate-500">3 · Save</p>
+                    <p class="mt-2 text-sm text-slate-200">Create, update, skip, or save flagged rows for manual review without reuploading everything.</p>
                 </div>
             </div>
-            <label class="block">
-                <span class="mb-2 block field-label">Fit payload</span>
-                <textarea name="fit_payload" class="field-input font-mono text-sm" style="min-height: 24rem;" spellcheck="false" placeholder="[Scimitar, Shield Scimi]\nDamage Control II\nNanofiber Internal Structure II\n\nLarge Shield Extender II\n10MN Afterburner II\n\nLarge Remote Shield Booster II x4\n\nMedium Core Defense Field Extender II x2\n\nWarrior II x5"><?= htmlspecialchars((string) $formValues['fit_payload'], ENT_QUOTES) ?></textarea>
-            </label>
-            <div class="flex flex-wrap items-center justify-between gap-3">
-                <div class="text-sm text-slate-400">EFT hulls come from <code>[Ship, Fit Name]</code>. BuyAll hulls come from the first line. If anything looks ambiguous, correct it in the confirmation step before saving.</div>
-                <button type="submit" class="btn-primary">Preview import</button>
-            </div>
+
+            <button type="submit" class="btn-primary">Build preview</button>
         </form>
     </article>
 
-    <aside class="surface-secondary">
-        <div class="section-header">
-            <div>
-                <p class="eyebrow">Import behavior</p>
-                <h2 class="mt-2 section-title">Confirmation control</h2>
+    <aside class="space-y-6">
+        <article class="surface-secondary">
+            <div class="section-header">
+                <div>
+                    <p class="eyebrow">Normalization rules</p>
+                    <h2 class="mt-2 section-title">What SupplyCore persists</h2>
+                </div>
             </div>
-            <span class="badge border-cyan-400/18 bg-cyan-500/10 text-cyan-100">No silent saves</span>
-        </div>
-        <div class="space-y-3 text-sm text-slate-300">
-            <div class="surface-tertiary">
-                <p class="font-semibold text-slate-100">1. Parse the hull correctly</p>
-                <p class="mt-2 text-slate-400">EFT imports use the ship from the header. BuyAll imports use the first line as the hull and keep it visible for correction.</p>
+            <ul class="space-y-3 text-sm text-slate-300">
+                <li class="surface-tertiary">Every fit gets exactly one persisted <span class="font-semibold text-white">Hull</span> row, even if the source omits it from visible modules.</li>
+                <li class="surface-tertiary">Buy All payloads are preferred over visible item text. EFT is used as fallback and hull/identity validation.</li>
+                <li class="surface-tertiary">Detected doctrine labels are preserved as many-to-many group memberships and can auto-create missing groups at save time.</li>
+                <li class="surface-tertiary">Duplicate-name, duplicate-item, version, unresolved, and source-mismatch states are surfaced in preview instead of silently overwriting data.</li>
+            </ul>
+        </article>
+
+        <article class="surface-secondary">
+            <div class="section-header">
+                <div>
+                    <p class="eyebrow">After import</p>
+                    <h2 class="mt-2 section-title">Bulk management</h2>
+                </div>
+                <a href="/doctrine/fits" class="btn-secondary">Open fit overview</a>
             </div>
-            <div class="surface-tertiary">
-                <p class="font-semibold text-slate-100">2. Confirm every decision</p>
-                <p class="mt-2 text-slate-400">Before saving you can edit the fit name, ship name, groups, raw payload, and normalized line list.</p>
-            </div>
-            <div class="surface-tertiary">
-                <p class="font-semibold text-slate-100">3. Save only clean data</p>
-                <p class="mt-2 text-slate-400">Broken hull resolution or unresolved items keep the fit in preview instead of silently storing a bad doctrine record.</p>
-            </div>
-        </div>
+            <p class="text-sm text-slate-400">The fit overview provides search, filters, sortable columns, bulk delete, bulk group assignment, review marking, and per-fit inspection of raw source and parse warnings.</p>
+        </article>
     </aside>
 </section>
 
-<?php if (is_array($previewDraft)): ?>
-    <?php $readyToSave = (bool) ($previewDraft['ready_to_save'] ?? false); ?>
-    <section class="surface-secondary mt-8">
-        <div class="section-header">
-            <div>
-                <p class="eyebrow">Confirmation step</p>
-                <h2 class="mt-2 section-title">Review and finalize doctrine fit</h2>
-                <p class="mt-2 text-sm text-slate-400">Correct anything below before saving. Suggested multi-group matches are preselected when SupplyCore finds existing doctrines with the same hull or fit name.</p>
-            </div>
-            <span class="badge <?= htmlspecialchars(doctrine_supply_status_tone($readyToSave ? 'ready' : 'critical'), ENT_QUOTES) ?>"><?= $readyToSave ? 'Ready to save' : 'Needs correction' ?></span>
+<section class="mt-8 surface-secondary">
+    <div class="section-header">
+        <div>
+            <p class="eyebrow">Preview queue</p>
+            <h2 class="mt-2 section-title">Bulk parse results</h2>
+            <p class="mt-2 text-sm text-slate-400">Preview clean fits and only spend time on the rows that need review.</p>
         </div>
+        <?php if ($rows !== []): ?>
+            <div class="flex flex-wrap gap-2">
+                <span class="badge border-emerald-400/20 bg-emerald-500/10 text-emerald-100"><?= (int) ($summary['ready'] ?? 0) ?> ready</span>
+                <span class="badge border-amber-400/20 bg-amber-500/10 text-amber-100"><?= (int) ($summary['review'] ?? 0) ?> review</span>
+                <span class="badge border-cyan-400/20 bg-cyan-500/10 text-cyan-100"><?= (int) ($summary['total'] ?? 0) ?> total</span>
+            </div>
+        <?php endif; ?>
+    </div>
 
-        <form method="post" class="space-y-5">
+    <?php if ($rows === []): ?>
+        <div class="surface-tertiary text-sm text-slate-400">No import preview is active. Upload Winter Coalition HTML pages to stage a bulk ingest batch.</div>
+    <?php else: ?>
+        <form method="post" class="space-y-4">
             <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
-            <input type="hidden" name="action" value="save">
-            <input type="hidden" name="fit_payload" value="<?= htmlspecialchars((string) $formValues['fit_payload'], ENT_QUOTES) ?>">
-            <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                <label class="block xl:col-span-2">
-                    <span class="mb-2 block field-label">Fit name</span>
-                    <input type="text" name="fit_name" class="field-input" maxlength="190" value="<?= htmlspecialchars((string) ($formValues['fit_name'] ?: ($previewDraft['fit']['fit_name'] ?? '')), ENT_QUOTES) ?>">
-                </label>
-                <label class="block">
-                    <span class="mb-2 block field-label">Ship name</span>
-                    <input type="text" name="ship_name" class="field-input" maxlength="255" value="<?= htmlspecialchars((string) ($formValues['ship_name'] ?: ($previewDraft['fit']['ship_name'] ?? '')), ENT_QUOTES) ?>">
-                </label>
-                <label class="block">
-                    <span class="mb-2 block field-label">Source format</span>
-                    <select name="source_format" class="field-select">
-                        <?php foreach (['eft' => 'EFT', 'buyall' => 'BuyAll'] as $value => $label): ?>
-                            <option value="<?= $value ?>" <?= (($formValues['source_format'] ?: ($previewDraft['fit']['source_format'] ?? 'buyall')) === $value) ? 'selected' : '' ?>><?= $label ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </label>
+            <input type="hidden" name="action" value="save_preview">
+
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-white/10 text-sm text-slate-200">
+                    <thead>
+                        <tr class="text-left text-xs uppercase tracking-[0.16em] text-slate-500">
+                            <th class="px-3 py-3">Source</th>
+                            <th class="px-3 py-3">Fit</th>
+                            <th class="px-3 py-3">Groups</th>
+                            <th class="px-3 py-3">Items</th>
+                            <th class="px-3 py-3">Warnings</th>
+                            <th class="px-3 py-3">Action</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-white/5 align-top">
+                    <?php foreach ($rows as $row): ?>
+                        <?php
+                        $fit = (array) ($row['fit'] ?? []);
+                        $warnings = (array) ($row['warnings'] ?? []);
+                        $conflicts = (array) ($row['conflicts'] ?? []);
+                        $sourceKey = (string) ($row['source_filename'] ?? md5((string) (($fit['fit_name'] ?? '') . '|' . ($fit['ship_name'] ?? ''))));
+                        $defaultAction = (($fit['parse_status'] ?? 'ready') === 'ready' && $conflicts === []) ? 'create' : 'review';
+                        ?>
+                        <tr>
+                            <td class="px-3 py-4">
+                                <div class="space-y-2">
+                                    <div class="font-medium text-white"><?= htmlspecialchars((string) ($row['source_filename'] ?? 'Uploaded fit'), ENT_QUOTES) ?></div>
+                                    <span class="badge border-sky-400/20 bg-sky-500/10 text-sky-100"><?= htmlspecialchars((string) ($fit['source_type'] ?? 'html'), ENT_QUOTES) ?></span>
+                                    <div class="text-xs text-slate-500"><?= htmlspecialchars((string) ($fit['source_format'] ?? 'buyall'), ENT_QUOTES) ?> normalization</div>
+                                </div>
+                            </td>
+                            <td class="px-3 py-4">
+                                <div class="space-y-2">
+                                    <div>
+                                        <p class="font-semibold text-white"><?= htmlspecialchars((string) ($fit['fit_name'] ?? 'Untitled fit'), ENT_QUOTES) ?></p>
+                                        <p class="text-xs text-slate-400"><?= htmlspecialchars((string) ($fit['ship_name'] ?? 'Unknown hull'), ENT_QUOTES) ?></p>
+                                    </div>
+                                    <div class="flex flex-wrap gap-2">
+                                        <span class="badge <?= (($fit['parse_status'] ?? 'ready') === 'ready') ? 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100' : 'border-amber-400/20 bg-amber-500/10 text-amber-100' ?>"><?= htmlspecialchars((string) (($fit['parse_status'] ?? 'ready') === 'ready' ? 'Ready' : 'Review'), ENT_QUOTES) ?></span>
+                                        <?php if (((int) ($fit['unresolved_count'] ?? 0)) > 0): ?>
+                                            <span class="badge border-rose-400/20 bg-rose-500/10 text-rose-100"><?= (int) ($fit['unresolved_count'] ?? 0) ?> unresolved</span>
+                                        <?php endif; ?>
+                                        <?php if (($fit['conflict_state'] ?? 'none') !== 'none'): ?>
+                                            <span class="badge border-fuchsia-400/20 bg-fuchsia-500/10 text-fuchsia-100"><?= htmlspecialchars((string) ($fit['conflict_state'] ?? 'conflict'), ENT_QUOTES) ?></span>
+                                        <?php endif; ?>
+                                    </div>
+                                    <?php if ($conflicts !== []): ?>
+                                        <div class="rounded-2xl border border-fuchsia-400/15 bg-fuchsia-500/5 p-3 text-xs text-fuchsia-100">
+                                            <p class="font-semibold">Existing matches</p>
+                                            <ul class="mt-2 space-y-2">
+                                                <?php foreach ($conflicts as $conflict): ?>
+                                                    <li>
+                                                        <label class="flex items-start gap-2">
+                                                            <input type="radio" name="row_target_fit_id[<?= htmlspecialchars($sourceKey, ENT_QUOTES) ?>]" value="<?= (int) ($conflict['id'] ?? 0) ?>" class="mt-1">
+                                                            <span>#<?= (int) ($conflict['id'] ?? 0) ?> · <?= htmlspecialchars((string) ($conflict['fit_name'] ?? ''), ENT_QUOTES) ?> · <?= htmlspecialchars(implode(', ', (array) ($conflict['group_names'] ?? [])) ?: 'Ungrouped', ENT_QUOTES) ?></span>
+                                                        </label>
+                                                    </li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+                            </td>
+                            <td class="px-3 py-4">
+                                <div class="space-y-2">
+                                    <div class="flex flex-wrap gap-2">
+                                        <?php foreach ((array) ($row['detected_group_labels'] ?? []) as $label): ?>
+                                            <span class="badge border-white/10 bg-white/[0.04] text-slate-200"><?= htmlspecialchars((string) $label, ENT_QUOTES) ?></span>
+                                        <?php endforeach; ?>
+                                        <?php if ((array) ($row['detected_group_labels'] ?? []) === []): ?>
+                                            <span class="text-xs text-slate-500">No HTML group labels detected</span>
+                                        <?php endif; ?>
+                                    </div>
+                                    <select multiple name="row_group_ids[<?= htmlspecialchars($sourceKey, ENT_QUOTES) ?>][]" class="field-input min-h-[8rem]">
+                                        <?php foreach ($groupOptions as $group): ?>
+                                            <?php $groupId = (int) ($group['id'] ?? 0); ?>
+                                            <option value="<?= $groupId ?>" <?= in_array($groupId, (array) ($row['group_ids'] ?? []), true) ? 'selected' : '' ?>><?= htmlspecialchars((string) ($group['group_name'] ?? ''), ENT_QUOTES) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                            </td>
+                            <td class="px-3 py-4">
+                                <div class="space-y-2 text-xs text-slate-400">
+                                    <p><span class="font-semibold text-slate-200"><?= (int) ($fit['item_count'] ?? 0) ?></span> normalized rows</p>
+                                    <p><span class="font-semibold text-slate-200"><?= count((array) ($row['items'] ?? [])) ?></span> parsed lines</p>
+                                    <?php if (!empty($fit['notes'])): ?>
+                                        <p class="rounded-2xl border border-white/8 bg-white/[0.03] p-3 text-slate-300"><?= htmlspecialchars((string) $fit['notes'], ENT_QUOTES) ?></p>
+                                    <?php endif; ?>
+                                </div>
+                            </td>
+                            <td class="px-3 py-4">
+                                <?php if ($warnings === [] && (array) ($row['unresolved'] ?? []) === []): ?>
+                                    <span class="text-xs text-emerald-200">No parse warnings</span>
+                                <?php else: ?>
+                                    <ul class="space-y-2 text-xs text-amber-100">
+                                        <?php foreach ($warnings as $warning): ?>
+                                            <li class="rounded-2xl border border-amber-400/15 bg-amber-500/5 px-3 py-2"><?= htmlspecialchars((string) $warning, ENT_QUOTES) ?></li>
+                                        <?php endforeach; ?>
+                                        <?php foreach ((array) ($row['unresolved'] ?? []) as $unresolved): ?>
+                                            <li class="rounded-2xl border border-rose-400/15 bg-rose-500/5 px-3 py-2">Unresolved: <?= htmlspecialchars((string) $unresolved, ENT_QUOTES) ?></li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                <?php endif; ?>
+                            </td>
+                            <td class="px-3 py-4">
+                                <div class="space-y-3">
+                                    <select name="row_action[<?= htmlspecialchars($sourceKey, ENT_QUOTES) ?>]" class="field-input">
+                                        <option value="create" <?= $defaultAction === 'create' ? 'selected' : '' ?>>Create new</option>
+                                        <option value="update">Update existing</option>
+                                        <option value="review" <?= $defaultAction === 'review' ? 'selected' : '' ?>>Save for review</option>
+                                        <option value="skip">Skip</option>
+                                    </select>
+                                    <p class="text-xs text-slate-500">Use <span class="font-semibold text-slate-300">Save for review</span> for mismatches, unresolved names, or version conflicts you want to fix later from the fit overview.</p>
+                                </div>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
             </div>
 
-            <div class="grid gap-4 xl:grid-cols-[minmax(280px,0.8fr)_minmax(0,1fr)]">
-                <div class="space-y-4">
-                    <div class="rounded-[1.2rem] border border-white/8 bg-slate-950/50 p-4">
-                        <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Doctrine groups</p>
-                        <div class="mt-3 space-y-2">
-                            <?php foreach ($groupOptions as $group): ?>
-                                <?php $groupId = (int) ($group['id'] ?? 0); ?>
-                                <label class="flex items-start gap-3 text-sm text-slate-300">
-                                    <input type="checkbox" name="group_ids[]" value="<?= $groupId ?>" class="mt-1" <?= in_array($groupId, (array) ($previewDraft['group_ids'] ?? []), true) ? 'checked' : '' ?>>
-                                    <span><?= htmlspecialchars((string) ($group['group_name'] ?? ''), ENT_QUOTES) ?></span>
-                                </label>
-                            <?php endforeach; ?>
-                        </div>
-                        <?php if (($previewDraft['suggested_groups'] ?? []) !== []): ?>
-                            <p class="mt-3 text-xs text-cyan-200/80">Suggested from existing hull / fit matches.</p>
-                        <?php endif; ?>
-                    </div>
-                    <label class="block">
-                        <span class="mb-2 block field-label">New group name</span>
-                        <input type="text" name="new_group_name" class="field-input" maxlength="190" value="<?= htmlspecialchars((string) $formValues['new_group_name'], ENT_QUOTES) ?>">
-                    </label>
-                    <label class="block">
-                        <span class="mb-2 block field-label">New group description</span>
-                        <input type="text" name="new_group_description" class="field-input" maxlength="1000" value="<?= htmlspecialchars((string) $formValues['new_group_description'], ENT_QUOTES) ?>">
-                    </label>
-                    <div class="surface-tertiary text-sm text-slate-300">
-                        <label class="flex items-start gap-3 rounded-[1rem] border border-white/8 bg-slate-950/40 p-3">
-                            <input type="hidden" name="hull_stock_tracked" value="0">
-                            <input type="checkbox" name="hull_stock_tracked" value="1" class="mt-1" <?= !empty($previewDraft['hull_is_stock_tracked']) ? 'checked' : '' ?>>
-                            <span>
-                                <span class="font-semibold text-slate-100">Track hull for stocking</span>
-                                <span class="mt-1 block text-xs text-slate-400">Disable this for specialty or externally managed hulls so they still cap readiness without driving spend, missing-item lists, or urgency.</span>
-                            </span>
-                        </label>
-                        <p class="mt-3 text-xs <?= !empty($previewDraft['hull_is_stock_tracked']) ? 'text-cyan-100' : 'text-amber-100' ?>">
-                            <?= htmlspecialchars((string) ($previewDraft['hull_tracking_default_reason'] ?? ''), ENT_QUOTES) ?>
-                        </p>
-                    </div>
-                    <div class="surface-tertiary text-sm text-slate-300">
-                        <?php if (($previewDraft['unresolved'] ?? []) !== []): ?>
-                            <p class="font-semibold text-amber-100">Resolve these names before saving:</p>
-                            <p class="mt-2 text-amber-100"><?= htmlspecialchars(implode(', ', (array) ($previewDraft['unresolved'] ?? [])), ENT_QUOTES) ?></p>
-                        <?php else: ?>
-                            <p class="font-semibold text-emerald-100">Resolution looks clean.</p>
-                            <p class="mt-2 text-slate-400">This fit will save with a mapped hull image, normalized items, and multi-group memberships.</p>
-                        <?php endif; ?>
-                    </div>
-                </div>
-
-                <div class="space-y-4">
-                    <label class="block">
-                        <span class="mb-2 block field-label">Raw import text</span>
-                        <textarea name="import_body" class="field-input font-mono text-sm" style="min-height: 14rem;" spellcheck="false"><?= htmlspecialchars((string) ($formValues['import_body'] ?: ($previewDraft['fit']['import_body'] ?? '')), ENT_QUOTES) ?></textarea>
-                    </label>
-                    <label class="block">
-                        <span class="mb-2 block field-label">Normalized item lines</span>
-                        <textarea name="item_lines_text" class="field-input font-mono text-sm" style="min-height: 16rem;" spellcheck="false"><?= htmlspecialchars((string) ($formValues['item_lines_text'] ?: ($previewDraft['item_lines_text'] ?? '')), ENT_QUOTES) ?></textarea>
-                    </label>
-                </div>
-            </div>
-
-            <div class="flex flex-wrap items-center justify-between gap-3">
-                <div class="text-sm text-slate-400">Use <code>Category :: Item xQty</code> when editing normalized lines directly.</div>
-                <button type="submit" class="btn-primary" <?= $readyToSave ? '' : 'disabled' ?>>Finalize doctrine fit</button>
+            <div class="flex flex-wrap justify-between gap-3">
+                <button type="submit" class="btn-primary">Save selected actions</button>
             </div>
         </form>
-    </section>
-<?php endif; ?>
+
+        <form method="post" class="mt-4">
+            <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
+            <input type="hidden" name="action" value="clear_preview">
+            <button type="submit" class="btn-secondary">Clear preview</button>
+        </form>
+    <?php endif; ?>
+</section>
 <?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/doctrine/index.php
+++ b/public/doctrine/index.php
@@ -57,11 +57,14 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <h2 class="mt-2 section-title">Alliance doctrine groups</h2>
                 <p class="mt-2 text-sm text-slate-400">Every card now separates fieldable readiness from replenishment pressure before you even open the fit.</p>
             </div>
-            <a href="/doctrine/import" class="btn-primary">Import fit</a>
+            <div class="flex flex-wrap gap-3">
+                <a href="/doctrine/fits" class="btn-secondary">Fit overview</a>
+                <a href="/doctrine/import" class="btn-primary">Bulk import</a>
+            </div>
         </div>
 
         <?php if ($groups === []): ?>
-            <div class="surface-tertiary text-sm text-slate-400">No doctrine groups yet. Create one, then import an EFT or BuyAll payload.</div>
+            <div class="surface-tertiary text-sm text-slate-400">No doctrine groups yet. Create one, then import Winter Coalition HTML pages or EFT fallback payloads in bulk.</div>
         <?php else: ?>
             <div class="space-y-4">
                 <?php foreach ($groups as $group): ?>

--- a/src/db.php
+++ b/src/db.php
@@ -3546,6 +3546,52 @@ function doctrine_db_ensure_schema(): void
         db()->exec('ALTER TABLE doctrine_fit_items ADD COLUMN is_stock_tracked TINYINT(1) NOT NULL DEFAULT 1 AFTER quantity');
     }
 
+    $fitColumnDefinitions = [
+        'source_type' => "ALTER TABLE doctrine_fits ADD COLUMN source_type ENUM('html', 'eft', 'buyall', 'manual') NOT NULL DEFAULT 'manual' AFTER ship_type_id",
+        'source_reference' => 'ALTER TABLE doctrine_fits ADD COLUMN source_reference VARCHAR(255) DEFAULT NULL AFTER source_format',
+        'notes' => 'ALTER TABLE doctrine_fits ADD COLUMN notes TEXT DEFAULT NULL AFTER source_reference',
+        'raw_html' => 'ALTER TABLE doctrine_fits ADD COLUMN raw_html LONGTEXT DEFAULT NULL AFTER import_body',
+        'raw_buyall' => 'ALTER TABLE doctrine_fits ADD COLUMN raw_buyall LONGTEXT DEFAULT NULL AFTER raw_html',
+        'raw_eft' => 'ALTER TABLE doctrine_fits ADD COLUMN raw_eft LONGTEXT DEFAULT NULL AFTER raw_buyall',
+        'metadata_json' => 'ALTER TABLE doctrine_fits ADD COLUMN metadata_json LONGTEXT DEFAULT NULL AFTER raw_eft',
+        'parse_warnings_json' => 'ALTER TABLE doctrine_fits ADD COLUMN parse_warnings_json LONGTEXT DEFAULT NULL AFTER metadata_json',
+        'parse_status' => "ALTER TABLE doctrine_fits ADD COLUMN parse_status ENUM('ready', 'review') NOT NULL DEFAULT 'ready' AFTER parse_warnings_json",
+        'review_status' => "ALTER TABLE doctrine_fits ADD COLUMN review_status ENUM('clean', 'needs_review', 'reparse_requested') NOT NULL DEFAULT 'clean' AFTER parse_status",
+        'conflict_state' => "ALTER TABLE doctrine_fits ADD COLUMN conflict_state ENUM('none', 'duplicate_name', 'duplicate_items', 'version_conflict', 'source_mismatch') NOT NULL DEFAULT 'none' AFTER review_status",
+        'fingerprint_hash' => 'ALTER TABLE doctrine_fits ADD COLUMN fingerprint_hash CHAR(64) DEFAULT NULL AFTER conflict_state',
+        'warning_count' => 'ALTER TABLE doctrine_fits ADD COLUMN warning_count INT UNSIGNED NOT NULL DEFAULT 0 AFTER fingerprint_hash',
+    ];
+
+    foreach ($fitColumnDefinitions as $column => $sql) {
+        if (db_table_exists('doctrine_fits') && !db_column_exists('doctrine_fits', $column)) {
+            db()->exec($sql);
+        }
+    }
+
+    if (db_table_exists('doctrine_fits') && !db_index_exists('doctrine_fits', 'idx_source_type')) {
+        db()->exec('ALTER TABLE doctrine_fits ADD KEY idx_source_type (source_type)');
+    }
+
+    if (db_table_exists('doctrine_fits') && !db_index_exists('doctrine_fits', 'idx_parse_status')) {
+        db()->exec('ALTER TABLE doctrine_fits ADD KEY idx_parse_status (parse_status, review_status)');
+    }
+
+    if (db_table_exists('doctrine_fits') && !db_index_exists('doctrine_fits', 'idx_conflict_state')) {
+        db()->exec('ALTER TABLE doctrine_fits ADD KEY idx_conflict_state (conflict_state)');
+    }
+
+    if (db_table_exists('doctrine_fits') && !db_index_exists('doctrine_fits', 'idx_fingerprint_hash')) {
+        db()->exec('ALTER TABLE doctrine_fits ADD KEY idx_fingerprint_hash (fingerprint_hash)');
+    }
+
+    if (db_table_exists('doctrine_fit_items') && !db_column_exists('doctrine_fit_items', 'source_role')) {
+        db()->exec("ALTER TABLE doctrine_fit_items ADD COLUMN source_role VARCHAR(80) NOT NULL DEFAULT 'fit' AFTER slot_category");
+    }
+
+    if (db_table_exists('doctrine_fit_items') && !db_index_exists('doctrine_fit_items', 'idx_source_role')) {
+        db()->exec('ALTER TABLE doctrine_fit_items ADD KEY idx_source_role (source_role)');
+    }
+
     $ensured = true;
 }
 
@@ -3723,8 +3769,16 @@ function db_doctrine_fits_all(): array
             df.fit_name,
             df.ship_name,
             df.ship_type_id,
+            df.source_type,
             df.source_format,
+            df.source_reference,
+            df.notes,
             df.import_body,
+            df.parse_status,
+            df.review_status,
+            df.conflict_state,
+            df.fingerprint_hash,
+            df.warning_count,
             df.item_count,
             df.unresolved_count,
             df.created_at,
@@ -3734,7 +3788,7 @@ function db_doctrine_fits_all(): array
          FROM doctrine_fits df
          LEFT JOIN doctrine_fit_groups dfg ON dfg.doctrine_fit_id = df.id
          LEFT JOIN doctrine_groups dg ON dg.id = dfg.doctrine_group_id
-         GROUP BY df.id, df.doctrine_group_id, df.fit_name, df.ship_name, df.ship_type_id, df.source_format, df.import_body, df.item_count, df.unresolved_count, df.created_at, df.updated_at
+         GROUP BY df.id, df.doctrine_group_id, df.fit_name, df.ship_name, df.ship_type_id, df.source_type, df.source_format, df.source_reference, df.notes, df.import_body, df.parse_status, df.review_status, df.conflict_state, df.fingerprint_hash, df.warning_count, df.item_count, df.unresolved_count, df.created_at, df.updated_at
          ORDER BY df.updated_at DESC, df.fit_name ASC'
     );
 }
@@ -3754,8 +3808,16 @@ function db_doctrine_fits_by_group(int $groupId): array
             df.fit_name,
             df.ship_name,
             df.ship_type_id,
+            df.source_type,
             df.source_format,
+            df.source_reference,
+            df.notes,
             df.import_body,
+            df.parse_status,
+            df.review_status,
+            df.conflict_state,
+            df.fingerprint_hash,
+            df.warning_count,
             df.item_count,
             df.unresolved_count,
             df.created_at,
@@ -3766,7 +3828,7 @@ function db_doctrine_fits_by_group(int $groupId): array
          INNER JOIN doctrine_fits df ON df.id = dfg.doctrine_fit_id
          LEFT JOIN doctrine_fit_items dfi ON dfi.doctrine_fit_id = df.id
          WHERE dfg.doctrine_group_id = ?
-         GROUP BY df.id, df.doctrine_group_id, df.fit_name, df.ship_name, df.ship_type_id, df.source_format, df.import_body, df.item_count, df.unresolved_count, df.created_at, df.updated_at
+         GROUP BY df.id, df.doctrine_group_id, df.fit_name, df.ship_name, df.ship_type_id, df.source_type, df.source_format, df.source_reference, df.notes, df.import_body, df.parse_status, df.review_status, df.conflict_state, df.fingerprint_hash, df.warning_count, df.item_count, df.unresolved_count, df.created_at, df.updated_at
          ORDER BY df.updated_at DESC, df.fit_name ASC',
         [$groupId]
     );
@@ -3804,7 +3866,7 @@ function db_doctrine_fit_by_id(int $fitId): ?array
          LEFT JOIN doctrine_fit_groups dfg ON dfg.doctrine_fit_id = df.id
          LEFT JOIN doctrine_groups dg ON dg.id = dfg.doctrine_group_id
          WHERE df.id = ?
-         GROUP BY df.id, df.doctrine_group_id, df.fit_name, df.ship_name, df.ship_type_id, df.source_format, df.import_body, df.item_count, df.unresolved_count, df.created_at, df.updated_at, pg.group_name
+         GROUP BY df.id, df.doctrine_group_id, df.fit_name, df.ship_name, df.ship_type_id, df.source_type, df.source_format, df.source_reference, df.notes, df.import_body, df.raw_html, df.raw_buyall, df.raw_eft, df.metadata_json, df.parse_warnings_json, df.parse_status, df.review_status, df.conflict_state, df.fingerprint_hash, df.warning_count, df.item_count, df.unresolved_count, df.created_at, df.updated_at, pg.group_name
          LIMIT 1',
         [$fitId]
     );
@@ -3824,6 +3886,7 @@ function db_doctrine_fit_items_by_fit(int $fitId): array
             dfi.doctrine_fit_id,
             dfi.line_number,
             dfi.slot_category,
+            dfi.source_role,
             dfi.item_name,
             dfi.type_id,
             dfi.quantity,
@@ -3855,6 +3918,7 @@ function db_doctrine_fit_items_by_fit_ids(array $fitIds): array
             dfi.doctrine_fit_id,
             dfi.line_number,
             dfi.slot_category,
+            dfi.source_role,
             dfi.item_name,
             dfi.type_id,
             dfi.quantity,
@@ -4132,6 +4196,7 @@ function db_doctrine_fit_replace_items(int $fitId, array $items): void
             'doctrine_fit_id' => $fitId,
             'line_number' => (int) ($item['line_number'] ?? 0),
             'slot_category' => (string) ($item['slot_category'] ?? 'Items'),
+            'source_role' => (string) ($item['source_role'] ?? 'fit'),
             'item_name' => (string) ($item['item_name'] ?? ''),
             'type_id' => isset($item['type_id']) ? (int) $item['type_id'] : null,
             'quantity' => max(1, (int) ($item['quantity'] ?? 1)),
@@ -4142,7 +4207,7 @@ function db_doctrine_fit_replace_items(int $fitId, array $items): void
 
     db_bulk_insert_or_upsert(
         'doctrine_fit_items',
-        ['doctrine_fit_id', 'line_number', 'slot_category', 'item_name', 'type_id', 'quantity', 'is_stock_tracked', 'resolution_source'],
+        ['doctrine_fit_id', 'line_number', 'slot_category', 'source_role', 'item_name', 'type_id', 'quantity', 'is_stock_tracked', 'resolution_source'],
         $rows
     );
 }
@@ -4192,18 +4257,44 @@ function db_doctrine_fit_create(array $fit, array $items, array $groupIds = []):
                 fit_name,
                 ship_name,
                 ship_type_id,
+                source_type,
                 source_format,
+                source_reference,
+                notes,
                 import_body,
+                raw_html,
+                raw_buyall,
+                raw_eft,
+                metadata_json,
+                parse_warnings_json,
+                parse_status,
+                review_status,
+                conflict_state,
+                fingerprint_hash,
+                warning_count,
                 item_count,
                 unresolved_count
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $groupIds[0] ?? (isset($fit['doctrine_group_id']) ? (int) $fit['doctrine_group_id'] : null),
                 (string) ($fit['fit_name'] ?? ''),
                 (string) ($fit['ship_name'] ?? ''),
                 isset($fit['ship_type_id']) ? (int) $fit['ship_type_id'] : null,
+                (string) ($fit['source_type'] ?? 'manual'),
                 (string) ($fit['source_format'] ?? 'buyall'),
+                ($fit['source_reference'] ?? null) !== null ? (string) $fit['source_reference'] : null,
+                ($fit['notes'] ?? null) !== null ? (string) $fit['notes'] : null,
                 (string) ($fit['import_body'] ?? ''),
+                ($fit['raw_html'] ?? null) !== null ? (string) $fit['raw_html'] : null,
+                ($fit['raw_buyall'] ?? null) !== null ? (string) $fit['raw_buyall'] : null,
+                ($fit['raw_eft'] ?? null) !== null ? (string) $fit['raw_eft'] : null,
+                ($fit['metadata_json'] ?? null) !== null ? (string) $fit['metadata_json'] : null,
+                ($fit['parse_warnings_json'] ?? null) !== null ? (string) $fit['parse_warnings_json'] : null,
+                (string) ($fit['parse_status'] ?? 'ready'),
+                (string) ($fit['review_status'] ?? 'clean'),
+                (string) ($fit['conflict_state'] ?? 'none'),
+                ($fit['fingerprint_hash'] ?? null) !== null ? (string) $fit['fingerprint_hash'] : null,
+                max(0, (int) ($fit['warning_count'] ?? 0)),
                 (int) ($fit['item_count'] ?? 0),
                 (int) ($fit['unresolved_count'] ?? 0),
             ]
@@ -4229,15 +4320,28 @@ function db_doctrine_fit_update(int $fitId, array $fit, array $items, array $gro
         $groupIds = array_values(array_unique(array_filter(array_map('intval', $groupIds), static fn (int $id): bool => $id > 0)));
         db_execute(
             'UPDATE doctrine_fits
-             SET doctrine_group_id = ?, fit_name = ?, ship_name = ?, ship_type_id = ?, source_format = ?, import_body = ?, item_count = ?, unresolved_count = ?, updated_at = CURRENT_TIMESTAMP
+             SET doctrine_group_id = ?, fit_name = ?, ship_name = ?, ship_type_id = ?, source_type = ?, source_format = ?, source_reference = ?, notes = ?, import_body = ?, raw_html = ?, raw_buyall = ?, raw_eft = ?, metadata_json = ?, parse_warnings_json = ?, parse_status = ?, review_status = ?, conflict_state = ?, fingerprint_hash = ?, warning_count = ?, item_count = ?, unresolved_count = ?, updated_at = CURRENT_TIMESTAMP
              WHERE id = ? LIMIT 1',
             [
                 $groupIds[0] ?? null,
                 (string) ($fit['fit_name'] ?? ''),
                 (string) ($fit['ship_name'] ?? ''),
                 isset($fit['ship_type_id']) ? (int) $fit['ship_type_id'] : null,
+                (string) ($fit['source_type'] ?? 'manual'),
                 (string) ($fit['source_format'] ?? 'buyall'),
+                ($fit['source_reference'] ?? null) !== null ? (string) $fit['source_reference'] : null,
+                ($fit['notes'] ?? null) !== null ? (string) $fit['notes'] : null,
                 (string) ($fit['import_body'] ?? ''),
+                ($fit['raw_html'] ?? null) !== null ? (string) $fit['raw_html'] : null,
+                ($fit['raw_buyall'] ?? null) !== null ? (string) $fit['raw_buyall'] : null,
+                ($fit['raw_eft'] ?? null) !== null ? (string) $fit['raw_eft'] : null,
+                ($fit['metadata_json'] ?? null) !== null ? (string) $fit['metadata_json'] : null,
+                ($fit['parse_warnings_json'] ?? null) !== null ? (string) $fit['parse_warnings_json'] : null,
+                (string) ($fit['parse_status'] ?? 'ready'),
+                (string) ($fit['review_status'] ?? 'clean'),
+                (string) ($fit['conflict_state'] ?? 'none'),
+                ($fit['fingerprint_hash'] ?? null) !== null ? (string) $fit['fingerprint_hash'] : null,
+                max(0, (int) ($fit['warning_count'] ?? 0)),
                 (int) ($fit['item_count'] ?? 0),
                 (int) ($fit['unresolved_count'] ?? 0),
                 $fitId,
@@ -4265,6 +4369,328 @@ function db_doctrine_fit_delete(int $fitId): bool
 
         return db_execute('DELETE FROM doctrine_fits WHERE id = ? LIMIT 1', [$fitId]);
     });
+}
+
+function db_doctrine_fit_conflicts(string $fitName, ?int $shipTypeId = null, string $shipName = '', ?string $fingerprintHash = null, int $excludeFitId = 0): array
+{
+    doctrine_db_ensure_schema();
+
+    $conditions = ['df.id <> ?'];
+    $params = [$excludeFitId];
+
+    $name = trim($fitName);
+    $shipName = trim($shipName);
+    $fingerprintHash = trim((string) $fingerprintHash);
+
+    $conflictParts = [];
+    if ($name !== '' && ($shipTypeId ?? 0) > 0) {
+        $conflictParts[] = '(df.fit_name = ? AND df.ship_type_id = ?)';
+        $params[] = $name;
+        $params[] = $shipTypeId;
+    } elseif ($name !== '' && $shipName !== '') {
+        $conflictParts[] = '(df.fit_name = ? AND df.ship_name = ?)';
+        $params[] = $name;
+        $params[] = $shipName;
+    }
+
+    if ($fingerprintHash !== '') {
+        if (($shipTypeId ?? 0) > 0) {
+            $conflictParts[] = '(df.fingerprint_hash = ? AND df.ship_type_id = ?)';
+            $params[] = $fingerprintHash;
+            $params[] = $shipTypeId;
+        } elseif ($shipName !== '') {
+            $conflictParts[] = '(df.fingerprint_hash = ? AND df.ship_name = ?)';
+            $params[] = $fingerprintHash;
+            $params[] = $shipName;
+        } else {
+            $conflictParts[] = 'df.fingerprint_hash = ?';
+            $params[] = $fingerprintHash;
+        }
+    }
+
+    if ($conflictParts === []) {
+        return [];
+    }
+
+    $conditions[] = '(' . implode(' OR ', $conflictParts) . ')';
+
+    return db_select(
+        'SELECT
+            df.id,
+            df.fit_name,
+            df.ship_name,
+            df.ship_type_id,
+            df.source_type,
+            df.source_format,
+            df.source_reference,
+            df.parse_status,
+            df.review_status,
+            df.conflict_state,
+            df.fingerprint_hash,
+            df.updated_at,
+            GROUP_CONCAT(DISTINCT dg.group_name ORDER BY dg.group_name SEPARATOR "||") AS group_names_csv
+         FROM doctrine_fits df
+         LEFT JOIN doctrine_fit_groups dfg ON dfg.doctrine_fit_id = df.id
+         LEFT JOIN doctrine_groups dg ON dg.id = dfg.doctrine_group_id
+         WHERE ' . implode(' AND ', $conditions) . '
+         GROUP BY df.id, df.fit_name, df.ship_name, df.ship_type_id, df.source_type, df.source_format, df.source_reference, df.parse_status, df.review_status, df.conflict_state, df.fingerprint_hash, df.updated_at
+         ORDER BY df.updated_at DESC, df.id DESC',
+        $params
+    );
+}
+
+function db_doctrine_fit_overview(array $filters = [], string $sort = 'updated_desc'): array
+{
+    doctrine_db_ensure_schema();
+
+    $joins = [
+        'LEFT JOIN doctrine_fit_groups dfg ON dfg.doctrine_fit_id = df.id',
+        'LEFT JOIN doctrine_groups dg ON dg.id = dfg.doctrine_group_id',
+        'LEFT JOIN doctrine_fit_items dfi ON dfi.doctrine_fit_id = df.id',
+    ];
+    $where = ['1 = 1'];
+    $params = [];
+
+    $search = trim((string) ($filters['search'] ?? ''));
+    if ($search !== '') {
+        $where[] = '(df.fit_name LIKE ? OR df.ship_name LIKE ? OR df.notes LIKE ? OR df.source_reference LIKE ?)';
+        $like = '%' . $search . '%';
+        array_push($params, $like, $like, $like, $like);
+    }
+
+    $groupId = (int) ($filters['group_id'] ?? 0);
+    if ($groupId > 0) {
+        $where[] = 'EXISTS (SELECT 1 FROM doctrine_fit_groups x WHERE x.doctrine_fit_id = df.id AND x.doctrine_group_id = ?)';
+        $params[] = $groupId;
+    }
+
+    $sourceType = trim((string) ($filters['source_type'] ?? ''));
+    if ($sourceType !== '') {
+        $where[] = 'df.source_type = ?';
+        $params[] = $sourceType;
+    }
+
+    $parseStatus = trim((string) ($filters['parse_status'] ?? ''));
+    if ($parseStatus !== '') {
+        $where[] = 'df.parse_status = ?';
+        $params[] = $parseStatus;
+    }
+
+    $reviewStatus = trim((string) ($filters['review_status'] ?? ''));
+    if ($reviewStatus !== '') {
+        $where[] = 'df.review_status = ?';
+        $params[] = $reviewStatus;
+    }
+
+    $conflictState = trim((string) ($filters['conflict_state'] ?? ''));
+    if ($conflictState !== '') {
+        if ($conflictState === 'has_conflict') {
+            $where[] = "df.conflict_state <> 'none'";
+        } else {
+            $where[] = 'df.conflict_state = ?';
+            $params[] = $conflictState;
+        }
+    }
+
+    if (!empty($filters['unresolved_only'])) {
+        $where[] = 'df.unresolved_count > 0';
+    }
+
+    $hullSearch = trim((string) ($filters['hull'] ?? ''));
+    if ($hullSearch !== '') {
+        $where[] = 'df.ship_name LIKE ?';
+        $params[] = '%' . $hullSearch . '%';
+    }
+
+    $sortSql = match ($sort) {
+        'fit_name_asc' => 'df.fit_name ASC, df.updated_at DESC',
+        'fit_name_desc' => 'df.fit_name DESC, df.updated_at DESC',
+        'hull_asc' => 'df.ship_name ASC, df.fit_name ASC',
+        'groups_desc' => 'group_count DESC, df.updated_at DESC',
+        'items_desc' => 'df.item_count DESC, df.updated_at DESC',
+        'warnings_desc' => 'df.warning_count DESC, df.unresolved_count DESC, df.updated_at DESC',
+        'status_asc' => 'df.parse_status ASC, df.review_status ASC, df.updated_at DESC',
+        default => 'df.updated_at DESC, df.fit_name ASC',
+    };
+
+    return db_select(
+        'SELECT
+            df.id,
+            df.doctrine_group_id,
+            df.fit_name,
+            df.ship_name,
+            df.ship_type_id,
+            df.source_type,
+            df.source_format,
+            df.source_reference,
+            df.notes,
+            df.parse_status,
+            df.review_status,
+            df.conflict_state,
+            df.fingerprint_hash,
+            df.warning_count,
+            df.item_count,
+            df.unresolved_count,
+            df.created_at,
+            df.updated_at,
+            COUNT(DISTINCT dfg.doctrine_group_id) AS group_count,
+            COUNT(DISTINCT dfi.id) AS normalized_item_rows,
+            GROUP_CONCAT(DISTINCT dg.group_name ORDER BY dg.group_name SEPARATOR "||") AS group_names_csv
+         FROM doctrine_fits df
+         ' . implode(' ', $joins) . '
+         WHERE ' . implode(' AND ', $where) . '
+         GROUP BY df.id, df.doctrine_group_id, df.fit_name, df.ship_name, df.ship_type_id, df.source_type, df.source_format, df.source_reference, df.notes, df.parse_status, df.review_status, df.conflict_state, df.fingerprint_hash, df.warning_count, df.item_count, df.unresolved_count, df.created_at, df.updated_at
+         ORDER BY ' . $sortSql
+        ,
+        $params
+    );
+}
+
+function db_doctrine_fit_bulk_delete(array $fitIds): int
+{
+    doctrine_db_ensure_schema();
+
+    $fitIds = array_values(array_unique(array_filter(array_map('intval', $fitIds), static fn (int $id): bool => $id > 0)));
+    if ($fitIds === []) {
+        return 0;
+    }
+
+    return db_transaction(static function () use ($fitIds): int {
+        $placeholders = implode(', ', array_fill(0, count($fitIds), '?'));
+        db_execute("DELETE FROM doctrine_fit_groups WHERE doctrine_fit_id IN ({$placeholders})", $fitIds);
+        db_execute("DELETE FROM doctrine_fit_items WHERE doctrine_fit_id IN ({$placeholders})", $fitIds);
+        db_execute("DELETE FROM doctrine_fits WHERE id IN ({$placeholders})", $fitIds);
+
+        return count($fitIds);
+    });
+}
+
+function db_doctrine_fit_bulk_assign_groups(array $fitIds, array $groupIds, bool $replaceExisting = false): int
+{
+    doctrine_db_ensure_schema();
+
+    $fitIds = array_values(array_unique(array_filter(array_map('intval', $fitIds), static fn (int $id): bool => $id > 0)));
+    $groupIds = array_values(array_unique(array_filter(array_map('intval', $groupIds), static fn (int $id): bool => $id > 0)));
+
+    if ($fitIds === [] || $groupIds === []) {
+        return 0;
+    }
+
+    return db_transaction(static function () use ($fitIds, $groupIds, $replaceExisting): int {
+        $fitPlaceholders = implode(', ', array_fill(0, count($fitIds), '?'));
+
+        if ($replaceExisting) {
+            db_execute("DELETE FROM doctrine_fit_groups WHERE doctrine_fit_id IN ({$fitPlaceholders})", $fitIds);
+        }
+
+        $rows = [];
+        foreach ($fitIds as $fitId) {
+            foreach ($groupIds as $groupId) {
+                $rows[] = ['doctrine_fit_id' => $fitId, 'doctrine_group_id' => $groupId];
+            }
+        }
+
+        db_bulk_insert_or_upsert('doctrine_fit_groups', ['doctrine_fit_id', 'doctrine_group_id'], $rows);
+
+        $memberships = db_select(
+            "SELECT doctrine_fit_id, MIN(doctrine_group_id) AS primary_group_id
+             FROM doctrine_fit_groups
+             WHERE doctrine_fit_id IN ({$fitPlaceholders})
+             GROUP BY doctrine_fit_id",
+            $fitIds
+        );
+
+        foreach ($memberships as $row) {
+            db_execute(
+                'UPDATE doctrine_fits SET doctrine_group_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? LIMIT 1',
+                [(int) ($row['primary_group_id'] ?? 0), (int) ($row['doctrine_fit_id'] ?? 0)]
+            );
+        }
+
+        return count($fitIds);
+    });
+}
+
+function db_doctrine_fit_bulk_remove_groups(array $fitIds, array $groupIds): int
+{
+    doctrine_db_ensure_schema();
+
+    $fitIds = array_values(array_unique(array_filter(array_map('intval', $fitIds), static fn (int $id): bool => $id > 0)));
+    $groupIds = array_values(array_unique(array_filter(array_map('intval', $groupIds), static fn (int $id): bool => $id > 0)));
+
+    if ($fitIds === [] || $groupIds === []) {
+        return 0;
+    }
+
+    return db_transaction(static function () use ($fitIds, $groupIds): int {
+        $fitPlaceholders = implode(', ', array_fill(0, count($fitIds), '?'));
+        $groupPlaceholders = implode(', ', array_fill(0, count($groupIds), '?'));
+        $params = array_merge($fitIds, $groupIds);
+
+        db_execute(
+            "DELETE FROM doctrine_fit_groups
+             WHERE doctrine_fit_id IN ({$fitPlaceholders})
+               AND doctrine_group_id IN ({$groupPlaceholders})",
+            $params
+        );
+
+        $memberships = db_select(
+            "SELECT doctrine_fit_id, MIN(doctrine_group_id) AS primary_group_id
+             FROM doctrine_fit_groups
+             WHERE doctrine_fit_id IN ({$fitPlaceholders})
+             GROUP BY doctrine_fit_id",
+            $fitIds
+        );
+        $primaryByFit = [];
+        foreach ($memberships as $row) {
+            $primaryByFit[(int) ($row['doctrine_fit_id'] ?? 0)] = (int) ($row['primary_group_id'] ?? 0);
+        }
+
+        foreach ($fitIds as $fitId) {
+            db_execute(
+                'UPDATE doctrine_fits SET doctrine_group_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? LIMIT 1',
+                [($primaryByFit[$fitId] ?? 0) > 0 ? $primaryByFit[$fitId] : null, $fitId]
+            );
+        }
+
+        return count($fitIds);
+    });
+}
+
+function db_doctrine_fit_bulk_update_metadata(array $fitIds, array $changes): int
+{
+    doctrine_db_ensure_schema();
+
+    $fitIds = array_values(array_unique(array_filter(array_map('intval', $fitIds), static fn (int $id): bool => $id > 0)));
+    if ($fitIds === []) {
+        return 0;
+    }
+
+    $sets = [];
+    $params = [];
+
+    foreach (['notes', 'parse_status', 'review_status', 'conflict_state', 'source_reference'] as $column) {
+        if (!array_key_exists($column, $changes)) {
+            continue;
+        }
+
+        $sets[] = $column . ' = ?';
+        $params[] = $changes[$column];
+    }
+
+    if ($sets === []) {
+        return 0;
+    }
+
+    $placeholders = implode(', ', array_fill(0, count($fitIds), '?'));
+    $params = array_merge($params, $fitIds);
+
+    db_execute(
+        'UPDATE doctrine_fits SET ' . implode(', ', $sets) . ', updated_at = CURRENT_TIMESTAMP WHERE id IN (' . $placeholders . ')',
+        $params
+    );
+
+    return count($fitIds);
 }
 
 function db_doctrine_group_suggestions_for_fit(string $fitName, ?int $shipTypeId = null, int $excludeFitId = 0): array

--- a/src/functions.php
+++ b/src/functions.php
@@ -113,7 +113,8 @@ function nav_items(): array
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 5h14v14H5z"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 9h6M9 13h6M9 17h4"/></svg>',
             'children' => [
                 ['label' => 'Doctrine Groups', 'path' => '/doctrine'],
-                ['label' => 'Import Fit', 'path' => '/doctrine/import'],
+                ['label' => 'Fit Overview', 'path' => '/doctrine/fits'],
+                ['label' => 'Bulk Import', 'path' => '/doctrine/import'],
             ],
         ],
         [
@@ -10325,6 +10326,408 @@ function doctrine_detect_format(string $text): string
     return 'buyall';
 }
 
+function doctrine_normalize_label(string $value): string
+{
+    $clean = preg_replace('/\s+/', ' ', trim($value));
+
+    return mb_strtolower((string) $clean);
+}
+
+function doctrine_html_xpath(string $html): ?DOMXPath
+{
+    if (trim($html) === '' || !class_exists(DOMDocument::class)) {
+        return null;
+    }
+
+    $internalErrors = libxml_use_internal_errors(true);
+    $document = new DOMDocument();
+    $loaded = $document->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_NOERROR | LIBXML_NOWARNING | LIBXML_NONET);
+    libxml_clear_errors();
+    libxml_use_internal_errors($internalErrors);
+
+    if ($loaded !== true) {
+        return null;
+    }
+
+    return new DOMXPath($document);
+}
+
+function doctrine_html_text(?DOMNode $node): string
+{
+    if (!$node instanceof DOMNode) {
+        return '';
+    }
+
+    return trim(preg_replace('/\s+/', ' ', (string) $node->textContent) ?? '');
+}
+
+function doctrine_html_collect_texts(DOMXPath $xpath, array $queries, int $maxLength = 1000, ?DOMNode $contextNode = null): array
+{
+    $texts = [];
+
+    foreach ($queries as $query) {
+        $nodes = @$xpath->query($query, $contextNode);
+        if (!$nodes instanceof DOMNodeList) {
+            continue;
+        }
+
+        foreach ($nodes as $node) {
+            $text = doctrine_html_text($node);
+            if ($text === '') {
+                continue;
+            }
+
+            $key = doctrine_normalize_label($text);
+            if ($key === '') {
+                continue;
+            }
+
+            $texts[$key] = mb_substr($text, 0, $maxLength);
+        }
+    }
+
+    return array_values($texts);
+}
+
+function doctrine_html_first_text(DOMXPath $xpath, array $queries, ?DOMNode $contextNode = null): ?string
+{
+    foreach (doctrine_html_collect_texts($xpath, $queries, 1000, $contextNode) as $text) {
+        if ($text !== '') {
+            return $text;
+        }
+    }
+
+    return null;
+}
+
+function doctrine_html_attr_candidates(DOMXPath $xpath, array $attributeNames): array
+{
+    $values = [];
+
+    foreach ($attributeNames as $attributeName) {
+        $nodes = @$xpath->query('//*[@' . $attributeName . ']');
+        if (!$nodes instanceof DOMNodeList) {
+            continue;
+        }
+
+        foreach ($nodes as $node) {
+            if (!$node instanceof DOMElement) {
+                continue;
+            }
+
+            $value = trim($node->getAttribute($attributeName));
+            if ($value === '') {
+                continue;
+            }
+
+            $values[] = $value;
+        }
+    }
+
+    return $values;
+}
+
+function doctrine_extract_buyall_payload_from_html(string $html, ?DOMXPath $xpath = null): ?string
+{
+    $candidates = [];
+    $xpath ??= doctrine_html_xpath($html);
+
+    if ($xpath instanceof DOMXPath) {
+        foreach (['data-clipboard-text', 'data-clipboard', 'data-copy', 'data-fit-buyall', 'data-buyall', 'data-raw-buyall'] as $attr) {
+            foreach (doctrine_html_attr_candidates($xpath, [$attr]) as $value) {
+                $candidates[] = html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+            }
+        }
+
+        foreach (doctrine_html_collect_texts($xpath, [
+            '//textarea[contains(@name, "buy") or contains(@id, "buy") or contains(@class, "buy")]',
+            '//pre[contains(@class, "buy") or contains(@id, "buy")]',
+            '//code[contains(@class, "buy") or contains(@id, "buy")]',
+        ], 20000) as $value) {
+            $candidates[] = html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+        }
+    }
+
+    if (preg_match_all('/(?:clipboard|buyall|copy)[^>="\']{0,80}(?:text|payload|value)?[^"\']*["\']([^"\']*(?:\r?\n)[^"\']*)["\']/i', $html, $matches) === 1 || !empty($matches[1])) {
+        foreach ((array) ($matches[1] ?? []) as $value) {
+            $candidates[] = html_entity_decode((string) $value, ENT_QUOTES | ENT_HTML5);
+        }
+    }
+
+    foreach ($candidates as $candidate) {
+        $candidate = trim(str_replace(["\r\n", "\r"], "\n", (string) $candidate));
+        if ($candidate === '' || substr_count($candidate, "\n") < 1) {
+            continue;
+        }
+
+        $lines = array_values(array_filter(array_map('trim', explode("\n", $candidate)), static fn (string $line): bool => $line !== ''));
+        if ($lines === []) {
+            continue;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    return null;
+}
+
+function doctrine_extract_eft_payload_from_html(string $html, ?DOMXPath $xpath = null): ?string
+{
+    $xpath ??= doctrine_html_xpath($html);
+    $candidates = [];
+
+    if ($xpath instanceof DOMXPath) {
+        foreach (['data-eft', 'data-clipboard-eft', 'data-raw-eft'] as $attr) {
+            foreach (doctrine_html_attr_candidates($xpath, [$attr]) as $value) {
+                $candidates[] = html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+            }
+        }
+
+        foreach (doctrine_html_collect_texts($xpath, [
+            '//textarea[contains(@name, "eft") or contains(@id, "eft") or contains(@class, "eft")]',
+            '//pre[contains(@class, "eft") or contains(@id, "eft")]',
+            '//code[contains(@class, "eft") or contains(@id, "eft")]',
+        ], 20000) as $value) {
+            $candidates[] = html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+        }
+    }
+
+    if (preg_match_all('/\[[^\],]+\s*,\s*[^\]]+\](?:\R.+)+/m', html_entity_decode($html, ENT_QUOTES | ENT_HTML5), $matches) === 1 || !empty($matches[0])) {
+        foreach ((array) ($matches[0] ?? []) as $value) {
+            $candidates[] = trim((string) $value);
+        }
+    }
+
+    foreach ($candidates as $candidate) {
+        $candidate = trim(str_replace(["\r\n", "\r"], "\n", (string) $candidate));
+        if ($candidate !== '' && preg_match('/^\[[^\],]+\s*,\s*[^\]]+\]/', $candidate) === 1) {
+            return $candidate;
+        }
+    }
+
+    return null;
+}
+
+function doctrine_extract_html_group_labels(DOMXPath $xpath): array
+{
+    $labels = doctrine_html_collect_texts($xpath, [
+        '//*[contains(@class, "breadcrumb")]//a',
+        '//*[contains(@class, "group")]//a',
+        '//*[contains(@class, "group")][self::a or self::span or self::div]',
+        '//*[contains(@class, "group")]//*[self::a or self::span]',
+        '//*[contains(@class, "tag")][self::a or self::span or self::div]',
+        '//*[contains(@class, "tag")]//*[self::a or self::span]',
+        '//*[contains(@class, "chip")][self::a or self::span or self::div]',
+        '//*[contains(@class, "chip")]//*[self::a or self::span]',
+        '//*[contains(@class, "badge")][self::a or self::span or self::div]',
+        '//*[contains(@class, "badge")]//*[self::a or self::span]',
+        '//a[contains(@href, "doctrine") or contains(@href, "group")]',
+    ], 190);
+
+    $ignored = [
+        'buy all', 'copy buy all', 'copy eft', 'copy fit', 'back', 'doctrine fits',
+        'fit', 'fitting', 'eft', 'copy', 'clipboard',
+    ];
+
+    return array_values(array_filter($labels, static function (string $label) use ($ignored): bool {
+        $normalized = doctrine_normalize_label($label);
+        if ($normalized === '' || in_array($normalized, $ignored, true)) {
+            return false;
+        }
+
+        return mb_strlen($label) >= 3 && mb_strlen($label) <= 190;
+    }));
+}
+
+function doctrine_extract_html_notes(DOMXPath $xpath): ?string
+{
+    $notes = doctrine_html_collect_texts($xpath, [
+        '//*[contains(@class, "note") or contains(@class, "help") or contains(@class, "comment")]',
+        '//*[contains(@data-role, "note") or contains(@data-role, "comment")]',
+        '//section[contains(@class, "note")]//p',
+        '//article[contains(@class, "note")]//p',
+    ], 5000);
+
+    if ($notes === []) {
+        return null;
+    }
+
+    return trim(implode("\n\n", array_slice($notes, 0, 6)));
+}
+
+function doctrine_extract_html_visible_items(DOMXPath $xpath): array
+{
+    $items = [];
+    $groupQueries = [
+        '//*[contains(@class, "slot") and (self::section or self::div)]',
+        '//*[contains(@class, "fit-items") and (self::section or self::div)]/*',
+        '//*[contains(@class, "module-group")]',
+    ];
+
+    foreach ($groupQueries as $query) {
+        $groups = @$xpath->query($query);
+        if (!$groups instanceof DOMNodeList) {
+            continue;
+        }
+
+        foreach ($groups as $groupNode) {
+            $category = doctrine_html_first_text($xpath, [
+                './/h2', './/h3', './/h4', './/*[@data-slot-group]', './/*[contains(@class, "title")]',
+            ], $groupNode);
+            $category = $category !== null ? mb_substr($category, 0, 80) : 'Items';
+
+            $itemNodes = @$xpath->query('.//li|.//tr|.//*[contains(@class, "item")]', $groupNode);
+            if (!$itemNodes instanceof DOMNodeList) {
+                continue;
+            }
+
+            foreach ($itemNodes as $itemNode) {
+                $text = doctrine_html_text($itemNode);
+                if ($text === '' || mb_strlen($text) > 255) {
+                    continue;
+                }
+
+                $parsed = doctrine_parse_quantity_and_name($text);
+                $itemName = trim((string) ($parsed['item_name'] ?? ''));
+                if ($itemName === '') {
+                    continue;
+                }
+
+                $items[] = [
+                    'line_number' => count($items) + 1,
+                    'slot_category' => $category,
+                    'source_role' => doctrine_source_role_from_category($category),
+                    'item_name' => $itemName,
+                    'quantity' => max(1, (int) ($parsed['quantity'] ?? 1)),
+                ];
+            }
+        }
+
+        if ($items !== []) {
+            break;
+        }
+    }
+
+    return $items;
+}
+
+function doctrine_source_role_from_category(string $category): string
+{
+    $normalized = doctrine_normalize_label($category);
+
+    return match (true) {
+        str_contains($normalized, 'drone') => 'drone',
+        str_contains($normalized, 'cargo') || str_contains($normalized, 'ammo') => 'cargo',
+        str_contains($normalized, 'implant') => 'implant',
+        str_contains($normalized, 'booster') => 'booster',
+        str_contains($normalized, 'subsystem') => 'subsystem',
+        str_contains($normalized, 'service') => 'service',
+        str_contains($normalized, 'hull') => 'hull',
+        default => 'fit',
+    };
+}
+
+function doctrine_parse_html_fit_page(string $html, string $sourceReference = ''): array
+{
+    $xpath = doctrine_html_xpath($html);
+    if (!$xpath instanceof DOMXPath) {
+        throw new RuntimeException('Uploaded HTML could not be parsed.');
+    }
+
+    $fitTitle = doctrine_html_first_text($xpath, [
+        '//main//h1',
+        '//header//h1',
+        '//*[@data-fit-title]',
+        '//*[contains(@class, "fit-title")]',
+        '//title',
+    ]) ?? '';
+
+    $buyAllPayload = doctrine_extract_buyall_payload_from_html($html, $xpath);
+    $eftPayload = doctrine_extract_eft_payload_from_html($html, $xpath);
+    $groupLabels = doctrine_extract_html_group_labels($xpath);
+    $notes = doctrine_extract_html_notes($xpath);
+    $visibleItems = doctrine_extract_html_visible_items($xpath);
+
+    $buyAllParsed = null;
+    $eftParsed = null;
+    $warnings = [];
+
+    if ($buyAllPayload !== null) {
+        try {
+            $buyAllParsed = doctrine_parse_buyall($buyAllPayload);
+        } catch (Throwable $exception) {
+            $warnings[] = 'Buy All payload could not be parsed: ' . $exception->getMessage();
+        }
+    }
+
+    if ($eftPayload !== null) {
+        try {
+            $eftParsed = doctrine_parse_eft($eftPayload);
+        } catch (Throwable $exception) {
+            $warnings[] = 'Embedded EFT payload could not be parsed: ' . $exception->getMessage();
+        }
+    }
+
+    $candidateHulls = array_values(array_unique(array_filter([
+        trim((string) ($buyAllParsed['ship_name'] ?? '')),
+        trim((string) ($eftParsed['ship_name'] ?? '')),
+        doctrine_html_first_text($xpath, [
+            '//*[contains(@class, "ship")]//*[self::h1 or self::h2 or self::h3 or self::span]',
+            '//*[@data-ship-name]',
+            '//*[contains(@class, "hull")]//*[self::span or self::h2 or self::h3]',
+        ]) ?? '',
+    ])));
+
+    $shipName = $candidateHulls[0] ?? '';
+    if (count(array_map('doctrine_normalize_label', $candidateHulls)) > 1) {
+        $normalizedHulls = array_values(array_unique(array_map('doctrine_normalize_label', $candidateHulls)));
+        if (count($normalizedHulls) > 1) {
+            $warnings[] = 'HTML and fallback sources disagree on hull name.';
+        }
+    }
+
+    $fitName = trim((string) $fitTitle);
+    if ($fitName === '') {
+        $fitName = trim((string) ($eftParsed['fit_name'] ?? ''));
+    }
+    if ($fitName === '' && $buyAllParsed !== null) {
+        $fitName = trim((string) ($buyAllParsed['fit_name'] ?? ''));
+    }
+
+    if ($fitName === '') {
+        $fitName = pathinfo($sourceReference !== '' ? $sourceReference : 'Imported HTML Fit', PATHINFO_FILENAME);
+    }
+
+    $sourceFormat = $buyAllParsed !== null ? 'buyall' : ($eftParsed !== null ? 'eft' : 'buyall');
+    $items = $buyAllParsed['items'] ?? ($eftParsed['items'] ?? $visibleItems);
+
+    if ($buyAllParsed === null && $eftParsed === null && $visibleItems === []) {
+        $warnings[] = 'No Buy All payload, embedded EFT, or visible item list was detected.';
+    }
+
+    return [
+        'format' => $sourceFormat,
+        'source_type' => 'html',
+        'source_reference' => $sourceReference,
+        'fit_name' => trim($fitName),
+        'ship_name' => trim($shipName),
+        'items' => is_array($items) ? $items : [],
+        'notes' => $notes,
+        'raw_html' => $html,
+        'raw_buyall' => $buyAllPayload,
+        'raw_eft' => $eftPayload,
+        'group_labels' => $groupLabels,
+        'visible_items' => $visibleItems,
+        'warnings' => array_values(array_unique(array_filter($warnings))),
+        'metadata' => [
+            'fit_title' => $fitTitle,
+            'candidate_hulls' => $candidateHulls,
+            'group_labels' => $groupLabels,
+            'visible_items' => $visibleItems,
+        ],
+    ];
+}
+
 function doctrine_parse_quantity_and_name(string $line): array
 {
     $trimmed = preg_replace('/\s+/', ' ', trim($line));
@@ -10425,6 +10828,7 @@ function doctrine_parse_eft(string $text): array
         $items[] = [
             'line_number' => count($items) + 1,
             'slot_category' => doctrine_eft_category_label($blockIndex, $itemName),
+            'source_role' => doctrine_source_role_from_category(doctrine_eft_category_label($blockIndex, $itemName)),
             'item_name' => $itemName,
             'quantity' => max(1, (int) ($parsed['quantity'] ?? 1)),
         ];
@@ -10463,6 +10867,7 @@ function doctrine_parse_buyall(string $text): array
         $items[] = [
             'line_number' => count($items) + 1,
             'slot_category' => $index === 0 ? 'Hull' : 'Items',
+            'source_role' => $index === 0 ? 'hull' : 'fit',
             'item_name' => $itemName,
             'quantity' => max(1, (int) ($parsed['quantity'] ?? 1)),
         ];
@@ -10774,24 +11179,52 @@ function doctrine_resolve_parsed_fit(array $parsed, string $rawText): array
     }
 
     $shipMissing = (int) ($shipResolved['type_id'] ?? 0) <= 0;
+    $warnings = array_values(array_unique(array_filter(array_map(
+        static fn (mixed $warning): string => trim((string) $warning),
+        (array) ($parsed['warnings'] ?? [])
+    ))));
     $unresolved = array_values(array_unique(array_filter(array_merge(
         $shipMissing ? [trim((string) ($shipResolved['item_name'] ?? $parsed['ship_name'] ?? 'Unknown Hull'))] : [],
         $unresolvedItems
     ))));
+    $status = doctrine_fit_status_from_warnings($warnings, $unresolved, (string) ($parsed['conflict_state'] ?? 'none'));
+    $metadata = (array) ($parsed['metadata'] ?? []);
+    $metadata['group_labels'] = array_values(array_unique(array_filter(array_map(
+        static fn (mixed $value): string => trim((string) $value),
+        (array) ($parsed['group_labels'] ?? [])
+    ))));
+    $metadata['source_reference'] = (string) ($parsed['source_reference'] ?? '');
+    $metadata['detected_source_type'] = (string) ($parsed['source_type'] ?? 'manual');
+    $fingerprintHash = doctrine_fit_item_fingerprint($resolvedItems);
 
     return [
         'fit' => [
             'fit_name' => mb_substr($fitName, 0, 190),
             'ship_name' => trim((string) ($shipResolved['item_name'] ?? $parsed['ship_name'] ?? 'Unknown Hull')),
             'ship_type_id' => isset($shipResolved['type_id']) && $shipResolved['type_id'] !== null ? (int) $shipResolved['type_id'] : null,
+            'source_type' => (string) ($parsed['source_type'] ?? 'manual'),
             'source_format' => (string) ($parsed['format'] ?? doctrine_detect_format($rawText)),
+            'source_reference' => ($parsed['source_reference'] ?? null) !== null ? mb_substr(trim((string) $parsed['source_reference']), 0, 255) : null,
+            'notes' => ($parsed['notes'] ?? null) !== null ? trim((string) $parsed['notes']) : null,
             'import_body' => $rawText,
+            'raw_html' => ($parsed['raw_html'] ?? null) !== null ? (string) $parsed['raw_html'] : null,
+            'raw_buyall' => ($parsed['raw_buyall'] ?? null) !== null ? (string) $parsed['raw_buyall'] : null,
+            'raw_eft' => ($parsed['raw_eft'] ?? null) !== null ? (string) $parsed['raw_eft'] : null,
+            'metadata_json' => json_encode($metadata, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+            'parse_warnings_json' => json_encode($warnings, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+            'parse_status' => $status['parse_status'],
+            'review_status' => $status['review_status'],
+            'conflict_state' => (string) ($parsed['conflict_state'] ?? 'none'),
+            'fingerprint_hash' => $fingerprintHash,
+            'warning_count' => $status['warning_count'],
             'item_count' => count($resolvedItems),
             'unresolved_count' => count($unresolved),
         ],
         'items' => $resolvedItems,
         'ship' => $shipResolved,
         'unresolved' => $unresolved,
+        'warnings' => $warnings,
+        'metadata' => $metadata,
         'ship_missing' => $shipMissing,
         'hull_is_stock_tracked' => $hullIsStockTracked,
         'hull_tracking_default_reason' => doctrine_hull_stock_tracking_reason($shipResolved, $hullIsStockTracked),
@@ -10892,6 +11325,7 @@ function doctrine_ensure_hull_item(array $items, array $shipResolved, string $fa
         'resolution_source' => (string) ($shipResolved['resolution_source'] ?? 'missing'),
     ];
     $hullItem['slot_category'] = 'Hull';
+    $hullItem['source_role'] = 'hull';
     $hullItem['item_name'] = $shipName;
     $hullItem['type_id'] = $shipTypeId;
     $hullItem['quantity'] = 1;
@@ -10903,10 +11337,46 @@ function doctrine_ensure_hull_item(array $items, array $shipResolved, string $fa
     foreach ($items as $index => &$item) {
         $item['line_number'] = $index + 1;
         $item['is_stock_tracked'] = array_key_exists('is_stock_tracked', $item) ? (bool) $item['is_stock_tracked'] : true;
+        $item['source_role'] = (string) ($item['source_role'] ?? doctrine_source_role_from_category((string) ($item['slot_category'] ?? 'Items')));
     }
     unset($item);
 
     return $items;
+}
+
+function doctrine_fit_item_fingerprint(array $items): string
+{
+    $parts = [];
+
+    foreach ($items as $item) {
+        $name = doctrine_normalize_item_name((string) ($item['item_name'] ?? ''));
+        if ($name === '') {
+            continue;
+        }
+
+        $parts[] = implode(':', [
+            (string) ($item['source_role'] ?? doctrine_source_role_from_category((string) ($item['slot_category'] ?? 'Items'))),
+            doctrine_normalize_label((string) ($item['slot_category'] ?? 'Items')),
+            (string) ((int) ($item['type_id'] ?? 0)),
+            $name,
+            (string) max(1, (int) ($item['quantity'] ?? 1)),
+        ]);
+    }
+
+    sort($parts, SORT_STRING);
+
+    return hash('sha256', implode('|', $parts));
+}
+
+function doctrine_fit_status_from_warnings(array $warnings, array $unresolved, string $conflictState = 'none'): array
+{
+    $needsReview = $warnings !== [] || $unresolved !== [] || $conflictState !== 'none';
+
+    return [
+        'parse_status' => $needsReview ? 'review' : 'ready',
+        'review_status' => $needsReview ? 'needs_review' : 'clean',
+        'warning_count' => count($warnings),
+    ];
 }
 
 function doctrine_selected_group_ids(array $post): array
@@ -10984,6 +11454,7 @@ function doctrine_parse_editable_item_lines(string $text, string $shipName = '')
         $items[] = [
             'line_number' => count($items) + 1,
             'slot_category' => mb_substr($category, 0, 80),
+            'source_role' => doctrine_source_role_from_category($category),
             'item_name' => $itemName,
             'quantity' => max(1, (int) ($parsed['quantity'] ?? 1)),
         ];
@@ -11023,8 +11494,20 @@ function doctrine_prepare_fit_draft(array $resolved, array $groupIds = [], int $
     $fit = (array) ($resolved['fit'] ?? []);
     $items = (array) ($resolved['items'] ?? []);
     $suggestions = doctrine_fit_group_suggestions($fit, $fitId);
+    $detectedLabels = array_values(array_unique(array_filter(array_map(
+        'trim',
+        (array) (($resolved['metadata'] ?? [])['group_labels'] ?? [])
+    ))));
+    $detectedGroupIds = [];
+    foreach ($detectedLabels as $label) {
+        foreach (doctrine_group_options() as $group) {
+            if (doctrine_normalize_label((string) ($group['group_name'] ?? '')) === doctrine_normalize_label($label)) {
+                $detectedGroupIds[] = (int) ($group['id'] ?? 0);
+            }
+        }
+    }
     $suggestedGroupIds = array_values(array_map(static fn (array $row): int => (int) ($row['id'] ?? 0), $suggestions));
-    $selectedGroupIds = array_values(array_unique(array_merge($groupIds, $suggestedGroupIds)));
+    $selectedGroupIds = array_values(array_unique(array_merge($groupIds, $detectedGroupIds, $suggestedGroupIds)));
 
     return [
         'fit_id' => $fitId,
@@ -11034,10 +11517,13 @@ function doctrine_prepare_fit_draft(array $resolved, array $groupIds = [], int $
         'group_ids' => $selectedGroupIds,
         'suggested_groups' => $suggestions,
         'unresolved' => array_values(array_unique((array) ($resolved['unresolved'] ?? []))),
+        'warnings' => array_values(array_unique((array) ($resolved['warnings'] ?? []))),
+        'detected_group_labels' => $detectedLabels,
+        'metadata' => (array) ($resolved['metadata'] ?? []),
         'ship_missing' => (bool) ($resolved['ship_missing'] ?? false),
         'hull_is_stock_tracked' => (bool) ($resolved['hull_is_stock_tracked'] ?? true),
         'hull_tracking_default_reason' => (string) ($resolved['hull_tracking_default_reason'] ?? ''),
-        'ready_to_save' => ((array) ($resolved['unresolved'] ?? [])) === [] && trim((string) ($fit['ship_name'] ?? '')) !== '' && trim((string) ($fit['fit_name'] ?? '')) !== '',
+        'ready_to_save' => ((array) ($resolved['unresolved'] ?? [])) === [] && ((array) ($resolved['warnings'] ?? [])) === [] && trim((string) ($fit['ship_name'] ?? '')) !== '' && trim((string) ($fit['fit_name'] ?? '')) !== '',
     ];
 }
 
@@ -11089,10 +11575,347 @@ function doctrine_build_draft_from_editor_request(array $post, int $fitId = 0): 
     return doctrine_prepare_fit_draft($resolved, doctrine_selected_group_ids($post), $fitId);
 }
 
+function doctrine_attach_conflicts_to_draft(array $draft, int $excludeFitId = 0): array
+{
+    $fit = (array) ($draft['fit'] ?? []);
+
+    try {
+        $conflicts = db_doctrine_fit_conflicts(
+            (string) ($fit['fit_name'] ?? ''),
+            isset($fit['ship_type_id']) && $fit['ship_type_id'] !== null ? (int) $fit['ship_type_id'] : null,
+            (string) ($fit['ship_name'] ?? ''),
+            isset($fit['fingerprint_hash']) ? (string) $fit['fingerprint_hash'] : null,
+            $excludeFitId
+        );
+    } catch (Throwable) {
+        $conflicts = [];
+    }
+
+    $conflictState = 'none';
+    foreach ($conflicts as $row) {
+        $sameName = doctrine_normalize_label((string) ($row['fit_name'] ?? '')) === doctrine_normalize_label((string) ($fit['fit_name'] ?? ''))
+            && doctrine_normalize_label((string) ($row['ship_name'] ?? '')) === doctrine_normalize_label((string) ($fit['ship_name'] ?? ''));
+        $sameFingerprint = trim((string) ($row['fingerprint_hash'] ?? '')) !== ''
+            && trim((string) ($row['fingerprint_hash'] ?? '')) === trim((string) ($fit['fingerprint_hash'] ?? ''));
+
+        if ($sameName && $sameFingerprint) {
+            $conflictState = 'duplicate_items';
+            break;
+        }
+
+        if ($sameName) {
+            $conflictState = 'duplicate_name';
+        } elseif ($sameFingerprint) {
+            $conflictState = 'version_conflict';
+        }
+    }
+
+    if ($conflictState !== 'none') {
+        $draft['warnings'][] = 'Potential duplicate or version conflict detected.';
+        $draft['ready_to_save'] = false;
+    }
+
+    $draft['warnings'] = array_values(array_unique(array_filter(array_map('trim', (array) ($draft['warnings'] ?? [])))));
+    $draft['conflicts'] = array_map(static function (array $row): array {
+        $row['group_names'] = doctrine_parse_group_names_csv($row['group_names_csv'] ?? null);
+
+        return $row;
+    }, $conflicts);
+    $draft['fit']['conflict_state'] = $conflictState;
+    $draft['fit']['parse_status'] = (($draft['warnings'] ?? []) !== [] || ($draft['unresolved'] ?? []) !== [] || $conflictState !== 'none') ? 'review' : (string) (($draft['fit']['parse_status'] ?? 'ready'));
+    $draft['fit']['review_status'] = (($draft['fit']['parse_status'] ?? 'ready') === 'review') ? 'needs_review' : 'clean';
+    $draft['fit']['warning_count'] = count((array) ($draft['warnings'] ?? []));
+    $draft['fit']['parse_warnings_json'] = json_encode((array) ($draft['warnings'] ?? []), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+
+    return $draft;
+}
+
+function doctrine_bulk_preview_session_key(): string
+{
+    return 'doctrine_bulk_import_preview';
+}
+
+function doctrine_bulk_import_preview_store(array $preview): void
+{
+    $_SESSION[doctrine_bulk_preview_session_key()] = $preview;
+}
+
+function doctrine_bulk_import_preview_fetch(): ?array
+{
+    $preview = $_SESSION[doctrine_bulk_preview_session_key()] ?? null;
+
+    return is_array($preview) ? $preview : null;
+}
+
+function doctrine_bulk_import_preview_clear(): void
+{
+    unset($_SESSION[doctrine_bulk_preview_session_key()]);
+}
+
+function doctrine_uploaded_files(string $field): array
+{
+    $files = $_FILES[$field] ?? null;
+    if (!is_array($files) || !isset($files['name']) || !is_array($files['name'])) {
+        return [];
+    }
+
+    $rows = [];
+    foreach ($files['name'] as $index => $name) {
+        $error = (int) ($files['error'][$index] ?? UPLOAD_ERR_NO_FILE);
+        if ($error !== UPLOAD_ERR_OK) {
+            continue;
+        }
+
+        $tmpName = (string) ($files['tmp_name'][$index] ?? '');
+        if ($tmpName === '' || !is_uploaded_file($tmpName)) {
+            continue;
+        }
+
+        $rows[] = [
+            'name' => (string) $name,
+            'tmp_name' => $tmpName,
+            'size' => (int) ($files['size'][$index] ?? 0),
+            'type' => (string) ($files['type'][$index] ?? ''),
+        ];
+    }
+
+    return $rows;
+}
+
+function doctrine_match_uploaded_eft_fallback(array $htmlParsed, array $eftDraftsByKey): ?array
+{
+    $keys = [
+        doctrine_normalize_label((string) ($htmlParsed['source_reference'] ?? '')),
+        doctrine_normalize_label(pathinfo((string) ($htmlParsed['source_reference'] ?? ''), PATHINFO_FILENAME)),
+        doctrine_normalize_label((string) ($htmlParsed['fit_name'] ?? '')),
+    ];
+
+    foreach ($keys as $key) {
+        if ($key !== '' && isset($eftDraftsByKey[$key]) && is_array($eftDraftsByKey[$key])) {
+            return $eftDraftsByKey[$key];
+        }
+    }
+
+    return null;
+}
+
+function doctrine_bulk_import_build_preview(): array
+{
+    $htmlFiles = doctrine_uploaded_files('html_files');
+    $eftFiles = doctrine_uploaded_files('eft_files');
+
+    if ($htmlFiles === [] && $eftFiles === []) {
+        throw new RuntimeException('Upload at least one Winter Coalition HTML fit page or EFT fallback file.');
+    }
+
+    $eftDraftsByKey = [];
+    foreach ($eftFiles as $file) {
+        $body = (string) file_get_contents($file['tmp_name']);
+        if (trim($body) === '') {
+            continue;
+        }
+
+        $parsed = doctrine_parse_eft($body);
+        $draft = doctrine_attach_conflicts_to_draft(
+            doctrine_prepare_fit_draft(
+                doctrine_resolve_parsed_fit([
+                    'format' => 'eft',
+                    'source_type' => 'eft',
+                    'source_reference' => (string) ($file['name'] ?? ''),
+                    'fit_name' => (string) ($parsed['fit_name'] ?? ''),
+                    'ship_name' => (string) ($parsed['ship_name'] ?? ''),
+                    'items' => (array) ($parsed['items'] ?? []),
+                    'raw_eft' => $body,
+                    'warnings' => [],
+                    'metadata' => ['group_labels' => []],
+                ], $body)
+            )
+        );
+
+        $eftDraftsByKey[doctrine_normalize_label((string) ($file['name'] ?? ''))] = $draft;
+        $eftDraftsByKey[doctrine_normalize_label(pathinfo((string) ($file['name'] ?? ''), PATHINFO_FILENAME))] = $draft;
+        $eftDraftsByKey[doctrine_normalize_label((string) ($draft['fit']['fit_name'] ?? ''))] = $draft;
+    }
+
+    $rows = [];
+    foreach ($htmlFiles as $index => $file) {
+        $html = (string) file_get_contents($file['tmp_name']);
+        if (trim($html) === '') {
+            continue;
+        }
+
+        $parsed = doctrine_parse_html_fit_page($html, (string) ($file['name'] ?? ('fit-' . $index . '.html')));
+        $eftFallback = doctrine_match_uploaded_eft_fallback($parsed, $eftDraftsByKey);
+
+        if ($eftFallback !== null) {
+            $fallbackFit = (array) ($eftFallback['fit'] ?? []);
+            $htmlHull = doctrine_normalize_label((string) ($parsed['ship_name'] ?? ''));
+            $eftHull = doctrine_normalize_label((string) ($fallbackFit['ship_name'] ?? ''));
+            if ($htmlHull !== '' && $eftHull !== '' && $htmlHull !== $eftHull) {
+                $parsed['warnings'][] = 'HTML and uploaded EFT fallback disagree on hull identity.';
+                $parsed['conflict_state'] = 'source_mismatch';
+            }
+
+            if (trim((string) ($parsed['raw_eft'] ?? '')) === '') {
+                $parsed['raw_eft'] = (string) ($fallbackFit['raw_eft'] ?? ($fallbackFit['import_body'] ?? ''));
+            }
+
+            if (($parsed['items'] ?? []) === [] && isset($eftFallback['items'])) {
+                $parsed['items'] = (array) $eftFallback['items'];
+                $parsed['format'] = 'eft';
+            }
+        }
+
+        $resolved = doctrine_resolve_parsed_fit($parsed, (string) ($parsed['raw_buyall'] ?? $parsed['raw_eft'] ?? $html));
+        $draft = doctrine_attach_conflicts_to_draft(doctrine_prepare_fit_draft($resolved));
+        $draft['source_filename'] = (string) ($file['name'] ?? '');
+        $draft['source_type_label'] = strtoupper((string) (($draft['fit']['source_type'] ?? 'html')));
+        $rows[] = $draft;
+    }
+
+    if ($rows === [] && $eftFiles !== []) {
+        foreach ($eftFiles as $file) {
+            $body = (string) file_get_contents($file['tmp_name']);
+            if (trim($body) === '') {
+                continue;
+            }
+
+            $parsed = doctrine_parse_eft($body);
+            $draft = doctrine_attach_conflicts_to_draft(
+                doctrine_prepare_fit_draft(
+                    doctrine_resolve_parsed_fit([
+                        'format' => 'eft',
+                        'source_type' => 'eft',
+                        'source_reference' => (string) ($file['name'] ?? ''),
+                        'fit_name' => (string) ($parsed['fit_name'] ?? ''),
+                        'ship_name' => (string) ($parsed['ship_name'] ?? ''),
+                        'items' => (array) ($parsed['items'] ?? []),
+                        'raw_eft' => $body,
+                        'warnings' => [],
+                        'metadata' => ['group_labels' => []],
+                    ], $body)
+                )
+            );
+            $draft['source_filename'] = (string) ($file['name'] ?? '');
+            $rows[] = $draft;
+        }
+    }
+
+    return [
+        'created_at' => gmdate('Y-m-d H:i:s'),
+        'rows' => $rows,
+        'counts' => [
+            'total' => count($rows),
+            'ready' => count(array_filter($rows, static fn (array $row): bool => (($row['fit']['parse_status'] ?? 'ready') === 'ready'))),
+            'review' => count(array_filter($rows, static fn (array $row): bool => (($row['fit']['parse_status'] ?? 'ready') === 'review'))),
+        ],
+    ];
+}
+
+function doctrine_bulk_import_selected_group_ids(array $row, array $post): array
+{
+    $index = (string) ($row['source_filename'] ?? md5((string) (($row['fit']['fit_name'] ?? '') . '|' . ($row['fit']['ship_name'] ?? ''))));
+    $posted = (array) ($post['row_group_ids'][$index] ?? []);
+    $groupIds = array_values(array_unique(array_filter(array_map('intval', $posted), static fn (int $id): bool => $id > 0)));
+
+    if ($groupIds !== []) {
+        return $groupIds;
+    }
+
+    return array_values(array_unique(array_filter(array_map('intval', (array) ($row['group_ids'] ?? [])), static fn (int $id): bool => $id > 0)));
+}
+
+function doctrine_ensure_groups_from_labels(array $labels, array $selectedGroupIds = []): array
+{
+    $groupIds = array_values(array_unique(array_filter(array_map('intval', $selectedGroupIds), static fn (int $id): bool => $id > 0)));
+    $existingByName = [];
+    foreach (doctrine_group_options() as $group) {
+        $existingByName[doctrine_normalize_label((string) ($group['group_name'] ?? ''))] = (int) ($group['id'] ?? 0);
+    }
+
+    foreach ($labels as $label) {
+        $clean = doctrine_sanitize_group_name((string) $label);
+        $key = doctrine_normalize_label($clean);
+        if ($key === '') {
+            continue;
+        }
+
+        if (isset($existingByName[$key]) && $existingByName[$key] > 0) {
+            $groupIds[] = $existingByName[$key];
+            continue;
+        }
+
+        $newId = db_doctrine_group_create($clean, null);
+        $existingByName[$key] = $newId;
+        $groupIds[] = $newId;
+    }
+
+    return array_values(array_unique(array_filter($groupIds, static fn (int $id): bool => $id > 0)));
+}
+
+function doctrine_bulk_import_save_from_request(array $post): array
+{
+    $preview = doctrine_bulk_import_preview_fetch();
+    if (!is_array($preview) || !isset($preview['rows']) || !is_array($preview['rows'])) {
+        return ['ok' => false, 'message' => 'The import preview expired. Upload the files again before saving.'];
+    }
+
+    $results = ['created' => 0, 'updated' => 0, 'skipped' => 0, 'review' => 0];
+
+    foreach ($preview['rows'] as $row) {
+        $sourceKey = (string) ($row['source_filename'] ?? md5((string) (($row['fit']['fit_name'] ?? '') . '|' . ($row['fit']['ship_name'] ?? ''))));
+        $action = (string) (($post['row_action'][$sourceKey] ?? (($row['fit']['parse_status'] ?? 'ready') === 'ready' ? 'create' : 'review')));
+        if ($action === 'skip') {
+            $results['skipped']++;
+            continue;
+        }
+
+        $groupIds = doctrine_ensure_groups_from_labels(
+            (array) ($row['detected_group_labels'] ?? []),
+            doctrine_bulk_import_selected_group_ids($row, $post)
+        );
+
+        $fit = (array) ($row['fit'] ?? []);
+        $items = (array) ($row['items'] ?? []);
+        $fit['conflict_state'] = (string) ($fit['conflict_state'] ?? 'none');
+
+        if ($action === 'review') {
+            $fit['parse_status'] = 'review';
+            $fit['review_status'] = 'needs_review';
+            $fit['warning_count'] = max((int) ($fit['warning_count'] ?? 0), count((array) ($row['warnings'] ?? [])));
+            $fit['parse_warnings_json'] = json_encode((array) ($row['warnings'] ?? []), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        }
+
+        if ($action === 'update') {
+            $targetId = (int) ($post['row_target_fit_id'][$sourceKey] ?? 0);
+            if ($targetId <= 0) {
+                $results['review']++;
+                continue;
+            }
+
+            db_doctrine_fit_update($targetId, $fit, $items, $groupIds);
+            $results['updated']++;
+            continue;
+        }
+
+        db_doctrine_fit_create($fit, $items, $groupIds);
+        if ($action === 'review') {
+            $results['review']++;
+        } else {
+            $results['created']++;
+        }
+    }
+
+    doctrine_bulk_import_preview_clear();
+    doctrine_schedule_intelligence_refresh('bulk-fit-import');
+
+    return ['ok' => true, 'message' => 'Bulk doctrine import processed.', 'results' => $results];
+}
+
 function doctrine_import_fit_from_request(array $post): array
 {
     try {
-        $draft = doctrine_build_draft_from_editor_request($post);
+        $draft = doctrine_attach_conflicts_to_draft(doctrine_build_draft_from_editor_request($post));
     } catch (Throwable $exception) {
         return ['ok' => false, 'message' => $exception->getMessage()];
     }
@@ -11111,9 +11934,6 @@ function doctrine_import_fit_from_request(array $post): array
     if ($groupIds === []) {
         return ['ok' => false, 'message' => 'Assign the fit to at least one doctrine group before saving.', 'draft' => $draft];
     }
-    if (($draft['unresolved'] ?? []) !== []) {
-        return ['ok' => false, 'message' => 'Resolve the ship or item names before saving the doctrine fit.', 'draft' => $draft];
-    }
 
     try {
         $fitId = db_doctrine_fit_create((array) ($draft['fit'] ?? []), (array) ($draft['items'] ?? []), $groupIds);
@@ -11125,7 +11945,9 @@ function doctrine_import_fit_from_request(array $post): array
 
     return [
         'ok' => true,
-        'message' => 'Doctrine fit imported successfully.',
+        'message' => (($draft['fit']['parse_status'] ?? 'ready') === 'review')
+            ? 'Doctrine fit saved and flagged for review.'
+            : 'Doctrine fit imported successfully.',
         'fit_id' => $fitId,
         'draft' => $draft,
     ];
@@ -11134,7 +11956,7 @@ function doctrine_import_fit_from_request(array $post): array
 function doctrine_update_fit_from_request(int $fitId, array $post): array
 {
     try {
-        $draft = doctrine_build_draft_from_editor_request($post, $fitId);
+        $draft = doctrine_attach_conflicts_to_draft(doctrine_build_draft_from_editor_request($post, $fitId), $fitId);
     } catch (Throwable $exception) {
         return ['ok' => false, 'message' => $exception->getMessage()];
     }
@@ -11142,9 +11964,6 @@ function doctrine_update_fit_from_request(int $fitId, array $post): array
     $groupIds = doctrine_selected_group_ids($post);
     if ($groupIds === []) {
         return ['ok' => false, 'message' => 'Assign the fit to at least one doctrine group before saving.', 'draft' => $draft];
-    }
-    if (($draft['unresolved'] ?? []) !== []) {
-        return ['ok' => false, 'message' => 'Resolve the ship or item names before saving the doctrine fit.', 'draft' => $draft];
     }
 
     try {
@@ -11155,7 +11974,13 @@ function doctrine_update_fit_from_request(int $fitId, array $post): array
 
     doctrine_schedule_intelligence_refresh('fit-update');
 
-    return ['ok' => true, 'message' => 'Doctrine fit updated successfully.', 'draft' => $draft];
+    return [
+        'ok' => true,
+        'message' => (($draft['fit']['parse_status'] ?? 'ready') === 'review')
+            ? 'Doctrine fit updated and remains flagged for review.'
+            : 'Doctrine fit updated successfully.',
+        'draft' => $draft,
+    ];
 }
 
 function doctrine_ship_image_url(?int $typeId, int $size = 128): ?string
@@ -11261,6 +12086,7 @@ function doctrine_fit_items_equal(array $before, array $after): bool
             return [
                 'line_number' => (int) ($item['line_number'] ?? 0),
                 'slot_category' => (string) ($item['slot_category'] ?? ''),
+                'source_role' => (string) ($item['source_role'] ?? ''),
                 'item_name' => (string) ($item['item_name'] ?? ''),
                 'type_id' => isset($item['type_id']) && $item['type_id'] !== null ? (int) $item['type_id'] : null,
                 'quantity' => (int) ($item['quantity'] ?? 0),
@@ -13307,6 +14133,79 @@ function doctrine_group_detail_data(int $groupId): array
     return ['group' => null, 'fits' => [], 'freshness' => $snapshot['_freshness'] ?? doctrine_snapshot_metadata()];
 }
 
+function doctrine_parse_json_array(mixed $value): array
+{
+    if (is_array($value)) {
+        return $value;
+    }
+
+    if (!is_string($value) || trim($value) === '') {
+        return [];
+    }
+
+    $decoded = json_decode($value, true);
+
+    return is_array($decoded) ? $decoded : [];
+}
+
+function doctrine_fit_readiness_status(array $fit): string
+{
+    if ((int) ($fit['unresolved_count'] ?? 0) > 0) {
+        return 'Unresolved';
+    }
+
+    if ((string) ($fit['parse_status'] ?? 'ready') === 'review') {
+        return 'Needs review';
+    }
+
+    if ((string) ($fit['conflict_state'] ?? 'none') !== 'none') {
+        return 'Conflict';
+    }
+
+    return 'Ready';
+}
+
+function doctrine_fit_overview_data(array $query = []): array
+{
+    $filters = [
+        'search' => (string) ($query['q'] ?? ''),
+        'group_id' => (int) ($query['group_id'] ?? 0),
+        'hull' => (string) ($query['hull'] ?? ''),
+        'source_type' => (string) ($query['source_type'] ?? ''),
+        'parse_status' => (string) ($query['parse_status'] ?? ''),
+        'review_status' => (string) ($query['review_status'] ?? ''),
+        'conflict_state' => (string) ($query['conflict_state'] ?? ''),
+        'unresolved_only' => in_array((string) ($query['unresolved_only'] ?? ''), ['1', 'true', 'yes', 'on'], true),
+    ];
+    $sort = (string) ($query['sort'] ?? 'updated_desc');
+
+    try {
+        $fits = db_doctrine_fit_overview($filters, $sort);
+    } catch (Throwable) {
+        $fits = [];
+    }
+
+    foreach ($fits as &$fit) {
+        $fit['group_names'] = doctrine_parse_group_names_csv($fit['group_names_csv'] ?? null);
+        $fit['readiness_status'] = doctrine_fit_readiness_status($fit);
+        $fit['parse_status_label'] = (($fit['parse_status'] ?? 'ready') === 'review') ? 'Review' : 'Ready';
+    }
+    unset($fit);
+
+    return [
+        'filters' => $filters,
+        'sort' => $sort,
+        'fits' => $fits,
+        'groups' => doctrine_group_options(),
+        'summary' => [
+            'total' => count($fits),
+            'review' => count(array_filter($fits, static fn (array $fit): bool => (($fit['parse_status'] ?? 'ready') === 'review'))),
+            'unresolved' => count(array_filter($fits, static fn (array $fit): bool => ((int) ($fit['unresolved_count'] ?? 0) > 0))),
+            'conflicts' => count(array_filter($fits, static fn (array $fit): bool => (($fit['conflict_state'] ?? 'none') !== 'none'))),
+        ],
+    ];
+}
+
 function doctrine_fit_detail_view_model(int $fitId): array
 {
     return supplycore_cache_aside('doctrine', ['fit-detail', $fitId], supplycore_cache_ttl('doctrine_detail'), static function () use ($fitId): array {
@@ -13338,6 +14237,9 @@ function doctrine_fit_detail_view_model(int $fitId): array
 
         $fit['group_ids'] = doctrine_parse_group_csv($fit['group_ids_csv'] ?? null);
         $fit['group_names'] = doctrine_parse_group_names_csv($fit['group_names_csv'] ?? null);
+        $fit['metadata'] = doctrine_parse_json_array($fit['metadata_json'] ?? null);
+        $fit['parse_warnings'] = doctrine_parse_json_array($fit['parse_warnings_json'] ?? null);
+        $fit['readiness_status'] = doctrine_fit_readiness_status($fit);
         $items = doctrine_normalize_persisted_fit_items($fit, $items);
         $items = item_scope_filter_rows(
             $items,


### PR DESCRIPTION
### Motivation
- Enable efficient, HTML-first ingestion of Winter Coalition fit pages (with Buy All as primary item payload and EFT as fallback/validator) so large batches of doctrine fits can be normalized with minimal manual work.
- Persist richer source metadata and parsing state to surface review/duplicate/conflict signals and allow bulk operator workflows without silent overwrites.

### Description
- Database: extended `doctrine_fits` and `doctrine_fit_items` schema to store source metadata, raw payloads, parse/review/conflict flags, fingerprinting, warning counts, and `source_role` for item rows; added indexes to support queries. (`database/schema.sql`, `src/db.php`).
- DB helpers: added robust DB migration checks and new primitives for conflict detection, fit overview queries, and bulk fit actions (`db_doctrine_fit_conflicts`, `db_doctrine_fit_overview`, `db_doctrine_fit_bulk_*`, `db_doctrine_fit_bulk_update_metadata`) and updated create/update/delete flows to persist the new fields (`src/db.php`).
- HTML-first parsing: implemented HTML parsing helpers that extract fit title, hull, group labels, notes, Buy All payload from clipboard attributes, embedded EFT blocks, visible grouped items, and candidate metadata; produces a normalized parsed fit shape for resolution (`doctrine_parse_html_fit_page` and helpers in `src/functions.php`).
- Normalization & resolution: integrated new normalization logic (ensure single Hull row, source-role mapping, fingerprint calculation, parse/review status derivation, group detection from HTML labels, EFT fallback matching, and name→type resolution reuse) and attached conflict detection to draft creation flows (`src/functions.php`).
- Bulk importer UI: replaced one-off import surface with a bulk upload/preview/save control at `/doctrine/import` that accepts multiple HTML files and optional EFT fallbacks, stages a session preview, shows detected groups/warnings/conflicts, and supports per-row create/update/review/skip actions (`public/doctrine/import.php`, `src/functions.php`).
- Fit overview & management: added `/doctrine/fits` overview page with search, filters (group, hull, source type, parse/conflict state), sorting, and bulk actions (delete, assign/replace/remove groups, mark review/reparse, bulk notes); backed by `db_doctrine_fit_overview` and bulk DB operations (`public/doctrine/fits.php`, `src/functions.php`, `src/db.php`).
- Fit detail: surface import status, parse warnings, notes, raw BuyAll/EFT payloads, and stored source metadata on the existing fit detail page to aid review/correction (`public/doctrine/fit.php`).
- Navigation & docs: added nav entry for Fit Overview and updated README to document HTML-first bulk importer and overview workflow (`src/functions.php`, `public/doctrine/index.php`, `README.md`).

### Testing
- Syntax checks: ran `php -l` on the modified files: `src/functions.php`, `src/db.php`, `public/doctrine/import.php`, `public/doctrine/fits.php`, `public/doctrine/fit.php`, and `public/doctrine/index.php`; all reported no syntax errors.
- Functional parse checks: executed quick runtime checks using `php -r` requiring `src/bootstrap.php` to validate `doctrine_parse_html_fit_page(...)` returns expected `fit_name`, `ship_name`, extracted `raw_buyall`, `group_labels`, and `notes`; and `doctrine_resolve_parsed_fit(...)` produced normalized fit structure and parse status; both succeeded in this environment.
- Commit-time validations: repository lint/parse checks were run before committing the changes; they passed.

Note: Existing installations must apply the schema changes (run `database/schema.sql` or let the app run its `doctrine_db_ensure_schema()` migrations) before using the new importer and fit-overview features.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd06877540832fbd06bf47c5d4ee14)