### PR TITLE
Add scheduler current status projection

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -699,6 +699,34 @@ CREATE TABLE IF NOT EXISTS scheduler_job_events (
     KEY idx_scheduler_job_events_created (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS scheduler_job_current_status (
+    job_key VARCHAR(190) PRIMARY KEY,
+    dataset_key VARCHAR(190) DEFAULT NULL,
+    latest_status VARCHAR(40) NOT NULL DEFAULT 'unknown',
+    latest_event_type VARCHAR(50) DEFAULT NULL,
+    last_started_at DATETIME DEFAULT NULL,
+    last_finished_at DATETIME DEFAULT NULL,
+    last_success_at DATETIME DEFAULT NULL,
+    last_failure_at DATETIME DEFAULT NULL,
+    last_failure_message VARCHAR(500) DEFAULT NULL,
+    current_pressure_state VARCHAR(32) NOT NULL DEFAULT 'healthy',
+    last_pressure_state VARCHAR(32) DEFAULT NULL,
+    recent_timeout_count INT UNSIGNED NOT NULL DEFAULT 0,
+    recent_lock_conflict_count INT UNSIGNED NOT NULL DEFAULT 0,
+    recent_deferral_count INT UNSIGNED NOT NULL DEFAULT 0,
+    recent_skip_count INT UNSIGNED NOT NULL DEFAULT 0,
+    last_resource_metrics_summary_json LONGTEXT DEFAULT NULL,
+    last_planner_decision_type VARCHAR(40) DEFAULT NULL,
+    last_planner_reason_text VARCHAR(500) DEFAULT NULL,
+    last_planner_decided_at DATETIME DEFAULT NULL,
+    last_event_at DATETIME DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_scheduler_job_current_status_dataset (dataset_key),
+    KEY idx_scheduler_job_current_status_status (latest_status, current_pressure_state),
+    KEY idx_scheduler_job_current_status_event (last_event_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS scheduler_tuning_actions (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     job_key VARCHAR(190) NOT NULL,

--- a/src/db.php
+++ b/src/db.php
@@ -6344,6 +6344,7 @@ function db_sync_schedule_fetch_locked_due_jobs(int $limit = 50): array
 function db_sync_schedule_claim_job(int $scheduleId, int $lockTtlSeconds = 300): ?array
 {
     db_sync_schedule_registry_columns_ensure();
+    db_scheduler_job_current_status_ensure();
 
     $safeLockTtl = max(30, min(7200, $lockTtlSeconds));
 
@@ -6370,7 +6371,22 @@ function db_sync_schedule_claim_job(int $scheduleId, int $lockTtlSeconds = 300):
         return null;
     }
 
-    return db_sync_schedule_fetch_by_id($scheduleId);
+    $claimed = db_sync_schedule_fetch_by_id($scheduleId);
+    if (is_array($claimed)) {
+        $jobKey = trim((string) ($claimed['job_key'] ?? ''));
+        if ($jobKey !== '') {
+            db_scheduler_job_current_status_upsert($jobKey, [
+                'latest_status' => 'running',
+                'latest_event_type' => 'claim',
+                'last_started_at' => $claimed['last_started_at'] ?? gmdate('Y-m-d H:i:s'),
+                'current_pressure_state' => $claimed['current_pressure_state'] ?? 'healthy',
+                'last_pressure_state' => $claimed['current_pressure_state'] ?? null,
+                'last_event_at' => $claimed['last_started_at'] ?? gmdate('Y-m-d H:i:s'),
+            ]);
+        }
+    }
+
+    return $claimed;
 }
 
 function db_sync_schedule_next_run_at_for_values(int $intervalSeconds, int $offsetSeconds, ?int $nowUnix = null): string
@@ -6428,6 +6444,10 @@ function db_sync_schedule_next_due_at_by_id(int $scheduleId, ?int $nowUnix = nul
 function db_sync_schedule_mark_success(int $scheduleId, ?array $runtime = null): bool
 {
     db_sync_schedule_registry_columns_ensure();
+    db_scheduler_job_current_status_ensure();
+
+    $schedule = db_sync_schedule_fetch_by_id($scheduleId);
+    $jobKey = trim((string) ($schedule['job_key'] ?? ''));
 
     $nextDueAt = db_sync_schedule_next_due_at_by_id($scheduleId);
     if ($nextDueAt === null) {
@@ -6439,7 +6459,7 @@ function db_sync_schedule_mark_success(int $scheduleId, ?array $runtime = null):
     $p95Duration = $runtime !== null ? (float) ($runtime['p95_duration_seconds'] ?? 0.0) : null;
     $lastResult = $runtime !== null ? mb_substr(trim((string) ($runtime['last_result'] ?? 'success')), 0, 120) : 'success';
 
-    return db_execute(
+    $updated = db_execute(
         'UPDATE sync_schedules
          SET last_run_at = UTC_TIMESTAMP(),
              last_finished_at = UTC_TIMESTAMP(),
@@ -6463,11 +6483,37 @@ function db_sync_schedule_mark_success(int $scheduleId, ?array $runtime = null):
          LIMIT 1',
         ['success', $lastResult, $nextDueAt, $nextDueAt, $nextDueAt, 'waiting', 'stopped', $lastDuration, $averageDuration, $p95Duration, $scheduleId]
     );
+
+    if ($updated && $jobKey !== '') {
+        $finishedAt = gmdate('Y-m-d H:i:s');
+        db_scheduler_job_current_status_upsert($jobKey, [
+            'latest_status' => $lastResult,
+            'latest_event_type' => 'completion',
+            'last_started_at' => $schedule['last_started_at'] ?? null,
+            'last_finished_at' => $finishedAt,
+            'last_success_at' => $finishedAt,
+            'last_failure_at' => $lastResult === 'skipped' ? ($runtime['last_failure_at'] ?? null) : null,
+            'last_failure_message' => null,
+            'current_pressure_state' => $runtime['current_pressure_state'] ?? ($schedule['current_pressure_state'] ?? 'healthy'),
+            'last_pressure_state' => $runtime['current_pressure_state'] ?? ($schedule['current_pressure_state'] ?? null),
+            'recent_timeout_count' => 0,
+            'recent_lock_conflict_count' => 0,
+            'recent_deferral_count' => 0,
+            'recent_skip_count' => $lastResult === 'skipped' ? max(1, (int) (($runtime['recent_skip_count'] ?? 0))) : 0,
+            'last_event_at' => $finishedAt,
+        ]);
+    }
+
+    return $updated;
 }
 
 function db_sync_schedule_mark_failure(int $scheduleId, string $errorMessage, ?array $runtime = null): bool
 {
     db_sync_schedule_registry_columns_ensure();
+    db_scheduler_job_current_status_ensure();
+
+    $schedule = db_sync_schedule_fetch_by_id($scheduleId);
+    $jobKey = trim((string) ($schedule['job_key'] ?? ''));
 
     $nextDueAt = db_sync_schedule_next_due_at_by_id($scheduleId);
     if ($nextDueAt === null) {
@@ -6480,7 +6526,7 @@ function db_sync_schedule_mark_failure(int $scheduleId, string $errorMessage, ?a
     $p95Duration = $runtime !== null ? (float) ($runtime['p95_duration_seconds'] ?? 0.0) : null;
     $lastResult = $runtime !== null ? mb_substr(trim((string) ($runtime['last_result'] ?? 'failed')), 0, 120) : 'failed';
 
-    return db_execute(
+    $updated = db_execute(
         'UPDATE sync_schedules
          SET last_run_at = UTC_TIMESTAMP(),
              last_finished_at = UTC_TIMESTAMP(),
@@ -6505,6 +6551,28 @@ function db_sync_schedule_mark_failure(int $scheduleId, string $errorMessage, ?a
          LIMIT 1',
         ['failed', $lastResult, $message, $nextDueAt, $nextDueAt, $nextDueAt, 'waiting', 'stopped', $lastDuration, $averageDuration, $p95Duration, !empty($runtime['timeout']) ? 1 : 0, $scheduleId]
     );
+
+    if ($updated && $jobKey !== '') {
+        $finishedAt = gmdate('Y-m-d H:i:s');
+        $current = db_scheduler_job_current_status_fetch_map([$jobKey])[$jobKey] ?? [];
+        db_scheduler_job_current_status_upsert($jobKey, [
+            'latest_status' => 'failed',
+            'latest_event_type' => !empty($runtime['timeout']) ? 'timeout' : 'failure',
+            'last_started_at' => $schedule['last_started_at'] ?? null,
+            'last_finished_at' => $finishedAt,
+            'last_failure_at' => $finishedAt,
+            'last_failure_message' => $message,
+            'current_pressure_state' => $runtime['current_pressure_state'] ?? ($schedule['current_pressure_state'] ?? 'healthy'),
+            'last_pressure_state' => $runtime['current_pressure_state'] ?? ($schedule['current_pressure_state'] ?? null),
+            'recent_timeout_count' => max(0, (int) ($current['recent_timeout_count'] ?? 0)) + (!empty($runtime['timeout']) ? 1 : 0),
+            'recent_lock_conflict_count' => max(0, (int) ($current['recent_lock_conflict_count'] ?? 0)),
+            'recent_deferral_count' => max(0, (int) ($current['recent_deferral_count'] ?? 0)),
+            'recent_skip_count' => 0,
+            'last_event_at' => $finishedAt,
+        ]);
+    }
+
+    return $updated;
 }
 
 function db_sync_schedule_fetch_by_job_keys(array $jobKeys): array
@@ -7514,8 +7582,185 @@ function db_sync_schedule_next_due_snapshot(): ?array
     return $row !== [] ? $row : null;
 }
 
+function db_scheduler_job_current_status_ensure(): void
+{
+    db_execute('CREATE TABLE IF NOT EXISTS scheduler_job_current_status (
+        job_key VARCHAR(190) PRIMARY KEY,
+        dataset_key VARCHAR(190) DEFAULT NULL,
+        latest_status VARCHAR(40) NOT NULL DEFAULT \'unknown\',
+        latest_event_type VARCHAR(50) DEFAULT NULL,
+        last_started_at DATETIME DEFAULT NULL,
+        last_finished_at DATETIME DEFAULT NULL,
+        last_success_at DATETIME DEFAULT NULL,
+        last_failure_at DATETIME DEFAULT NULL,
+        last_failure_message VARCHAR(500) DEFAULT NULL,
+        current_pressure_state VARCHAR(32) NOT NULL DEFAULT \'healthy\',
+        last_pressure_state VARCHAR(32) DEFAULT NULL,
+        recent_timeout_count INT UNSIGNED NOT NULL DEFAULT 0,
+        recent_lock_conflict_count INT UNSIGNED NOT NULL DEFAULT 0,
+        recent_deferral_count INT UNSIGNED NOT NULL DEFAULT 0,
+        recent_skip_count INT UNSIGNED NOT NULL DEFAULT 0,
+        last_resource_metrics_summary_json LONGTEXT DEFAULT NULL,
+        last_planner_decision_type VARCHAR(40) DEFAULT NULL,
+        last_planner_reason_text VARCHAR(500) DEFAULT NULL,
+        last_planner_decided_at DATETIME DEFAULT NULL,
+        last_event_at DATETIME DEFAULT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        KEY idx_scheduler_job_current_status_dataset (dataset_key),
+        KEY idx_scheduler_job_current_status_status (latest_status, current_pressure_state),
+        KEY idx_scheduler_job_current_status_event (last_event_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+}
+
+function db_scheduler_job_current_status_upsert(string $jobKey, array $status): bool
+{
+    db_scheduler_job_current_status_ensure();
+
+    $normalizedJobKey = mb_substr(trim($jobKey), 0, 190);
+    if ($normalizedJobKey === '') {
+        return false;
+    }
+
+    $datasetKey = array_key_exists('dataset_key', $status)
+        ? (($status['dataset_key'] !== null && trim((string) $status['dataset_key']) !== '') ? mb_substr(trim((string) $status['dataset_key']), 0, 190) : null)
+        : ('scheduler.job.' . $normalizedJobKey);
+    $latestStatus = mb_substr(trim((string) ($status['latest_status'] ?? 'unknown')), 0, 40);
+    $latestEventType = array_key_exists('latest_event_type', $status)
+        ? (($status['latest_event_type'] !== null && trim((string) $status['latest_event_type']) !== '') ? mb_substr(trim((string) $status['latest_event_type']), 0, 50) : null)
+        : null;
+    $currentPressureState = mb_substr(trim((string) ($status['current_pressure_state'] ?? 'healthy')), 0, 32);
+    $lastPressureState = array_key_exists('last_pressure_state', $status)
+        ? (($status['last_pressure_state'] !== null && trim((string) $status['last_pressure_state']) !== '') ? mb_substr(trim((string) $status['last_pressure_state']), 0, 32) : null)
+        : null;
+    $lastFailureMessage = array_key_exists('last_failure_message', $status)
+        ? (($status['last_failure_message'] !== null && trim((string) $status['last_failure_message']) !== '') ? mb_substr(trim((string) $status['last_failure_message']), 0, 500) : null)
+        : null;
+    $lastPlannerDecisionType = array_key_exists('last_planner_decision_type', $status)
+        ? (($status['last_planner_decision_type'] !== null && trim((string) $status['last_planner_decision_type']) !== '') ? mb_substr(trim((string) $status['last_planner_decision_type']), 0, 40) : null)
+        : null;
+    $lastPlannerReasonText = array_key_exists('last_planner_reason_text', $status)
+        ? (($status['last_planner_reason_text'] !== null && trim((string) $status['last_planner_reason_text']) !== '') ? mb_substr(trim((string) $status['last_planner_reason_text']), 0, 500) : null)
+        : null;
+    $resourceSummaryJson = null;
+    if (array_key_exists('last_resource_metrics_summary_json', $status) && $status['last_resource_metrics_summary_json'] !== null) {
+        $resourceSummaryJson = is_string($status['last_resource_metrics_summary_json'])
+            ? $status['last_resource_metrics_summary_json']
+            : json_encode($status['last_resource_metrics_summary_json'], JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    }
+
+    return db_execute(
+        'INSERT INTO scheduler_job_current_status (
+            job_key,
+            dataset_key,
+            latest_status,
+            latest_event_type,
+            last_started_at,
+            last_finished_at,
+            last_success_at,
+            last_failure_at,
+            last_failure_message,
+            current_pressure_state,
+            last_pressure_state,
+            recent_timeout_count,
+            recent_lock_conflict_count,
+            recent_deferral_count,
+            recent_skip_count,
+            last_resource_metrics_summary_json,
+            last_planner_decision_type,
+            last_planner_reason_text,
+            last_planner_decided_at,
+            last_event_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+            dataset_key = COALESCE(VALUES(dataset_key), dataset_key),
+            latest_status = VALUES(latest_status),
+            latest_event_type = COALESCE(VALUES(latest_event_type), latest_event_type),
+            last_started_at = COALESCE(VALUES(last_started_at), last_started_at),
+            last_finished_at = COALESCE(VALUES(last_finished_at), last_finished_at),
+            last_success_at = COALESCE(VALUES(last_success_at), last_success_at),
+            last_failure_at = COALESCE(VALUES(last_failure_at), last_failure_at),
+            last_failure_message = CASE
+                WHEN VALUES(last_failure_message) IS NULL AND VALUES(last_failure_at) IS NULL THEN last_failure_message
+                ELSE VALUES(last_failure_message)
+            END,
+            current_pressure_state = COALESCE(VALUES(current_pressure_state), current_pressure_state),
+            last_pressure_state = COALESCE(VALUES(last_pressure_state), last_pressure_state),
+            recent_timeout_count = VALUES(recent_timeout_count),
+            recent_lock_conflict_count = VALUES(recent_lock_conflict_count),
+            recent_deferral_count = VALUES(recent_deferral_count),
+            recent_skip_count = VALUES(recent_skip_count),
+            last_resource_metrics_summary_json = COALESCE(VALUES(last_resource_metrics_summary_json), last_resource_metrics_summary_json),
+            last_planner_decision_type = COALESCE(VALUES(last_planner_decision_type), last_planner_decision_type),
+            last_planner_reason_text = COALESCE(VALUES(last_planner_reason_text), last_planner_reason_text),
+            last_planner_decided_at = COALESCE(VALUES(last_planner_decided_at), last_planner_decided_at),
+            last_event_at = COALESCE(VALUES(last_event_at), last_event_at),
+            updated_at = CURRENT_TIMESTAMP',
+        [
+            $normalizedJobKey,
+            $datasetKey,
+            $latestStatus,
+            $latestEventType,
+            $status['last_started_at'] ?? null,
+            $status['last_finished_at'] ?? null,
+            $status['last_success_at'] ?? null,
+            $status['last_failure_at'] ?? null,
+            $lastFailureMessage,
+            $currentPressureState,
+            $lastPressureState,
+            max(0, (int) ($status['recent_timeout_count'] ?? 0)),
+            max(0, (int) ($status['recent_lock_conflict_count'] ?? 0)),
+            max(0, (int) ($status['recent_deferral_count'] ?? 0)),
+            max(0, (int) ($status['recent_skip_count'] ?? 0)),
+            $resourceSummaryJson,
+            $lastPlannerDecisionType,
+            $lastPlannerReasonText,
+            $status['last_planner_decided_at'] ?? null,
+            $status['last_event_at'] ?? null,
+        ]
+    );
+}
+
+function db_scheduler_job_current_status_fetch_map(array $jobKeys = []): array
+{
+    db_scheduler_job_current_status_ensure();
+
+    $params = [];
+    $sql = 'SELECT job_key, dataset_key, latest_status, latest_event_type, last_started_at, last_finished_at, last_success_at, last_failure_at, last_failure_message, current_pressure_state, last_pressure_state, recent_timeout_count, recent_lock_conflict_count, recent_deferral_count, recent_skip_count, last_resource_metrics_summary_json, last_planner_decision_type, last_planner_reason_text, last_planner_decided_at, last_event_at, created_at, updated_at
+            FROM scheduler_job_current_status';
+
+    $normalizedKeys = array_values(array_filter(array_map(static fn (mixed $jobKey): string => trim((string) $jobKey), $jobKeys), static fn (string $jobKey): bool => $jobKey !== ''));
+    if ($normalizedKeys !== []) {
+        $sql .= ' WHERE job_key IN (' . implode(',', array_fill(0, count($normalizedKeys), '?')) . ')';
+        $params = $normalizedKeys;
+    }
+
+    $rows = db_select($sql, $params);
+    $map = [];
+    foreach ($rows as $row) {
+        $currentJobKey = trim((string) ($row['job_key'] ?? ''));
+        if ($currentJobKey === '') {
+            continue;
+        }
+
+        $row['last_resource_metrics_summary'] = null;
+        $summaryJson = $row['last_resource_metrics_summary_json'] ?? null;
+        if (is_string($summaryJson) && trim($summaryJson) !== '') {
+            $decoded = json_decode($summaryJson, true);
+            if (is_array($decoded)) {
+                $row['last_resource_metrics_summary'] = $decoded;
+            }
+        }
+
+        $map[$currentJobKey] = $row;
+    }
+
+    return $map;
+}
+
 function db_scheduler_job_event_insert(string $jobKey, string $eventType, array $detail = [], int $latenessSeconds = 0, ?float $durationSeconds = null): bool
 {
+    db_scheduler_job_current_status_ensure();
     db_execute('CREATE TABLE IF NOT EXISTS scheduler_job_events (
         id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
         job_key VARCHAR(190) NOT NULL,
@@ -7529,11 +7774,47 @@ function db_scheduler_job_event_insert(string $jobKey, string $eventType, array 
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
     db_ensure_table_index('scheduler_job_events', 'idx_scheduler_job_events_created', 'INDEX idx_scheduler_job_events_created (created_at)');
 
-    return db_execute(
+    $inserted = db_execute(
         'INSERT INTO scheduler_job_events (job_key, event_type, detail_json, lateness_seconds, duration_seconds)
          VALUES (?, ?, ?, ?, ?)',
         [mb_substr(trim($jobKey), 0, 190), mb_substr(trim($eventType), 0, 50), $detail !== [] ? json_encode($detail, JSON_UNESCAPED_SLASHES) : null, $latenessSeconds, $durationSeconds]
     );
+
+    if (!$inserted) {
+        return false;
+    }
+
+    $jobKey = mb_substr(trim($jobKey), 0, 190);
+    $eventType = mb_substr(trim($eventType), 0, 50);
+    $current = db_scheduler_job_current_status_fetch_map([$jobKey])[$jobKey] ?? [];
+    $now = gmdate('Y-m-d H:i:s');
+    $latestStatus = match ($eventType) {
+        'started' => 'running',
+        'finished' => (string) (($detail['status'] ?? 'success') === 'success' ? 'success' : ($detail['status'] ?? 'finished')),
+        'timeout', 'failure' => 'failed',
+        'skipped' => 'skipped',
+        'lock_conflict', 'lock_skipped' => 'blocked',
+        'deferred_pressure' => 'deferred',
+        default => (string) ($current['latest_status'] ?? 'unknown'),
+    };
+
+    db_scheduler_job_current_status_upsert($jobKey, [
+        'latest_status' => $latestStatus,
+        'latest_event_type' => $eventType,
+        'last_started_at' => $eventType === 'started' ? $now : ($current['last_started_at'] ?? null),
+        'last_finished_at' => in_array($eventType, ['finished', 'skipped', 'timeout', 'failure'], true) ? $now : ($current['last_finished_at'] ?? null),
+        'last_failure_at' => in_array($eventType, ['timeout', 'failure'], true) ? $now : ($current['last_failure_at'] ?? null),
+        'last_failure_message' => in_array($eventType, ['timeout', 'failure'], true) ? ($detail['error'] ?? $current['last_failure_message'] ?? null) : ($current['last_failure_message'] ?? null),
+        'current_pressure_state' => $detail['pressure_state'] ?? ($current['current_pressure_state'] ?? 'healthy'),
+        'last_pressure_state' => $detail['pressure_state'] ?? ($current['last_pressure_state'] ?? null),
+        'recent_timeout_count' => max(0, (int) ($current['recent_timeout_count'] ?? 0)) + ($eventType === 'timeout' ? 1 : 0),
+        'recent_lock_conflict_count' => max(0, (int) ($current['recent_lock_conflict_count'] ?? 0)) + (in_array($eventType, ['lock_conflict', 'lock_skipped'], true) ? 1 : 0),
+        'recent_deferral_count' => max(0, (int) ($current['recent_deferral_count'] ?? 0)) + ($eventType === 'deferred_pressure' ? 1 : 0),
+        'recent_skip_count' => max(0, (int) ($current['recent_skip_count'] ?? 0)) + ($eventType === 'skipped' ? 1 : 0),
+        'last_event_at' => $now,
+    ]);
+
+    return true;
 }
 
 function db_scheduler_job_events_recent_summary(int $windowMinutes = 120): array
@@ -7673,8 +7954,9 @@ function db_scheduler_resource_metrics_ensure(): void
 function db_scheduler_resource_metric_insert(array $row): bool
 {
     db_scheduler_resource_metrics_ensure();
+    db_scheduler_job_current_status_ensure();
 
-    return db_execute(
+    $inserted = db_execute(
         'INSERT INTO scheduler_job_resource_metrics (
             schedule_id,
             job_key,
@@ -7724,6 +8006,41 @@ function db_scheduler_resource_metric_insert(array $row): bool
             $row['finished_at'] ?? null,
         ]
     );
+
+    if (!$inserted) {
+        return false;
+    }
+
+    $jobKey = mb_substr(trim((string) ($row['job_key'] ?? '')), 0, 190);
+    if ($jobKey === '') {
+        return true;
+    }
+
+    db_scheduler_job_current_status_upsert($jobKey, [
+        'latest_status' => mb_substr(trim((string) ($row['run_status'] ?? 'unknown')), 0, 40),
+        'current_pressure_state' => $row['pressure_state'] ?? 'healthy',
+        'last_pressure_state' => $row['pressure_state'] ?? null,
+        'recent_timeout_count' => !empty($row['timed_out']) ? 1 : 0,
+        'last_resource_metrics_summary_json' => [
+            'run_status' => (string) ($row['run_status'] ?? 'unknown'),
+            'wall_duration_seconds' => round((float) ($row['wall_duration_seconds'] ?? 0.0), 2),
+            'queue_wait_seconds' => round((float) ($row['queue_wait_seconds'] ?? 0.0), 2),
+            'lock_wait_seconds' => round((float) ($row['lock_wait_seconds'] ?? 0.0), 2),
+            'overlap_count' => max(0, (int) ($row['overlap_count'] ?? 0)),
+            'cpu_percent' => isset($row['cpu_percent']) ? round((float) $row['cpu_percent'], 2) : null,
+            'memory_peak_bytes' => isset($row['memory_peak_bytes']) ? max(0, (int) $row['memory_peak_bytes']) : null,
+            'memory_peak_delta_bytes' => isset($row['memory_peak_delta_bytes']) ? max(0, (int) $row['memory_peak_delta_bytes']) : null,
+            'projected_cpu_percent' => isset($row['projected_cpu_percent']) ? round((float) $row['projected_cpu_percent'], 2) : null,
+            'projected_memory_bytes' => isset($row['projected_memory_bytes']) ? max(0, (int) $row['projected_memory_bytes']) : null,
+            'timed_out' => !empty($row['timed_out']),
+            'failed' => !empty($row['failed']),
+            'started_at' => $row['started_at'] ?? null,
+            'finished_at' => $row['finished_at'] ?? null,
+        ],
+        'last_event_at' => $row['finished_at'] ?? $row['started_at'] ?? gmdate('Y-m-d H:i:s'),
+    ]);
+
+    return true;
 }
 
 function db_scheduler_resource_metrics_recent(string $jobKey, int $limit = 40): array
@@ -7866,12 +8183,14 @@ function db_sync_schedule_update_resource_profile(int $scheduleId, array $profil
 function db_sync_schedule_mark_planner_state(int $scheduleId, array $state): bool
 {
     db_sync_schedule_registry_columns_ensure();
+    db_scheduler_job_current_status_ensure();
 
     if ($scheduleId <= 0) {
         return false;
     }
 
-    return db_execute(
+    $schedule = db_sync_schedule_fetch_by_id($scheduleId);
+    $updated = db_execute(
         'UPDATE sync_schedules
          SET current_projected_cpu_percent = ?,
              current_projected_memory_bytes = ?,
@@ -7897,6 +8216,18 @@ function db_sync_schedule_mark_planner_state(int $scheduleId, array $state): boo
             $scheduleId,
         ]
     );
+
+    $jobKey = trim((string) ($schedule['job_key'] ?? ''));
+    if ($updated && $jobKey !== '') {
+        db_scheduler_job_current_status_upsert($jobKey, [
+            'latest_status' => (string) ($state['latest_status'] ?? ($schedule['last_result'] ?? $schedule['last_status'] ?? 'planned')),
+            'current_pressure_state' => $state['current_pressure_state'] ?? ($schedule['current_pressure_state'] ?? 'healthy'),
+            'last_pressure_state' => $state['current_pressure_state'] ?? ($schedule['current_pressure_state'] ?? null),
+            'last_event_at' => gmdate('Y-m-d H:i:s'),
+        ]);
+    }
+
+    return $updated;
 }
 
 function db_scheduler_planner_decisions_ensure(): void
@@ -7919,8 +8250,9 @@ function db_scheduler_planner_decisions_ensure(): void
 function db_scheduler_planner_decision_insert(?int $scheduleId, string $jobKey, string $decisionType, string $pressureState, string $reasonText, array $decision = []): bool
 {
     db_scheduler_planner_decisions_ensure();
+    db_scheduler_job_current_status_ensure();
 
-    return db_execute(
+    $inserted = db_execute(
         'INSERT INTO scheduler_planner_decisions (schedule_id, job_key, decision_type, pressure_state, reason_text, decision_json)
          VALUES (?, ?, ?, ?, ?, ?)',
         [
@@ -7932,6 +8264,30 @@ function db_scheduler_planner_decision_insert(?int $scheduleId, string $jobKey, 
             $decision !== [] ? json_encode($decision, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE) : null,
         ]
     );
+
+    if (!$inserted) {
+        return false;
+    }
+
+    $normalizedJobKey = mb_substr(trim($jobKey), 0, 190);
+    $current = db_scheduler_job_current_status_fetch_map([$normalizedJobKey])[$normalizedJobKey] ?? [];
+    $decisionType = mb_substr(trim($decisionType), 0, 40);
+    $latestStatus = str_contains($decisionType, 'deferred') ? 'deferred' : (($decisionType === 'allowed' || $decisionType === 'idle_backfill_allowed') ? 'planned' : ((string) ($current['latest_status'] ?? 'planned')));
+    db_scheduler_job_current_status_upsert($normalizedJobKey, [
+        'latest_status' => $latestStatus,
+        'current_pressure_state' => mb_substr(trim($pressureState), 0, 32),
+        'last_pressure_state' => mb_substr(trim($pressureState), 0, 32),
+        'recent_timeout_count' => max(0, (int) ($current['recent_timeout_count'] ?? 0)),
+        'recent_lock_conflict_count' => max(0, (int) ($current['recent_lock_conflict_count'] ?? 0)),
+        'recent_deferral_count' => max(0, (int) ($current['recent_deferral_count'] ?? 0)) + (str_contains($decisionType, 'deferred') ? 1 : 0),
+        'recent_skip_count' => max(0, (int) ($current['recent_skip_count'] ?? 0)),
+        'last_planner_decision_type' => $decisionType,
+        'last_planner_reason_text' => mb_substr(trim($reasonText), 0, 500),
+        'last_planner_decided_at' => gmdate('Y-m-d H:i:s'),
+        'last_event_at' => gmdate('Y-m-d H:i:s'),
+    ]);
+
+    return true;
 }
 
 function db_scheduler_planner_decisions_recent(int $limit = 30): array

--- a/src/functions.php
+++ b/src/functions.php
@@ -3701,6 +3701,47 @@ function scheduler_job_safety_rules(): array
 
 function scheduler_job_recent_resource_profile(string $jobKey, ?array $row = null): array
 {
+    $currentStatus = is_array($row['status_projection'] ?? null)
+        ? $row['status_projection']
+        : (db_scheduler_job_current_status_fetch_map([$jobKey])[$jobKey] ?? []);
+    $currentSummary = is_array($currentStatus['last_resource_metrics_summary'] ?? null) ? $currentStatus['last_resource_metrics_summary'] : [];
+
+    if ($currentSummary !== []) {
+        $derivedProfile = [
+            'sample_count' => max(0, (int) ($row['telemetry_sample_count'] ?? 0)),
+            'learning_mode' => !empty($row['learning_mode']) || ((int) ($row['telemetry_sample_count'] ?? 0) < 3),
+            'resource_class' => (string) ($row['resource_class'] ?? 'medium'),
+            'resource_class_confidence' => isset($row['resource_class_confidence']) ? round((float) $row['resource_class_confidence'], 4) : 0.0,
+            'average_cpu_percent' => isset($row['average_cpu_percent']) ? round((float) $row['average_cpu_percent'], 2) : null,
+            'p95_cpu_percent' => isset($row['p95_cpu_percent']) ? round((float) $row['p95_cpu_percent'], 2) : null,
+            'average_memory_peak_bytes' => isset($row['average_memory_peak_bytes']) ? (int) $row['average_memory_peak_bytes'] : null,
+            'p95_memory_peak_bytes' => isset($row['p95_memory_peak_bytes']) ? (int) $row['p95_memory_peak_bytes'] : null,
+            'average_duration_seconds' => isset($row['average_duration_seconds']) ? round((float) $row['average_duration_seconds'], 2) : null,
+            'p95_duration_seconds' => isset($row['p95_duration_seconds']) ? round((float) $row['p95_duration_seconds'], 2) : null,
+            'average_lock_wait_seconds' => isset($row['average_lock_wait_seconds']) ? round((float) $row['average_lock_wait_seconds'], 2) : null,
+            'recent_failure_rate' => isset($row['recent_failure_rate']) ? round((float) $row['recent_failure_rate'], 4) : (!empty($currentSummary['failed']) ? 1.0 : 0.0),
+            'recent_timeout_rate' => isset($row['recent_timeout_rate']) ? round((float) $row['recent_timeout_rate'], 4) : (!empty($currentSummary['timed_out']) ? 1.0 : 0.0),
+            'last_cpu_percent' => isset($currentSummary['cpu_percent']) ? round((float) $currentSummary['cpu_percent'], 2) : null,
+            'last_memory_peak_bytes' => isset($currentSummary['memory_peak_delta_bytes']) && $currentSummary['memory_peak_delta_bytes'] !== null
+                ? (int) $currentSummary['memory_peak_delta_bytes']
+                : (isset($currentSummary['memory_peak_bytes']) ? (int) $currentSummary['memory_peak_bytes'] : null),
+            'last_queue_wait_seconds' => isset($currentSummary['queue_wait_seconds']) ? round((float) $currentSummary['queue_wait_seconds'], 2) : null,
+            'last_lock_wait_seconds' => isset($currentSummary['lock_wait_seconds']) ? round((float) $currentSummary['lock_wait_seconds'], 2) : null,
+            'last_overlap_count' => max(0, (int) ($currentSummary['overlap_count'] ?? 0)),
+            'last_overlapped' => !empty($currentSummary['overlapped']),
+            'allow_parallel' => !empty($row['allow_parallel']),
+            'prefers_solo' => !empty($row['prefers_solo']),
+            'must_run_alone' => !empty($row['must_run_alone']),
+            'preferred_max_parallelism' => max(1, (int) ($row['preferred_max_parallelism'] ?? 1)),
+            'projection_cpu_percent' => isset($currentSummary['projected_cpu_percent']) ? round((float) $currentSummary['projected_cpu_percent'], 2) : (isset($row['current_projected_cpu_percent']) ? round((float) $row['current_projected_cpu_percent'], 2) : null),
+            'projection_memory_bytes' => isset($currentSummary['projected_memory_bytes']) ? (int) $currentSummary['projected_memory_bytes'] : (isset($row['current_projected_memory_bytes']) ? (int) $row['current_projected_memory_bytes'] : null),
+            'allowed_groups' => array_values((array) (scheduler_job_safety_rules()[$jobKey]['allowed_groups'] ?? ['light', 'medium', 'heavy'])),
+            'forbidden_with' => array_values(array_unique(array_filter((array) (scheduler_job_safety_rules()[$jobKey]['forbidden_with'] ?? [])))),
+        ];
+
+        return $derivedProfile;
+    }
+
     $metrics = db_scheduler_resource_metrics_recent($jobKey, 40);
     $capacity = scheduler_capacity_model();
     $samples = count($metrics);
@@ -3842,15 +3883,25 @@ function scheduler_job_urgency_snapshot(array $job, array $recentDecisionCounts 
 
 function scheduler_recent_planner_decision_counts(int $limit = 120): array
 {
-    $rows = db_scheduler_planner_decisions_recent($limit);
+    $rows = db_scheduler_job_current_status_fetch_map();
     $summary = [];
     foreach ($rows as $row) {
         $jobKey = (string) ($row['job_key'] ?? '');
-        $type = (string) ($row['decision_type'] ?? '');
-        if ($jobKey === '' || $type === '') {
+        if ($jobKey === '') {
             continue;
         }
-        $summary[$jobKey][$type] = (int) ($summary[$jobKey][$type] ?? 0) + 1;
+
+        $type = (string) ($row['last_planner_decision_type'] ?? '');
+        $deferredCount = max(0, (int) ($row['recent_deferral_count'] ?? 0));
+        if ($deferredCount <= 0) {
+            continue;
+        }
+
+        if ($type === '' || !str_contains($type, 'deferred')) {
+            $type = 'deferred_capacity';
+        }
+
+        $summary[$jobKey][$type] = $deferredCount;
     }
 
     return $summary;
@@ -4973,14 +5024,14 @@ function sync_schedule_settings_view_model(): array
 
     $definitions = data_sync_schedule_job_definitions();
     try {
-        $eventSummary = db_scheduler_job_events_recent_summary(180);
+        $currentStatusMap = db_scheduler_job_current_status_fetch_map(array_map(static fn (array $row): string => (string) ($row['job_key'] ?? ''), $rows));
         $recentActions = db_scheduler_tuning_actions_recent(12);
         $busiestOffsets = db_sync_schedule_busiest_offsets(12);
         $outcomeSummary = db_sync_schedule_recent_outcomes_summary(180);
         $recentPlannerDecisions = db_scheduler_planner_decisions_recent(20);
         $recentResourceMetrics = db_scheduler_resource_metrics_recent_all(20);
     } catch (Throwable) {
-        $eventSummary = [];
+        $currentStatusMap = [];
         $recentActions = [];
         $busiestOffsets = [];
         $outcomeSummary = [];
@@ -5042,7 +5093,7 @@ function sync_schedule_settings_view_model(): array
             'discovery_classification' => scheduler_is_internal_mechanic_job($jobKey) ? 'internal' : 'operational',
         ];
 
-        $jobEvents = $eventSummary[$jobKey] ?? [];
+        $statusProjection = $currentStatusMap[$jobKey] ?? [];
         $jobRunStats = db_sync_schedule_recent_job_run_stats($jobKey, 20);
         $currentState = (string) ($row['current_state'] ?? ((int) ($row['enabled'] ?? 1) === 1 ? 'waiting' : 'stopped'));
         $nextDueAt = $row['next_due_at'] ?? $row['next_run_at'] ?? null;
@@ -5065,8 +5116,8 @@ function sync_schedule_settings_view_model(): array
             'interval_minutes' => (int) ($row['interval_minutes'] ?? ($definition['default_interval_minutes'] ?? 30)),
             'offset_minutes' => (int) ($row['offset_minutes'] ?? ($definition['default_offset_minutes'] ?? 0)),
             'next_due_at' => $nextDueAt,
-            'last_started_at' => $row['last_started_at'] ?? null,
-            'last_finished_at' => $row['last_finished_at'] ?? null,
+            'last_started_at' => $statusProjection['last_started_at'] ?? $row['last_started_at'] ?? null,
+            'last_finished_at' => $statusProjection['last_finished_at'] ?? $row['last_finished_at'] ?? null,
             'last_duration_seconds' => $row['last_duration_seconds'] ?? null,
             'average_duration_seconds' => $row['average_duration_seconds'] ?? $jobRunStats['average_duration_seconds'],
             'p95_duration_seconds' => $row['p95_duration_seconds'] ?? $jobRunStats['p95_duration_seconds'],
@@ -5082,8 +5133,8 @@ function sync_schedule_settings_view_model(): array
             'env_timeout_seconds' => isset($timeoutResolution['env_timeout_seconds']) && $timeoutResolution['env_timeout_seconds'] !== null
                 ? (int) $timeoutResolution['env_timeout_seconds']
                 : null,
-            'last_result' => (string) ($row['last_result'] ?? $row['last_status'] ?? 'never'),
-            'last_error' => (string) ($row['last_error'] ?? ''),
+            'last_result' => (string) ($statusProjection['latest_status'] ?? $row['last_result'] ?? $row['last_status'] ?? 'never'),
+            'last_error' => (string) ($statusProjection['last_failure_message'] ?? $row['last_error'] ?? ''),
             'current_state' => $currentState,
             'allow_backfill' => !empty($row['allow_backfill']) || !empty($definition['allow_backfill']),
             'backfill_priority' => (string) ($row['backfill_priority'] ?? ($definition['backfill_priority'] ?? ($row['priority'] ?? ($definition['priority'] ?? 'normal')))),
@@ -5095,9 +5146,10 @@ function sync_schedule_settings_view_model(): array
             'value_source' => ((string) ($row['tuning_mode'] ?? 'automatic')) === 'manual' ? 'manual' : (!empty($row['last_auto_tuned_at']) ? 'auto-tuned' : 'baseline'),
             'last_auto_tune_reason' => (string) ($row['last_auto_tune_reason'] ?? ''),
             'last_auto_tuned_at' => $row['last_auto_tuned_at'] ?? null,
-            'skips_recent' => (int) (($jobEvents['skipped']['count'] ?? 0) + ($jobEvents['deferred_pressure']['count'] ?? 0)),
-            'lock_conflicts_recent' => (int) (($jobEvents['lock_conflict']['count'] ?? 0) + ($jobEvents['lock_skipped']['count'] ?? 0)),
-            'timeout_count_recent' => (int) ($jobEvents['timeout']['count'] ?? 0),
+            'skips_recent' => (int) (($statusProjection['recent_skip_count'] ?? 0) + ($statusProjection['recent_deferral_count'] ?? 0)),
+            'lock_conflicts_recent' => (int) ($statusProjection['recent_lock_conflict_count'] ?? 0),
+            'timeout_count_recent' => (int) ($statusProjection['recent_timeout_count'] ?? 0),
+            'recent_deferral_count' => (int) ($statusProjection['recent_deferral_count'] ?? 0),
             'lateness_seconds' => $latenessSeconds,
             'degraded' => $isDegraded,
             'explicitly_configured' => !empty($row['explicitly_configured']),
@@ -5116,7 +5168,7 @@ function sync_schedule_settings_view_model(): array
             'profile_timeout_seconds' => (int) (($profileMatrix['jobs'][$jobKey]['timeout_seconds'] ?? ($definition['timeout_seconds'] ?? 300))),
             'profile_priority' => (string) (($profileMatrix['jobs'][$jobKey]['priority'] ?? ($definition['priority'] ?? 'normal'))),
         ];
-        $resourceProfile = scheduler_job_recent_resource_profile($jobKey, $row);
+        $resourceProfile = scheduler_job_recent_resource_profile($jobKey, $row + ['status_projection' => $statusProjection]);
         $urgency = scheduler_job_urgency_snapshot($row, $recentDecisionCounts);
         $card += [
             'resource_class' => (string) ($row['resource_class'] ?? $resourceProfile['resource_class'] ?? 'medium'),
@@ -5145,8 +5197,9 @@ function sync_schedule_settings_view_model(): array
             'starvation_indicator' => !empty($urgency['starvation_indicator']),
             'queue_wait_seconds' => $urgency['queue_wait_seconds'] ?? 0,
             'seconds_to_latest_allowed_start' => $urgency['seconds_to_latest_allowed_start'] ?? null,
-            'current_pressure_state' => (string) ($row['current_pressure_state'] ?? $liveCapacity['pressure'] ?? 'healthy'),
-            'capacity_reason' => (string) ($row['last_capacity_reason'] ?? ''),
+            'current_pressure_state' => (string) ($statusProjection['current_pressure_state'] ?? $row['current_pressure_state'] ?? $liveCapacity['pressure'] ?? 'healthy'),
+            'capacity_reason' => (string) ($statusProjection['last_planner_reason_text'] ?? $row['last_capacity_reason'] ?? ''),
+            'status_projection' => $statusProjection,
         ];
 
         if ($card['discovery_classification'] === 'internal') {


### PR DESCRIPTION
### Motivation
- Provide a compact, current-state projection for scheduler/job health so operational pages can read a single, small row per job instead of scanning history tables. 
- Capture the small, frequently-updated fields (latest status, last timestamps, last failure message, pressure state, counters, last resource summary, planner metadata) to simplify dashboard and planner logic. 

### Description
- Add `scheduler_job_current_status` table in `database/schema.sql` with keys `job_key` (PK) and optional `dataset_key` and fields for `latest_status`, `last_started_at`, `last_finished_at`, `last_success_at`, `last_failure_at`, `last_failure_message`, pressure state fields, recent counters, `last_resource_metrics_summary_json`, planner decision metadata, and timestamps. 
- Implement projection helpers in `src/db.php`: `db_scheduler_job_current_status_ensure()`, `db_scheduler_job_current_status_upsert()`, and `db_scheduler_job_current_status_fetch_map()` to create, upsert, and fetch the projection. 
- Wire projection refresh into scheduler write paths in `src/db.php` so the projection is updated on job claim/start (`db_sync_schedule_claim_job`), job completion/success/failure (`db_sync_schedule_mark_success`, `db_sync_schedule_mark_failure`), resource metric inserts (`db_scheduler_resource_metric_insert`), planner state/decisions (`db_sync_schedule_mark_planner_state`, `db_scheduler_planner_decision_insert`), and job events (`db_scheduler_job_event_insert`). The resource metrics summary is serialized as JSON for the projection. 
- Refactor operational reads in `src/functions.php` to use the projection for live/dashboard views: `scheduler_job_recent_resource_profile()` now prefers the projection summary when present, `scheduler_recent_planner_decision_counts()` aggregates recent deferral counts from the projection, and `sync_schedule_settings_view_model()` (dashboard) pulls per-job `status_projection` and uses it for `last_*`, `timeout/lock/skip` counters, `current_pressure_state`, and capacity reason, while historical/audit queries remain on `scheduler_job_events`, `scheduler_job_resource_metrics`, `scheduler_planner_decisions`, and tuning tables. 

### Testing
- Ran PHP lint on modified files with `php -l src/db.php` and `php -l src/functions.php` and both returned no syntax errors. (succeeded) 
- Ran repository check `git diff --check` to ensure no whitespace/merge leftovers (succeeded). 
- No unit tests in repo were changed; changes are limited to schema and DB/write/read wiring and validated by the above static checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb039bfac832f80b477c36aa96517)