### PR TITLE
Adjust dashboard health panel layout

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -487,12 +487,12 @@ $statusThemes = [
     </article>
 </section>
 
-<section class="mt-8 grid gap-5 xl:grid-cols-3">
+<section class="mt-8 grid gap-5 lg:grid-cols-2 xl:grid-cols-3">
     <?php foreach ($healthPanels as $panelTitle => $panel): ?>
         <?php
         $status = (string) ($panel['status'] ?? 'Awaiting sync');
         $statusClass = $statusThemes[$status] ?? 'border-red-400/20 bg-red-500/10 text-red-100';
-        $wrapperClass = $panelTitle === 'Sync Health' ? 'surface-primary xl:col-span-2' : 'surface-secondary';
+        $wrapperClass = $panelTitle === 'Sync Health' ? 'surface-primary' : 'surface-secondary';
 
         $summaryText = match ($panelTitle) {
             'Alliance Market Freshness' => $status === 'Healthy'


### PR DESCRIPTION
### Motivation
- Allow the three operational status cards on the dashboard to sit side-by-side earlier on wide screens by changing the grid breakpoints and removing the special span for the `Sync Health` card.

### Description
- Updated the operational status section grid from `xl:grid-cols-3` to `lg:grid-cols-2 xl:grid-cols-3` so panels use two columns on large screens and three on extra-large screens.
- Removed the `xl:col-span-2` span from the `Sync Health` card by changing the `$wrapperClass` logic from `surface-primary xl:col-span-2` to `surface-primary` in `public/index.php` so it no longer forces a wrap.

### Testing
- Ran `php -l public/index.php` to validate PHP syntax and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd31a0ba64832f9b588a888b33a342)