### PR TITLE
Fix scheduler deferred reschedule parameters

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -4419,6 +4419,7 @@ function db_sync_schedule_upsert(string $jobKey, int $enabled, int $intervalSeco
 function db_sync_schedule_set_next_due_at(int $scheduleId, string $nextDueAt, string $reason = ''): bool
 {
     db_sync_schedule_registry_columns_ensure();
+    $result = mb_substr($reason, 0, 120);
 
     return db_execute(
         'UPDATE sync_schedules
@@ -4429,7 +4430,7 @@ function db_sync_schedule_set_next_due_at(int $scheduleId, string $nextDueAt, st
              updated_at = CURRENT_TIMESTAMP
          WHERE id = ?
          LIMIT 1',
-        [$nextDueAt, $nextDueAt, $nextDueAt, $reason, mb_substr($reason, 0, 120), $scheduleId]
+        [$nextDueAt, $nextDueAt, $result, $result, $scheduleId]
     );
 }
 


### PR DESCRIPTION
### Motivation
- Prevent scheduler cron ticks from failing with `SQLSTATE[HY093]: Invalid parameter number` when a due job is deferred and `db_sync_schedule_set_next_due_at()` updates `last_result`.

### Description
- Adjust `db_sync_schedule_set_next_due_at()` in `src/db.php` to compute a single truncated `$result = mb_substr($reason, 0, 120)` and bind it twice so the bound parameter list matches the SQL placeholders.

### Testing
- Ran `php -l src/db.php` which reported no syntax errors and the change was committed; attempting `php -d display_errors=1 bin/cron_tick.php` could not fully validate runtime behavior because the environment returned `SQLSTATE[HY000] [2002] Connection refused`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beafb233e8832fb42564d2e3bad760)