### PR TITLE
Refactor scheduler into a continuous, self-healing daemon with watchdog and health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 
 ## Production Cron Setup
 
-### Canonical crontab entry (single scheduler timer)
+### Canonical crontab entry (scheduler watchdog only)
 
 1. Determine the final app path and PHP binary path:
    ```bash
@@ -205,9 +205,11 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 
 ### Scheduling model
 
-- Cron is **timer-only**: it triggers `bin/cron_tick.php` once per minute.
-- Production cron must use `/usr/bin/flock -n /tmp/supplycore_cron.lock ...` as the first single-run guard, while `bin/cron_tick.php` also acquires the MariaDB advisory lock `GET_LOCK('supplycore:cron_tick', 0)` as an application-level safety net before any scheduler work begins.
-- The scheduler (`bin/cron_tick.php`) decides which jobs are due, runs standard jobs inline, and dispatches async-capable AI jobs to `bin/scheduler_job_runner.php` background workers so long-polling providers do not block the rest of the queue.
+- `bin/scheduler_daemon.php` is now the **primary scheduler master loop**. It stays alive, renews a database lease/heartbeat in `scheduler_daemon_state`, continuously re-evaluates due work, dispatches follow-up jobs immediately when capacity opens, and recycles itself cleanly when runtime, loop-count, or memory thresholds are reached.
+- Cron is now **watchdog-only**. `bin/cron_tick.php` no longer performs primary dispatch; it runs `bin/scheduler_watchdog.php` semantics to verify the daemon heartbeat, recover stale scheduler state, and start the daemon again when needed.
+- `bin/scheduler_health.php` prints the daemon health JSON and exits non-zero when the daemon is degraded or stopped, which makes it suitable for `systemd` health probes or manual checks.
+- The continuous daemon still reuses the existing scheduler intelligence: it claims due jobs from `sync_schedules`, preserves priority/fairness/latest-allowed-start behavior, keeps protected-job and incompatibility rules, uses the same resource-aware concurrency planner, and still dispatches async-capable AI jobs to `bin/scheduler_job_runner.php` background workers so long-polling providers do not block the rest of the queue.
+- The daemon does not busy-spin. When nothing is runnable it sleeps until the earliest of the next due timestamp, a short fallback poll interval, or a wake signal recorded by the watchdog/background workers after completions.
 - Interval and enable/disable controls are configured in **Settings → Data Sync** (`/settings?section=data-sync`) via scheduler rows in `sync_schedules`.
 - SupplyCore now separates cadences by workload:
   - **Fast ingestion / current state**: `killmail_r2z2_sync` runs every minute, while `alliance_current_sync`, `market_hub_current_sync`, and `current_state_refresh_sync` default to every 5 minutes.
@@ -225,12 +227,47 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 - CPU telemetry is derived from PHP process user+system CPU time (`getrusage()`) divided by wall-clock seconds, so the recorded percentage represents how much of one CPU core the job consumed on average during the run. Memory telemetry uses PHP's process memory usage and peak high-water mark (`memory_get_usage(true)` / `memory_get_peak_usage(true)`), with the stored run cost preferring the peak delta observed while the job was executing.
 - The planner learns a rolling light/medium/heavy class for each job from recent CPU, memory, duration, timeout/failure, and lock-wait behavior. Unknown jobs stay in learning mode and are projected conservatively until enough telemetry samples accumulate.
 - Capacity decisions combine current running-job projections, per-job p95 resource costs, fairness/urgency toward `latest_allowed_start_at`, explicit incompatibility rules, reserved headroom for critical jobs, and the pressure states `healthy`, `busy`, `congested`, and `overload_protection`.
+- Lease recovery and stale-state cleanup now happen during daemon startup and watchdog intervention. The daemon clears expired/stale running markers, updates the last recovery event in `scheduler_daemon_state`, and resumes scheduling without waiting for the next cron minute.
 - UI pages now read Redis first and fall back to `intelligence_snapshots` if Redis is unavailable; each intelligence surface also exposes its last computed timestamp and freshness state to operators.
 - The hub-history scheduler jobs (`market_hub_historical_sync` and `market_hub_local_history_sync`) now pre-aggregate raw hub-order snapshots into `market_order_snapshots_summary`, then rebuild `market_history_daily` from that summary layer using the recent window controlled by `raw_order_snapshot_retention_days` unless a CLI override is supplied.
 - `market_order_snapshots_summary` is indexed for the read paths the app uses most: latest snapshot reads via `(source_type, source_id, observed_at, type_id)`, per-type windows via `(source_type, source_id, type_id, observed_at)`, and daily stock-health rollups via `(source_type, source_id, observed_date, type_id)`.
 - **Trend Snippets** on the dashboard depend on that first-party snapshot history generation.
-- The **Run now** button in Settings → Data Sync includes the Hub Snapshot History job, forces the selected enabled schedule due immediately, and executes one scheduler tick.
+- The **Run now** button in Settings → Data Sync still forces the selected enabled schedule due immediately, but when the daemon is healthy it now wakes that daemon instead of waiting for the old minute-based cron trigger.
 - Backfill start dates are automatic: each pipeline starts from the date sync automation was enabled (`sync_automation_enabled_since`).
+
+### Example `systemd` unit
+
+Create `/etc/systemd/system/supplycore-scheduler.service`:
+
+```ini
+[Unit]
+Description=SupplyCore continuous scheduler daemon
+After=network.target mariadb.service
+
+[Service]
+Type=simple
+WorkingDirectory=/var/www/supplycore
+ExecStart=/usr/bin/php /var/www/supplycore/bin/scheduler_daemon.php
+Restart=always
+RestartSec=5
+User=www-data
+Group=www-data
+KillSignal=SIGTERM
+TimeoutStopSec=120
+StandardOutput=append:/var/www/supplycore/storage/logs/cron.log
+StandardError=append:/var/www/supplycore/storage/logs/cron.log
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Then enable it:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now supplycore-scheduler.service
+sudo systemctl status supplycore-scheduler.service
+```
 
 ### Required cron runtime environment
 
@@ -243,8 +280,8 @@ Cron must run with the same environment the app expects:
   - `SUPPLYCORE_ALLIANCE_SOURCE_ID` (for `alliance-current` and `alliance-history`)
   - `SUPPLYCORE_HUB_SOURCE_ID` (for `hub-current`, `hub-history`, and hub snapshot-history generation)
 
-The canonical log path for the cron tick is `storage/logs/cron.log` (relative to app root).
-If logs show `Job exceeded timeout of ... seconds.`, raise the matching scheduler timeout environment variable and reload cron/PHP so new worker processes inherit it.
+The canonical log path for the daemon and watchdog is `storage/logs/cron.log` (relative to app root).
+If logs show `Job exceeded timeout of ... seconds.`, raise the matching scheduler timeout environment variable and restart the `supplycore-scheduler.service` (or let the watchdog/systemd respawn it) so new worker processes inherit it.
 Raw order snapshots are pruned according to `raw_order_snapshot_retention_days` from Settings → Data Sync.
 Daily history rows are built from those local snapshots for both the alliance market and the reference hub, so keep the current-sync and history schedules enabled together for continuous trend updates.
 

--- a/bin/cron_tick.php
+++ b/bin/cron_tick.php
@@ -5,96 +5,53 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../src/bootstrap.php';
 
-const CRON_TICK_RUNNER_LOCK = 'cron_tick_runner';
-const CRON_TICK_APP_LOCK = 'supplycore:cron_tick';
+const CRON_TICK_WATCHDOG_LOCK = 'supplycore:scheduler_watchdog';
 
 function cron_tick_output(string $event, array $payload = [], $stream = STDOUT): void
 {
-    $line = ['event' => $event, 'ts' => gmdate(DATE_ATOM)] + $payload;
-    fwrite($stream, json_encode($line, JSON_UNESCAPED_SLASHES) . PHP_EOL);
-}
-
-function cron_tick_exit_code(array $summary): int
-{
-    return !empty($summary['scheduler_failed']) ? 1 : 0;
+    scheduler_daemon_output($event, $payload, $stream);
 }
 
 function cron_tick_main(): int
 {
-    $tickStartedAt = microtime(true);
-    $appLockAcquired = false;
+    $startedAt = microtime(true);
     $lockAcquired = false;
 
     try {
-        $appLockAcquired = db_runner_lock_acquire(CRON_TICK_APP_LOCK, 0);
-        if (!$appLockAcquired) {
-            $durationMs = (int) round((microtime(true) - $tickStartedAt) * 1000);
-            cron_tick_output('cron_tick.lock_skipped', [
-                'scheduler_status' => 'skipped_locked',
-                'duration_ms' => $durationMs,
-                'lock_name' => CRON_TICK_APP_LOCK,
-            ]);
-
-            return 0;
-        }
-
-        cron_tick_output('cron_tick.started', [
-            'scheduler_status' => 'starting',
-            'lock_name' => CRON_TICK_APP_LOCK,
-        ]);
-
-        $lockAcquired = runner_lock_acquire(CRON_TICK_RUNNER_LOCK);
+        $lockAcquired = db_runner_lock_acquire(CRON_TICK_WATCHDOG_LOCK, 0);
         if (!$lockAcquired) {
-            $durationMs = (int) round((microtime(true) - $tickStartedAt) * 1000);
-            cron_tick_output('cron_tick.lock_skipped', [
-                'scheduler_status' => 'skipped_locked',
-                'duration_ms' => $durationMs,
-                'lock_name' => CRON_TICK_RUNNER_LOCK,
+            cron_tick_output('cron_tick.watchdog_skipped', [
+                'reason' => 'lock_held',
+                'duration_ms' => (int) round((microtime(true) - $startedAt) * 1000),
             ]);
 
             return 0;
         }
 
-        cron_tick_output('cron_tick.lock_acquired', [
-            'scheduler_status' => 'running',
+        cron_tick_output('cron_tick.watchdog_started', [
+            'scheduler_status' => 'checking',
         ]);
 
-        $summary = cron_tick_run('cron_tick_output');
-        $summary['scheduler_failed'] = false;
-        $summary['duration_ms'] = (int) round((microtime(true) - $tickStartedAt) * 1000);
+        $result = scheduler_watchdog_run('cron_tick_output');
 
-        cron_tick_output('cron_tick.summary', [
-            'jobs_due' => (int) ($summary['jobs_due'] ?? 0),
-            'jobs_processed' => (int) ($summary['jobs_processed'] ?? 0),
-            'jobs_succeeded' => (int) ($summary['jobs_succeeded'] ?? 0),
-            'jobs_failed' => (int) ($summary['jobs_failed'] ?? 0),
-            'duration_ms' => (int) ($summary['duration_ms'] ?? 0),
-            'scheduler_failed' => false,
-            'scheduler_status' => 'ok',
-        ]);
+        cron_tick_output('cron_tick.watchdog_summary', [
+            'scheduler_status' => (string) ($result['status'] ?? 'healthy'),
+            'action' => (string) ($result['action'] ?? 'none'),
+            'duration_ms' => (int) round((microtime(true) - $startedAt) * 1000),
+        ] + (array) ($result['health'] ?? []));
 
-        cron_tick_output('cron_tick.completed', [
-            'scheduler_status' => 'ok',
-            'duration_ms' => (int) ($summary['duration_ms'] ?? 0),
-        ]);
-
-        return cron_tick_exit_code($summary);
+        return ($result['status'] ?? 'healthy') === 'degraded' ? 1 : 0;
     } catch (Throwable $exception) {
-        $durationMs = (int) round((microtime(true) - $tickStartedAt) * 1000);
-        cron_tick_output('cron_tick.scheduler_error', [
-            'scheduler_failed' => true,
+        cron_tick_output('cron_tick.watchdog_error', [
             'scheduler_status' => 'failed',
-            'duration_ms' => $durationMs,
-            'error' => $exception->getMessage(),
+            'duration_ms' => (int) round((microtime(true) - $startedAt) * 1000),
+            'error' => scheduler_normalize_error_message($exception->getMessage()),
         ], STDERR);
 
         return 1;
     } finally {
         if ($lockAcquired) {
-            runner_lock_release(CRON_TICK_RUNNER_LOCK);
-        }
-        if ($appLockAcquired) {
-            db_runner_lock_release(CRON_TICK_APP_LOCK);
+            db_runner_lock_release(CRON_TICK_WATCHDOG_LOCK);
         }
     }
 }

--- a/bin/scheduler_daemon.php
+++ b/bin/scheduler_daemon.php
@@ -1,0 +1,16 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+try {
+    exit(scheduler_daemon_run('scheduler_daemon_output'));
+} catch (Throwable $exception) {
+    scheduler_daemon_output('scheduler_daemon.bootstrap_error', [
+        'error' => scheduler_normalize_error_message($exception->getMessage()),
+    ], STDERR);
+
+    exit(1);
+}

--- a/bin/scheduler_health.php
+++ b/bin/scheduler_health.php
@@ -1,0 +1,23 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+try {
+    $state = scheduler_daemon_health_summary();
+    fwrite(STDOUT, json_encode($state, JSON_UNESCAPED_SLASHES) . PHP_EOL);
+
+    exit(!empty($state['is_healthy']) ? 0 : (($state['derived_status'] ?? 'stopped') === 'degraded' ? 1 : 2));
+} catch (Throwable $exception) {
+    fwrite(STDOUT, json_encode([
+        'daemon_key' => 'master',
+        'status' => 'failed',
+        'derived_status' => 'degraded',
+        'is_healthy' => false,
+        'error' => scheduler_normalize_error_message($exception->getMessage()),
+    ], JSON_UNESCAPED_SLASHES) . PHP_EOL);
+
+    exit(2);
+}

--- a/bin/scheduler_job_runner.php
+++ b/bin/scheduler_job_runner.php
@@ -75,6 +75,8 @@ function scheduler_job_runner_main(): int
         ] + $meta);
     }
 
+    db_scheduler_daemon_request_wake(scheduler_daemon_key());
+
     return $resultStatus === 'failed' ? 1 : 0;
 }
 

--- a/bin/scheduler_watchdog.php
+++ b/bin/scheduler_watchdog.php
@@ -1,0 +1,19 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+try {
+    $result = scheduler_watchdog_run('scheduler_daemon_output');
+    scheduler_daemon_output('scheduler_watchdog.summary', $result);
+
+    exit(($result['status'] ?? 'degraded') === 'degraded' ? 1 : 0);
+} catch (Throwable $exception) {
+    scheduler_daemon_output('scheduler_watchdog.error', [
+        'error' => scheduler_normalize_error_message($exception->getMessage()),
+    ], STDERR);
+
+    exit(1);
+}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -541,6 +541,42 @@ WHERE interval_minutes IS NULL
    OR offset_minutes IS NULL
    OR next_due_at IS NULL;
 
+CREATE TABLE IF NOT EXISTS scheduler_daemon_state (
+    daemon_key VARCHAR(64) NOT NULL PRIMARY KEY,
+    owner_token VARCHAR(190) DEFAULT NULL,
+    owner_label VARCHAR(190) DEFAULT NULL,
+    owner_pid INT UNSIGNED DEFAULT NULL,
+    owner_hostname VARCHAR(190) DEFAULT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'stopped',
+    loop_state VARCHAR(64) DEFAULT NULL,
+    stop_requested TINYINT(1) NOT NULL DEFAULT 0,
+    restart_requested TINYINT(1) NOT NULL DEFAULT 0,
+    active_dispatch_count INT UNSIGNED NOT NULL DEFAULT 0,
+    current_loop_count BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    current_memory_bytes BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    started_at DATETIME DEFAULT NULL,
+    heartbeat_at DATETIME DEFAULT NULL,
+    lease_expires_at DATETIME DEFAULT NULL,
+    last_dispatch_at DATETIME DEFAULT NULL,
+    last_recovery_at DATETIME DEFAULT NULL,
+    last_recovery_event VARCHAR(500) DEFAULT NULL,
+    last_watchdog_at DATETIME DEFAULT NULL,
+    watchdog_status VARCHAR(64) DEFAULT NULL,
+    wake_requested_at DATETIME DEFAULT NULL,
+    last_exit_at DATETIME DEFAULT NULL,
+    last_exit_code INT DEFAULT NULL,
+    last_exit_reason VARCHAR(500) DEFAULT NULL,
+    metadata_json LONGTEXT DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_scheduler_daemon_lease (lease_expires_at),
+    KEY idx_scheduler_daemon_heartbeat (heartbeat_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO scheduler_daemon_state (daemon_key, status, loop_state, watchdog_status)
+VALUES ('master', 'stopped', 'idle', 'unknown')
+ON DUPLICATE KEY UPDATE daemon_key = daemon_key;
+
 
 CREATE TABLE IF NOT EXISTS scheduler_job_pairing_rules (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1531,6 +1531,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 </label>
 
                 <?php $schedulerHealth = (array) ($syncDashboard['health_summary'] ?? []); ?>
+                <?php $schedulerDaemon = (array) ($syncDashboard['daemon_state'] ?? ($schedulerHealth['daemon'] ?? [])); ?>
                 <div class="space-y-4">
                     <div class="grid gap-4 xl:grid-cols-[1.2fr_1fr]">
                         <article class="rounded-xl border border-border bg-black/20 p-4">
@@ -1557,6 +1558,27 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             </div>
                         </article>
                         <article class="rounded-xl border border-border bg-black/20 p-4">
+                            <div class="flex items-start justify-between gap-3">
+                                <div>
+                                    <p class="text-sm text-slate-100">Scheduler daemon state</p>
+                                    <p class="mt-1 text-xs text-muted">Tracks the long-running master loop, lease heartbeat, wake/recovery state, and watchdog observations.</p>
+                                </div>
+                                <?php $daemonStatus = (string) ($schedulerDaemon['derived_status'] ?? 'stopped'); ?>
+                                <?php $daemonStatusClass = $daemonStatus === 'running' ? 'border-emerald-400/30 bg-emerald-500/10 text-emerald-100' : ($daemonStatus === 'degraded' ? 'border-amber-400/40 bg-amber-500/10 text-amber-100' : 'border-rose-400/40 bg-rose-500/10 text-rose-100'); ?>
+                                <span class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.16em] <?= $daemonStatusClass ?>"><?= htmlspecialchars($daemonStatus, ENT_QUOTES) ?></span>
+                            </div>
+                            <div class="mt-4 grid gap-3 sm:grid-cols-2">
+                                <div class="rounded-lg border border-border bg-black/30 p-3 text-sm"><p class="text-xs uppercase tracking-[0.16em] text-muted">Owner</p><p class="mt-2 font-semibold text-white"><?= htmlspecialchars((string) ($schedulerDaemon['owner_label'] ?? 'unclaimed'), ENT_QUOTES) ?></p><p class="mt-1 text-xs text-muted">PID <?= (int) ($schedulerDaemon['owner_pid'] ?? 0) ?> · <?= htmlspecialchars((string) ($schedulerDaemon['owner_hostname'] ?? 'unknown'), ENT_QUOTES) ?></p></div>
+                                <div class="rounded-lg border border-border bg-black/30 p-3 text-sm"><p class="text-xs uppercase tracking-[0.16em] text-muted">Loop</p><p class="mt-2 font-semibold text-white"><?= htmlspecialchars((string) ($schedulerDaemon['loop_state'] ?? 'idle'), ENT_QUOTES) ?></p><p class="mt-1 text-xs text-muted">Dispatches <?= (int) ($schedulerDaemon['active_dispatch_count'] ?? 0) ?> · loops <?= (int) ($schedulerDaemon['current_loop_count'] ?? 0) ?></p></div>
+                                <div class="rounded-lg border border-border bg-black/30 p-3 text-sm"><p class="text-xs uppercase tracking-[0.16em] text-muted">Heartbeat</p><p class="mt-2 font-semibold text-white"><?= htmlspecialchars((string) ($schedulerDaemon['heartbeat_at'] ?? 'never'), ENT_QUOTES) ?></p><p class="mt-1 text-xs text-muted">Age <?= isset($schedulerDaemon['heartbeat_age_seconds']) ? htmlspecialchars(human_duration_ago((int) $schedulerDaemon['heartbeat_age_seconds']), ENT_QUOTES) : '—' ?> · uptime <?= isset($schedulerDaemon['uptime_seconds']) ? htmlspecialchars(human_duration_ago((int) $schedulerDaemon['uptime_seconds']), ENT_QUOTES) : '—' ?></p></div>
+                                <div class="rounded-lg border border-border bg-black/30 p-3 text-sm"><p class="text-xs uppercase tracking-[0.16em] text-muted">Dispatch / watchdog</p><p class="mt-2 font-semibold text-white"><?= htmlspecialchars((string) ($schedulerDaemon['last_dispatch_at'] ?? 'never'), ENT_QUOTES) ?></p><p class="mt-1 text-xs text-muted">Watchdog <?= htmlspecialchars((string) ($schedulerDaemon['watchdog_status'] ?? 'unknown'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($schedulerDaemon['last_watchdog_at'] ?? 'never'), ENT_QUOTES) ?></p></div>
+                                <div class="rounded-lg border border-border bg-black/30 p-3 text-sm sm:col-span-2"><p class="text-xs uppercase tracking-[0.16em] text-muted">Recovery</p><p class="mt-2 font-semibold text-white"><?= htmlspecialchars((string) ($schedulerDaemon['last_recovery_event'] ?? 'No recovery event recorded.'), ENT_QUOTES) ?></p><p class="mt-1 text-xs text-muted">Last recovery <?= htmlspecialchars((string) ($schedulerDaemon['last_recovery_at'] ?? 'never'), ENT_QUOTES) ?> · last exit <?= htmlspecialchars((string) ($schedulerDaemon['last_exit_reason'] ?? 'n/a'), ENT_QUOTES) ?></p></div>
+                            </div>
+                        </article>
+                    </div>
+
+                    <div class="grid gap-4 xl:grid-cols-[1.2fr_1fr]">
+                        <article class="rounded-xl border border-border bg-black/20 p-4">
                             <p class="text-sm text-slate-100">Busiest minute offsets</p>
                             <p class="mt-1 text-xs text-muted">Use this to spot offset clustering before jobs contend for the same minute slot.</p>
                             <div class="mt-4 space-y-2 text-sm">
@@ -1566,6 +1588,16 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                         <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($offsetRow['job_keys'] ?? ''), ENT_QUOTES) ?></p>
                                     </div>
                                 <?php endforeach; ?>
+                            </div>
+                        </article>
+                        <article class="rounded-xl border border-border bg-black/20 p-4">
+                            <p class="text-sm text-slate-100">Daemon recycling / control flags</p>
+                            <p class="mt-1 text-xs text-muted">Long-running PHP workers recycle cleanly to control memory growth while systemd or the watchdog brings them back.</p>
+                            <div class="mt-4 grid gap-3 sm:grid-cols-2 text-sm">
+                                <div class="rounded-lg border border-border bg-black/30 p-3"><p class="text-xs uppercase tracking-[0.16em] text-muted">Memory</p><p class="mt-2 font-semibold text-white"><?= htmlspecialchars(scheduler_format_bytes((int) ($schedulerDaemon['current_memory_bytes'] ?? 0)), ENT_QUOTES) ?></p></div>
+                                <div class="rounded-lg border border-border bg-black/30 p-3"><p class="text-xs uppercase tracking-[0.16em] text-muted">Lease expires</p><p class="mt-2 font-semibold text-white"><?= htmlspecialchars((string) ($schedulerDaemon['lease_expires_at'] ?? 'n/a'), ENT_QUOTES) ?></p></div>
+                                <div class="rounded-lg border border-border bg-black/30 p-3"><p class="text-xs uppercase tracking-[0.16em] text-muted">Stop requested</p><p class="mt-2 font-semibold text-white"><?= !empty($schedulerDaemon['stop_requested']) ? 'Yes' : 'No' ?></p></div>
+                                <div class="rounded-lg border border-border bg-black/30 p-3"><p class="text-xs uppercase tracking-[0.16em] text-muted">Restart requested</p><p class="mt-2 font-semibold text-white"><?= !empty($schedulerDaemon['restart_requested']) ? 'Yes' : 'No' ?></p></div>
                             </div>
                         </article>
                     </div>

--- a/src/db.php
+++ b/src/db.php
@@ -3829,6 +3829,250 @@ function db_runner_lock_force_release(string $lockName): bool
     return db_runner_lock_holder_connection_id($lockName) === null;
 }
 
+function db_scheduler_daemon_state_ensure(): void
+{
+    db_execute('CREATE TABLE IF NOT EXISTS scheduler_daemon_state (
+        daemon_key VARCHAR(64) NOT NULL PRIMARY KEY,
+        owner_token VARCHAR(190) DEFAULT NULL,
+        owner_label VARCHAR(190) DEFAULT NULL,
+        owner_pid INT UNSIGNED DEFAULT NULL,
+        owner_hostname VARCHAR(190) DEFAULT NULL,
+        status VARCHAR(32) NOT NULL DEFAULT \'stopped\',
+        loop_state VARCHAR(64) DEFAULT NULL,
+        stop_requested TINYINT(1) NOT NULL DEFAULT 0,
+        restart_requested TINYINT(1) NOT NULL DEFAULT 0,
+        active_dispatch_count INT UNSIGNED NOT NULL DEFAULT 0,
+        current_loop_count BIGINT UNSIGNED NOT NULL DEFAULT 0,
+        current_memory_bytes BIGINT UNSIGNED NOT NULL DEFAULT 0,
+        started_at DATETIME DEFAULT NULL,
+        heartbeat_at DATETIME DEFAULT NULL,
+        lease_expires_at DATETIME DEFAULT NULL,
+        last_dispatch_at DATETIME DEFAULT NULL,
+        last_recovery_at DATETIME DEFAULT NULL,
+        last_recovery_event VARCHAR(500) DEFAULT NULL,
+        last_watchdog_at DATETIME DEFAULT NULL,
+        watchdog_status VARCHAR(64) DEFAULT NULL,
+        wake_requested_at DATETIME DEFAULT NULL,
+        last_exit_at DATETIME DEFAULT NULL,
+        last_exit_code INT DEFAULT NULL,
+        last_exit_reason VARCHAR(500) DEFAULT NULL,
+        metadata_json LONGTEXT DEFAULT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        KEY idx_scheduler_daemon_lease (lease_expires_at),
+        KEY idx_scheduler_daemon_heartbeat (heartbeat_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+    db_execute(
+        'INSERT INTO scheduler_daemon_state (daemon_key, status, loop_state, watchdog_status)
+         VALUES (?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE daemon_key = daemon_key',
+        ['master', 'stopped', 'idle', 'unknown']
+    );
+}
+
+function db_scheduler_daemon_state_fetch(string $daemonKey = 'master'): ?array
+{
+    db_scheduler_daemon_state_ensure();
+
+    $row = db_select_one(
+        'SELECT daemon_key, owner_token, owner_label, owner_pid, owner_hostname, status, loop_state, stop_requested, restart_requested, active_dispatch_count, current_loop_count, current_memory_bytes, started_at, heartbeat_at, lease_expires_at, last_dispatch_at, last_recovery_at, last_recovery_event, last_watchdog_at, watchdog_status, wake_requested_at, last_exit_at, last_exit_code, last_exit_reason, metadata_json, created_at, updated_at
+         FROM scheduler_daemon_state
+         WHERE daemon_key = ?
+         LIMIT 1',
+        [mb_substr(trim($daemonKey), 0, 64)]
+    );
+
+    return $row !== [] ? $row : null;
+}
+
+function db_scheduler_daemon_try_claim(string $daemonKey, string $ownerToken, string $ownerLabel, int $ownerPid, string $ownerHostname, int $leaseTtlSeconds, array $metadata = []): bool
+{
+    db_scheduler_daemon_state_ensure();
+
+    $safeDaemonKey = mb_substr(trim($daemonKey), 0, 64);
+    $safeOwnerToken = mb_substr(trim($ownerToken), 0, 190);
+    $safeOwnerLabel = mb_substr(trim($ownerLabel), 0, 190);
+    $safeHostname = mb_substr(trim($ownerHostname), 0, 190);
+    $safeTtl = max(5, min(300, $leaseTtlSeconds));
+    $metadataJson = $metadata !== [] ? json_encode($metadata, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE) : null;
+
+    $ok = db_execute(
+        'INSERT INTO scheduler_daemon_state (
+            daemon_key, owner_token, owner_label, owner_pid, owner_hostname, status, loop_state, stop_requested, restart_requested, active_dispatch_count, current_loop_count, current_memory_bytes, started_at, heartbeat_at, lease_expires_at, metadata_json, created_at, updated_at
+         ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, UTC_TIMESTAMP(), UTC_TIMESTAMP(), DATE_ADD(UTC_TIMESTAMP(), INTERVAL ? SECOND), ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+         )
+         ON DUPLICATE KEY UPDATE
+            owner_token = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), VALUES(owner_token), owner_token),
+            owner_label = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), VALUES(owner_label), owner_label),
+            owner_pid = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), VALUES(owner_pid), owner_pid),
+            owner_hostname = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), VALUES(owner_hostname), owner_hostname),
+            status = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), VALUES(status), status),
+            loop_state = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), VALUES(loop_state), loop_state),
+            stop_requested = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), 0, stop_requested),
+            restart_requested = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), 0, restart_requested),
+            active_dispatch_count = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), 0, active_dispatch_count),
+            current_loop_count = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), 0, current_loop_count),
+            current_memory_bytes = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), 0, current_memory_bytes),
+            started_at = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), UTC_TIMESTAMP(), started_at),
+            heartbeat_at = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), UTC_TIMESTAMP(), heartbeat_at),
+            lease_expires_at = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), DATE_ADD(UTC_TIMESTAMP(), INTERVAL ? SECOND), lease_expires_at),
+            metadata_json = IF(owner_token IS NULL OR owner_token = VALUES(owner_token) OR lease_expires_at IS NULL OR lease_expires_at <= UTC_TIMESTAMP(), VALUES(metadata_json), metadata_json),
+            updated_at = CURRENT_TIMESTAMP',
+        [$safeDaemonKey, $safeOwnerToken, $safeOwnerLabel, max(0, $ownerPid), $safeHostname, 'running', 'starting', $safeTtl, $metadataJson, $safeTtl]
+    );
+    if (!$ok) {
+        return false;
+    }
+
+    $row = db_scheduler_daemon_state_fetch($safeDaemonKey);
+
+    return (string) ($row['owner_token'] ?? '') === $safeOwnerToken;
+}
+
+function db_scheduler_daemon_heartbeat(string $daemonKey, string $ownerToken, array $state = [], int $leaseTtlSeconds = 30): bool
+{
+    db_scheduler_daemon_state_ensure();
+
+    $safeDaemonKey = mb_substr(trim($daemonKey), 0, 64);
+    $safeOwnerToken = mb_substr(trim($ownerToken), 0, 190);
+    $safeTtl = max(5, min(300, $leaseTtlSeconds));
+    $status = array_key_exists('status', $state) ? mb_substr(trim((string) $state['status']), 0, 32) : null;
+    $loopState = array_key_exists('loop_state', $state) ? mb_substr(trim((string) $state['loop_state']), 0, 64) : null;
+    $dispatchCount = array_key_exists('active_dispatch_count', $state) ? max(0, (int) $state['active_dispatch_count']) : null;
+    $loopCount = array_key_exists('current_loop_count', $state) ? max(0, (int) $state['current_loop_count']) : null;
+    $memoryBytes = array_key_exists('current_memory_bytes', $state) ? max(0, (int) $state['current_memory_bytes']) : null;
+    $metadataJson = array_key_exists('metadata', $state) && is_array($state['metadata'])
+        ? json_encode($state['metadata'], JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)
+        : null;
+    $touchDispatch = !empty($state['touch_last_dispatch']);
+    $touchRecovery = !empty($state['touch_last_recovery']);
+    $recoveryEvent = array_key_exists('last_recovery_event', $state) ? mb_substr(trim((string) $state['last_recovery_event']), 0, 500) : null;
+
+    return db_execute(
+        'UPDATE scheduler_daemon_state
+         SET heartbeat_at = UTC_TIMESTAMP(),
+             lease_expires_at = DATE_ADD(UTC_TIMESTAMP(), INTERVAL ? SECOND),
+             status = COALESCE(?, status),
+             loop_state = COALESCE(?, loop_state),
+             active_dispatch_count = COALESCE(?, active_dispatch_count),
+             current_loop_count = COALESCE(?, current_loop_count),
+             current_memory_bytes = COALESCE(?, current_memory_bytes),
+             last_dispatch_at = CASE WHEN ? = 1 THEN UTC_TIMESTAMP() ELSE last_dispatch_at END,
+             last_recovery_at = CASE WHEN ? = 1 THEN UTC_TIMESTAMP() ELSE last_recovery_at END,
+             last_recovery_event = CASE WHEN ? <> \'\' THEN ? ELSE last_recovery_event END,
+             metadata_json = COALESCE(?, metadata_json),
+             updated_at = CURRENT_TIMESTAMP
+         WHERE daemon_key = ?
+           AND owner_token = ?
+         LIMIT 1',
+        [$safeTtl, $status, $loopState, $dispatchCount, $loopCount, $memoryBytes, $touchDispatch ? 1 : 0, $touchRecovery ? 1 : 0, $recoveryEvent ?? '', $recoveryEvent, $metadataJson, $safeDaemonKey, $safeOwnerToken]
+    );
+}
+
+function db_scheduler_daemon_release(string $daemonKey, string $ownerToken, string $status = 'stopped', ?int $exitCode = null, string $exitReason = ''): bool
+{
+    db_scheduler_daemon_state_ensure();
+
+    return db_execute(
+        'UPDATE scheduler_daemon_state
+         SET status = ?,
+             loop_state = ?,
+             owner_token = NULL,
+             owner_label = NULL,
+             owner_pid = NULL,
+             owner_hostname = NULL,
+             active_dispatch_count = 0,
+             lease_expires_at = NULL,
+             wake_requested_at = NULL,
+             stop_requested = 0,
+             restart_requested = 0,
+             last_exit_at = UTC_TIMESTAMP(),
+             last_exit_code = ?,
+             last_exit_reason = CASE WHEN ? <> \'\' THEN ? ELSE last_exit_reason END,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE daemon_key = ?
+           AND owner_token = ?
+         LIMIT 1',
+        [mb_substr(trim($status), 0, 32), 'idle', $exitCode, mb_substr(trim($exitReason), 0, 500), mb_substr(trim($exitReason), 0, 500), mb_substr(trim($daemonKey), 0, 64), mb_substr(trim($ownerToken), 0, 190)]
+    );
+}
+
+function db_scheduler_daemon_watchdog_touch(string $daemonKey, string $watchdogStatus, array $metadata = []): bool
+{
+    db_scheduler_daemon_state_ensure();
+
+    $metadataJson = $metadata !== [] ? json_encode($metadata, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE) : null;
+
+    return db_execute(
+        'UPDATE scheduler_daemon_state
+         SET last_watchdog_at = UTC_TIMESTAMP(),
+             watchdog_status = ?,
+             metadata_json = COALESCE(?, metadata_json),
+             updated_at = CURRENT_TIMESTAMP
+         WHERE daemon_key = ?
+         LIMIT 1',
+        [mb_substr(trim($watchdogStatus), 0, 64), $metadataJson, mb_substr(trim($daemonKey), 0, 64)]
+    );
+}
+
+function db_scheduler_daemon_set_control_flags(string $daemonKey, ?bool $stopRequested = null, ?bool $restartRequested = null): bool
+{
+    db_scheduler_daemon_state_ensure();
+
+    return db_execute(
+        'UPDATE scheduler_daemon_state
+         SET stop_requested = COALESCE(?, stop_requested),
+             restart_requested = COALESCE(?, restart_requested),
+             updated_at = CURRENT_TIMESTAMP
+         WHERE daemon_key = ?
+         LIMIT 1',
+        [$stopRequested === null ? null : ($stopRequested ? 1 : 0), $restartRequested === null ? null : ($restartRequested ? 1 : 0), mb_substr(trim($daemonKey), 0, 64)]
+    );
+}
+
+function db_scheduler_daemon_request_wake(string $daemonKey = 'master'): bool
+{
+    db_scheduler_daemon_state_ensure();
+
+    return db_execute(
+        'UPDATE scheduler_daemon_state
+         SET wake_requested_at = UTC_TIMESTAMP(),
+             updated_at = CURRENT_TIMESTAMP
+         WHERE daemon_key = ?
+         LIMIT 1',
+        [mb_substr(trim($daemonKey), 0, 64)]
+    );
+}
+
+function db_scheduler_daemon_force_reset(string $daemonKey = 'master', string $exitReason = ''): bool
+{
+    db_scheduler_daemon_state_ensure();
+
+    return db_execute(
+        'UPDATE scheduler_daemon_state
+         SET status = ?,
+             loop_state = ?,
+             owner_token = NULL,
+             owner_label = NULL,
+             owner_pid = NULL,
+             owner_hostname = NULL,
+             active_dispatch_count = 0,
+             stop_requested = 0,
+             restart_requested = 0,
+             lease_expires_at = NULL,
+             heartbeat_at = NULL,
+             wake_requested_at = NULL,
+             last_exit_at = UTC_TIMESTAMP(),
+             last_exit_reason = CASE WHEN ? <> \'\' THEN ? ELSE last_exit_reason END,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE daemon_key = ?
+         LIMIT 1',
+        ['stopped', 'idle', mb_substr(trim($exitReason), 0, 500), mb_substr(trim($exitReason), 0, 500), mb_substr(trim($daemonKey), 0, 64)]
+    );
+}
+
 function db_sync_schedule_registry_columns_ensure(): void
 {
     db_ensure_table_column('sync_schedules', 'offset_seconds', 'INT UNSIGNED NOT NULL DEFAULT 0');
@@ -5030,6 +5274,63 @@ function db_sync_schedule_reset_locks(string $errorMessage): int
     $stmt->execute([$message]);
 
     return (int) $stmt->rowCount();
+}
+
+function db_sync_schedule_recover_stale_running_jobs(string $errorMessage, int $staleGraceSeconds = 300): int
+{
+    db_sync_schedule_registry_columns_ensure();
+
+    $message = mb_substr(trim($errorMessage), 0, 500);
+    if ($message === '') {
+        $message = 'Recovered stale scheduler job state after daemon restart.';
+    }
+
+    $safeGrace = max(60, min(7200, $staleGraceSeconds));
+    $stmt = db()->prepare(
+        'UPDATE sync_schedules
+         SET locked_until = NULL,
+             last_status = \'failed\',
+             last_result = \'recovered\',
+             last_error = ?,
+             next_run_at = CASE WHEN enabled = 1 THEN UTC_TIMESTAMP() ELSE NULL END,
+             next_due_at = CASE WHEN enabled = 1 THEN UTC_TIMESTAMP() ELSE NULL END,
+             latest_allowed_start_at = CASE
+                WHEN enabled = 1 THEN DATE_ADD(UTC_TIMESTAMP(), INTERVAL GREATEST(1, interval_minutes) MINUTE)
+                ELSE NULL
+             END,
+             current_state = CASE WHEN enabled = 1 THEN \'waiting\' ELSE \'stopped\' END,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE enabled = 1
+           AND (
+                (locked_until IS NOT NULL AND locked_until <= UTC_TIMESTAMP())
+                OR (
+                    current_state = \'running\'
+                    AND last_started_at IS NOT NULL
+                    AND last_started_at <= DATE_SUB(UTC_TIMESTAMP(), INTERVAL GREATEST(timeout_seconds + ?, 120) SECOND)
+                )
+           )'
+    );
+    $stmt->execute([$message, $safeGrace]);
+
+    return (int) $stmt->rowCount();
+}
+
+function db_sync_schedule_next_due_snapshot(): ?array
+{
+    db_sync_schedule_registry_columns_ensure();
+
+    $row = db_select_one(
+        'SELECT id, job_key, next_due_at
+         FROM sync_schedules
+         WHERE enabled = 1
+           AND next_due_at IS NOT NULL
+           AND current_state <> ?
+         ORDER BY next_due_at ASC, id ASC
+         LIMIT 1',
+        ['stopped']
+    );
+
+    return $row !== [] ? $row : null;
 }
 
 function db_scheduler_job_event_insert(string $jobKey, string $eventType, array $detail = [], int $latenessSeconds = 0, ?float $durationSeconds = null): bool

--- a/src/functions.php
+++ b/src/functions.php
@@ -2218,6 +2218,24 @@ function run_data_sync_now(?string $jobKey = null): array
     }
 
     try {
+        $daemonState = scheduler_daemon_state_view();
+        if (!empty($daemonState['is_healthy'])) {
+            $forcedJobs = $normalizedJobKey === ''
+                ? db_sync_schedule_force_due_all_enabled()
+                : db_sync_schedule_force_due_by_job_keys([$normalizedJobKey]);
+            db_scheduler_daemon_request_wake(scheduler_daemon_key());
+
+            $jobLabel = $normalizedJobKey === ''
+                ? 'all enabled jobs'
+                : ((string) ($definitions[$normalizedJobKey]['label'] ?? $normalizedJobKey) . ' job');
+
+            return [
+                'ok' => true,
+                'message' => 'Run now queued for ' . $jobLabel . '. Forced ' . $forcedJobs . ' schedule(s) and signaled the active scheduler daemon to dispatch immediately.',
+                'summary' => ['jobs_forced' => $forcedJobs, 'mode' => 'daemon_wake'],
+            ];
+        }
+
         $lockAcquired = runner_lock_acquire($lockName, 0);
         if (!$lockAcquired) {
             return [
@@ -2256,6 +2274,8 @@ function scheduler_reset_process_targets(): array
 {
     $paths = [
         scheduler_job_runner_script_path(),
+        scheduler_daemon_script_path(),
+        scheduler_watchdog_script_path(),
         dirname(__DIR__) . '/bin/cron_tick.php',
     ];
 
@@ -2370,6 +2390,7 @@ function scheduler_reset_runtime_state(): array
 
     $appLockReleased = db_runner_lock_force_release('supplycore:cron_tick');
     $runnerLockReleased = db_runner_lock_force_release('cron_tick_runner');
+    db_scheduler_daemon_force_reset(scheduler_daemon_key(), 'Scheduler runtime was reset manually from Settings.');
 
     if (supplycore_redis_locking_enabled()) {
         supplycore_redis_del(['lock:runner:cron_tick_runner']);
@@ -2408,6 +2429,574 @@ function scheduler_reset_runtime_state_message(array $result): string
     }
 
     return $message;
+}
+
+function scheduler_daemon_key(): string
+{
+    return 'master';
+}
+
+function scheduler_daemon_script_path(): string
+{
+    return dirname(__DIR__) . '/bin/scheduler_daemon.php';
+}
+
+function scheduler_watchdog_script_path(): string
+{
+    return dirname(__DIR__) . '/bin/scheduler_watchdog.php';
+}
+
+function scheduler_health_script_path(): string
+{
+    return dirname(__DIR__) . '/bin/scheduler_health.php';
+}
+
+function scheduler_daemon_hostname(): string
+{
+    $host = trim((string) gethostname());
+    if ($host !== '') {
+        return $host;
+    }
+
+    return trim((string) php_uname('n'));
+}
+
+function scheduler_daemon_owner_label(?int $pid = null): string
+{
+    $resolvedPid = $pid ?? (function_exists('getmypid') ? (int) getmypid() : 0);
+
+    return 'scheduler-daemon@' . scheduler_daemon_hostname() . ($resolvedPid > 0 ? ('#' . $resolvedPid) : '');
+}
+
+function scheduler_daemon_owner_token(?int $pid = null): string
+{
+    $seed = scheduler_daemon_hostname() . '|' . ($pid ?? (function_exists('getmypid') ? (int) getmypid() : 0)) . '|' . microtime(true) . '|' . bin2hex(random_bytes(8));
+
+    return substr(hash('sha256', $seed), 0, 40);
+}
+
+function scheduler_daemon_lease_ttl_seconds(): int
+{
+    $configured = (int) config('scheduler.daemon_lease_ttl_seconds', (int) getenv('SCHEDULER_DAEMON_LEASE_TTL_SECONDS'));
+
+    return max(10, min(120, $configured > 0 ? $configured : 30));
+}
+
+function scheduler_daemon_poll_interval_seconds(): int
+{
+    $configured = (int) config('scheduler.daemon_poll_interval_seconds', (int) getenv('SCHEDULER_DAEMON_POLL_INTERVAL_SECONDS'));
+
+    return max(2, min(30, $configured > 0 ? $configured : 5));
+}
+
+function scheduler_daemon_running_poll_interval_seconds(): int
+{
+    $configured = (int) config('scheduler.daemon_running_poll_interval_seconds', (int) getenv('SCHEDULER_DAEMON_RUNNING_POLL_INTERVAL_SECONDS'));
+
+    return max(1, min(10, $configured > 0 ? $configured : 2));
+}
+
+function scheduler_daemon_max_runtime_seconds(): int
+{
+    $configured = (int) config('scheduler.daemon_max_runtime_seconds', (int) getenv('SCHEDULER_DAEMON_MAX_RUNTIME_SECONDS'));
+
+    return max(300, $configured > 0 ? $configured : 21600);
+}
+
+function scheduler_daemon_max_loop_count(): int
+{
+    $configured = (int) config('scheduler.daemon_max_loop_count', (int) getenv('SCHEDULER_DAEMON_MAX_LOOP_COUNT'));
+
+    return max(100, $configured > 0 ? $configured : 10000);
+}
+
+function scheduler_daemon_memory_recycle_bytes(): int
+{
+    $configured = (int) config('scheduler.daemon_memory_recycle_bytes', (int) getenv('SCHEDULER_DAEMON_MEMORY_RECYCLE_BYTES'));
+    if ($configured > 0) {
+        return $configured;
+    }
+
+    $memoryLimit = scheduler_parse_memory_limit_bytes((string) ini_get('memory_limit'));
+    if ($memoryLimit !== null && $memoryLimit > 0) {
+        return max(134217728, (int) round($memoryLimit * 0.7));
+    }
+
+    return 268435456;
+}
+
+function scheduler_daemon_watchdog_service_name(): string
+{
+    $configured = trim((string) config('scheduler.systemd_service', (string) getenv('SCHEDULER_SYSTEMD_SERVICE')));
+
+    return $configured !== '' ? $configured : 'supplycore-scheduler.service';
+}
+
+function scheduler_daemon_watchdog_grace_seconds(): int
+{
+    $configured = (int) config('scheduler.daemon_watchdog_grace_seconds', (int) getenv('SCHEDULER_DAEMON_WATCHDOG_GRACE_SECONDS'));
+
+    return max(30, min(900, $configured > 0 ? $configured : (scheduler_daemon_lease_ttl_seconds() * 3)));
+}
+
+function scheduler_daemon_log_path(): string
+{
+    return scheduler_cron_log_path();
+}
+
+function scheduler_daemon_state_view(?array $state = null): array
+{
+    $row = $state ?? db_scheduler_daemon_state_fetch(scheduler_daemon_key()) ?? [];
+    $metadata = scheduler_json_decode_assoc($row['metadata_json'] ?? null);
+    $now = time();
+    $heartbeatAt = trim((string) ($row['heartbeat_at'] ?? ''));
+    $leaseExpiresAt = trim((string) ($row['lease_expires_at'] ?? ''));
+    $startedAt = trim((string) ($row['started_at'] ?? ''));
+    $lastDispatchAt = trim((string) ($row['last_dispatch_at'] ?? ''));
+    $lastRecoveryAt = trim((string) ($row['last_recovery_at'] ?? ''));
+    $lastWatchdogAt = trim((string) ($row['last_watchdog_at'] ?? ''));
+    $status = trim((string) ($row['status'] ?? 'stopped'));
+    $derived = 'stopped';
+
+    if ($leaseExpiresAt !== '' && strtotime($leaseExpiresAt) !== false && strtotime($leaseExpiresAt) > $now && in_array($status, ['running', 'starting', 'idle'], true)) {
+        $derived = $status === 'starting' ? 'degraded' : 'running';
+    } elseif ($heartbeatAt !== '' && strtotime($heartbeatAt) !== false && ($now - (int) strtotime($heartbeatAt)) <= scheduler_daemon_watchdog_grace_seconds()) {
+        $derived = 'degraded';
+    }
+
+    return [
+        'daemon_key' => (string) ($row['daemon_key'] ?? scheduler_daemon_key()),
+        'status' => $status,
+        'derived_status' => $derived,
+        'owner_token' => (string) ($row['owner_token'] ?? ''),
+        'owner_label' => (string) ($row['owner_label'] ?? ''),
+        'owner_pid' => (int) ($row['owner_pid'] ?? 0),
+        'owner_hostname' => (string) ($row['owner_hostname'] ?? ''),
+        'loop_state' => (string) ($row['loop_state'] ?? 'idle'),
+        'stop_requested' => !empty($row['stop_requested']),
+        'restart_requested' => !empty($row['restart_requested']),
+        'active_dispatch_count' => (int) ($row['active_dispatch_count'] ?? 0),
+        'current_loop_count' => (int) ($row['current_loop_count'] ?? 0),
+        'current_memory_bytes' => (int) ($row['current_memory_bytes'] ?? 0),
+        'started_at' => $startedAt !== '' ? $startedAt : null,
+        'heartbeat_at' => $heartbeatAt !== '' ? $heartbeatAt : null,
+        'lease_expires_at' => $leaseExpiresAt !== '' ? $leaseExpiresAt : null,
+        'last_dispatch_at' => $lastDispatchAt !== '' ? $lastDispatchAt : null,
+        'last_recovery_at' => $lastRecoveryAt !== '' ? $lastRecoveryAt : null,
+        'last_recovery_event' => (string) ($row['last_recovery_event'] ?? ''),
+        'last_watchdog_at' => $lastWatchdogAt !== '' ? $lastWatchdogAt : null,
+        'watchdog_status' => (string) ($row['watchdog_status'] ?? 'unknown'),
+        'wake_requested_at' => !empty($row['wake_requested_at']) ? (string) $row['wake_requested_at'] : null,
+        'last_exit_at' => !empty($row['last_exit_at']) ? (string) $row['last_exit_at'] : null,
+        'last_exit_code' => isset($row['last_exit_code']) ? (int) $row['last_exit_code'] : null,
+        'last_exit_reason' => (string) ($row['last_exit_reason'] ?? ''),
+        'heartbeat_age_seconds' => $heartbeatAt !== '' ? max(0, $now - (int) strtotime($heartbeatAt)) : null,
+        'uptime_seconds' => $startedAt !== '' ? max(0, $now - (int) strtotime($startedAt)) : null,
+        'metadata' => $metadata,
+        'is_healthy' => $derived === 'running',
+    ];
+}
+
+function scheduler_daemon_health_summary(): array
+{
+    return scheduler_daemon_state_view();
+}
+
+function scheduler_daemon_output(string $event, array $payload = [], $stream = STDOUT): void
+{
+    $line = ['event' => $event, 'ts' => gmdate(DATE_ATOM)] + $payload;
+    fwrite($stream, json_encode($line, JSON_UNESCAPED_SLASHES) . PHP_EOL);
+}
+
+function scheduler_daemon_write_heartbeat(string $ownerToken, array $state = []): bool
+{
+    return db_scheduler_daemon_heartbeat(scheduler_daemon_key(), $ownerToken, $state, scheduler_daemon_lease_ttl_seconds());
+}
+
+function scheduler_daemon_recover_runtime_state(string $ownerToken, ?callable $logger = null): array
+{
+    $daemonState = scheduler_daemon_state_view();
+    $details = [];
+    $messageParts = [];
+    $recoveredCount = 0;
+
+    if (($daemonState['derived_status'] ?? 'stopped') !== 'running' && !empty($daemonState['owner_token'])) {
+        $messageParts[] = 'Recovered expired scheduler daemon lease previously owned by ' . ($daemonState['owner_label'] ?? 'unknown') . '.';
+    }
+
+    $staleSchedules = db_sync_schedule_recover_stale_running_jobs(
+        'Recovered stale scheduler job markers after daemon startup.',
+        scheduler_daemon_watchdog_grace_seconds()
+    );
+    if ($staleSchedules > 0) {
+        $details['recovered_schedule_count'] = $staleSchedules;
+        $messageParts[] = 'Released ' . $staleSchedules . ' stale running-job marker(s).';
+        $recoveredCount += $staleSchedules;
+    }
+
+    $message = $messageParts !== [] ? implode(' ', $messageParts) : 'No stale scheduler runtime artifacts required recovery.';
+    scheduler_daemon_write_heartbeat($ownerToken, [
+        'status' => 'running',
+        'loop_state' => 'recovery',
+        'touch_last_recovery' => true,
+        'last_recovery_event' => $message,
+        'metadata' => ['recovery' => $details],
+    ]);
+
+    if ($logger !== null) {
+        $logger('scheduler_daemon.recovery', [
+            'recovered_count' => $recoveredCount,
+            'message' => $message,
+        ] + $details);
+    }
+
+    return [
+        'recovered_count' => $recoveredCount,
+        'message' => $message,
+    ] + $details;
+}
+
+function scheduler_daemon_should_exit_for_recycle(float $startedAtUnix, int $loopCount): ?string
+{
+    $runtimeSeconds = microtime(true) - $startedAtUnix;
+    if ($runtimeSeconds >= scheduler_daemon_max_runtime_seconds()) {
+        return 'max_runtime_reached';
+    }
+
+    if ($loopCount >= scheduler_daemon_max_loop_count()) {
+        return 'max_loop_count_reached';
+    }
+
+    $memoryUsage = function_exists('memory_get_usage') ? (int) memory_get_usage(true) : 0;
+    if ($memoryUsage >= scheduler_daemon_memory_recycle_bytes()) {
+        return 'memory_recycle_threshold_reached';
+    }
+
+    return null;
+}
+
+function scheduler_daemon_next_sleep_seconds(): int
+{
+    $fallback = scheduler_daemon_poll_interval_seconds();
+    $nextDue = db_sync_schedule_next_due_snapshot();
+    $running = db_sync_schedule_fetch_running_jobs();
+    $nextDueAt = trim((string) ($nextDue['next_due_at'] ?? ''));
+    $nextDueSeconds = $fallback;
+
+    if ($nextDueAt !== '' && strtotime($nextDueAt) !== false) {
+        $nextDueSeconds = max(0, (int) ceil(strtotime($nextDueAt) - microtime(true)));
+    }
+
+    if ($nextDueSeconds <= 0) {
+        return 0;
+    }
+
+    $candidate = min($fallback, $nextDueSeconds);
+    if ($running !== []) {
+        $candidate = min($candidate, scheduler_daemon_running_poll_interval_seconds());
+    }
+
+    return max(1, $candidate);
+}
+
+function scheduler_daemon_wait_for_wake_or_timeout(int $seconds, string $ownerToken, ?callable $logger = null): void
+{
+    if ($seconds <= 0) {
+        return;
+    }
+
+    $startedWaitAt = gmdate('Y-m-d H:i:s');
+    $deadline = microtime(true) + $seconds;
+
+    while (microtime(true) < $deadline) {
+        usleep(500000);
+
+        $state = scheduler_daemon_state_view();
+        if (($state['owner_token'] ?? '') !== '' && ($state['owner_token'] ?? '') !== $ownerToken) {
+            break;
+        }
+
+        if (!empty($state['stop_requested']) || !empty($state['restart_requested'])) {
+            break;
+        }
+
+        $wakeRequestedAt = trim((string) ($state['wake_requested_at'] ?? ''));
+        if ($wakeRequestedAt !== '' && strtotime($wakeRequestedAt) !== false && strtotime($wakeRequestedAt) >= strtotime($startedWaitAt)) {
+            if ($logger !== null) {
+                $logger('scheduler_daemon.wake', [
+                    'wake_requested_at' => $wakeRequestedAt,
+                ]);
+            }
+            break;
+        }
+
+        scheduler_daemon_write_heartbeat($ownerToken, [
+            'status' => 'running',
+            'loop_state' => 'sleeping',
+            'active_dispatch_count' => 0,
+            'current_memory_bytes' => function_exists('memory_get_usage') ? (int) memory_get_usage(true) : 0,
+        ]);
+    }
+}
+
+function scheduler_daemon_spawn_detached(): array
+{
+    if (!function_exists('exec')) {
+        return ['ok' => false, 'mode' => 'spawn', 'message' => 'PHP exec() is unavailable, so the watchdog could not start the scheduler daemon directly.'];
+    }
+
+    $phpBinary = PHP_BINARY !== '' ? PHP_BINARY : 'php';
+    $command = sprintf(
+        'cd %s && nohup %s %s >> %s 2>&1 & echo $!',
+        escapeshellarg(dirname(__DIR__)),
+        escapeshellarg($phpBinary),
+        escapeshellarg(scheduler_daemon_script_path()),
+        escapeshellarg(scheduler_daemon_log_path())
+    );
+
+    $output = [];
+    $exitCode = 1;
+    @exec($command, $output, $exitCode);
+    $pid = isset($output[0]) ? (int) $output[0] : 0;
+
+    return [
+        'ok' => $exitCode === 0 && $pid > 0,
+        'mode' => 'spawn',
+        'pid' => $pid > 0 ? $pid : null,
+        'message' => $exitCode === 0 && $pid > 0
+            ? 'Watchdog spawned scheduler daemon process #' . $pid . '.'
+            : 'Watchdog failed to spawn the scheduler daemon process.',
+    ];
+}
+
+function scheduler_watchdog_start_daemon(): array
+{
+    if (!function_exists('exec')) {
+        return scheduler_daemon_spawn_detached();
+    }
+
+    $serviceName = scheduler_daemon_watchdog_service_name();
+    $systemctlPath = trim((string) @shell_exec('command -v systemctl 2>/dev/null'));
+    if ($systemctlPath !== '') {
+        $output = [];
+        $exitCode = 1;
+        @exec($systemctlPath . ' restart ' . escapeshellarg($serviceName) . ' 2>&1', $output, $exitCode);
+        if ($exitCode === 0) {
+            return [
+                'ok' => true,
+                'mode' => 'systemd',
+                'message' => 'Watchdog asked systemd to restart ' . $serviceName . '.',
+            ];
+        }
+    }
+
+    return scheduler_daemon_spawn_detached();
+}
+
+function scheduler_watchdog_run(?callable $logger = null): array
+{
+    $state = scheduler_daemon_state_view();
+    $result = [
+        'checked_at' => gmdate('Y-m-d H:i:s'),
+        'health' => $state,
+        'action' => 'none',
+        'recovery' => null,
+        'start' => null,
+        'status' => 'healthy',
+    ];
+
+    if ($state['is_healthy']) {
+        db_scheduler_daemon_watchdog_touch(scheduler_daemon_key(), 'healthy', ['watchdog' => ['status' => 'healthy']]);
+        if ($logger !== null) {
+            $logger('scheduler_watchdog.healthy', [
+                'owner' => $state['owner_label'] ?? null,
+                'heartbeat_at' => $state['heartbeat_at'] ?? null,
+            ]);
+        }
+
+        return $result;
+    }
+
+    $recoveryMessage = 'Watchdog observed a stale or stopped scheduler daemon and prepared recovery.';
+    $recoveredSchedules = db_sync_schedule_recover_stale_running_jobs($recoveryMessage, scheduler_daemon_watchdog_grace_seconds());
+    $result['recovery'] = [
+        'recovered_schedule_count' => $recoveredSchedules,
+        'message' => $recoveryMessage,
+    ];
+
+    $startResult = scheduler_watchdog_start_daemon();
+    $result['start'] = $startResult;
+    $result['action'] = !empty($startResult['ok']) ? 'restart_attempted' : 'restart_failed';
+    $result['status'] = !empty($startResult['ok']) ? 'recovery_started' : 'degraded';
+
+    db_scheduler_daemon_watchdog_touch(
+        scheduler_daemon_key(),
+        !empty($startResult['ok']) ? 'restart_requested' : 'restart_failed',
+        ['watchdog' => $result]
+    );
+
+    if ($logger !== null) {
+        $logger('scheduler_watchdog.recovery', [
+            'status' => $result['status'],
+            'action' => $result['action'],
+            'recovered_schedule_count' => $recoveredSchedules,
+            'start_mode' => $startResult['mode'] ?? null,
+            'message' => $startResult['message'] ?? null,
+        ]);
+    }
+
+    return $result;
+}
+
+function scheduler_daemon_run(?callable $logger = null): int
+{
+    $pid = function_exists('getmypid') ? (int) getmypid() : 0;
+    $ownerToken = scheduler_daemon_owner_token($pid);
+    $ownerLabel = scheduler_daemon_owner_label($pid);
+    $hostname = scheduler_daemon_hostname();
+    $leaseTtl = scheduler_daemon_lease_ttl_seconds();
+    $startedAtUnix = microtime(true);
+
+    if (!db_scheduler_daemon_try_claim(scheduler_daemon_key(), $ownerToken, $ownerLabel, $pid, $hostname, $leaseTtl, [
+        'boot' => [
+            'php_binary' => PHP_BINARY,
+            'hostname' => $hostname,
+        ],
+    ])) {
+        if ($logger !== null) {
+            $logger('scheduler_daemon.lock_skipped', [
+                'owner' => $ownerLabel,
+                'reason' => 'claim_failed',
+            ]);
+        }
+
+        return 0;
+    }
+
+    $shouldStop = false;
+    $shouldRestart = false;
+    if (function_exists('pcntl_async_signals')) {
+        pcntl_async_signals(true);
+        pcntl_signal(SIGTERM, static function () use (&$shouldStop): void {
+            $shouldStop = true;
+        });
+        pcntl_signal(SIGINT, static function () use (&$shouldStop): void {
+            $shouldStop = true;
+        });
+        pcntl_signal(SIGHUP, static function () use (&$shouldRestart): void {
+            $shouldRestart = true;
+        });
+    }
+
+    if ($logger !== null) {
+        $logger('scheduler_daemon.started', [
+            'owner' => $ownerLabel,
+            'lease_ttl_seconds' => $leaseTtl,
+        ]);
+    }
+
+    $recovery = scheduler_daemon_recover_runtime_state($ownerToken, $logger);
+    $loopCount = 0;
+    $exitReason = 'graceful_stop';
+    $exitCode = 0;
+
+    try {
+        while (true) {
+            $loopCount++;
+            $currentMemory = function_exists('memory_get_usage') ? (int) memory_get_usage(true) : 0;
+            scheduler_daemon_write_heartbeat($ownerToken, [
+                'status' => 'running',
+                'loop_state' => 'evaluating',
+                'active_dispatch_count' => 0,
+                'current_loop_count' => $loopCount,
+                'current_memory_bytes' => $currentMemory,
+                'metadata' => ['recovery' => $recovery],
+            ]);
+
+            $summary = cron_tick_run($logger);
+            $processedCount = (int) ($summary['jobs_processed'] ?? 0);
+            $dispatchCount = (int) ($summary['jobs_dispatched'] ?? 0);
+            $runningCount = count((array) (($summary['planner']['running'] ?? [])));
+            scheduler_daemon_write_heartbeat($ownerToken, [
+                'status' => 'running',
+                'loop_state' => 'post_dispatch',
+                'active_dispatch_count' => max($dispatchCount, $runningCount),
+                'current_loop_count' => $loopCount,
+                'current_memory_bytes' => function_exists('memory_get_usage') ? (int) memory_get_usage(true) : 0,
+                'touch_last_dispatch' => ($processedCount + $dispatchCount) > 0,
+                'metadata' => [
+                    'last_summary' => [
+                        'jobs_due' => (int) ($summary['jobs_due'] ?? 0),
+                        'jobs_planned' => (int) ($summary['jobs_planned'] ?? 0),
+                        'jobs_processed' => $processedCount,
+                        'jobs_dispatched' => $dispatchCount,
+                    ],
+                    'recovery' => $recovery,
+                ],
+            ]);
+
+            if ($shouldStop) {
+                $exitReason = 'signal_stop_requested';
+                break;
+            }
+            if ($shouldRestart) {
+                $exitReason = 'signal_restart_requested';
+                break;
+            }
+
+            $state = scheduler_daemon_state_view();
+            if (!empty($state['stop_requested'])) {
+                $exitReason = 'database_stop_requested';
+                break;
+            }
+            if (!empty($state['restart_requested'])) {
+                $exitReason = 'database_restart_requested';
+                break;
+            }
+
+            $recycleReason = scheduler_daemon_should_exit_for_recycle($startedAtUnix, $loopCount);
+            if ($recycleReason !== null) {
+                $exitReason = $recycleReason;
+                break;
+            }
+
+            if ($processedCount > 0 || $dispatchCount > 0 || (int) ($summary['jobs_due'] ?? 0) > 0) {
+                continue;
+            }
+
+            $sleepSeconds = scheduler_daemon_next_sleep_seconds();
+            scheduler_daemon_write_heartbeat($ownerToken, [
+                'status' => 'running',
+                'loop_state' => 'sleeping',
+                'active_dispatch_count' => 0,
+                'current_loop_count' => $loopCount,
+                'current_memory_bytes' => function_exists('memory_get_usage') ? (int) memory_get_usage(true) : 0,
+                'metadata' => ['sleep_seconds' => $sleepSeconds, 'recovery' => $recovery],
+            ]);
+            scheduler_daemon_wait_for_wake_or_timeout($sleepSeconds, $ownerToken, $logger);
+        }
+    } catch (Throwable $exception) {
+        $exitReason = scheduler_normalize_error_message($exception->getMessage());
+        $exitCode = 1;
+        if ($logger !== null) {
+            $logger('scheduler_daemon.failed', [
+                'error' => $exitReason,
+            ]);
+        }
+    } finally {
+        $finalStatus = $exitCode === 0 ? 'stopped' : 'failed';
+        db_scheduler_daemon_release(scheduler_daemon_key(), $ownerToken, $finalStatus, $exitCode, $exitReason);
+        if ($logger !== null) {
+            $logger('scheduler_daemon.stopped', [
+                'status' => $finalStatus,
+                'exit_code' => $exitCode,
+                'exit_reason' => $exitReason,
+                'loop_count' => $loopCount,
+            ]);
+        }
+    }
+
+    return $exitCode;
 }
 
 function scheduler_priority_options(): array
@@ -4104,6 +4693,7 @@ function sync_schedule_settings_view_model(): array
     $internalJobs = [];
     $liveCapacity = scheduler_live_capacity_snapshot();
     $recentDecisionCounts = scheduler_recent_planner_decision_counts();
+    $daemonState = scheduler_daemon_health_summary();
     $healthSummary = [
         'total_jobs' => 0,
         'running_jobs' => 0,
@@ -4125,6 +4715,7 @@ function sync_schedule_settings_view_model(): array
         'reserved_critical_cpu_percent' => (float) ($liveCapacity['reserved_critical_cpu_percent'] ?? 0.0),
         'reserved_critical_memory_bytes' => (int) ($liveCapacity['reserved_critical_memory_bytes'] ?? 0),
         'pressure' => (string) ($liveCapacity['pressure'] ?? 'healthy'),
+        'daemon' => $daemonState,
     ];
 
     foreach ($rows as $row) {
@@ -4283,6 +4874,7 @@ function sync_schedule_settings_view_model(): array
         'discovered_jobs' => $discoveredJobs,
         'internal_jobs' => $internalJobs,
         'health_summary' => $healthSummary,
+        'daemon_state' => $daemonState,
         'busiest_offsets' => $busiestOffsets,
         'recent_actions' => $recentActions,
         'recent_planner_decisions' => $recentPlannerDecisions,


### PR DESCRIPTION
### Motivation
- Replace the minute-tick cron trigger with a continuously running scheduler master so eligible work is dispatched immediately when capacity exists while preserving existing planner rules (priority, fairness, latest_allowed_start, resource-aware concurrency, protected jobs, incompatibilities, and adaptive tuning). 
- Provide a singleton-safe lease/heartbeat with takeover/recovery semantics so a single master controls dispatch and the system recovers cleanly after crashes.
- Add a lightweight cron watchdog and a health probe usable by `systemd` so cron becomes a backup/watchdog rather than the primary dispatcher.

### Description
- Added persistent daemon state and helpers in `src/db.php` (`scheduler_daemon_state` DDL + claim/heartbeat/release/watchdog/wake APIs) and a recovery helper for stale running-job markers. 
- Implemented the long-running master loop and lifecycle helpers in `src/functions.php` (`scheduler_daemon_run`, lease/heartbeat, smart sleep/wake logic, recycle thresholds, signal handling, and recovery). 
- Added CLI entry points: `bin/scheduler_daemon.php` (master loop), `bin/scheduler_watchdog.php` (standalone watchdog), and `bin/scheduler_health.php` (JSON health probe), and converted `bin/cron_tick.php` into a cron-safe watchdog invoker. 
- Made worker/controls signal the daemon: `bin/scheduler_job_runner.php` now requests a daemon wake after background job completion and the Settings → Data Sync `Run now` path will wake the daemon when healthy. 
- Exposed daemon state in the admin UI (`public/settings/index.php`) and documented deployment notes including an example `systemd` unit and the new cron watchdog model in `README.md`. 
- Files changed: `src/db.php`, `src/functions.php`, `database/schema.sql`, `bin/scheduler_daemon.php`, `bin/scheduler_watchdog.php`, `bin/scheduler_health.php`, `bin/cron_tick.php`, `bin/scheduler_job_runner.php`, `public/settings/index.php`, `README.md`.

### Testing
- Ran PHP syntax checks: `php -l` validated `src/db.php`, `src/functions.php`, `bin/scheduler_daemon.php`, `bin/scheduler_watchdog.php`, `bin/scheduler_health.php`, `bin/cron_tick.php`, `bin/scheduler_job_runner.php`, and `public/settings/index.php` (all passed). 
- Ran the watchdog/health smoke check: `php bin/scheduler_health.php` produced a degraded/failed health response in this container because the MySQL connection is unavailable (`SQLSTATE[HY000] [2002] Connection refused`), which is expected in the local test environment; the command prints JSON and exits non-zero when the DB/daemon is not reachable. 
- Performed diff/format checks (`git diff --check` and lint-style checks) with no blocking issues found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bedce693d4832f941de1b9c35ed933)