### PR TITLE
Add Apache rewrite rule for /doctrine/fits

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -25,6 +25,7 @@ RewriteRule ^killmail-intelligence/?$ killmail-intelligence/index.php [L,QSA]
 RewriteRule ^killmail-intelligence/view/?$ killmail-intelligence/view.php [L,QSA]
 
 RewriteRule ^doctrine/?$ doctrine/index.php [L,QSA]
+RewriteRule ^doctrine/fits/?$ doctrine/fits.php [L,QSA]
 RewriteRule ^doctrine/group/?$ doctrine/group.php [L,QSA]
 RewriteRule ^doctrine/fit/?$ doctrine/fit.php [L,QSA]
 RewriteRule ^doctrine/import/?$ doctrine/import.php [L,QSA]


### PR DESCRIPTION
### Motivation
- The app navigation includes a "Fit Overview" link at `/doctrine/fits` but the Apache rewrite rules did not route that path to the existing controller, causing the menu link to fail.

### Description
- Add `RewriteRule ^doctrine/fits/?$ doctrine/fits.php [L,QSA]` to `public/.htaccess` to route `/doctrine/fits` to `public/doctrine/fits.php`.

### Testing
- Verified the new rule is present with `rg`/`grep` and confirmed the target file exists with `test -f public/doctrine/fits.php`; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd0eb07d90832f9e7962dab0de60ac)