### PR TITLE
Unify scheduler logging destination and standardize dashboard header

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,8 +373,8 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-StandardOutput=journal
-StandardError=journal
+StandardOutput=append:/var/www/SupplyCore/storage/logs/cron.log
+StandardError=append:/var/www/SupplyCore/storage/logs/cron.log
 
 [Install]
 WantedBy=multi-user.target
@@ -452,8 +452,8 @@ The remaining environment-sensitive source values are:
   - `SUPPLYCORE_ALLIANCE_SOURCE_ID` (for `alliance-current` and `alliance-history`)
   - `SUPPLYCORE_HUB_SOURCE_ID` (for `hub-current`, `hub-history`, and hub snapshot-history generation)
 
-The canonical log path for the daemon and watchdog is `storage/logs/cron.log` (relative to app root).
-When the Python orchestrator is enabled, the canonical service log stream moves to `journalctl -u supplycore-orchestrator.service`, while PHP scheduler events still include their structured JSON payloads in child stdout/stderr captured by Python.
+The canonical log path for cron ticks, the PHP scheduler daemon, and the Python orchestrator supervisor is `storage/logs/cron.log` (relative to app root).
+When the Python orchestrator is enabled, the systemd unit appends its stdout/stderr to that same file, so operator tails stay in one place.
 If logs show `Job exceeded timeout of ... seconds.`, move the deployment to a stronger scheduler profile first (`Low` → `Medium` → `High`) and only use hard environment overrides if you have a very specific reason.
 Market history retention is tiered from Settings → Data Sync:
 
@@ -495,11 +495,14 @@ mysql -u "$DB_USERNAME" -p"$DB_PASSWORD" -h "$DB_HOST" -P "$DB_PORT" "$DB_DATABA
 
 If the UI says the scheduler daemon is **stopped** while no jobs are running:
 
-1. Check the Python supervisor logs first:
+1. Check `storage/logs/cron.log` for the last `scheduler_daemon.stopped`, `worker.health.failed`, or `orchestrator.stopped` event first:
    ```bash
-   journalctl -u supplycore-orchestrator.service -n 200 --no-pager
+   tail -n 200 /var/www/SupplyCore/storage/logs/cron.log
    ```
-2. Check `storage/logs/cron.log` for the last `scheduler_daemon.stopped` event if you still mirror PHP output there or run transitional cron tooling.
+2. Confirm the systemd unit is still active:
+   ```bash
+   systemctl status supplycore-orchestrator.service --no-pager
+   ```
 3. Look at `exit_reason`.
    - `memory_recycle_threshold_reached` means the daemon intentionally recycled itself.
    - In Python-supervised mode, the orchestrator should detect that exit and restart the managed PHP worker.
@@ -532,7 +535,7 @@ tail -f /var/www/SupplyCore/storage/logs/cron.log
 Tail the orchestrator log stream:
 
 ```bash
-journalctl -u supplycore-orchestrator.service -f
+tail -f /var/www/SupplyCore/storage/logs/cron.log
 ```
 
 Inspect scheduler state tables:

--- a/ops/systemd/supplycore-orchestrator.service
+++ b/ops/systemd/supplycore-orchestrator.service
@@ -16,8 +16,8 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-StandardOutput=journal
-StandardError=journal
+StandardOutput=append:/var/www/SupplyCore/storage/logs/cron.log
+StandardError=append:/var/www/SupplyCore/storage/logs/cron.log
 
 [Install]
 WantedBy=multi-user.target

--- a/public/index.php
+++ b/public/index.php
@@ -11,6 +11,20 @@ $doctrine = $intel['doctrine'] ?? doctrine_groups_overview_data();
 $pageFreshness = supplycore_page_freshness_view_model((array) ($intel['_freshness'] ?? []));
 $buyAll = buy_all_dashboard_summary();
 $liveRefreshConfig = supplycore_live_refresh_page_config('dashboard');
+$pageHeaderBadge = 'Alliance logistics intelligence';
+$pageHeaderSummary = 'Prioritized coverage, doctrine readiness, queue risk, and procurement signals aligned to the latest sync output.';
+$pageHeaderMeta = [
+    [
+        'label' => 'Deployment profile',
+        'value' => 'PHP 8 · MySQL · Apache2',
+        'caption' => 'Production stack aligned with the supported SupplyCore deployment target.',
+    ],
+    [
+        'label' => 'Scheduler log',
+        'value' => scheduler_daemon_log_label(),
+        'caption' => 'Cron jobs and the Python supervisor now share the same runtime logfile destination.',
+    ],
+];
 
 include __DIR__ . '/../src/views/partials/header.php';
 ?>

--- a/python/orchestrator/config.py
+++ b/python/orchestrator/config.py
@@ -46,6 +46,10 @@ class OrchestratorConfig:
         return Path(self.raw["orchestrator"]["lock_file"]).resolve()
 
     @property
+    def log_file(self) -> Path:
+        return Path(self.raw["paths"]["log_file"]).resolve()
+
+    @property
     def worker_grace_seconds(self) -> int:
         return int(self.raw["orchestrator"]["worker_grace_seconds"])
 

--- a/python/orchestrator/logging_utils.py
+++ b/python/orchestrator/logging_utils.py
@@ -4,6 +4,7 @@ import json
 import logging
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 
@@ -32,12 +33,20 @@ class LoggerAdapter(logging.LoggerAdapter):
         return msg, kwargs
 
 
-def configure_logging(verbose: bool = False) -> LoggerAdapter:
+def configure_logging(verbose: bool = False, log_file: Path | None = None) -> LoggerAdapter:
     logger = logging.getLogger("supplycore.orchestrator")
     logger.handlers.clear()
     logger.setLevel(logging.DEBUG if verbose else logging.INFO)
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(JsonFormatter())
-    logger.addHandler(handler)
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(JsonFormatter())
+    logger.addHandler(stream_handler)
+
+    if log_file is not None:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setFormatter(JsonFormatter())
+        logger.addHandler(file_handler)
+
     logger.propagate = False
     return LoggerAdapter(logger, {})

--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from .config import load_php_runtime_config
 from .logging_utils import configure_logging
 from .supervisor import run_supervisor
 
@@ -20,5 +21,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    logger = configure_logging(verbose=args.verbose)
-    return run_supervisor(app_root=Path(args.app_root), logger=logger)
+    app_root = Path(args.app_root).resolve()
+    config = load_php_runtime_config(app_root)
+    logger = configure_logging(verbose=args.verbose, log_file=config.log_file)
+    return run_supervisor(app_root=app_root, logger=logger)

--- a/src/functions.php
+++ b/src/functions.php
@@ -2781,6 +2781,11 @@ function scheduler_daemon_log_path(): string
     return scheduler_cron_log_path();
 }
 
+function scheduler_daemon_log_label(): string
+{
+    return 'storage/logs/' . basename(scheduler_daemon_log_path());
+}
+
 function scheduler_daemon_state_view(?array $state = null): array
 {
     $row = $state ?? db_scheduler_daemon_state_fetch(scheduler_daemon_key()) ?? [];

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -2,6 +2,21 @@
 $notice = flash('success');
 $dealAlertPopupRows = deal_alert_popup_view_model();
 $dealAlertDismissMinutes = (int) (deal_alert_settings()['deal_alert_popup_dismiss_minutes'] ?? 120);
+$pageHeaderSummary = trim((string) ($pageHeaderSummary ?? brand_tagline()));
+$pageHeaderBadge = trim((string) ($pageHeaderBadge ?? 'Operations aligned'));
+$pageHeaderBadgeTone = trim((string) ($pageHeaderBadgeTone ?? 'border-cyan/20 bg-cyan/10 text-cyan-100'));
+$pageHeaderMeta = is_array($pageHeaderMeta ?? null) ? $pageHeaderMeta : [
+    [
+        'label' => 'Deployment profile',
+        'value' => 'PHP 8 · MySQL · Apache2',
+        'caption' => 'Aligned with the supported production stack.',
+    ],
+    [
+        'label' => 'Scheduler log',
+        'value' => scheduler_daemon_log_label(),
+        'caption' => 'Cron jobs and the orchestrator append to the same runtime log.',
+    ],
+];
 ?>
 <!doctype html>
 <html lang="en">
@@ -21,32 +36,42 @@ $dealAlertDismissMinutes = (int) (deal_alert_settings()['deal_alert_popup_dismis
     <?php include __DIR__ . '/sidebar.php'; ?>
     <main class="relative flex-1 px-5 py-6 sm:px-6 lg:px-8 xl:px-10 xl:py-8">
         <header class="page-header mb-8">
-            <div class="relative z-10 flex flex-wrap items-start justify-between gap-5">
+            <div class="relative z-10 grid gap-5 xl:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.95fr)] xl:items-start">
                 <div class="max-w-3xl">
                     <p class="eyebrow text-cyan/80"><?= htmlspecialchars(brand_console_label(), ENT_QUOTES) ?></p>
                     <div class="mt-3 flex flex-wrap items-center gap-3">
                         <h1 class="text-3xl font-semibold tracking-tight text-white sm:text-[2.1rem]"><?= htmlspecialchars($title ?? 'Dashboard', ENT_QUOTES) ?></h1>
-                        <span class="status-chip border-cyan/20 bg-cyan/10 text-cyan-100">
+                        <span class="status-chip <?= htmlspecialchars($pageHeaderBadgeTone, ENT_QUOTES) ?>">
                             <span class="h-2 w-2 rounded-full bg-cyan shadow-[0_0_12px_rgba(34,211,238,0.65)]"></span>
-                            Alliance logistics intelligence
+                            <?= htmlspecialchars($pageHeaderBadge, ENT_QUOTES) ?>
                         </span>
                     </div>
-                    <p class="mt-3 max-w-2xl text-sm leading-6 text-slate-300/88">Alliance logistics intelligence for coverage, risk, and market readiness.</p>
+                    <p class="mt-3 max-w-2xl text-sm leading-6 text-slate-300/88"><?= htmlspecialchars($pageHeaderSummary, ENT_QUOTES) ?></p>
                 </div>
-                <div class="flex flex-col gap-3 sm:items-end">
-                    <div class="surface-tertiary relative z-10 flex flex-col items-start gap-3 px-4 py-3 text-sm text-slate-300 sm:items-end">
-                        <span class="eyebrow">Deployment profile</span>
-                        <span class="font-medium text-slate-100">PHP 8 · MySQL · Apache2</span>
-                        <span class="text-xs text-slate-500">Premium operational command layer</span>
-                    </div>
+                <div class="grid gap-3 xl:grid-cols-2">
+                    <?php foreach ($pageHeaderMeta as $metaCard): ?>
+                        <div class="surface-tertiary relative z-10 px-4 py-3 text-sm text-slate-300">
+                            <span class="eyebrow"><?= htmlspecialchars((string) ($metaCard['label'] ?? 'Operational context'), ENT_QUOTES) ?></span>
+                            <p class="mt-3 font-medium text-slate-100"><?= htmlspecialchars((string) ($metaCard['value'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
+                            <?php if (trim((string) ($metaCard['caption'] ?? '')) !== ''): ?>
+                                <p class="mt-2 text-xs leading-5 text-slate-500"><?= htmlspecialchars((string) ($metaCard['caption'] ?? ''), ENT_QUOTES) ?></p>
+                            <?php endif; ?>
+                        </div>
+                    <?php endforeach; ?>
                     <?php if (supplycore_live_refresh_should_include($liveRefreshConfig ?? null)): ?>
-                        <section class="live-refresh-panel relative z-10 min-w-[280px] text-left text-xs text-slate-300" data-ui-refresh-diagnostics>
-                            <p class="eyebrow text-cyan-100/80">Live refresh diagnostics</p>
-                            <div class="mt-3 space-y-2">
-                                <p><span class="text-slate-500">Transport</span> · <span class="text-slate-100" data-live-refresh-transport>Starting…</span></p>
-                                <p><span class="text-slate-500">Last event</span> · <span class="text-slate-100" data-live-refresh-last-event>No published refresh event yet</span></p>
-                                <p><span class="text-slate-500">Section refresh</span> · <span class="text-slate-100" data-live-refresh-last-refresh>No section refreshed yet</span></p>
-                                <p><span class="text-slate-500">Version markers</span> · <span class="text-slate-100" data-live-refresh-versions>Loading…</span></p>
+                        <section class="live-refresh-panel relative z-10 xl:col-span-2 text-left text-xs text-slate-300" data-ui-refresh-diagnostics>
+                            <div class="flex flex-wrap items-start justify-between gap-3">
+                                <div>
+                                    <p class="eyebrow text-cyan-100/80">Live refresh diagnostics</p>
+                                    <p class="mt-2 text-xs leading-5 text-slate-500">Track the active transport, latest publish event, and version markers without leaving the page.</p>
+                                </div>
+                                <span class="badge border-white/10 bg-white/[0.04] text-slate-200">Diagnostics</span>
+                            </div>
+                            <div class="mt-4 grid gap-3 sm:grid-cols-2">
+                                <p><span class="text-slate-500">Transport</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-transport>Starting…</span></p>
+                                <p><span class="text-slate-500">Last event</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-last-event>No published refresh event yet</span></p>
+                                <p><span class="text-slate-500">Section refresh</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-last-refresh>No section refreshed yet</span></p>
+                                <p><span class="text-slate-500">Version markers</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-versions>Loading…</span></p>
                             </div>
                         </section>
                     <?php endif; ?>


### PR DESCRIPTION
### Motivation
- Operators saw inconsistent guidance and scattered log outputs between cron, the PHP scheduler, and the Python orchestrator supervisor, and the page header lacked a consistent, reusable summary/meta treatment.
- Centralize the canonical runtime logfile and surface that path in the UI so operators can tail one file for scheduler and orchestrator events.

### Description
- Route Python orchestrator output into the same `storage/logs/cron.log` destination by adding `log_file` to `OrchestratorConfig`, passing it to `configure_logging`, and adding a file handler in `python/orchestrator/logging_utils.py`.
- Load the PHP-exported runtime config from Python at startup via `load_php_runtime_config` and wire `config.log_file` into `python/orchestrator/main.py` so supervisor logs are appended to the shared file.
- Add `scheduler_daemon_log_label()` in `src/functions.php` and update the shared header partial `src/views/partials/header.php` to expose a compact header summary/badge/meta card layout that includes the canonical scheduler log label; adjust `public/index.php` to provide the dashboard-specific header values.
- Change the systemd unit `ops/systemd/supplycore-orchestrator.service` to append `stdout`/`stderr` to `/var/www/SupplyCore/storage/logs/cron.log` and update `README.md` troubleshooting to document the single logfile workflow.

### Testing
- Ran PHP syntax checks with `php -l` for `src/views/partials/header.php`, `public/index.php`, and `src/functions.php`, all succeeded.
- Compiled Python modules with `python -m py_compile` for `python/orchestrator/*`, which completed with no errors.
- Verified runtime config and logging wiring by loading the PHP runtime config from Python and calling `configure_logging(log_file=config.log_file)` in a small `PYTHONPATH=python` invocation, which returned the expected `log_file` path and logger instance.
- Verified the PHP helper with `php -r "require 'src/bootstrap.php'; echo scheduler_daemon_log_label(), PHP_EOL;"` which printed the expected `storage/logs/cron.log` label.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfedc75f78832f81591ff4edd04552)