### PR TITLE
Fix profiling transaction bootstrap

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -199,8 +199,14 @@ function db_transaction(callable $callback): mixed
         $result = $callback($pdo);
 
         if ($isRootTransaction) {
+            if (!$pdo->inTransaction()) {
+                throw new RuntimeException('The active database transaction ended before db_transaction() could commit. Avoid running implicit-commit SQL inside transactional callbacks.');
+            }
             $pdo->commit();
         } else {
+            if (!$pdo->inTransaction()) {
+                throw new RuntimeException('The active database savepoint ended before db_transaction() could release it. Avoid running implicit-commit SQL inside transactional callbacks.');
+            }
             $pdo->exec("RELEASE SAVEPOINT {$savepoint}");
         }
 
@@ -4646,6 +4652,12 @@ function db_scheduler_pairing_rules_replace_from_profiling_run(int $profilingRun
 
 function db_scheduler_profiling_tables_ensure(): void
 {
+    static $ensured = false;
+
+    if ($ensured) {
+        return;
+    }
+
     db_execute('CREATE TABLE IF NOT EXISTS scheduler_profiling_runs (
         id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
         run_status VARCHAR(30) NOT NULL,
@@ -4724,6 +4736,8 @@ function db_scheduler_profiling_tables_ensure(): void
         KEY idx_scheduler_schedule_snapshots_run (profiling_run_id, created_at),
         KEY idx_scheduler_schedule_snapshots_label (snapshot_label, created_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+    $ensured = true;
 }
 
 function db_scheduler_profiling_active_run(): ?array


### PR DESCRIPTION
### Motivation

- The scheduler profiling flow could trigger `CREATE TABLE IF NOT EXISTS` calls while inside a `db_transaction()` callback, which on MySQL can implicitly end the active transaction and cause a `PDOException` when `commit()` is later called.
- Make this failure mode explicit and avoid re-running DDL repeatedly during a single request so transactional callbacks are not exposed to implicit commits.

### Description

- Added defensive checks in `db_transaction()` that call `inTransaction()` before attempting `commit()` or `RELEASE SAVEPOINT`, and throw a `RuntimeException` with a clear message if the transaction/savepoint was lost and implicit-commit SQL was likely executed inside the callback.
- Memoized the profiling table bootstrap by adding a `static $ensured` guard in `db_scheduler_profiling_tables_ensure()` so the `CREATE TABLE IF NOT EXISTS` work runs at most once per request and will not execute repeatedly inside transactional callbacks.
- No other business logic or DB calls were moved; changes were kept localized to `src/db.php` to preserve centralized DB behavior.

### Testing

- Ran PHP lint on the modified file with `php -l src/db.php`, which returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec8aa6c84832fb0e26715274630ce)