### PR TITLE
Prefer compact market projection reads

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -2527,6 +2527,82 @@ function db_market_order_current_projection_latest_rows(string $sourceType, int 
     );
 }
 
+function db_market_orders_current_compact_type_names(array $typeIds): array
+{
+    $normalizedTypeIds = array_values(array_unique(array_filter(array_map('intval', $typeIds), static fn (int $typeId): bool => $typeId > 0)));
+    if ($normalizedTypeIds === []) {
+        return [];
+    }
+
+    $rows = db_select(
+        'SELECT type_id, type_name
+         FROM ref_item_types
+         WHERE type_id IN (' . implode(', ', array_fill(0, count($normalizedTypeIds), '?')) . ')',
+        $normalizedTypeIds
+    );
+
+    $typeNameMap = [];
+    foreach ($rows as $row) {
+        $typeNameMap[(int) ($row['type_id'] ?? 0)] = (string) ($row['type_name'] ?? '');
+    }
+
+    return $typeNameMap;
+}
+
+function db_market_orders_current_compact_projection_rows(string $sourceType, int $sourceId, array $typeIds = []): array
+{
+    $projectionRows = db_market_order_current_projection_latest_rows($sourceType, $sourceId, $typeIds);
+    if ($projectionRows === []) {
+        return [];
+    }
+
+    $typeNameMap = db_market_orders_current_compact_type_names(array_map(
+        static fn (array $row): int => (int) ($row['type_id'] ?? 0),
+        $projectionRows
+    ));
+
+    return array_map(static function (array $row) use ($typeNameMap): array {
+        $typeId = (int) ($row['type_id'] ?? 0);
+        $totalSellVolume = max(0, (int) ($row['total_sell_volume'] ?? 0));
+        $totalBuyVolume = max(0, (int) ($row['total_buy_volume'] ?? 0));
+        $totalVolume = array_key_exists('total_volume', $row) && $row['total_volume'] !== null
+            ? max(0, (int) $row['total_volume'])
+            : ($totalSellVolume + $totalBuyVolume);
+        $observedAt = (string) ($row['observed_at'] ?? '');
+
+        return [
+            'source_type' => (string) ($row['source_type'] ?? ''),
+            'source_id' => max(0, (int) ($row['source_id'] ?? 0)),
+            'type_id' => $typeId,
+            'type_name' => $typeNameMap[$typeId] ?? null,
+            'best_sell_price' => $row['best_sell_price'] ?? null,
+            'best_buy_price' => $row['best_buy_price'] ?? null,
+            'total_sell_volume' => $totalSellVolume,
+            'total_buy_volume' => $totalBuyVolume,
+            'total_volume' => $totalVolume,
+            'sell_order_count' => max(0, (int) ($row['sell_order_count'] ?? 0)),
+            'buy_order_count' => max(0, (int) ($row['buy_order_count'] ?? 0)),
+            'last_observed_at' => $observedAt,
+        ];
+    }, $projectionRows);
+}
+
+function db_market_orders_current_compact_snapshot_rows(string $sourceType, int $sourceId, array $typeIds = []): array
+{
+    $safeSourceType = trim($sourceType);
+    $safeSourceId = max(0, $sourceId);
+    if ($safeSourceType === '' || $safeSourceId <= 0) {
+        return [];
+    }
+
+    $projectionRows = db_market_orders_current_compact_projection_rows($safeSourceType, $safeSourceId, $typeIds);
+    if ($projectionRows !== []) {
+        return $projectionRows;
+    }
+
+    return db_market_orders_current_source_aggregates($safeSourceType, $safeSourceId, $typeIds);
+}
+
 function db_market_orders_current_bulk_upsert(array $orders, ?int $chunkSize = null): int
 {
     $written = db_bulk_insert_or_upsert(
@@ -4175,41 +4251,9 @@ function db_market_orders_history_stock_health_series(
 
 function db_market_orders_current_source_aggregates(string $sourceType, int $sourceId, array $typeIds = []): array
 {
-    $projectionRows = db_market_order_current_projection_latest_rows($sourceType, $sourceId, $typeIds);
+    $projectionRows = db_market_orders_current_compact_projection_rows($sourceType, $sourceId, $typeIds);
     if ($projectionRows !== []) {
-        $typeNameMap = [];
-        $projectionTypeIds = array_values(array_unique(array_filter(array_map(
-            static fn (array $row): int => (int) ($row['type_id'] ?? 0),
-            $projectionRows
-        ))));
-
-        if ($projectionTypeIds !== []) {
-            $typeNameRows = db_select(
-                'SELECT type_id, type_name
-                 FROM ref_item_types
-                 WHERE type_id IN (' . implode(', ', array_fill(0, count($projectionTypeIds), '?')) . ')',
-                $projectionTypeIds
-            );
-            foreach ($typeNameRows as $typeNameRow) {
-                $typeNameMap[(int) ($typeNameRow['type_id'] ?? 0)] = (string) ($typeNameRow['type_name'] ?? '');
-            }
-        }
-
-        return array_map(static function (array $row) use ($typeNameMap): array {
-            $typeId = (int) ($row['type_id'] ?? 0);
-
-            return [
-                'type_id' => $typeId,
-                'type_name' => $typeNameMap[$typeId] ?? null,
-                'best_sell_price' => $row['best_sell_price'] ?? null,
-                'best_buy_price' => $row['best_buy_price'] ?? null,
-                'total_sell_volume' => max(0, (int) ($row['total_sell_volume'] ?? 0)),
-                'total_buy_volume' => max(0, (int) ($row['total_buy_volume'] ?? 0)),
-                'sell_order_count' => max(0, (int) ($row['sell_order_count'] ?? 0)),
-                'buy_order_count' => max(0, (int) ($row['buy_order_count'] ?? 0)),
-                'last_observed_at' => (string) ($row['observed_at'] ?? ''),
-            ];
-        }, $projectionRows);
+        return $projectionRows;
     }
 
     $params = [$sourceType, $sourceId];

--- a/src/functions.php
+++ b/src/functions.php
@@ -11839,8 +11839,8 @@ function market_hub_current_sync_latest_dataset(string|int|null $hubRef = null):
     }
 
     $sourceId = sync_source_id_from_hub_ref($resolvedHubRef);
-    $rows = db_market_orders_current_latest_snapshot_rows('market_hub', $sourceId);
-    $observedAt = $rows !== [] ? (string) ($rows[0]['observed_at'] ?? '') : '';
+    $rows = db_market_orders_current_compact_snapshot_rows('market_hub', $sourceId);
+    $observedAt = $rows !== [] ? (string) (($rows[0]['last_observed_at'] ?? $rows[0]['observed_at'] ?? '')) : '';
 
     return [
         'hub_ref' => $resolvedHubRef,
@@ -11911,6 +11911,7 @@ function market_hub_current_snapshot_finalize_metric(array $metric): ?array
 function market_hub_current_snapshot_metrics_by_type(array $rows, ?int $sourceId = null): array
 {
     $aggregates = [];
+    $canonicalRows = [];
 
     foreach ($rows as $row) {
         if (!is_array($row)) {
@@ -11923,8 +11924,28 @@ function market_hub_current_snapshot_metrics_by_type(array $rows, ?int $sourceId
         }
 
         $rowSourceId = max(0, (int) ($row['source_id'] ?? $sourceId ?? 0));
-        $observedAt = trim((string) ($row['observed_at'] ?? ''));
+        $observedAt = trim((string) (($row['last_observed_at'] ?? $row['observed_at'] ?? '')));
         if ($rowSourceId <= 0 || $observedAt === '') {
+            continue;
+        }
+
+        if (array_key_exists('best_sell_price', $row) || array_key_exists('best_buy_price', $row)) {
+            $canonical = market_hub_current_snapshot_finalize_metric([
+                'source_id' => $rowSourceId,
+                'type_id' => $typeId,
+                'observed_at' => $observedAt,
+                'best_sell_price' => $row['best_sell_price'] ?? null,
+                'best_buy_price' => $row['best_buy_price'] ?? null,
+                'total_volume' => array_key_exists('total_volume', $row)
+                    ? max(0, (int) ($row['total_volume'] ?? 0))
+                    : max(0, (int) ($row['total_sell_volume'] ?? 0)) + max(0, (int) ($row['total_buy_volume'] ?? 0)),
+                'buy_order_count' => max(0, (int) ($row['buy_order_count'] ?? 0)),
+                'sell_order_count' => max(0, (int) ($row['sell_order_count'] ?? 0)),
+            ]);
+            if ($canonical !== null) {
+                $canonicalRows[$typeId] = $canonical;
+            }
+
             continue;
         }
 
@@ -11959,7 +11980,6 @@ function market_hub_current_snapshot_metrics_by_type(array $rows, ?int $sourceId
         }
     }
 
-    $canonicalRows = [];
     foreach ($aggregates as $typeId => $aggregate) {
         $canonical = market_hub_current_snapshot_finalize_metric($aggregate);
         if ($canonical === null) {


### PR DESCRIPTION
### Motivation

- Simplify market current/aggregate reads so page/controller code consumes a compact, normalized projection shape instead of deciding between `market_orders_current`, `market_order_snapshots_summary`, and history tables. 
- Keep historical/summary tables available for trend charts, backfills, and rebuilds while isolating temporary fallback logic in the DB layer. 
- Make the market-hub operational path projection-first to reduce repeated heavy queries and centralize fallback behavior in `src/db.php`.

### Description

- Added compact projection helpers in `src/db.php`: `db_market_orders_current_compact_type_names()`, `db_market_orders_current_compact_projection_rows()`, and `db_market_orders_current_compact_snapshot_rows()` which return normalized per-type rows with `type_name`, `total_volume`, and `last_observed_at` where available. 
- Made `db_market_orders_current_source_aggregates()` projection-first by delegating to `db_market_orders_current_compact_projection_rows()` and returning its normalized rows when present, otherwise falling back to existing current/summary logic inside the DB layer. 
- Updated the market-hub helpers in `src/functions.php` to use `db_market_orders_current_compact_snapshot_rows()` in `market_hub_current_sync_latest_dataset()` and to accept compact aggregated rows in `market_hub_current_snapshot_metrics_by_type()` (use `last_observed_at` or `observed_at`, and accept rows that already contain `best_sell_price`/`best_buy_price`/`total_volume`). 
- Preserved history/summary usage for long-window reads and backfills by keeping the fallback chain inside `src/db.php` so controllers do not pick tables directly.

### Testing

- Ran `php -l src/functions.php` and `php -l src/db.php` and both reported no syntax errors. 
- Verified caller replacement with `rg -n "db_market_orders_current_latest_snapshot_rows\(" src/functions.php` to confirm the market-hub path now uses `db_market_orders_current_compact_snapshot_rows()`; the check passed. 
- Basic grep/inspection of diffs confirmed new functions are present and `db_market_orders_current_source_aggregates()` now prefers the compact projection result.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa7c4d214832fa9f12290dca6a8f4)