### PR TITLE
Handle invalid local PHP config syntax and return structured CLI errors

### DIFF
--- a/bin/orchestrator_config.php
+++ b/bin/orchestrator_config.php
@@ -3,9 +3,9 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../src/bootstrap.php';
-
 try {
+    require_once __DIR__ . '/../src/bootstrap.php';
+
     fwrite(STDOUT, json_encode(orchestrator_runtime_config_export(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
     exit(0);
 } catch (Throwable $exception) {

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -45,12 +45,41 @@ $config = [
     ],
 ];
 
-$localConfigPath = __DIR__ . '/local.php';
-if (is_file($localConfigPath)) {
-    $localConfig = require $localConfigPath;
-    if (is_array($localConfig)) {
-        $config = array_replace_recursive($config, $localConfig);
+/**
+ * @return array<string, mixed>|null
+ */
+function supplycore_load_local_config(string $localConfigPath): ?array
+{
+    if (!is_file($localConfigPath)) {
+        return null;
     }
+
+    try {
+        $localConfig = (static function (string $path): mixed {
+            return require $path;
+        })($localConfigPath);
+    } catch (ParseError $exception) {
+        throw new RuntimeException(
+            sprintf('Invalid PHP syntax in %s: %s', $localConfigPath, $exception->getMessage()),
+            previous: $exception,
+        );
+    }
+
+    if ($localConfig === null) {
+        return null;
+    }
+
+    if (!is_array($localConfig)) {
+        throw new RuntimeException(sprintf('Local config file at %s must return an array.', $localConfigPath));
+    }
+
+    return $localConfig;
+}
+
+$localConfigPath = __DIR__ . '/local.php';
+$localConfig = supplycore_load_local_config($localConfigPath);
+if (is_array($localConfig)) {
+    $config = array_replace_recursive($config, $localConfig);
 }
 
 return $config;


### PR DESCRIPTION
### Motivation
- Prevent an uncaught fatal parse error when `src/config/local.php` contains invalid PHP and surface a clear runtime error instead. 
- Ensure the CLI entrypoint `bin/orchestrator_config.php` returns structured JSON error output on bootstrap failures rather than a raw PHP stack trace.

### Description
- Add `supplycore_load_local_config()` to `src/config/app.php` that `require`s `src/config/local.php` inside a small wrapper and catches `ParseError`, rethrowing a `RuntimeException` with a clear message and enforcing that the local file returns an array. 
- Replace the previous direct `require $localConfigPath` behavior with the new loader and merge the returned config via `array_replace_recursive` when present. 
- Move the `require_once __DIR__ . '/../src/bootstrap.php';` into the existing `try` block in `bin/orchestrator_config.php` so bootstrap-time failures are caught and emitted as the JSON error payload produced by `scheduler_normalize_error_message`.

### Testing
- Ran `php -l src/config/app.php` and `php -l bin/orchestrator_config.php` for syntax checking, both succeeded. 
- Executed `php bin/orchestrator_config.php` with a temporary malformed `src/config/local.php` fixture and verified the CLI returned a JSON error like `{"error":"Invalid PHP syntax in /workspace/SupplyCore/src/config/local.php: Unclosed '[' on line 6"}`. 
- Ran `php bin/orchestrator_config.php | head -n 5` with no `local.php` present and verified normal config JSON output was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfcd9d2444832f852c3c0857f0c3a0)