### PR TITLE
Add scheduler reset control (clear locks and target PHP workers)

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -108,6 +108,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 exit;
             }
 
+            if ($dataSyncAction === 'reset-scheduler') {
+                $resetResult = scheduler_reset_runtime_state();
+                $saved = (bool) ($resetResult['ok'] ?? false);
+                flash('success', scheduler_reset_runtime_state_message($resetResult));
+                header('Location: /settings?section=' . urlencode($submittedSection));
+                exit;
+            }
+
             if ($dataSyncAction === 'static-data-import') {
                 try {
                     $result = static_data_import_reference_data('auto', false);
@@ -1518,6 +1526,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     </select>
                     <button name="data_sync_action" value="run-now" class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-slate-100 hover:bg-white/5">Run selected now</button>
                     <p class="text-xs text-muted">Local History is available in this selector and is required to populate Trend Snippets.</p>
+                    <button name="data_sync_action" value="reset-scheduler" class="rounded-lg border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-100 hover:bg-amber-500/20">Reset scheduler locks</button>
+                    <p class="text-xs text-muted">Clears stuck schedule locks and attempts to terminate related background PHP workers before the next run.</p>
                     <button name="data_sync_action" value="static-data-import" class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-slate-100 hover:bg-white/5">Import EVE Static Data</button>
                 </div>
             </form>

--- a/src/db.php
+++ b/src/db.php
@@ -3163,6 +3163,30 @@ function db_runner_lock_release(string $lockName): bool
     return (int) ($row['lock_released'] ?? 0) === 1;
 }
 
+function db_runner_lock_holder_connection_id(string $lockName): ?int
+{
+    $row = db_select_one('SELECT IS_USED_LOCK(?) AS connection_id', [$lockName]);
+    $connectionId = (int) ($row['connection_id'] ?? 0);
+
+    return $connectionId > 0 ? $connectionId : null;
+}
+
+function db_runner_lock_force_release(string $lockName): bool
+{
+    $connectionId = db_runner_lock_holder_connection_id($lockName);
+    if ($connectionId === null) {
+        return true;
+    }
+
+    try {
+        db()->exec('KILL CONNECTION ' . $connectionId);
+    } catch (Throwable) {
+        return false;
+    }
+
+    return db_runner_lock_holder_connection_id($lockName) === null;
+}
+
 function db_sync_schedule_fetch_due_jobs(int $limit = 20): array
 {
     $safeLimit = max(1, min(200, $limit));
@@ -3408,6 +3432,39 @@ function db_sync_schedule_force_due_by_job_keys(array $jobKeys): int
 
     $stmt = db()->prepare($sql);
     $stmt->execute($keys);
+
+    return (int) $stmt->rowCount();
+}
+
+function db_sync_schedule_reset_locks(string $errorMessage): int
+{
+    $message = mb_substr(trim($errorMessage), 0, 500);
+    if ($message === '') {
+        $message = 'Scheduler locks were reset manually.';
+    }
+
+    $stmt = db()->prepare(
+        'UPDATE sync_schedules
+         SET locked_until = NULL,
+             last_status = CASE
+                WHEN last_status = ? OR locked_until IS NOT NULL THEN ?
+                ELSE last_status
+             END,
+             last_error = CASE
+                WHEN last_status = ? OR locked_until IS NOT NULL THEN ?
+                ELSE last_error
+             END,
+             next_run_at = CASE
+                WHEN enabled = 1 AND (last_status = ? OR locked_until IS NOT NULL) THEN UTC_TIMESTAMP()
+                WHEN enabled = 0 THEN NULL
+                ELSE next_run_at
+             END,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE last_status = ?
+            OR locked_until IS NOT NULL'
+    );
+
+    $stmt->execute(['running', 'failed', 'running', $message, 'running', 'running']);
 
     return (int) $stmt->rowCount();
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -2113,6 +2113,164 @@ function run_data_sync_now(?string $jobKey = null): array
     }
 }
 
+function scheduler_reset_process_targets(): array
+{
+    $paths = [
+        scheduler_job_runner_script_path(),
+        dirname(__DIR__) . '/bin/cron_tick.php',
+    ];
+
+    return array_values(array_unique(array_filter(array_map(static function (string $path): string {
+        $resolved = realpath($path);
+
+        return $resolved !== false ? $resolved : $path;
+    }, $paths), static fn (string $path): bool => $path !== '')));
+}
+
+function scheduler_find_running_processes(): array
+{
+    if (!function_exists('exec')) {
+        return [];
+    }
+
+    $targets = scheduler_reset_process_targets();
+    if ($targets === []) {
+        return [];
+    }
+
+    $output = [];
+    $exitCode = 1;
+    @exec('ps -eo pid=,command=', $output, $exitCode);
+    if ($exitCode !== 0) {
+        return [];
+    }
+
+    $currentPid = function_exists('getmypid') ? (int) getmypid() : 0;
+    $processes = [];
+
+    foreach ($output as $line) {
+        $trimmed = trim((string) $line);
+        if ($trimmed === '') {
+            continue;
+        }
+
+        if (!preg_match('/^(\d+)\s+(.*)$/', $trimmed, $matches)) {
+            continue;
+        }
+
+        $pid = (int) ($matches[1] ?? 0);
+        $command = trim((string) ($matches[2] ?? ''));
+        if ($pid <= 0 || $command === '' || $pid === $currentPid) {
+            continue;
+        }
+
+        foreach ($targets as $target) {
+            if (!str_contains($command, $target)) {
+                continue;
+            }
+
+            $processes[$pid] = [
+                'pid' => $pid,
+                'command' => $command,
+            ];
+            break;
+        }
+    }
+
+    ksort($processes);
+
+    return array_values($processes);
+}
+
+function scheduler_signal_processes(array $pids, int $signal): void
+{
+    if ($pids === []) {
+        return;
+    }
+
+    $safeSignal = max(1, $signal);
+    $safePids = array_values(array_filter(array_map(static fn (mixed $pid): int => (int) $pid, $pids), static fn (int $pid): bool => $pid > 0));
+    if ($safePids === []) {
+        return;
+    }
+
+    if (function_exists('posix_kill')) {
+        foreach ($safePids as $pid) {
+            @posix_kill($pid, $safeSignal);
+        }
+
+        return;
+    }
+
+    if (!function_exists('exec')) {
+        return;
+    }
+
+    @exec(sprintf(
+        'kill -%d %s >/dev/null 2>&1',
+        $safeSignal,
+        implode(' ', array_map('intval', $safePids))
+    ));
+}
+
+function scheduler_reset_runtime_state(): array
+{
+    $message = 'Scheduler locks were reset manually from Settings.';
+    $processes = scheduler_find_running_processes();
+    $pids = array_values(array_map(static fn (array $process): int => (int) ($process['pid'] ?? 0), $processes));
+
+    scheduler_signal_processes($pids, 15);
+    usleep(250000);
+
+    $remainingProcesses = scheduler_find_running_processes();
+    $remainingPids = array_values(array_map(static fn (array $process): int => (int) ($process['pid'] ?? 0), $remainingProcesses));
+    if ($remainingPids !== []) {
+        scheduler_signal_processes($remainingPids, 9);
+        usleep(250000);
+    }
+
+    $appLockReleased = db_runner_lock_force_release('supplycore:cron_tick');
+    $runnerLockReleased = db_runner_lock_force_release('cron_tick_runner');
+
+    if (supplycore_redis_locking_enabled()) {
+        supplycore_redis_del(['lock:runner:cron_tick_runner']);
+    }
+
+    $resetSchedules = db_sync_schedule_reset_locks($message);
+    $finalProcesses = scheduler_find_running_processes();
+
+    $releasedLocks = [];
+    if ($appLockReleased) {
+        $releasedLocks[] = 'supplycore:cron_tick';
+    }
+    if ($runnerLockReleased) {
+        $releasedLocks[] = 'cron_tick_runner';
+    }
+
+    return [
+        'ok' => $finalProcesses === [],
+        'killed_processes' => $processes,
+        'remaining_processes' => $finalProcesses,
+        'released_locks' => $releasedLocks,
+        'reset_schedule_count' => $resetSchedules,
+    ];
+}
+
+function scheduler_reset_runtime_state_message(array $result): string
+{
+    $killedCount = count((array) ($result['killed_processes'] ?? []));
+    $remainingCount = count((array) ($result['remaining_processes'] ?? []));
+    $lockCount = count((array) ($result['released_locks'] ?? []));
+    $scheduleCount = (int) ($result['reset_schedule_count'] ?? 0);
+
+    $message = 'Scheduler reset completed. Cleared ' . $scheduleCount . ' locked schedule(s), released ' . $lockCount . ' runner lock(s), and targeted ' . $killedCount . ' PHP scheduler process(es).';
+    if ($remainingCount > 0) {
+        $message .= ' Warning: ' . $remainingCount . ' scheduler process(es) still appear to be running and may need manual review.';
+    }
+
+    return $message;
+}
+
 function data_sync_schedule_job_definitions(): array
 {
     return [


### PR DESCRIPTION
### Motivation
- Provide operators a safe way to recover from stuck scheduler state by clearing runner locks, un-sticking schedule rows, and attempting to terminate background PHP scheduler workers so the next tick can proceed.

### Description
- Add DB helpers in `src/db.php`: `db_runner_lock_holder_connection_id`, `db_runner_lock_force_release`, and `db_sync_schedule_reset_locks` to inspect `IS_USED_LOCK()`, `KILL CONNECTION`, and reset locked `sync_schedules` rows with a manual-reset note.
- Add runtime helpers in `src/functions.php`: `scheduler_reset_process_targets`, `scheduler_find_running_processes`, `scheduler_signal_processes`, `scheduler_reset_runtime_state`, and `scheduler_reset_runtime_state_message` to locate matching `cron_tick.php`/`scheduler_job_runner.php` processes, send `TERM` then `KILL` (via `posix_kill` or `kill`), clear Redis runner locks when configured, and produce an operator-facing summary.
- Wire a UI control and action in `public/settings/index.php` under the Data Sync section to trigger the reset flow (`data_sync_action = reset-scheduler`) and surface the resulting status message to the user.
- When Redis locking is enabled the reset clears the Redis lock key for the runner; otherwise the MySQL named locks are force-released.

### Testing
- Ran `php -l src/db.php` and it reported no syntax errors (success).
- Ran `php -l src/functions.php` and it reported no syntax errors (success).
- Ran `php -l public/settings/index.php` and it reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7e7515fc832f8c0a3c8d9133550f)