### PR TITLE
Fix scheduler running jobs query

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -4210,7 +4210,8 @@ function db_sync_schedule_fetch_running_jobs(?array $excludeScheduleIds = null):
 '
         . 'WHERE enabled = 1
 '
-        . '  AND current_state = \'running\'\n'
+        . '  AND current_state = \'running\'
+'
         . '  AND locked_until IS NOT NULL
 '
         . '  AND locked_until > UTC_TIMESTAMP()';


### PR DESCRIPTION
### Motivation
- Prevent a MariaDB syntax error caused by a literal `\n` inside the `db_sync_schedule_fetch_running_jobs()` SQL string which caused the scheduler settings page to fatally error while loading live capacity data.

### Description
- Replace the escaped newline in the concatenated SQL string with a real line break in `src/db.php` so the `current_state = 'running'` predicate is emitted correctly to the database.

### Testing
- Ran `php -l src/db.php` and it returned no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bead558ee4832fbc9992569def7cb2)