### PR TITLE
Fix scheduler auto-tuning parameter binding

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -4530,7 +4530,7 @@ function db_sync_schedule_apply_adjustment(int $scheduleId, array $changes): boo
              updated_at = CURRENT_TIMESTAMP
          WHERE id = ?
          LIMIT 1',
-        [$intervalMinutes, $intervalMinutes * 60, $offsetMinutes, $offsetMinutes * 60, $timeoutSeconds, $priority, $tuningMode, $reason, $reason, $reason, $nextDueAt, $nextDueAt, $nextDueAt, $currentState, $scheduleId]
+        [$intervalMinutes, $intervalMinutes * 60, $offsetMinutes, $offsetMinutes * 60, $timeoutSeconds, $priority, $tuningMode, $reason, $reason, $reason, $nextDueAt, $nextDueAt, $currentState, $scheduleId]
     );
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the scheduler optimizer from raising `SQLSTATE[HY093]: Invalid parameter number` by ensuring the `UPDATE sync_schedules` auto-tuning query binds the same number of parameters as it contains placeholders.

### Description
- Adjusted `db_sync_schedule_apply_adjustment()` in `src/db.php` so the bound parameter array matches the 14 `?` placeholders in the `UPDATE sync_schedules` statement.

### Testing
- Ran `php -l src/db.php` (PHP lint) which reported no syntax errors, and executed a small verification script that confirmed the SQL placeholder count matches the bound parameter count, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beba2733a8832f8f009d5c28e08921)