### PR TITLE
Fix partitioned market_orders_history_p schema and populate observed_date for inserts/backfills

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1260,7 +1260,7 @@ CREATE TABLE IF NOT EXISTS market_orders_history_p (
     issued DATETIME NOT NULL,
     expires DATETIME NOT NULL,
     observed_at DATETIME NOT NULL,
-    observed_date DATE GENERATED ALWAYS AS (DATE(observed_at)) STORED,
+    observed_date DATE NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id, observed_date),
     UNIQUE KEY unique_source_order_observed (source_type, source_id, order_id, observed_at, observed_date),

--- a/src/db.php
+++ b/src/db.php
@@ -2162,7 +2162,7 @@ function db_market_orders_history_partitioned_table_sql(): string
 "
         . "    observed_at DATETIME NOT NULL,
 "
-        . "    observed_date DATE GENERATED ALWAYS AS (DATE(observed_at)) STORED,
+        . "    observed_date DATE NOT NULL,
 "
         . "    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 "
@@ -2240,6 +2240,39 @@ function db_market_orders_history_partition_boundaries(string $table = 'market_o
     }
 
     return $boundaries;
+}
+
+
+function db_market_orders_history_normalize_observed_date(string $observedAt): string
+{
+    $safeObservedAt = trim($observedAt);
+    if ($safeObservedAt === '') {
+        return '';
+    }
+
+    $timestamp = strtotime($safeObservedAt);
+    if ($timestamp === false) {
+        return '';
+    }
+
+    return gmdate('Y-m-d', $timestamp);
+}
+
+function db_market_orders_history_rows_with_observed_date(array $rows): array
+{
+    if ($rows === []) {
+        return [];
+    }
+
+    return array_values(array_map(static function (array $row): array {
+        if (trim((string) ($row['observed_date'] ?? '')) !== '') {
+            return $row;
+        }
+
+        $row['observed_date'] = db_market_orders_history_normalize_observed_date((string) ($row['observed_at'] ?? ''));
+
+        return $row;
+    }, $rows));
 }
 
 function db_market_orders_history_partitioned_schema_ensure(int $futureMonths = 3): void
@@ -2350,7 +2383,7 @@ function db_market_orders_history_backfill_window(
         db_market_orders_history_ensure_future_monthly_partitions($monthsAhead + 1, $target);
     }
 
-    $columns = [
+    $baseColumns = [
         'source_type',
         'source_id',
         'type_id',
@@ -2395,9 +2428,15 @@ function db_market_orders_history_backfill_window(
             break;
         }
 
+        $targetColumns = $baseColumns;
+        if ($target === db_market_orders_history_partitioned_table()) {
+            $targetColumns[] = 'observed_date';
+            $rows = db_market_orders_history_rows_with_observed_date($rows);
+        }
+
         $written += db_bulk_insert_or_upsert(
             $target,
-            $columns,
+            $targetColumns,
             $rows,
             [
                 'type_id',
@@ -2876,7 +2915,7 @@ function db_market_orders_history_bulk_insert(array $orders, ?int $chunkSize = n
         return 0;
     }
 
-    $columns = [
+    $baseColumns = [
         'source_type',
         'source_id',
         'type_id',
@@ -2892,7 +2931,7 @@ function db_market_orders_history_bulk_insert(array $orders, ?int $chunkSize = n
         'expires',
         'observed_at',
     ];
-    return db_transaction(function () use ($orders, $columns, $chunkSize): int {
+    return db_transaction(function () use ($orders, $baseColumns, $chunkSize): int {
         $written = 0;
 
         foreach (db_market_orders_history_write_tables() as $table) {
@@ -2906,7 +2945,10 @@ function db_market_orders_history_bulk_insert(array $orders, ?int $chunkSize = n
                         continue;
                     }
 
-                    $observedDate = gmdate('Y-m-d', strtotime($observedAt));
+                    $observedDate = db_market_orders_history_normalize_observed_date($observedAt);
+                    if ($observedDate === '') {
+                        continue;
+                    }
                     if ($observedDate > $latestObservedDate) {
                         $latestObservedDate = $observedDate;
                     }
@@ -2919,12 +2961,19 @@ function db_market_orders_history_bulk_insert(array $orders, ?int $chunkSize = n
                 }
             }
 
+            $tableColumns = $baseColumns;
+            $tableRows = $orders;
+            if ($table === db_market_orders_history_partitioned_table()) {
+                $tableColumns[] = 'observed_date';
+                $tableRows = db_market_orders_history_rows_with_observed_date($orders);
+            }
+
             $written = max(
                 $written,
                 db_bulk_insert_or_upsert(
                     $table,
-                    $columns,
-                    $orders,
+                    $tableColumns,
+                    $tableRows,
                     [
                         'type_id',
                         'is_buy_order',


### PR DESCRIPTION
### Motivation
- The partitioned table `market_orders_history_p` failed to create because the primary key referenced a generated column (`observed_date`) derived from `observed_at`, which MySQL disallows in a primary key for partitioned tables.
- The intent is to keep monthly partitioning on `observed_date` while ensuring the table can be created/imported and writes/backfills correctly populate the partition key.

### Description
- Change `database/schema.sql` and the `db_market_orders_history_partitioned_table_sql()` SQL generator so `observed_date` is a stored `DATE NOT NULL` column instead of a generated column derived from `observed_at`.
- Add `db_market_orders_history_normalize_observed_date()` and `db_market_orders_history_rows_with_observed_date()` helpers in `src/db.php` to derive and attach `observed_date` to rows when missing.
- Update the backfill path `db_market_orders_history_backfill_window()` to append an `observed_date` column and normalize rows when the target is the partitioned table.
- Update live bulk writes `db_market_orders_history_bulk_insert()` to compute and include `observed_date` only when writing into the partitioned history table so partition keys and future partitions are created correctly.

### Testing
- Ran PHP linting with `php -l src/db.php`, `php -l public/settings/index.php`, and `php -l src/functions.php`, all of which reported no syntax errors.
- Executed `php -r "require 'src/db.php'; var_export(db_market_orders_history_rows_with_observed_date([['observed_at'=>'2026-03-22 14:15:16'] ]));"` to validate normalization logic and it returned the expected `observed_date`.
- Rendered the generated partitioned table SQL with `php -r "require 'src/db.php'; echo db_market_orders_history_partitioned_table_sql();"` to verify `observed_date` appears as `DATE NOT NULL` in the CREATE statement.
- Confirmed the modified `database/schema.sql` no longer contains the generated-column definition causing the MySQL error; PHP validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb5ccd4e8832fbbea06e7dd4b9b4d)