### PR TITLE
Refactor killmail overview to use structured overview columns

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -927,6 +927,11 @@ CREATE TABLE IF NOT EXISTS killmail_events (
     victim_corporation_id BIGINT UNSIGNED DEFAULT NULL,
     victim_alliance_id BIGINT UNSIGNED DEFAULT NULL,
     victim_ship_type_id INT UNSIGNED DEFAULT NULL,
+    zkb_total_value DECIMAL(20,2) DEFAULT NULL,
+    zkb_points INT UNSIGNED DEFAULT NULL,
+    zkb_npc TINYINT(1) DEFAULT NULL,
+    zkb_solo TINYINT(1) DEFAULT NULL,
+    zkb_awox TINYINT(1) DEFAULT NULL,
     zkb_json LONGTEXT NOT NULL,
     raw_killmail_json LONGTEXT NOT NULL,
     effective_killmail_at DATETIME GENERATED ALWAYS AS (COALESCE(killmail_time, created_at)) STORED,
@@ -971,6 +976,126 @@ FROM killmail_events e
 LEFT JOIN killmail_event_payloads p ON p.sequence_id = e.sequence_id
 WHERE p.sequence_id IS NULL
   AND (e.zkb_json IS NOT NULL OR e.raw_killmail_json IS NOT NULL);
+
+SET @killmail_events_zkb_total_value_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'killmail_events'
+      AND COLUMN_NAME = 'zkb_total_value'
+);
+SET @killmail_events_zkb_total_value_sql := IF(
+    @killmail_events_zkb_total_value_exists = 0,
+    'ALTER TABLE killmail_events ADD COLUMN zkb_total_value DECIMAL(20,2) DEFAULT NULL AFTER victim_ship_type_id',
+    'SELECT 1'
+);
+PREPARE killmail_events_zkb_total_value_stmt FROM @killmail_events_zkb_total_value_sql;
+EXECUTE killmail_events_zkb_total_value_stmt;
+DEALLOCATE PREPARE killmail_events_zkb_total_value_stmt;
+
+SET @killmail_events_zkb_points_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'killmail_events'
+      AND COLUMN_NAME = 'zkb_points'
+);
+SET @killmail_events_zkb_points_sql := IF(
+    @killmail_events_zkb_points_exists = 0,
+    'ALTER TABLE killmail_events ADD COLUMN zkb_points INT UNSIGNED DEFAULT NULL AFTER zkb_total_value',
+    'SELECT 1'
+);
+PREPARE killmail_events_zkb_points_stmt FROM @killmail_events_zkb_points_sql;
+EXECUTE killmail_events_zkb_points_stmt;
+DEALLOCATE PREPARE killmail_events_zkb_points_stmt;
+
+SET @killmail_events_zkb_npc_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'killmail_events'
+      AND COLUMN_NAME = 'zkb_npc'
+);
+SET @killmail_events_zkb_npc_sql := IF(
+    @killmail_events_zkb_npc_exists = 0,
+    'ALTER TABLE killmail_events ADD COLUMN zkb_npc TINYINT(1) DEFAULT NULL AFTER zkb_points',
+    'SELECT 1'
+);
+PREPARE killmail_events_zkb_npc_stmt FROM @killmail_events_zkb_npc_sql;
+EXECUTE killmail_events_zkb_npc_stmt;
+DEALLOCATE PREPARE killmail_events_zkb_npc_stmt;
+
+SET @killmail_events_zkb_solo_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'killmail_events'
+      AND COLUMN_NAME = 'zkb_solo'
+);
+SET @killmail_events_zkb_solo_sql := IF(
+    @killmail_events_zkb_solo_exists = 0,
+    'ALTER TABLE killmail_events ADD COLUMN zkb_solo TINYINT(1) DEFAULT NULL AFTER zkb_npc',
+    'SELECT 1'
+);
+PREPARE killmail_events_zkb_solo_stmt FROM @killmail_events_zkb_solo_sql;
+EXECUTE killmail_events_zkb_solo_stmt;
+DEALLOCATE PREPARE killmail_events_zkb_solo_stmt;
+
+SET @killmail_events_zkb_awox_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'killmail_events'
+      AND COLUMN_NAME = 'zkb_awox'
+);
+SET @killmail_events_zkb_awox_sql := IF(
+    @killmail_events_zkb_awox_exists = 0,
+    'ALTER TABLE killmail_events ADD COLUMN zkb_awox TINYINT(1) DEFAULT NULL AFTER zkb_solo',
+    'SELECT 1'
+);
+PREPARE killmail_events_zkb_awox_stmt FROM @killmail_events_zkb_awox_sql;
+EXECUTE killmail_events_zkb_awox_stmt;
+DEALLOCATE PREPARE killmail_events_zkb_awox_stmt;
+
+UPDATE killmail_events e
+LEFT JOIN killmail_event_payloads p ON p.sequence_id = e.sequence_id
+SET
+    e.zkb_total_value = CASE
+        WHEN JSON_VALID(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'))
+             AND JSON_EXTRACT(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'), '$.totalValue') IS NOT NULL
+            THEN CAST(JSON_UNQUOTE(JSON_EXTRACT(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'), '$.totalValue')) AS DECIMAL(20,2))
+        ELSE NULL
+    END,
+    e.zkb_points = CASE
+        WHEN JSON_VALID(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'))
+             AND JSON_EXTRACT(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'), '$.points') IS NOT NULL
+            THEN CAST(JSON_UNQUOTE(JSON_EXTRACT(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'), '$.points')) AS UNSIGNED)
+        ELSE NULL
+    END,
+    e.zkb_npc = CASE
+        WHEN JSON_VALID(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'))
+             AND JSON_EXTRACT(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'), '$.npc') IS NOT NULL
+            THEN IF(LOWER(JSON_UNQUOTE(JSON_EXTRACT(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'), '$.npc'))) IN ('1', 'true'), 1, 0)
+        ELSE NULL
+    END,
+    e.zkb_solo = CASE
+        WHEN JSON_VALID(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'))
+             AND JSON_EXTRACT(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'), '$.solo') IS NOT NULL
+            THEN IF(LOWER(JSON_UNQUOTE(JSON_EXTRACT(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'), '$.solo'))) IN ('1', 'true'), 1, 0)
+        ELSE NULL
+    END,
+    e.zkb_awox = CASE
+        WHEN JSON_VALID(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'))
+             AND JSON_EXTRACT(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'), '$.awox') IS NOT NULL
+            THEN IF(LOWER(JSON_UNQUOTE(JSON_EXTRACT(COALESCE(NULLIF(p.zkb_json, ''), NULLIF(e.zkb_json, ''), '{}'), '$.awox'))) IN ('1', 'true'), 1, 0)
+        ELSE NULL
+    END
+WHERE e.zkb_total_value IS NULL
+  AND e.zkb_points IS NULL
+  AND e.zkb_npc IS NULL
+  AND e.zkb_solo IS NULL
+  AND e.zkb_awox IS NULL
+  AND (p.sequence_id IS NOT NULL OR NULLIF(e.zkb_json, '') IS NOT NULL);
 
 CREATE TABLE IF NOT EXISTS killmail_attackers (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,

--- a/src/db.php
+++ b/src/db.php
@@ -412,14 +412,87 @@ function db_killmail_payload_schema_ensure(): void
                 e.sequence_id,
                 e.killmail_id,
                 e.killmail_hash,
-                COALESCE(e.zkb_json, '{}'),
-                COALESCE(e.raw_killmail_json, '{}')
+               COALESCE(e.zkb_json, '{}'),
+               COALESCE(e.raw_killmail_json, '{}')
              FROM killmail_events e
              LEFT JOIN killmail_event_payloads p ON p.sequence_id = e.sequence_id
              WHERE p.sequence_id IS NULL
                AND (e.zkb_json IS NOT NULL OR e.raw_killmail_json IS NOT NULL)"
         );
     }
+
+    db_killmail_overview_schema_ensure();
+
+    $ensured = true;
+}
+
+function db_killmail_overview_schema_ensure(): void
+{
+    static $ensured = false;
+
+    if ($ensured) {
+        return;
+    }
+
+    db()->exec("CREATE TABLE IF NOT EXISTS killmail_event_payloads (
+        sequence_id BIGINT UNSIGNED NOT NULL,
+        killmail_id BIGINT UNSIGNED NOT NULL,
+        killmail_hash VARCHAR(128) NOT NULL,
+        zkb_json LONGTEXT NOT NULL,
+        raw_killmail_json LONGTEXT NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        PRIMARY KEY (sequence_id),
+        UNIQUE KEY uniq_killmail_event_payloads_killmail (killmail_id, killmail_hash),
+        CONSTRAINT fk_killmail_event_payloads_sequence
+            FOREIGN KEY (sequence_id) REFERENCES killmail_events (sequence_id)
+            ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+    db_ensure_table_column('killmail_events', 'zkb_total_value', 'DECIMAL(20,2) DEFAULT NULL AFTER victim_ship_type_id');
+    db_ensure_table_column('killmail_events', 'zkb_points', 'INT UNSIGNED DEFAULT NULL AFTER zkb_total_value');
+    db_ensure_table_column('killmail_events', 'zkb_npc', 'TINYINT(1) DEFAULT NULL AFTER zkb_points');
+    db_ensure_table_column('killmail_events', 'zkb_solo', 'TINYINT(1) DEFAULT NULL AFTER zkb_npc');
+    db_ensure_table_column('killmail_events', 'zkb_awox', 'TINYINT(1) DEFAULT NULL AFTER zkb_solo');
+
+    $legacyEventJsonSql = db_table_has_column('killmail_events', 'zkb_json') ? "NULLIF(e.zkb_json, '')" : 'NULL';
+    $zkbJsonSql = "COALESCE(NULLIF(p.zkb_json, ''), {$legacyEventJsonSql}, '{}')";
+    db_execute(
+        "UPDATE killmail_events e
+         LEFT JOIN killmail_event_payloads p ON p.sequence_id = e.sequence_id
+         SET
+            e.zkb_total_value = CASE
+                WHEN JSON_VALID({$zkbJsonSql}) AND JSON_EXTRACT({$zkbJsonSql}, '$.totalValue') IS NOT NULL
+                    THEN CAST(JSON_UNQUOTE(JSON_EXTRACT({$zkbJsonSql}, '$.totalValue')) AS DECIMAL(20,2))
+                ELSE NULL
+            END,
+            e.zkb_points = CASE
+                WHEN JSON_VALID({$zkbJsonSql}) AND JSON_EXTRACT({$zkbJsonSql}, '$.points') IS NOT NULL
+                    THEN CAST(JSON_UNQUOTE(JSON_EXTRACT({$zkbJsonSql}, '$.points')) AS UNSIGNED)
+                ELSE NULL
+            END,
+            e.zkb_npc = CASE
+                WHEN JSON_VALID({$zkbJsonSql}) AND JSON_EXTRACT({$zkbJsonSql}, '$.npc') IS NOT NULL
+                    THEN IF(LOWER(JSON_UNQUOTE(JSON_EXTRACT({$zkbJsonSql}, '$.npc'))) IN ('1', 'true'), 1, 0)
+                ELSE NULL
+            END,
+            e.zkb_solo = CASE
+                WHEN JSON_VALID({$zkbJsonSql}) AND JSON_EXTRACT({$zkbJsonSql}, '$.solo') IS NOT NULL
+                    THEN IF(LOWER(JSON_UNQUOTE(JSON_EXTRACT({$zkbJsonSql}, '$.solo'))) IN ('1', 'true'), 1, 0)
+                ELSE NULL
+            END,
+            e.zkb_awox = CASE
+                WHEN JSON_VALID({$zkbJsonSql}) AND JSON_EXTRACT({$zkbJsonSql}, '$.awox') IS NOT NULL
+                    THEN IF(LOWER(JSON_UNQUOTE(JSON_EXTRACT({$zkbJsonSql}, '$.awox'))) IN ('1', 'true'), 1, 0)
+                ELSE NULL
+            END
+         WHERE e.zkb_total_value IS NULL
+           AND e.zkb_points IS NULL
+           AND e.zkb_npc IS NULL
+           AND e.zkb_solo IS NULL
+           AND e.zkb_awox IS NULL
+           AND (p.sequence_id IS NOT NULL OR {$legacyEventJsonSql} IS NOT NULL)"
+    );
 
     $ensured = true;
 }
@@ -8166,8 +8239,13 @@ function db_killmail_event_upsert(array $event): bool
                 victim_character_id,
                 victim_corporation_id,
                 victim_alliance_id,
-                victim_ship_type_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                victim_ship_type_id,
+                zkb_total_value,
+                zkb_points,
+                zkb_npc,
+                zkb_solo,
+                zkb_awox
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
                 killmail_id = VALUES(killmail_id),
                 killmail_hash = VALUES(killmail_hash),
@@ -8180,6 +8258,11 @@ function db_killmail_event_upsert(array $event): bool
                 victim_corporation_id = VALUES(victim_corporation_id),
                 victim_alliance_id = VALUES(victim_alliance_id),
                 victim_ship_type_id = VALUES(victim_ship_type_id),
+                zkb_total_value = VALUES(zkb_total_value),
+                zkb_points = VALUES(zkb_points),
+                zkb_npc = VALUES(zkb_npc),
+                zkb_solo = VALUES(zkb_solo),
+                zkb_awox = VALUES(zkb_awox),
                 updated_at = CURRENT_TIMESTAMP',
             [
                 (int) ($event['sequence_id'] ?? 0),
@@ -8194,6 +8277,11 @@ function db_killmail_event_upsert(array $event): bool
                 isset($event['victim_corporation_id']) ? (int) $event['victim_corporation_id'] : null,
                 isset($event['victim_alliance_id']) ? (int) $event['victim_alliance_id'] : null,
                 isset($event['victim_ship_type_id']) ? (int) $event['victim_ship_type_id'] : null,
+                isset($event['zkb_total_value']) ? (float) $event['zkb_total_value'] : null,
+                isset($event['zkb_points']) ? (int) $event['zkb_points'] : null,
+                array_key_exists('zkb_npc', $event) ? (int) ((bool) $event['zkb_npc']) : null,
+                array_key_exists('zkb_solo', $event) ? (int) ((bool) $event['zkb_solo']) : null,
+                array_key_exists('zkb_awox', $event) ? (int) ((bool) $event['zkb_awox']) : null,
             ]
         );
         $payloadWritten = db_killmail_event_payload_upsert($event);
@@ -8615,7 +8703,7 @@ function db_killmail_items_by_sequence(int $sequenceId): array
 
 function db_killmail_overview_page(array $filters = []): array
 {
-    db_killmail_payload_schema_ensure();
+    db_killmail_overview_schema_ensure();
 
     $page = max(1, (int) ($filters['page'] ?? 1));
     $pageSize = max(1, min(100, (int) ($filters['page_size'] ?? 25)));
@@ -8630,7 +8718,6 @@ function db_killmail_overview_page(array $filters = []): array
     $fromSql = " FROM killmail_events e
         {$trackedJoinType} {$trackedMatchesSql} tracked
           ON tracked.sequence_id = e.sequence_id
-        LEFT JOIN killmail_event_payloads p ON p.sequence_id = e.sequence_id
         LEFT JOIN ref_item_types ship ON ship.type_id = e.victim_ship_type_id
         LEFT JOIN ref_systems system_ref ON system_ref.system_id = e.solar_system_id
         LEFT JOIN ref_regions region_ref ON region_ref.region_id = e.region_id
@@ -8691,12 +8778,16 @@ function db_killmail_overview_page(array $filters = []): array
             e.killmail_time,
             e.uploaded_at,
             e.created_at,
-            COALESCE(p.zkb_json, '{}') AS zkb_json,
             e.victim_corporation_id,
             e.victim_alliance_id,
             e.victim_ship_type_id,
             e.solar_system_id,
             e.region_id,
+            e.zkb_total_value,
+            e.zkb_points,
+            e.zkb_npc,
+            e.zkb_solo,
+            e.zkb_awox,
             COALESCE(NULLIF(victim_tc.label, ''), CONCAT('Corporation #', e.victim_corporation_id)) AS victim_corporation_label,
             COALESCE(NULLIF(victim_ta.label, ''), CONCAT('Alliance #', e.victim_alliance_id)) AS victim_alliance_label,
             COALESCE(NULLIF(ship.type_name, ''), CONCAT('Type #', e.victim_ship_type_id)) AS ship_type_name,

--- a/src/functions.php
+++ b/src/functions.php
@@ -8421,6 +8421,33 @@ function killmail_value_amount(array $zkb): ?float
     return (float) $zkb['totalValue'];
 }
 
+function killmail_overview_value_amount(array $row): ?float
+{
+    if (!isset($row['zkb_total_value']) || $row['zkb_total_value'] === null || $row['zkb_total_value'] === '') {
+        return null;
+    }
+
+    return is_numeric($row['zkb_total_value']) ? (float) $row['zkb_total_value'] : null;
+}
+
+function killmail_overview_points(array $row): ?int
+{
+    if (!isset($row['zkb_points']) || $row['zkb_points'] === null || $row['zkb_points'] === '') {
+        return null;
+    }
+
+    return is_numeric($row['zkb_points']) ? (int) $row['zkb_points'] : null;
+}
+
+function killmail_overview_flag_enabled(array $row, string $field): bool
+{
+    if (!array_key_exists($field, $row) || $row[$field] === null) {
+        return false;
+    }
+
+    return (int) $row[$field] === 1;
+}
+
 function killmail_signal_strength_meta(int $itemCount, int $attackerCount, bool $trackedVictimLoss): array
 {
     $score = $itemCount;
@@ -8886,11 +8913,16 @@ function killmail_overview_data(): array
 
         $rows = array_map(static function (array $row) use ($resolvedOverviewEntities): array {
             $matchSources = killmail_match_sources($row);
-            $zkb = killmail_decode_json_array(isset($row['zkb_json']) ? (string) $row['zkb_json'] : null);
-            $estimatedValue = killmail_value_amount($zkb);
+            $estimatedValue = killmail_overview_value_amount($row);
+            $points = killmail_overview_points($row);
             $shipTypeId = isset($row['victim_ship_type_id']) ? (int) $row['victim_ship_type_id'] : null;
             $signalStrength = killmail_signal_strength_meta(0, 0, (int) ($row['matched_tracked'] ?? 0) === 1);
             $supplyImpact = killmail_supply_impact_meta($estimatedValue, 0, 0, 0);
+            $killmailFlags = array_values(array_filter([
+                killmail_overview_flag_enabled($row, 'zkb_npc') ? 'NPC' : null,
+                killmail_overview_flag_enabled($row, 'zkb_solo') ? 'Solo' : null,
+                killmail_overview_flag_enabled($row, 'zkb_awox') ? 'Awox' : null,
+            ]));
 
             return [
                 'sequence_id' => (int) ($row['sequence_id'] ?? 0),
@@ -8907,6 +8939,9 @@ function killmail_overview_data(): array
                 'match_context' => $matchSources === [] ? 'No tracked victim entity currently matches this stored loss.' : ('Matched on ' . implode(', ', $matchSources) . '.'),
                 'ship_icon_url' => $shipTypeId !== null ? killmail_entity_image_url('type', $shipTypeId, 'icon', 64) : null,
                 'estimated_value_display' => $estimatedValue !== null ? number_format($estimatedValue, 0) . ' ISK' : 'Value unavailable',
+                'points_display' => $points !== null ? number_format($points) : 'Unavailable',
+                'killmail_flags' => $killmailFlags,
+                'killmail_flags_display' => $killmailFlags === [] ? 'No special flags' : implode(' · ', $killmailFlags),
                 'signal_strength' => $signalStrength,
                 'supply_impact' => $supplyImpact,
                 'inspect_url' => '/killmail-intelligence/view.php?sequence_id=' . urlencode((string) ((int) ($row['sequence_id'] ?? 0))),
@@ -14987,6 +15022,11 @@ function killmail_transform_r2z2_payload(array $payload): array
         'victim_corporation_id' => isset($victim['corporation_id']) ? (int) $victim['corporation_id'] : null,
         'victim_alliance_id' => isset($victim['alliance_id']) ? (int) $victim['alliance_id'] : null,
         'victim_ship_type_id' => isset($victim['ship_type_id']) ? (int) $victim['ship_type_id'] : null,
+        'zkb_total_value' => isset($zkb['totalValue']) && is_numeric($zkb['totalValue']) ? (float) $zkb['totalValue'] : null,
+        'zkb_points' => isset($zkb['points']) && is_numeric($zkb['points']) ? (int) $zkb['points'] : null,
+        'zkb_npc' => !empty($zkb['npc']),
+        'zkb_solo' => !empty($zkb['solo']),
+        'zkb_awox' => !empty($zkb['awox']),
         'zkb_json' => json_encode($zkb, JSON_UNESCAPED_SLASHES),
         'raw_killmail_json' => json_encode($killmail, JSON_UNESCAPED_SLASHES),
     ];


### PR DESCRIPTION
### Motivation

- Reduce expensive JSON decoding on list pages by projecting a small set of frequently-displayed zKill fields into lean columns on `killmail_events` so overview queries stay fast and simple.

### Description

- Added structured overview columns on `killmail_events`: `zkb_total_value`, `zkb_points`, `zkb_npc`, `zkb_solo`, and `zkb_awox`, and migration/backfill logic in `database/schema.sql` and `src/db.php` to populate them from existing payloads when available.
- Introduced `db_killmail_overview_schema_ensure()` and wired it into onboarding/migration paths so the overview projection is created and backfilled without changing detail payload storage.
- Updated ingestion and persistence so transformed R2Z2 events include the new overview fields (`killmail_transform_r2z2_payload()` in `src/functions.php` and `db_killmail_event_upsert()` in `src/db.php`).
- Modified `db_killmail_overview_page()` to select the new structured fields instead of fetching/decoding `zkb_json`, and updated overview formatting helpers in `src/functions.php` to use `killmail_overview_value_amount()`, `killmail_overview_points()`, and `killmail_overview_flag_enabled()` so overview pages no longer decode raw JSON payloads.

### Testing

- Ran syntax checks: `php -l src/db.php` and `php -l src/functions.php`, both succeeded. 
- Ran `git diff --check` to validate whitespace/format issues, which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfaa68adb8832fb866a7dffaf01adb)