### PR TITLE
Optimize market snapshot state, indexes, and retention

### DIFF
--- a/database/OPTIMIZATION_AUDIT.md
+++ b/database/OPTIMIZATION_AUDIT.md
@@ -1,0 +1,208 @@
+# Database architecture and optimization audit
+
+## Source inputs used
+
+- `database/export-schema.sql` as the structural baseline.
+- `database/table-counts.txt` for scale and hot-table prioritization.
+- `database/sample_ref.sql`, `database/sample_app.sql`, and `database/sample_heavy_recent.sql` for row shape, payload width, and query-path inference.
+- `src/db.php` and `src/functions.php` for live query paths, materialization code, retention logic, and scheduler access patterns.
+
+## Target architecture
+
+1. Keep EVE/static dimensions normalized and joined by IDs.
+2. Keep current-state operational rows compact and separately addressable from history.
+3. Keep append-heavy raw/history tables on explicit retention windows and narrow pruning indexes.
+4. Keep UI/static pages on materialized summary tables or tiny freshness/state tables.
+5. Keep scheduler/control-plane state separate from its audit/event history.
+6. Keep JSON/LONGTEXT payloads off hot read paths whenever structured columns already exist.
+
+## Table-by-table architecture map
+
+| Table | Layer | Scale / heat | Findings |
+| --- | --- | --- | --- |
+| `alliance_structure_metadata` | application entities | 19 rows, cold | Correctly keyed by `structure_id`; small metadata table, no material issue. |
+| `app_settings` | application entities | 84 rows, hot-read / cold-write | Central config table; good fit, but increasingly used to drive retention behavior. |
+| `doctrine_activity_snapshots` | materialized/static page summary | 4.7k rows, append-light | Page-serving summary table; acceptable denormalization for UI reads. |
+| `doctrine_ai_briefings` | materialized/static page summary | 43 rows, cold | Stores generated text and status; payload-heavy but not on hot path. |
+| `doctrine_fits` | application entities | 127 rows, medium read / low write | Wide by design because raw imports and review payloads live here; acceptable because table is tiny. |
+| `doctrine_fit_activity_1d` | materialized/static page summary | 412 rows, hot-read | Compact daily projection; appropriate current-vs-history separation. |
+| `doctrine_fit_groups` | normalization bridge | 351 rows, static-ish | Good many-to-many bridge; already normalized. |
+| `doctrine_fit_items` | application entities | 5.0k rows, medium read | Duplicates `item_name`, but row count is small and unresolved items require name retention. Keep as-is. |
+| `doctrine_fit_snapshots` | history/time-series | 6.6k rows, append-light | Useful snapshot history; safe size. |
+| `doctrine_fit_stock_pressure_1d` | materialized/static page summary | 412 rows, hot-read | Slim, appropriate daily read model. |
+| `doctrine_groups` | application entities | 34 rows, static | Well-normalized dimension-like app table. |
+| `doctrine_group_activity_1d` | materialized/static page summary | 46 rows, hot-read | Slim group rollup; good summary model. |
+| `doctrine_item_stock_1d` | materialized/static page summary | 7.0k rows, hot-read | Narrow enough and keyed by IDs. |
+| `entity_metadata_cache` | staging/cache/import | 12k rows, hot-read / async-write | Useful central metadata cache; good normalization anchor for character/corp/alliance labels. |
+| `esi_cache_entries` | staging/cache/import | 3 rows, cold | Raw payload cache with LONGTEXT; acceptable because off hot operational path. |
+| `esi_cache_namespaces` | staging/cache/import | 58 rows, static | Small namespace dimension. |
+| `esi_oauth_tokens` | control-plane / secrets | 0 rows in export | Sensitive operational table, excluded from samples. |
+| `intelligence_snapshots` | materialized/static page summary | 6 rows, cold-read | Summary table; low concern. |
+| `item_name_cache` | staging/cache/import | 985 rows, hot-read | Good normalization/caching layer for doctrine imports; string storage justified. |
+| `item_priority_snapshots` | materialized/static page summary | 83.9k rows, read-heavy | Summary-scale table; not the largest load driver. |
+| `killmail_attackers` | history/detail child | 21.5k rows, append-heavy | Narrow child table; good extraction of hot analytic fields away from raw JSON. |
+| `killmail_doctrine_activity_1d` | materialized/static page summary | 545 rows, hot-read | Good doctrine rollup. |
+| `killmail_events` | history/time-series + raw payload | 3.9k sampled, append-heavy in prod | Mixes hot victim fields with large raw JSON payloads. Acceptable short-term because hot analytic columns are extracted, but long-term raw JSON should move to archive storage. |
+| `killmail_hull_loss_1d` | materialized/static page summary | 929 rows, hot-read | Good daily rollup. |
+| `killmail_items` | history/detail child | 68.9k rows, append-heavy | Good decomposition out of raw killmail JSON. |
+| `killmail_item_loss_1d` | materialized/static page summary | 21.5k rows, hot-read | Good daily rollup. |
+| `killmail_item_loss_1h` | materialized/static page summary | 38.8k rows, hot-read | Good short-window rollup; retention already exists. |
+| `killmail_tracked_alliances` | scheduler/control-plane | 3 rows, static | Small control table. |
+| `killmail_tracked_corporations` | scheduler/control-plane | 0 rows | Small control table. |
+| `market_deal_alerts_current` | current-state operational | 0 rows in sample, hot-read when enabled | Denormalized `source_name` is acceptable because this is a page-serving current-state table. |
+| `market_deal_alert_dismissals` | audit/log/event | 0 rows | Small audit table. |
+| `market_history_daily` | history/time-series | 65.7k rows, read-heavy | Proper daily history table keyed by IDs. |
+| `market_hub_local_history_daily` | materialized/static page summary | 0 rows in sample | Derived local daily projection; good separation from raw snapshot history. |
+| `market_item_price_1d` | materialized/static page summary | 7.0k rows, hot-read | Good compact rollup. |
+| `market_item_price_1h` | materialized/static page summary | 12.0k rows, hot-read | Good compact rollup. |
+| `market_item_stock_1d` | materialized/static page summary | 7.0k rows, hot-read | Good compact rollup. |
+| `market_item_stock_1h` | materialized/static page summary | 12.0k rows, hot-read | Good compact rollup. |
+| `market_orders_current` | current-state operational | 468.8k rows, hot-read / heavy-write | Correctly separated from deep history, but repeatedly needs “latest snapshot for a source” lookups. |
+| `market_orders_history` | history/time-series | 108.0M rows, dominant append-heavy table | Primary load/storage driver. Needed better prune index and explicit retention focus. |
+| `market_order_snapshots_summary` | materialized/static page summary | 6.1M rows, read-heavy / append-heavy | Useful read model, but it had no explicit retention cap and no cheap global prune index. |
+| `ref_constellations` | reference/static dimensions | 1.2k rows, static | Correct dimension. |
+| `ref_item_categories` | reference/static dimensions | 47 rows, static | Correct dimension. |
+| `ref_item_groups` | reference/static dimensions | 1.6k rows, static | Correct dimension. |
+| `ref_item_types` | reference/static dimensions | 45.6k rows, hot-read | Core normalization anchor for item names and taxonomy. |
+| `ref_market_groups` | reference/static dimensions | 2.1k rows, static | Correct dimension. |
+| `ref_meta_groups` | reference/static dimensions | 13 rows, static | Correct dimension. |
+| `ref_npc_stations` | reference/static dimensions | 5.3k rows, static | Good dimension. |
+| `ref_regions` | reference/static dimensions | 114 rows, static | Good dimension. |
+| `ref_systems` | reference/static dimensions | 8.6k rows, static | Good dimension. |
+| `scheduler_daemon_state` | scheduler/control-plane current state | 1 row, hot-read | Correctly isolated current daemon state. |
+| `scheduler_job_events` | audit/log/event | 5.8k rows, append-heavy | Needed a dedicated `created_at` prune index. |
+| `scheduler_job_pairing_rules` | scheduler/control-plane | 0 rows | Small control table. |
+| `scheduler_job_resource_metrics` | audit/log/event | 970 rows, append-heavy | Needed a dedicated `created_at` prune index. |
+| `scheduler_planner_decisions` | audit/log/event | 2.5k rows, append-heavy | Needed a dedicated `created_at` prune index. |
+| `scheduler_profiling_pairings` | audit/log/event | 16 rows | Small profiling table. |
+| `scheduler_profiling_runs` | audit/log/event | 2 rows | Small profiling table. |
+| `scheduler_profiling_samples` | audit/log/event | 22 rows | Small profiling table. |
+| `scheduler_schedule_snapshots` | audit/log/event | 2 rows | Small snapshot table. |
+| `scheduler_tuning_actions` | audit/log/event | 1.6k rows, append-heavy | Needed a dedicated `created_at` prune index. |
+| `static_data_import_state` | scheduler/control-plane current state | 1 row, hot-read | Good single-row current-state table. |
+| `sync_runs` | audit/log/event | 7.5k rows, append-heavy | Needed explicit retention and a prune-friendly `created_at` index. |
+| `sync_schedules` | scheduler/control-plane current state | 34 rows, hot-read | Current state table was good conceptually but missing composite indexes for due/backfill/running lookups. |
+| `sync_state` | scheduler/control-plane current state | 29 rows, hot-read | Small status table; fine. |
+| `trading_stations` | application entities | 6 rows, static | Small app table; station names acceptable here. |
+| `ui_refresh_events` | audit/log/event | 409 rows, append-heavy over time | Already has `created_at`; now included in retention cleanup. |
+| `ui_refresh_section_versions` | current-state operational | 9 rows, hot-read | Good tiny freshness/version table for UI fragments. |
+
+## Biggest DB load drivers
+
+1. `market_orders_history` at ~108M rows is the dominant write, storage, and prune driver.
+2. `market_order_snapshots_summary` at ~6.1M rows is the main page-serving market summary table and would keep growing without retention.
+3. `market_orders_current` is smaller than history but sits directly on hot page/query paths.
+4. Scheduler/event tables are not yet huge, but they were on an uncapped growth path.
+5. Killmail raw JSON is wide, but current counts show market tables are the urgent load source.
+
+## Normalization audit
+
+### Already good
+
+- Market and doctrine paths already use integer IDs for item, system, region, and station joins through reference tables.
+- `ref_item_types` is the central item dimension and is used heavily in query paths.
+- Doctrine group/fit relationships are already normalized through `doctrine_groups`, `doctrine_fits`, and `doctrine_fit_groups`.
+- Entity labels are mostly centralized in `entity_metadata_cache` rather than repeatedly stored on hot tables.
+
+### Pragmatic keep-as-is denormalization
+
+- `market_deal_alerts_current.source_name` is acceptable because it serves a current-state UI table and avoids joins on alert rendering.
+- `doctrine_fit_items.item_name` should remain for unresolved/manual imports even though `type_id` is the preferred normalized key.
+- `doctrine_fits` intentionally stores raw import payloads because it is a low-volume authoring table, not a hot history table.
+
+### Main normalization/storage issue found
+
+- Market freshness/current-state metadata was not centralized. Pages repeatedly derived “latest snapshot per source” from large market tables. A tiny state table is a better normalization point for current-source freshness and summary readiness.
+
+## Key/data type audit
+
+- Heavy market tables already use integer IDs instead of string keys; this is good.
+- Time fields are mostly `DATETIME`/`TIMESTAMP` and generally consistent for operational queries.
+- Scheduler control-plane booleans are stored compactly as `TINYINT(1)`; acceptable.
+- Main width problem remains JSON/LONGTEXT payloads mixed into `killmail_events`, but those are not yet the top-cost path compared with market history.
+
+## Index audit summary
+
+### High-value missing indexes identified
+
+- `market_orders_history(observed_at)` for global retention pruning.
+- `market_order_snapshots_summary(observed_at)` for global retention pruning.
+- Composite due/backfill/running indexes on `sync_schedules`.
+- Single-column `created_at` indexes on scheduler event/metrics/planner/tuning tables and `sync_runs`.
+
+### Redundant index findings
+
+- No obviously safe redundant market indexes were removed in this pass because the heavy tables still need both source+time and source+type+time access patterns.
+- Doctrine and reference tables are small enough that aggressive index cleanup would have negligible payoff versus risk.
+
+## Query-path audit
+
+### Hot market paths reviewed
+
+- `db_market_orders_current_latest_snapshot_rows()` was previously using a `MAX(observed_at)` subquery over `market_orders_current` for each source lookup.
+- `db_market_orders_current_source_aggregates()` was previously using a `MAX(observed_at)` subquery over `market_order_snapshots_summary` for each aggregate page load.
+- `sync_market_orders_history_prune()` only pruned raw history, leaving snapshot summary and control-plane logs to grow unchecked.
+
+### Query-path improvements implemented
+
+- Introduced a tiny `market_source_snapshot_state` table so hot reads can resolve the latest current/summary timestamp from a compact current-state row instead of repeatedly rediscovering it from large market tables.
+- Backfilled that state lazily from read paths and updated it proactively during market syncs/materialization.
+- Added prune-friendly indexes and expanded retention cleanup to include summary rows and control-plane audit tables.
+
+## JSON/TEXT payload audit
+
+- `killmail_events.raw_killmail_json` and `killmail_events.zkb_json` are intentionally wide. The operational analytics path already extracts attacker/item/victim columns into child tables, which is the right direction.
+- Scheduler log tables store JSON/LONGTEXT details, but those fields are audit-only and acceptable so long as retention is enforced.
+- Doctrine import tables store raw HTML/EFT/buy-all content; acceptable due to small table size.
+
+## Implemented changes in this phase
+
+### Schema/index changes
+
+- Added `market_source_snapshot_state` to centralize latest current/summary timestamps and source-level row counts.
+- Added `market_orders_history(observed_at)` to make global retention pruning sargable.
+- Added `market_order_snapshots_summary(observed_at)` to make summary retention pruning sargable.
+- Added composite scheduler indexes for due-job, backfill, and running-job lookups.
+- Added `created_at` indexes to `sync_runs`, `scheduler_job_events`, `scheduler_job_resource_metrics`, `scheduler_planner_decisions`, and `scheduler_tuning_actions` for cheap retention cleanup.
+
+### Code/query changes
+
+- Market current snapshot reads now prefer `market_source_snapshot_state.latest_current_observed_at`.
+- Market summary aggregate reads now prefer `market_source_snapshot_state.latest_summary_observed_at`.
+- Market sync writers now refresh `market_source_snapshot_state` after current-order upserts.
+- Snapshot summary materialization now refreshes `market_source_snapshot_state` as it writes summary rows.
+- Maintenance prune now deletes from raw market history, snapshot summary history, and capped control-plane/audit tables in one pass.
+
+### Retention changes implemented
+
+Defaults used when no setting exists:
+
+- `raw_order_snapshot_retention_days`: 30 days for raw market history and snapshot summary.
+- `sync_run_retention_days`: 30 days.
+- `scheduler_event_retention_days`: 14 days.
+- `scheduler_metric_retention_days`: 30 days.
+- `scheduler_planner_retention_days`: 30 days.
+- `scheduler_tuning_retention_days`: 30 days.
+- `ui_refresh_event_retention_days`: 14 days.
+
+## Expected impact
+
+### Load reduction
+
+- Lower page-load CPU and buffer churn on market pages by removing repeated latest-timestamp discovery from large tables.
+- Lower maintenance-prune cost on `market_orders_history` because pruning is now supported by an `observed_at` index.
+- Lower long-term storage and read amplification by capping `market_order_snapshots_summary` alongside raw snapshots.
+- Lower background/control-plane storage growth and reduce future dashboard query cost by pruning scheduler and UI audit tables.
+
+### Storage reduction
+
+- Immediate long-run storage savings will come primarily from pruning `market_order_snapshots_summary` in addition to `market_orders_history`.
+- Scheduler/event tables now have explicit caps, preventing silent long-term accumulation.
+
+## Follow-up plan for riskier phases
+
+1. **Killmail raw archive split**: move `raw_killmail_json` and `zkb_json` to an archive table keyed by `sequence_id` once volume justifies it.
+2. **Market partitioning**: range partition `market_orders_history` by `observed_date` once operational migration windows allow it.
+3. **Current-state compaction**: consider a separate current best-price/volume projection table if market page count or concurrency grows materially.
+4. **Summary retention tiers**: keep 30-day fine-grain snapshot summaries and optionally roll older summary data into hourly/daily source-level aggregates.
+5. **Scheduler log severity model**: if control-plane volume rises, split “current health” from “full audit” more aggressively and downgrade verbose JSON payload retention.

--- a/database/README.md
+++ b/database/README.md
@@ -6,6 +6,7 @@ Files:
 - `sample_ref.sql` — reference/static tables
 - `sample_app.sql` — sampled application-owned operational tables
 - `sample_heavy_recent.sql` — sampled recent rows from heavy killmail/market/history tables
+- `OPTIMIZATION_AUDIT.md` — architecture map, hot-path findings, implemented DB optimizations, and phased follow-up plan
 
 Notes:
 - These files are intended for schema review, query planning, and DB optimization.

--- a/database/export-schema.sql
+++ b/database/export-schema.sql
@@ -95,7 +95,8 @@ CREATE TABLE IF NOT EXISTS sync_runs (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     KEY idx_dataset_started (dataset_key, started_at),
-    KEY idx_run_status (run_status)
+    KEY idx_run_status (run_status),
+    KEY idx_sync_runs_created_at (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS sync_schedules (
@@ -148,7 +149,10 @@ CREATE TABLE IF NOT EXISTS sync_schedules (
     UNIQUE KEY unique_job_key (job_key),
     KEY idx_enabled (enabled),
     KEY idx_next_run_at (next_run_at),
-    KEY idx_job_key (job_key)
+    KEY idx_job_key (job_key),
+    KEY idx_sync_schedules_due_lookup (enabled, current_state, next_due_at, locked_until, id),
+    KEY idx_sync_schedules_backfill_lookup (enabled, allow_backfill, current_state, degraded_until, locked_until, next_due_at, last_finished_at, id),
+    KEY idx_sync_schedules_running_lookup (enabled, current_state, locked_until, last_started_at, id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 SET @sync_schedules_offset_seconds_exists := (
@@ -691,7 +695,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job_events (
     duration_seconds DECIMAL(10,2) DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     KEY idx_scheduler_job_events_job_created (job_key, created_at),
-    KEY idx_scheduler_job_events_type_created (event_type, created_at)
+    KEY idx_scheduler_job_events_type_created (event_type, created_at),
+    KEY idx_scheduler_job_events_created (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS scheduler_tuning_actions (
@@ -705,7 +710,8 @@ CREATE TABLE IF NOT EXISTS scheduler_tuning_actions (
     metrics_json LONGTEXT DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     KEY idx_scheduler_tuning_actions_job_created (job_key, created_at),
-    KEY idx_scheduler_tuning_actions_actor_created (actor, created_at)
+    KEY idx_scheduler_tuning_actions_actor_created (actor, created_at),
+    KEY idx_scheduler_tuning_actions_created (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
@@ -736,7 +742,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job_resource_metrics (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     KEY idx_scheduler_resource_metrics_job_created (job_key, created_at),
     KEY idx_scheduler_resource_metrics_schedule_created (schedule_id, created_at),
-    KEY idx_scheduler_resource_metrics_job_started (job_key, started_at)
+    KEY idx_scheduler_resource_metrics_job_started (job_key, started_at),
+    KEY idx_scheduler_resource_metrics_created (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS scheduler_planner_decisions (
@@ -749,7 +756,8 @@ CREATE TABLE IF NOT EXISTS scheduler_planner_decisions (
     decision_json LONGTEXT DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     KEY idx_scheduler_planner_decisions_job_created (job_key, created_at),
-    KEY idx_scheduler_planner_decisions_type_created (decision_type, created_at)
+    KEY idx_scheduler_planner_decisions_type_created (decision_type, created_at),
+    KEY idx_scheduler_planner_decisions_created (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS intelligence_snapshots (
@@ -1052,7 +1060,8 @@ CREATE TABLE IF NOT EXISTS market_orders_history (
     UNIQUE KEY unique_source_order_observed (source_type, source_id, order_id, observed_at),
     KEY idx_market_orders_history_type_observed (source_type, source_id, type_id, observed_at),
     KEY idx_market_orders_history_observed (source_type, source_id, observed_at),
-    KEY idx_market_orders_history_source_date_type (source_type, source_id, observed_date, type_id)
+    KEY idx_market_orders_history_source_date_type (source_type, source_id, observed_date, type_id),
+    KEY idx_market_orders_history_observed_at (observed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS market_order_snapshots_summary (
@@ -1074,7 +1083,24 @@ CREATE TABLE IF NOT EXISTS market_order_snapshots_summary (
     UNIQUE KEY unique_market_order_snapshot_summary (source_type, source_id, type_id, observed_at),
     KEY idx_snapshot_summary_source_observed_type (source_type, source_id, observed_at, type_id),
     KEY idx_snapshot_summary_source_type_observed (source_type, source_id, type_id, observed_at),
-    KEY idx_snapshot_summary_source_date_type (source_type, source_id, observed_date, type_id)
+    KEY idx_snapshot_summary_source_date_type (source_type, source_id, observed_date, type_id),
+    KEY idx_snapshot_summary_observed (observed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS market_source_snapshot_state (
+    source_type ENUM('market_hub', 'alliance_structure') NOT NULL,
+    source_id BIGINT UNSIGNED NOT NULL,
+    latest_current_observed_at DATETIME DEFAULT NULL,
+    latest_summary_observed_at DATETIME DEFAULT NULL,
+    current_order_count INT UNSIGNED NOT NULL DEFAULT 0,
+    current_distinct_type_count INT UNSIGNED NOT NULL DEFAULT 0,
+    summary_row_count INT UNSIGNED NOT NULL DEFAULT 0,
+    last_synced_at DATETIME DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (source_type, source_id),
+    KEY idx_market_source_snapshot_state_current (latest_current_observed_at),
+    KEY idx_market_source_snapshot_state_summary (latest_summary_observed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS market_history_daily (

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -95,7 +95,8 @@ CREATE TABLE IF NOT EXISTS sync_runs (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     KEY idx_dataset_started (dataset_key, started_at),
-    KEY idx_run_status (run_status)
+    KEY idx_run_status (run_status),
+    KEY idx_sync_runs_created_at (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS sync_schedules (
@@ -148,7 +149,10 @@ CREATE TABLE IF NOT EXISTS sync_schedules (
     UNIQUE KEY unique_job_key (job_key),
     KEY idx_enabled (enabled),
     KEY idx_next_run_at (next_run_at),
-    KEY idx_job_key (job_key)
+    KEY idx_job_key (job_key),
+    KEY idx_sync_schedules_due_lookup (enabled, current_state, next_due_at, locked_until, id),
+    KEY idx_sync_schedules_backfill_lookup (enabled, allow_backfill, current_state, degraded_until, locked_until, next_due_at, last_finished_at, id),
+    KEY idx_sync_schedules_running_lookup (enabled, current_state, locked_until, last_started_at, id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 SET @sync_schedules_offset_seconds_exists := (
@@ -691,7 +695,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job_events (
     duration_seconds DECIMAL(10,2) DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     KEY idx_scheduler_job_events_job_created (job_key, created_at),
-    KEY idx_scheduler_job_events_type_created (event_type, created_at)
+    KEY idx_scheduler_job_events_type_created (event_type, created_at),
+    KEY idx_scheduler_job_events_created (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS scheduler_tuning_actions (
@@ -705,7 +710,8 @@ CREATE TABLE IF NOT EXISTS scheduler_tuning_actions (
     metrics_json LONGTEXT DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     KEY idx_scheduler_tuning_actions_job_created (job_key, created_at),
-    KEY idx_scheduler_tuning_actions_actor_created (actor, created_at)
+    KEY idx_scheduler_tuning_actions_actor_created (actor, created_at),
+    KEY idx_scheduler_tuning_actions_created (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
@@ -736,7 +742,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job_resource_metrics (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     KEY idx_scheduler_resource_metrics_job_created (job_key, created_at),
     KEY idx_scheduler_resource_metrics_schedule_created (schedule_id, created_at),
-    KEY idx_scheduler_resource_metrics_job_started (job_key, started_at)
+    KEY idx_scheduler_resource_metrics_job_started (job_key, started_at),
+    KEY idx_scheduler_resource_metrics_created (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS scheduler_planner_decisions (
@@ -749,7 +756,8 @@ CREATE TABLE IF NOT EXISTS scheduler_planner_decisions (
     decision_json LONGTEXT DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     KEY idx_scheduler_planner_decisions_job_created (job_key, created_at),
-    KEY idx_scheduler_planner_decisions_type_created (decision_type, created_at)
+    KEY idx_scheduler_planner_decisions_type_created (decision_type, created_at),
+    KEY idx_scheduler_planner_decisions_created (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS intelligence_snapshots (
@@ -1052,7 +1060,8 @@ CREATE TABLE IF NOT EXISTS market_orders_history (
     UNIQUE KEY unique_source_order_observed (source_type, source_id, order_id, observed_at),
     KEY idx_market_orders_history_type_observed (source_type, source_id, type_id, observed_at),
     KEY idx_market_orders_history_observed (source_type, source_id, observed_at),
-    KEY idx_market_orders_history_source_date_type (source_type, source_id, observed_date, type_id)
+    KEY idx_market_orders_history_source_date_type (source_type, source_id, observed_date, type_id),
+    KEY idx_market_orders_history_observed_at (observed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS market_order_snapshots_summary (
@@ -1074,7 +1083,24 @@ CREATE TABLE IF NOT EXISTS market_order_snapshots_summary (
     UNIQUE KEY unique_market_order_snapshot_summary (source_type, source_id, type_id, observed_at),
     KEY idx_snapshot_summary_source_observed_type (source_type, source_id, observed_at, type_id),
     KEY idx_snapshot_summary_source_type_observed (source_type, source_id, type_id, observed_at),
-    KEY idx_snapshot_summary_source_date_type (source_type, source_id, observed_date, type_id)
+    KEY idx_snapshot_summary_source_date_type (source_type, source_id, observed_date, type_id),
+    KEY idx_snapshot_summary_observed (observed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS market_source_snapshot_state (
+    source_type ENUM('market_hub', 'alliance_structure') NOT NULL,
+    source_id BIGINT UNSIGNED NOT NULL,
+    latest_current_observed_at DATETIME DEFAULT NULL,
+    latest_summary_observed_at DATETIME DEFAULT NULL,
+    current_order_count INT UNSIGNED NOT NULL DEFAULT 0,
+    current_distinct_type_count INT UNSIGNED NOT NULL DEFAULT 0,
+    summary_row_count INT UNSIGNED NOT NULL DEFAULT 0,
+    last_synced_at DATETIME DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (source_type, source_id),
+    KEY idx_market_source_snapshot_state_current (latest_current_observed_at),
+    KEY idx_market_source_snapshot_state_summary (latest_summary_observed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS market_history_daily (

--- a/src/db.php
+++ b/src/db.php
@@ -378,6 +378,29 @@ function db_ensure_table_index(string $table, string $indexName, string $definit
     db()->exec(sprintf('ALTER TABLE %s ADD %s', db_validate_identifier($table), $definitionSql));
 }
 
+function db_setting_int(string $settingKey, int $default, int $min, int $max): int
+{
+    $row = db_select_one('SELECT setting_value FROM app_settings WHERE setting_key = ? LIMIT 1', [$settingKey]);
+    $value = (int) ($row['setting_value'] ?? $default);
+
+    return max($min, min($max, $value > 0 ? $value : $default));
+}
+
+function db_prune_before_datetime(string $table, string $column, string $cutoff, int $limit = 50000): int
+{
+    $safeLimit = max(100, min(200000, $limit));
+    $sql = sprintf(
+        'DELETE FROM %s WHERE %s < ? LIMIT %d',
+        db_validate_identifier($table),
+        db_validate_identifier($column),
+        $safeLimit
+    );
+
+    db_execute($sql, [$cutoff]);
+
+    return (int) db()->query('SELECT ROW_COUNT()')->fetchColumn();
+}
+
 function db_table_has_column(string $table, string $columnName): bool
 {
     $row = db_select_one(
@@ -1834,6 +1857,8 @@ function db_market_orders_current_bulk_upsert(array $orders, ?int $chunkSize = n
 
 function db_market_orders_history_bulk_insert(array $orders, ?int $chunkSize = null): int
 {
+    db_market_snapshot_optimization_ensure();
+
     return db_bulk_insert_or_upsert(
         'market_orders_history',
         [
@@ -1858,14 +1883,132 @@ function db_market_orders_history_bulk_insert(array $orders, ?int $chunkSize = n
     );
 }
 
+function db_market_snapshot_optimization_ensure(): void
+{
+    db_ensure_table_index('market_orders_history', 'idx_market_orders_history_observed_at', 'INDEX idx_market_orders_history_observed_at (observed_at)');
+    db_ensure_table_index('market_order_snapshots_summary', 'idx_snapshot_summary_observed', 'INDEX idx_snapshot_summary_observed (observed_at)');
+}
+
+function db_market_source_snapshot_state_ensure(): void
+{
+    db_market_snapshot_optimization_ensure();
+
+    db_execute(
+        "CREATE TABLE IF NOT EXISTS market_source_snapshot_state (
+            source_type ENUM('market_hub', 'alliance_structure') NOT NULL,
+            source_id BIGINT UNSIGNED NOT NULL,
+            latest_current_observed_at DATETIME DEFAULT NULL,
+            latest_summary_observed_at DATETIME DEFAULT NULL,
+            current_order_count INT UNSIGNED NOT NULL DEFAULT 0,
+            current_distinct_type_count INT UNSIGNED NOT NULL DEFAULT 0,
+            summary_row_count INT UNSIGNED NOT NULL DEFAULT 0,
+            last_synced_at DATETIME DEFAULT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY (source_type, source_id),
+            KEY idx_market_source_snapshot_state_current (latest_current_observed_at),
+            KEY idx_market_source_snapshot_state_summary (latest_summary_observed_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+    );
+}
+
+function db_market_source_snapshot_state_get(string $sourceType, int $sourceId): ?array
+{
+    db_market_source_snapshot_state_ensure();
+
+    $safeSourceType = trim($sourceType);
+    $safeSourceId = max(0, $sourceId);
+    if ($safeSourceType === '' || $safeSourceId <= 0) {
+        return null;
+    }
+
+    return db_select_one(
+        'SELECT source_type, source_id, latest_current_observed_at, latest_summary_observed_at, current_order_count, current_distinct_type_count, summary_row_count, last_synced_at, created_at, updated_at
+         FROM market_source_snapshot_state
+         WHERE source_type = ?
+           AND source_id = ?
+         LIMIT 1',
+        [$safeSourceType, $safeSourceId]
+    );
+}
+
+function db_market_source_snapshot_state_upsert(array $row): bool
+{
+    db_market_source_snapshot_state_ensure();
+
+    $sourceType = trim((string) ($row['source_type'] ?? ''));
+    $sourceId = max(0, (int) ($row['source_id'] ?? 0));
+    if ($sourceType === '' || $sourceId <= 0) {
+        return false;
+    }
+
+    $existing = db_select_one(
+        'SELECT current_order_count, current_distinct_type_count, summary_row_count
+         FROM market_source_snapshot_state
+         WHERE source_type = ?
+           AND source_id = ?
+         LIMIT 1',
+        [$sourceType, $sourceId]
+    ) ?? [];
+    $latestCurrentObservedAt = isset($row['latest_current_observed_at']) && trim((string) $row['latest_current_observed_at']) !== ''
+        ? trim((string) $row['latest_current_observed_at'])
+        : null;
+    $latestSummaryObservedAt = isset($row['latest_summary_observed_at']) && trim((string) $row['latest_summary_observed_at']) !== ''
+        ? trim((string) $row['latest_summary_observed_at'])
+        : null;
+    $currentOrderCount = array_key_exists('current_order_count', $row)
+        ? max(0, (int) $row['current_order_count'])
+        : max(0, (int) ($existing['current_order_count'] ?? 0));
+    $currentDistinctTypeCount = array_key_exists('current_distinct_type_count', $row)
+        ? max(0, (int) $row['current_distinct_type_count'])
+        : max(0, (int) ($existing['current_distinct_type_count'] ?? 0));
+    $summaryRowCount = array_key_exists('summary_row_count', $row)
+        ? max(0, (int) $row['summary_row_count'])
+        : max(0, (int) ($existing['summary_row_count'] ?? 0));
+    $lastSyncedAt = isset($row['last_synced_at']) && trim((string) $row['last_synced_at']) !== ''
+        ? trim((string) $row['last_synced_at'])
+        : ($latestCurrentObservedAt ?? $latestSummaryObservedAt);
+
+    return db_execute(
+        'INSERT INTO market_source_snapshot_state (
+            source_type, source_id, latest_current_observed_at, latest_summary_observed_at, current_order_count, current_distinct_type_count, summary_row_count, last_synced_at
+         ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?
+         )
+         ON DUPLICATE KEY UPDATE
+            latest_current_observed_at = COALESCE(VALUES(latest_current_observed_at), latest_current_observed_at),
+            latest_summary_observed_at = COALESCE(VALUES(latest_summary_observed_at), latest_summary_observed_at),
+            current_order_count = VALUES(current_order_count),
+            current_distinct_type_count = VALUES(current_distinct_type_count),
+            summary_row_count = VALUES(summary_row_count),
+            last_synced_at = COALESCE(VALUES(last_synced_at), last_synced_at),
+            updated_at = CURRENT_TIMESTAMP',
+        [
+            $sourceType,
+            $sourceId,
+            $latestCurrentObservedAt,
+            $latestSummaryObservedAt,
+            $currentOrderCount,
+            $currentDistinctTypeCount,
+            $summaryRowCount,
+            $lastSyncedAt,
+        ]
+    );
+}
+
 
 function db_market_orders_history_prune_before(string $cutoffObservedAt): int
 {
-    db_query_cache_clear();
-    $stmt = db()->prepare('DELETE FROM market_orders_history WHERE observed_at < ?');
-    $stmt->execute([$cutoffObservedAt]);
+    db_market_snapshot_optimization_ensure();
 
-    return $stmt->rowCount();
+    return db_prune_before_datetime('market_orders_history', 'observed_at', $cutoffObservedAt);
+}
+
+function db_market_order_snapshots_summary_prune_before(string $cutoffObservedAt): int
+{
+    db_market_snapshot_optimization_ensure();
+
+    return db_prune_before_datetime('market_order_snapshots_summary', 'observed_at', $cutoffObservedAt);
 }
 
 function db_market_orders_current_latest_snapshot_rows(string $sourceType, int $sourceId): array
@@ -1877,7 +2020,36 @@ function db_market_orders_current_latest_snapshot_rows(string $sourceType, int $
         return [];
     }
 
-    return db_select(
+    $state = db_market_source_snapshot_state_get($safeSourceType, $safeSourceId);
+    $latestObservedAt = trim((string) ($state['latest_current_observed_at'] ?? ''));
+
+    if ($latestObservedAt !== '') {
+        return db_select(
+            'SELECT
+                source_type,
+                source_id,
+                type_id,
+                order_id,
+                is_buy_order,
+                price,
+                volume_remain,
+                volume_total,
+                min_volume,
+                `range`,
+                duration,
+                issued,
+                expires,
+                observed_at
+             FROM market_orders_current
+             WHERE source_type = ?
+               AND source_id = ?
+               AND observed_at = ?
+             ORDER BY type_id ASC, is_buy_order ASC, price ASC, order_id ASC',
+            [$safeSourceType, $safeSourceId, $latestObservedAt]
+        );
+    }
+
+    $rows = db_select(
         'SELECT
             source_type,
             source_id,
@@ -1905,6 +2077,25 @@ function db_market_orders_current_latest_snapshot_rows(string $sourceType, int $
          ORDER BY type_id ASC, is_buy_order ASC, price ASC, order_id ASC',
         [$safeSourceType, $safeSourceId, $safeSourceType, $safeSourceId]
     );
+
+    if ($rows !== []) {
+        $latestObservedAt = trim((string) ($rows[0]['observed_at'] ?? ''));
+        if ($latestObservedAt !== '') {
+            db_market_source_snapshot_state_upsert([
+                'source_type' => $safeSourceType,
+                'source_id' => $safeSourceId,
+                'latest_current_observed_at' => $latestObservedAt,
+                'current_order_count' => count($rows),
+                'current_distinct_type_count' => count(array_unique(array_filter(array_map(
+                    static fn (array $row): int => (int) ($row['type_id'] ?? 0),
+                    $rows
+                )))),
+                'last_synced_at' => $latestObservedAt,
+            ]);
+        }
+    }
+
+    return $rows;
 }
 
 function db_market_order_snapshots_summary_normalize_row(array $row): array
@@ -2111,6 +2302,7 @@ function db_market_orders_snapshot_metrics_window_ensure_summary(string $sourceT
     );
 
     $normalizedSummaryRows = array_map('db_market_order_snapshots_summary_normalize_row', $summaryRows);
+    $stateUpdated = false;
     $latestObservedAt = '';
     foreach ($normalizedSummaryRows as $row) {
         $observedAt = trim((string) ($row['observed_at'] ?? ''));
@@ -2122,6 +2314,32 @@ function db_market_orders_snapshot_metrics_window_ensure_summary(string $sourceT
     $rawRowsStartObservedAt = $latestObservedAt !== '' ? $latestObservedAt : $safeStartObservedAt;
     $rawRows = db_market_orders_snapshot_metrics_window_raw($safeSourceType, $safeSourceId, $rawRowsStartObservedAt);
     $summaryRowsWritten = $rawRows === [] ? 0 : db_market_order_snapshots_summary_bulk_upsert($rawRows);
+    if ($rawRows !== []) {
+        $latestRawObservedAt = trim((string) ($rawRows[array_key_last($rawRows)]['observed_at'] ?? ''));
+        if ($latestRawObservedAt !== '') {
+            db_market_source_snapshot_state_upsert([
+                'source_type' => $safeSourceType,
+                'source_id' => $safeSourceId,
+                'latest_summary_observed_at' => $latestRawObservedAt,
+                'summary_row_count' => count($rawRows),
+                'last_synced_at' => $latestRawObservedAt,
+            ]);
+            $stateUpdated = true;
+        }
+    }
+
+    if (!$stateUpdated && $latestObservedAt !== '') {
+        db_market_source_snapshot_state_upsert([
+            'source_type' => $safeSourceType,
+            'source_id' => $safeSourceId,
+            'latest_summary_observed_at' => $latestObservedAt,
+            'summary_row_count' => count(array_filter(
+                $normalizedSummaryRows,
+                static fn (array $row): bool => (string) ($row['observed_at'] ?? '') === $latestObservedAt
+            )),
+            'last_synced_at' => $latestObservedAt,
+        ]);
+    }
 
     if ($normalizedSummaryRows === []) {
         return [
@@ -2886,6 +3104,8 @@ function db_market_orders_current_source_aggregates(string $sourceType, int $sou
     $params = [$sourceType, $sourceId];
     $typeFilterSql = '';
     $rawTypeFilterSql = '';
+    $state = db_market_source_snapshot_state_get($sourceType, $sourceId);
+    $latestSummaryObservedAt = trim((string) ($state['latest_summary_observed_at'] ?? ''));
 
     if ($typeIds !== []) {
         $normalizedTypeIds = array_values(array_unique(array_filter(array_map('intval', $typeIds), static fn (int $typeId): bool => $typeId > 0)));
@@ -2899,38 +3119,62 @@ function db_market_orders_current_source_aggregates(string $sourceType, int $sou
         $params = array_merge($params, $normalizedTypeIds);
     }
 
-    $rows = db_select_cached(
-        "SELECT
-            moss.type_id,
-            rit.type_name,
-            moss.best_sell_price,
-            moss.best_buy_price,
-            moss.total_sell_volume,
-            moss.total_buy_volume,
-            moss.sell_order_count,
-            moss.buy_order_count,
-            moss.observed_at AS last_observed_at
-         FROM market_order_snapshots_summary moss
-         LEFT JOIN ref_item_types rit ON rit.type_id = moss.type_id
-         WHERE moss.source_type = ?
-           AND moss.source_id = ?
-           AND moss.observed_at = (
-                SELECT MAX(summary_latest.observed_at)
-                FROM market_order_snapshots_summary summary_latest
-                WHERE summary_latest.source_type = ?
-                  AND summary_latest.source_id = ?
-           ){$typeFilterSql}
-         ORDER BY moss.type_id ASC",
-        [$sourceType, $sourceId, $sourceType, $sourceId, ...array_slice($params, 2)],
-        60,
-        'market.snapshot.current-aggregates'
-    );
+    $rows = [];
+    if ($latestSummaryObservedAt !== '') {
+        $rows = db_select_cached(
+            "SELECT
+                moss.type_id,
+                rit.type_name,
+                moss.best_sell_price,
+                moss.best_buy_price,
+                moss.total_sell_volume,
+                moss.total_buy_volume,
+                moss.sell_order_count,
+                moss.buy_order_count,
+                moss.observed_at AS last_observed_at
+             FROM market_order_snapshots_summary moss
+             LEFT JOIN ref_item_types rit ON rit.type_id = moss.type_id
+             WHERE moss.source_type = ?
+               AND moss.source_id = ?
+               AND moss.observed_at = ?{$typeFilterSql}
+             ORDER BY moss.type_id ASC",
+            [$sourceType, $sourceId, $latestSummaryObservedAt, ...array_slice($params, 2)],
+            60,
+            'market.snapshot.current-aggregates'
+        );
+    } else {
+        $rows = db_select_cached(
+            "SELECT
+                moss.type_id,
+                rit.type_name,
+                moss.best_sell_price,
+                moss.best_buy_price,
+                moss.total_sell_volume,
+                moss.total_buy_volume,
+                moss.sell_order_count,
+                moss.buy_order_count,
+                moss.observed_at AS last_observed_at
+             FROM market_order_snapshots_summary moss
+             LEFT JOIN ref_item_types rit ON rit.type_id = moss.type_id
+             WHERE moss.source_type = ?
+               AND moss.source_id = ?
+               AND moss.observed_at = (
+                    SELECT MAX(summary_latest.observed_at)
+                    FROM market_order_snapshots_summary summary_latest
+                    WHERE summary_latest.source_type = ?
+                      AND summary_latest.source_id = ?
+               ){$typeFilterSql}
+             ORDER BY moss.type_id ASC",
+            [$sourceType, $sourceId, $sourceType, $sourceId, ...array_slice($params, 2)],
+            60,
+            'market.snapshot.current-aggregates'
+        );
+    }
 
     if ($rows !== []) {
         return $rows;
     }
-
-    return db_select(
+    $rows = db_select(
         "SELECT
             moc.type_id,
             rit.type_name,
@@ -2949,6 +3193,21 @@ function db_market_orders_current_source_aggregates(string $sourceType, int $sou
          ORDER BY moc.type_id ASC",
         $params
     );
+
+    if ($rows !== []) {
+        $latestCurrentObservedAt = trim((string) ($rows[0]['last_observed_at'] ?? ''));
+        if ($latestCurrentObservedAt !== '') {
+            db_market_source_snapshot_state_upsert([
+                'source_type' => $sourceType,
+                'source_id' => $sourceId,
+                'latest_current_observed_at' => $latestCurrentObservedAt,
+                'current_distinct_type_count' => count($rows),
+                'last_synced_at' => $latestCurrentObservedAt,
+            ]);
+        }
+    }
+
+    return $rows;
 }
 
 function db_market_orders_current_alliance_vs_reference_aggregates(int $allianceStructureId, int $referenceSourceId, array $typeIds = []): array
@@ -4499,6 +4758,11 @@ function db_sync_schedule_registry_columns_ensure(): void
              END
          WHERE 1 = 1"
     );
+
+    db_ensure_table_index('sync_schedules', 'idx_sync_schedules_due_lookup', 'INDEX idx_sync_schedules_due_lookup (enabled, current_state, next_due_at, locked_until, id)');
+    db_ensure_table_index('sync_schedules', 'idx_sync_schedules_backfill_lookup', 'INDEX idx_sync_schedules_backfill_lookup (enabled, allow_backfill, current_state, degraded_until, locked_until, next_due_at, last_finished_at, id)');
+    db_ensure_table_index('sync_schedules', 'idx_sync_schedules_running_lookup', 'INDEX idx_sync_schedules_running_lookup (enabled, current_state, locked_until, last_started_at, id)');
+    db_ensure_table_index('sync_runs', 'idx_sync_runs_created_at', 'INDEX idx_sync_runs_created_at (created_at)');
 }
 
 function db_sync_schedule_select_columns_sql(): string
@@ -5777,6 +6041,7 @@ function db_scheduler_job_event_insert(string $jobKey, string $eventType, array 
         KEY idx_scheduler_job_events_job_created (job_key, created_at),
         KEY idx_scheduler_job_events_type_created (event_type, created_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+    db_ensure_table_index('scheduler_job_events', 'idx_scheduler_job_events_created', 'INDEX idx_scheduler_job_events_created (created_at)');
 
     return db_execute(
         'INSERT INTO scheduler_job_events (job_key, event_type, detail_json, lateness_seconds, duration_seconds)
@@ -5798,6 +6063,7 @@ function db_scheduler_job_events_recent_summary(int $windowMinutes = 120): array
         KEY idx_scheduler_job_events_job_created (job_key, created_at),
         KEY idx_scheduler_job_events_type_created (event_type, created_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+    db_ensure_table_index('scheduler_job_events', 'idx_scheduler_job_events_created', 'INDEX idx_scheduler_job_events_created (created_at)');
 
     $safeWindow = max(5, min(1440, $windowMinutes));
     $rows = db_select(
@@ -5840,6 +6106,7 @@ function db_scheduler_tuning_action_log(string $jobKey, string $actor, string $a
         KEY idx_scheduler_tuning_actions_job_created (job_key, created_at),
         KEY idx_scheduler_tuning_actions_actor_created (actor, created_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+    db_ensure_table_index('scheduler_tuning_actions', 'idx_scheduler_tuning_actions_created', 'INDEX idx_scheduler_tuning_actions_created (created_at)');
 
     return db_execute(
         'INSERT INTO scheduler_tuning_actions (job_key, actor, action_type, reason_text, before_json, after_json, metrics_json)
@@ -5871,6 +6138,7 @@ function db_scheduler_tuning_actions_recent(int $limit = 20): array
         KEY idx_scheduler_tuning_actions_job_created (job_key, created_at),
         KEY idx_scheduler_tuning_actions_actor_created (actor, created_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+    db_ensure_table_index('scheduler_tuning_actions', 'idx_scheduler_tuning_actions_created', 'INDEX idx_scheduler_tuning_actions_created (created_at)');
 
     $safeLimit = max(1, min(100, $limit));
     return db_select(
@@ -5913,6 +6181,7 @@ function db_scheduler_resource_metrics_ensure(): void
         KEY idx_scheduler_resource_metrics_schedule_created (schedule_id, created_at),
         KEY idx_scheduler_resource_metrics_job_started (job_key, started_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+    db_ensure_table_index('scheduler_job_resource_metrics', 'idx_scheduler_resource_metrics_created', 'INDEX idx_scheduler_resource_metrics_created (created_at)');
 }
 
 function db_scheduler_resource_metric_insert(array $row): bool
@@ -5997,6 +6266,47 @@ function db_scheduler_resource_metrics_recent_all(int $limit = 20): array
          ORDER BY created_at DESC, id DESC
          LIMIT ' . $safeLimit
     );
+}
+
+function db_control_plane_retention_cleanup(int $limitPerTable = 5000): array
+{
+    db_sync_schedule_registry_columns_ensure();
+    db_scheduler_job_events_recent_summary(5);
+    db_scheduler_resource_metrics_ensure();
+    db_scheduler_planner_decisions_ensure();
+    db_scheduler_tuning_actions_recent(1);
+    db_ui_refresh_schema_ensure();
+
+    $safeLimit = max(100, min(50000, $limitPerTable));
+    $specs = [
+        ['table' => 'market_order_snapshots_summary', 'column' => 'observed_at', 'setting' => 'raw_order_snapshot_retention_days', 'default' => 30, 'min' => 1, 'max' => 3650],
+        ['table' => 'sync_runs', 'column' => 'created_at', 'setting' => 'sync_run_retention_days', 'default' => 30, 'min' => 7, 'max' => 3650],
+        ['table' => 'scheduler_job_events', 'column' => 'created_at', 'setting' => 'scheduler_event_retention_days', 'default' => 14, 'min' => 1, 'max' => 3650],
+        ['table' => 'scheduler_job_resource_metrics', 'column' => 'created_at', 'setting' => 'scheduler_metric_retention_days', 'default' => 30, 'min' => 7, 'max' => 3650],
+        ['table' => 'scheduler_planner_decisions', 'column' => 'created_at', 'setting' => 'scheduler_planner_retention_days', 'default' => 30, 'min' => 7, 'max' => 3650],
+        ['table' => 'scheduler_tuning_actions', 'column' => 'created_at', 'setting' => 'scheduler_tuning_retention_days', 'default' => 30, 'min' => 7, 'max' => 3650],
+        ['table' => 'ui_refresh_events', 'column' => 'created_at', 'setting' => 'ui_refresh_event_retention_days', 'default' => 14, 'min' => 1, 'max' => 3650],
+    ];
+
+    $deleted = [];
+    $rowsWritten = 0;
+
+    foreach ($specs as $spec) {
+        $retentionDays = db_setting_int((string) $spec['setting'], (int) $spec['default'], (int) $spec['min'], (int) $spec['max']);
+        $cutoff = gmdate('Y-m-d H:i:s', strtotime('-' . $retentionDays . ' days'));
+        $rowsDeleted = db_prune_before_datetime((string) $spec['table'], (string) $spec['column'], $cutoff, $safeLimit);
+        $deleted[(string) $spec['table']] = [
+            'rows_deleted' => $rowsDeleted,
+            'cutoff' => $cutoff,
+            'retention_days' => $retentionDays,
+        ];
+        $rowsWritten += $rowsDeleted;
+    }
+
+    return [
+        'rows_written' => $rowsWritten,
+        'deleted' => $deleted,
+    ];
 }
 
 
@@ -6118,6 +6428,7 @@ function db_scheduler_planner_decisions_ensure(): void
         KEY idx_scheduler_planner_decisions_job_created (job_key, created_at),
         KEY idx_scheduler_planner_decisions_type_created (decision_type, created_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+    db_ensure_table_index('scheduler_planner_decisions', 'idx_scheduler_planner_decisions_created', 'INDEX idx_scheduler_planner_decisions_created (created_at)');
 }
 
 function db_scheduler_planner_decision_insert(?int $scheduleId, string $jobKey, string $decisionType, string $pressureState, string $reasonText, array $decision = []): bool

--- a/src/functions.php
+++ b/src/functions.php
@@ -11997,6 +11997,24 @@ function market_snapshot_trade_date(string $observedAt): string
     }
 }
 
+function market_order_distinct_type_count(array $rows): int
+{
+    $typeIds = [];
+
+    foreach ($rows as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+
+        $typeId = (int) ($row['type_id'] ?? 0);
+        if ($typeId > 0) {
+            $typeIds[$typeId] = true;
+        }
+    }
+
+    return count($typeIds);
+}
+
 function market_history_daily_point_from_snapshot_metric(array $metric, string $sourceType): ?array
 {
     $normalizedSourceType = $sourceType === 'market_hub' ? 'market_hub' : 'alliance_structure';
@@ -12487,6 +12505,14 @@ function sync_alliance_structure_orders(int $structureId, string $runMode = 'inc
         }
 
         $writtenCurrent = db_market_orders_current_bulk_upsert($mappedOrders);
+        db_market_source_snapshot_state_upsert([
+            'source_type' => 'alliance_structure',
+            'source_id' => $structureId,
+            'latest_current_observed_at' => $observedAt,
+            'current_order_count' => count($mappedOrders),
+            'current_distinct_type_count' => market_order_distinct_type_count($mappedOrders),
+            'last_synced_at' => $observedAt,
+        ]);
         sync_run_finalize_success($runIdCurrent, $datasetKeyCurrent, $syncMode, $result['rows_seen'], $writtenCurrent, $snapshotCursor, $checksum);
         $currentFinished = true;
 
@@ -12847,6 +12873,14 @@ function sync_market_hub_current_orders(string|int $hubRef, string $runMode = 'i
         }
 
         $writtenCurrent = db_market_orders_current_bulk_upsert($canonicalRows);
+        db_market_source_snapshot_state_upsert([
+            'source_type' => 'market_hub',
+            'source_id' => $sourceId,
+            'latest_current_observed_at' => $observedAt,
+            'current_order_count' => count($canonicalRows),
+            'current_distinct_type_count' => market_order_distinct_type_count($canonicalRows),
+            'last_synced_at' => $observedAt,
+        ]);
         sync_run_finalize_success($runIdCurrent, $datasetKeyCurrent, $syncMode, $result['rows_seen'], $writtenCurrent, $result['cursor'], $result['checksum']);
         $currentFinished = true;
 
@@ -13167,13 +13201,23 @@ function sync_market_orders_history_prune(int $retentionDays, string $runMode = 
     try {
         $safeRetentionDays = max(1, min(3650, $retentionDays));
         $cutoffObservedAt = gmdate('Y-m-d H:i:s', strtotime('-' . $safeRetentionDays . ' days'));
-        $deletedRows = db_market_orders_history_prune_before($cutoffObservedAt);
+        $deletedHistoryRows = db_market_orders_history_prune_before($cutoffObservedAt);
+        $deletedSummaryRows = db_market_order_snapshots_summary_prune_before($cutoffObservedAt);
+        $controlPlaneCleanup = db_control_plane_retention_cleanup(10000);
+        $controlPlaneDeleted = array_sum(array_map(
+            static fn (array $row): int => (int) ($row['rows_deleted'] ?? 0),
+            (array) ($controlPlaneCleanup['deleted'] ?? [])
+        ));
+        $deletedRows = $deletedHistoryRows + $deletedSummaryRows + $controlPlaneDeleted;
 
         $result['rows_seen'] = $deletedRows;
         $result['rows_written'] = $deletedRows;
         $result['cursor'] = 'cutoff:' . $cutoffObservedAt;
         $result['checksum'] = sync_checksum([
             'deleted_rows' => $deletedRows,
+            'deleted_history_rows' => $deletedHistoryRows,
+            'deleted_summary_rows' => $deletedSummaryRows,
+            'deleted_control_plane_rows' => $controlPlaneDeleted,
             'retention_days' => $safeRetentionDays,
             'cutoff_observed_at' => $cutoffObservedAt,
         ]);
@@ -13185,6 +13229,10 @@ function sync_market_orders_history_prune(int $retentionDays, string $runMode = 
             'records_deleted' => $deletedRows,
             'history_rows_generated' => 0,
             'retention_days' => $safeRetentionDays,
+            'market_orders_history_deleted' => $deletedHistoryRows,
+            'market_snapshot_summary_deleted' => $deletedSummaryRows,
+            'control_plane_deleted' => $controlPlaneDeleted,
+            'control_plane_cleanup' => $controlPlaneCleanup['deleted'] ?? [],
             'no_changes' => $deletedRows === 0,
         ];
 


### PR DESCRIPTION
### Motivation
- Reduce repeated expensive scans on large market tables by centralizing latest-snapshot metadata. 
- Make global retention/prune operations sargable and cap growth of summary and control-plane audit tables. 
- Lower read/write amplification on hot market and scheduler paths while preserving existing behavior.

### Description
- Added a compact current-state table `market_source_snapshot_state` and accompanying helpers (`db_market_source_snapshot_state_*`) to store latest current/summary `observed_at` timestamps and source-level counts so pages can resolve freshness without `MAX(observed_at)` scans. 
- Added high-value indexes and schema changes: `market_orders_history(observed_at)`, `market_order_snapshots_summary(observed_at)`, composite scheduler lookup indexes on `sync_schedules`, and single-column `created_at` indexes for `sync_runs`, `scheduler_job_events`, `scheduler_job_resource_metrics`, `scheduler_planner_decisions`, and `scheduler_tuning_actions`. These are added via both runtime `db_ensure_table_index()` calls and updated `database/schema.sql`/`database/export-schema.sql`. 
- Implemented DB helper functions: `db_setting_int()`, `db_prune_before_datetime()`, `db_control_plane_retention_cleanup()` and `db_market_snapshot_optimization_ensure()` to centralize retention/read helpers and make pruning bounded and index-backed. 
- Updated market sync and materialization flows to refresh `market_source_snapshot_state` after current-order upserts and snapshot summary writes, and added `market_order_distinct_type_count()` helper used for diagnostics; expanded the maintenance prune job to delete from `market_orders_history`, `market_order_snapshots_summary`, and control-plane audit tables in one pass. 
- Added a full audit and deliverable `database/OPTIMIZATION_AUDIT.md` with table-by-table mappings, findings, implemented changes, and a phased follow-up plan; referenced it from `database/README.md`.

### Testing
- Ran PHP syntax checks: `php -l src/db.php` succeeded (no syntax errors). 
- Ran PHP syntax checks: `php -l src/functions.php` succeeded (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9557f904832f9b4f1a5483c2c595)