### PR TITLE
Idempotent schema backfill for sync_schedules.offset_seconds

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -117,6 +117,22 @@ CREATE TABLE IF NOT EXISTS sync_schedules (
     KEY idx_job_key (job_key)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+SET @sync_schedules_offset_seconds_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'sync_schedules'
+      AND COLUMN_NAME = 'offset_seconds'
+);
+SET @sync_schedules_offset_seconds_sql := IF(
+    @sync_schedules_offset_seconds_exists = 0,
+    'ALTER TABLE sync_schedules ADD COLUMN offset_seconds INT UNSIGNED NOT NULL DEFAULT 0 AFTER interval_seconds',
+    'SELECT 1'
+);
+PREPARE sync_schedules_offset_seconds_stmt FROM @sync_schedules_offset_seconds_sql;
+EXECUTE sync_schedules_offset_seconds_stmt;
+DEALLOCATE PREPARE sync_schedules_offset_seconds_stmt;
+
 CREATE TABLE IF NOT EXISTS intelligence_snapshots (
     snapshot_key VARCHAR(190) PRIMARY KEY,
     snapshot_status ENUM('ready', 'updating', 'failed') NOT NULL DEFAULT 'ready',


### PR DESCRIPTION
### Motivation
- Importing `database/schema.sql` into an existing database failed with `Unknown column 'offset_seconds'` because older installs may lack the `sync_schedules.offset_seconds` column.

### Description
- Added an idempotent `INFORMATION_SCHEMA` guard and conditional `ALTER TABLE` (via a prepared statement) immediately after the `sync_schedules` table definition in `database/schema.sql` to add the `offset_seconds` column only when it is missing, so the seeded `INSERT` works for both fresh installs and upgrades.

### Testing
- Ran `git diff --check` and inspected the updated file with `sed -n '96,135p' database/schema.sql` and `nl -ba database/schema.sql | sed -n '100,140p'` to verify the idempotent backfill block was added and these checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd8dc922ac832fbea7b63804a74c36)