### PR TITLE
Run history syncs in background and reuse snapshot summaries to avoid cron lock

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -1898,15 +1898,26 @@ function db_market_orders_snapshot_metrics_window_raw(string $sourceType, int $s
 
 function db_market_orders_snapshot_metrics_window(string $sourceType, int $sourceId, string $startObservedAt): array
 {
+    $result = db_market_orders_snapshot_metrics_window_ensure_summary($sourceType, $sourceId, $startObservedAt);
+
+    return is_array($result['rows'] ?? null) ? $result['rows'] : [];
+}
+
+function db_market_orders_snapshot_metrics_window_ensure_summary(string $sourceType, int $sourceId, string $startObservedAt): array
+{
     $safeSourceType = trim($sourceType);
     $safeSourceId = max(0, $sourceId);
     $safeStartObservedAt = trim($startObservedAt);
 
     if ($safeSourceType === '' || $safeSourceId <= 0 || $safeStartObservedAt === '') {
-        return [];
+        return [
+            'rows' => [],
+            'summary_rows_written' => 0,
+            'loaded_from_summary' => false,
+        ];
     }
 
-    $rows = db_select_cached(
+    $summaryRows = db_select_cached(
         "SELECT
             source_type,
             source_id,
@@ -1929,11 +1940,56 @@ function db_market_orders_snapshot_metrics_window(string $sourceType, int $sourc
         'market.snapshot.metrics'
     );
 
-    if ($rows === []) {
-        return db_market_orders_snapshot_metrics_window_raw($safeSourceType, $safeSourceId, $safeStartObservedAt);
+    $normalizedSummaryRows = array_map('db_market_order_snapshots_summary_normalize_row', $summaryRows);
+    $latestObservedAt = '';
+    foreach ($normalizedSummaryRows as $row) {
+        $observedAt = trim((string) ($row['observed_at'] ?? ''));
+        if ($observedAt !== '' && strcmp($observedAt, $latestObservedAt) > 0) {
+            $latestObservedAt = $observedAt;
+        }
     }
 
-    return array_map('db_market_order_snapshots_summary_normalize_row', $rows);
+    $rawRowsStartObservedAt = $latestObservedAt !== '' ? $latestObservedAt : $safeStartObservedAt;
+    $rawRows = db_market_orders_snapshot_metrics_window_raw($safeSourceType, $safeSourceId, $rawRowsStartObservedAt);
+    $summaryRowsWritten = $rawRows === [] ? 0 : db_market_order_snapshots_summary_bulk_upsert($rawRows);
+
+    if ($normalizedSummaryRows === []) {
+        return [
+            'rows' => $rawRows,
+            'summary_rows_written' => $summaryRowsWritten,
+            'loaded_from_summary' => false,
+        ];
+    }
+
+    $mergedRows = [];
+    foreach (array_merge($normalizedSummaryRows, $rawRows) as $row) {
+        $rowKey = implode(':', [
+            (string) ($row['source_type'] ?? ''),
+            (string) ($row['source_id'] ?? ''),
+            (string) ($row['type_id'] ?? ''),
+            (string) ($row['observed_at'] ?? ''),
+        ]);
+        if ($rowKey === ':::') {
+            continue;
+        }
+
+        $mergedRows[$rowKey] = db_market_order_snapshots_summary_normalize_row($row);
+    }
+
+    uasort($mergedRows, static function (array $left, array $right): int {
+        $observedCompare = strcmp((string) ($left['observed_at'] ?? ''), (string) ($right['observed_at'] ?? ''));
+        if ($observedCompare !== 0) {
+            return $observedCompare;
+        }
+
+        return ((int) ($left['type_id'] ?? 0)) <=> ((int) ($right['type_id'] ?? 0));
+    });
+
+    return [
+        'rows' => array_values($mergedRows),
+        'summary_rows_written' => $summaryRowsWritten,
+        'loaded_from_summary' => true,
+    ];
 }
 
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -5961,8 +5961,9 @@ function scheduler_job_definitions(): array
             },
         ],
         'alliance_historical_sync' => [
-            'timeout_seconds' => 480,
-            'lock_ttl_seconds' => 600,
+            'timeout_seconds' => 3600,
+            'lock_ttl_seconds' => 3900,
+            'execution' => 'background',
             'handler' => static function (): array {
                 $structureId = configured_structure_destination_id_for_esi_sync();
                 if ($structureId <= 0) {
@@ -5973,8 +5974,9 @@ function scheduler_job_definitions(): array
             },
         ],
         'market_hub_historical_sync' => [
-            'timeout_seconds' => 300,
-            'lock_ttl_seconds' => 420,
+            'timeout_seconds' => 3600,
+            'lock_ttl_seconds' => 3900,
+            'execution' => 'background',
             'handler' => static function (): array {
                 $hubRef = market_hub_setting_reference();
                 if ($hubRef === '') {
@@ -5985,8 +5987,9 @@ function scheduler_job_definitions(): array
             },
         ],
         'market_hub_local_history_sync' => [
-            'timeout_seconds' => 180,
-            'lock_ttl_seconds' => 300,
+            'timeout_seconds' => 3600,
+            'lock_ttl_seconds' => 3900,
+            'execution' => 'background',
             'handler' => static function (): array {
                 $hubRef = market_hub_setting_reference();
                 if ($hubRef === '') {
@@ -8148,7 +8151,9 @@ function sync_market_history_from_snapshots(
             return $result;
         }
 
-        $snapshotMetrics = db_market_orders_snapshot_metrics_window_raw($normalizedSourceType, $sourceId, $windowStartObservedAt);
+        $snapshotMetricResult = db_market_orders_snapshot_metrics_window_ensure_summary($normalizedSourceType, $sourceId, $windowStartObservedAt);
+        $snapshotMetrics = is_array($snapshotMetricResult['rows'] ?? null) ? $snapshotMetricResult['rows'] : [];
+        $summaryRowsWritten = max(0, (int) ($snapshotMetricResult['summary_rows_written'] ?? 0));
         $result['rows_seen'] = count($snapshotMetrics);
 
         if ($snapshotMetrics === []) {
@@ -8182,7 +8187,6 @@ function sync_market_history_from_snapshots(
             return $result;
         }
 
-        $summaryRowsWritten = db_market_order_snapshots_summary_bulk_upsert($snapshotMetrics);
         $rebuilt = market_history_daily_rebuild_from_snapshot_metrics($snapshotMetrics, $normalizedSourceType);
         $canonicalRows = is_array($rebuilt['rows'] ?? null) ? $rebuilt['rows'] : [];
         $historyRowCount = count($canonicalRows);


### PR DESCRIPTION
### Motivation

- History rebuild jobs can run for many minutes and were holding the main cron tick lock, causing repeated `cron_tick.lock_skipped` entries and job timeouts.  
- Re-aggregating the full raw snapshot window on every run is expensive and duplicates work across runs.  
- Move long/expensive history work to background workers and reuse persisted snapshot summaries to make repeat runs cheap and avoid monopolizing the scheduler lock.

### Description

- Changed the three history scheduler jobs (`alliance_historical_sync`, `market_hub_historical_sync`, `market_hub_local_history_sync`) to execute in the background and increased their `timeout_seconds` and `lock_ttl_seconds` to accommodate long backfills, and set `execution => 'background'` in `scheduler_job_definitions()` in `src/functions.php`.
- Added `db_market_orders_snapshot_metrics_window_ensure_summary()` in `src/db.php` to load cached `market_order_snapshots_summary` rows, fetch any newer raw snapshot rows, backfill the summary table, and merge results so subsequent syncs avoid re-scanning the full raw window.
- Updated snapshot-history rebuilding (`sync_market_history_from_snapshots` in `src/functions.php`) to call the new summary-aware DB helper and consume the merged rows; the code now captures `summary_rows_written` when new summary rows are backfilled.
- Files changed: `src/functions.php` and `src/db.php` (new helper and scheduler adjustments).  The changes preserve existing behavior when no summary rows exist while reducing repeated raw aggregation work and removing long-running jobs from the cron tick lock.

### Testing

- Ran syntax checks `php -l src/db.php` and `php -l src/functions.php`, both returned "No syntax errors detected".  
- No additional automated unit tests were added; the change focuses on scheduler behavior and DB helper performance improvements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7c4721c0832f889c6d87efa97fe9)