### PR TITLE
Fix doctrine bulk fit insert placeholders

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -4274,7 +4274,7 @@ function db_doctrine_fit_create(array $fit, array $items, array $groupIds = []):
                 warning_count,
                 item_count,
                 unresolved_count
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $groupIds[0] ?? (isset($fit['doctrine_group_id']) ? (int) $fit['doctrine_group_id'] : null),
                 (string) ($fit['fit_name'] ?? ''),


### PR DESCRIPTION
### Motivation
- The bulk Winter Coalition fit importer raised `SQLSTATE[21S01]` due to a mismatch between the number of columns listed in the `INSERT INTO doctrine_fits` statement and the number of `VALUES` placeholders, preventing preview rows from being saved.

### Description
- Adjusted the `INSERT` statement in `db_doctrine_fit_create` so the `VALUES` placeholder count matches the 21 persisted columns in `src/db.php` (fixes the column/value mismatch during bulk save).

### Testing
- Ran a PHP syntax check with `php -l src/db.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd1d070f08832fbb83b5564c3c17da)