### PR TITLE
Add Retry and Stop-for-Investigation actions for data-sync jobs in settings UI

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -108,6 +108,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 exit;
             }
 
+            if ($dataSyncAction === 'retry-job') {
+                $requestedJob = trim((string) (($_POST['job_action_job_key'] ?? $_GET['job_action_job_key'] ?? '')));
+                $retry = retry_data_sync_job_now($requestedJob);
+                $saved = (bool) ($retry['ok'] ?? false);
+                flash('success', (string) ($retry['message'] ?? 'Retry submitted.'));
+                header('Location: /settings?section=' . urlencode($submittedSection));
+                exit;
+            }
+
+            if ($dataSyncAction === 'stop-investigate-job') {
+                $requestedJob = trim((string) (($_POST['job_action_job_key'] ?? $_GET['job_action_job_key'] ?? '')));
+                $stop = stop_data_sync_job_for_investigation($requestedJob);
+                $saved = (bool) ($stop['ok'] ?? false);
+                flash('success', (string) ($stop['message'] ?? 'Job stopped for investigation.'));
+                header('Location: /settings?section=' . urlencode($submittedSection));
+                exit;
+            }
+
             if ($dataSyncAction === 'start-profiling-run') {
                 $profiling = scheduler_profiling_start($_POST);
                 flash('success', (string) ($profiling['message'] ?? 'Performance Monitoring Run request submitted.'));
@@ -1679,6 +1697,9 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 $stateClass = $state === 'running'
                                     ? 'border-sky-400/40 bg-sky-500/10 text-sky-100'
                                     : ($state === 'stopped' ? 'border-rose-400/40 bg-rose-500/10 text-rose-100' : 'border-amber-400/40 bg-amber-500/10 text-amber-100');
+                                $jobKey = (string) ($schedule['job_key'] ?? '');
+                                $canRetry = !empty($schedule['enabled']) && $state === 'stopped';
+                                $canStopForInvestigation = !empty($schedule['enabled']) && $state !== 'stopped';
                             ?>
                             <div class="rounded-xl border border-border bg-black/20 p-4">
                                 <div class="flex flex-wrap items-start justify-between gap-3">
@@ -1687,8 +1708,18 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                             <p class="text-sm font-medium text-slate-100"><?= htmlspecialchars((string) ($schedule['label'] ?? $schedule['job_key']), ENT_QUOTES) ?></p>
                                             <span class="inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.14em] <?= $stateClass ?>"><?= htmlspecialchars($state, ENT_QUOTES) ?></span>
                                             <?php if (!empty($schedule['allow_backfill'])): ?><span class="inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-emerald-100">idle backfill</span><?php endif; ?>
+                                            <?php if ($canRetry): ?>
+                                                <button type="submit" name="data_sync_action" value="retry-job" class="inline-flex items-center rounded-full border border-emerald-400/40 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-emerald-100 hover:bg-emerald-500/20" formaction="/settings?section=data-sync&amp;job_action_job_key=<?= urlencode($jobKey) ?>" formnovalidate>
+                                                    <span>Retry now</span>
+                                                </button>
+                                            <?php endif; ?>
+                                            <?php if ($canStopForInvestigation): ?>
+                                                <button type="submit" name="data_sync_action" value="stop-investigate-job" class="inline-flex items-center rounded-full border border-amber-400/40 bg-amber-500/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-amber-100 hover:bg-amber-500/20" formaction="/settings?section=data-sync&amp;job_action_job_key=<?= urlencode($jobKey) ?>" formnovalidate>
+                                                    <span>Stop &amp; investigate</span>
+                                                </button>
+                                            <?php endif; ?>
                                         </div>
-                                        <p class="mt-1 text-xs text-muted font-mono"><?= htmlspecialchars((string) ($schedule['job_key'] ?? ''), ENT_QUOTES) ?></p>
+                                        <p class="mt-1 text-xs text-muted font-mono"><?= htmlspecialchars($jobKey, ENT_QUOTES) ?></p>
                                     </div>
                                     <div class="grid gap-2 text-xs text-muted sm:grid-cols-2 xl:grid-cols-4">
                                         <div><span class="block text-[11px] uppercase tracking-[0.14em]">Live cadence</span><span class="text-slate-100">every <?= (int) ($schedule['interval_minutes'] ?? 0) ?>m</span></div>

--- a/src/db.php
+++ b/src/db.php
@@ -7118,6 +7118,69 @@ function db_sync_schedule_force_due_by_job_keys(array $jobKeys): int
     return (int) $stmt->rowCount();
 }
 
+function db_sync_schedule_retry_by_job_key(string $jobKey): bool
+{
+    db_sync_schedule_registry_columns_ensure();
+
+    $normalizedKey = trim($jobKey);
+    if ($normalizedKey === '') {
+        return false;
+    }
+
+    return db_execute(
+        'UPDATE sync_schedules
+         SET next_run_at = CASE WHEN enabled = 1 THEN UTC_TIMESTAMP() ELSE next_run_at END,
+             next_due_at = CASE WHEN enabled = 1 THEN UTC_TIMESTAMP() ELSE next_due_at END,
+             latest_allowed_start_at = CASE
+                WHEN enabled = 1 THEN DATE_ADD(UTC_TIMESTAMP(), INTERVAL GREATEST(1, interval_minutes) MINUTE)
+                ELSE latest_allowed_start_at
+             END,
+             locked_until = NULL,
+             current_state = CASE WHEN enabled = 1 THEN \'waiting\' ELSE \'stopped\' END,
+             failure_streak = 0,
+             degraded_until = NULL,
+             consecutive_deferrals = 0,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE job_key = ?
+         LIMIT 1',
+        [$normalizedKey]
+    );
+}
+
+function db_sync_schedule_stop_for_investigation_by_job_key(string $jobKey, string $reason, int $holdMinutes = 240): bool
+{
+    db_sync_schedule_registry_columns_ensure();
+
+    $normalizedKey = trim($jobKey);
+    if ($normalizedKey === '') {
+        return false;
+    }
+
+    $message = mb_substr(trim($reason), 0, 500);
+    if ($message === '') {
+        $message = 'Stopped by operator for investigation.';
+    }
+
+    $safeHoldMinutes = max(5, min(1440, $holdMinutes));
+
+    return db_execute(
+        'UPDATE sync_schedules
+         SET locked_until = NULL,
+             current_state = CASE WHEN enabled = 1 THEN \'stopped\' ELSE \'stopped\' END,
+             degraded_until = CASE
+                WHEN enabled = 1 THEN DATE_ADD(UTC_TIMESTAMP(), INTERVAL ? MINUTE)
+                ELSE degraded_until
+             END,
+             last_status = CASE WHEN enabled = 1 THEN \'stopped\' ELSE last_status END,
+             last_result = CASE WHEN enabled = 1 THEN \'investigating\' ELSE last_result END,
+             last_error = CASE WHEN enabled = 1 THEN ? ELSE last_error END,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE job_key = ?
+         LIMIT 1',
+        [$safeHoldMinutes, $message, $normalizedKey]
+    );
+}
+
 function db_sync_schedule_apply_adjustment(int $scheduleId, array $changes): bool
 {
     db_sync_schedule_registry_columns_ensure();

--- a/src/functions.php
+++ b/src/functions.php
@@ -2471,6 +2471,105 @@ function run_data_sync_now(?string $jobKey = null): array
     }
 }
 
+function retry_data_sync_job_now(string $jobKey): array
+{
+    $definitions = data_sync_schedule_job_definitions();
+    $normalizedJobKey = trim($jobKey);
+    if ($normalizedJobKey === '' || !isset($definitions[$normalizedJobKey])) {
+        return [
+            'ok' => false,
+            'message' => 'Retry failed: unknown sync job selected.',
+        ];
+    }
+
+    $scheduleRow = db_sync_schedule_fetch_by_job_keys([$normalizedJobKey])[0] ?? null;
+    if (!is_array($scheduleRow) || (int) ($scheduleRow['enabled'] ?? 0) !== 1) {
+        return [
+            'ok' => false,
+            'message' => 'Retry failed: the selected sync job is not enabled.',
+        ];
+    }
+
+    if (!db_sync_schedule_retry_by_job_key($normalizedJobKey)) {
+        return [
+            'ok' => false,
+            'message' => 'Retry failed: scheduler state could not be reset.',
+        ];
+    }
+
+    $queued = run_data_sync_now($normalizedJobKey);
+    if (!empty($queued['ok'])) {
+        $timestamp = gmdate('Y-m-d H:i:s');
+        db_scheduler_job_event_insert($normalizedJobKey, 'manual_retry_requested', ['actor' => 'operator'], 0, null);
+        db_scheduler_tuning_action_log($normalizedJobKey, 'admin', 'manual_retry', 'Cleared scheduler quarantine state and re-queued the job.', [], ['current_state' => 'waiting'], ['source' => 'settings']);
+        db_scheduler_job_current_status_upsert($normalizedJobKey, [
+            'latest_status' => 'queued',
+            'latest_event_type' => 'manual_retry_requested',
+            'last_failure_message' => null,
+            'current_pressure_state' => 'healthy',
+            'last_pressure_state' => 'healthy',
+            'recent_timeout_count' => 0,
+            'recent_lock_conflict_count' => 0,
+            'recent_deferral_count' => 0,
+            'recent_skip_count' => 0,
+            'last_event_at' => $timestamp,
+        ]);
+    }
+
+    return $queued;
+}
+
+function stop_data_sync_job_for_investigation(string $jobKey): array
+{
+    $definitions = data_sync_schedule_job_definitions();
+    $normalizedJobKey = trim($jobKey);
+    if ($normalizedJobKey === '' || !isset($definitions[$normalizedJobKey])) {
+        return [
+            'ok' => false,
+            'message' => 'Stop failed: unknown sync job selected.',
+        ];
+    }
+
+    $scheduleRow = db_sync_schedule_fetch_by_job_keys([$normalizedJobKey])[0] ?? null;
+    if (!is_array($scheduleRow) || (int) ($scheduleRow['enabled'] ?? 0) !== 1) {
+        return [
+            'ok' => false,
+            'message' => 'Stop failed: the selected sync job is not enabled.',
+        ];
+    }
+
+    $reason = 'Stopped by operator for investigation. Use Retry now after resolving the issue.';
+    if (!db_sync_schedule_stop_for_investigation_by_job_key($normalizedJobKey, $reason)) {
+        return [
+            'ok' => false,
+            'message' => 'Stop failed: scheduler state could not be updated.',
+        ];
+    }
+
+    $timestamp = gmdate('Y-m-d H:i:s');
+    db_scheduler_job_event_insert($normalizedJobKey, 'manual_stop_requested', ['actor' => 'operator', 'reason' => $reason], 0, null);
+    db_scheduler_tuning_action_log($normalizedJobKey, 'admin', 'manual_investigation_stop', $reason, [], ['current_state' => 'stopped'], ['source' => 'settings']);
+    db_scheduler_job_current_status_upsert($normalizedJobKey, [
+        'latest_status' => 'investigating',
+        'latest_event_type' => 'manual_stop_requested',
+        'last_failure_message' => $reason,
+        'current_pressure_state' => 'healthy',
+        'last_pressure_state' => 'healthy',
+        'recent_timeout_count' => 0,
+        'recent_lock_conflict_count' => 0,
+        'recent_deferral_count' => 0,
+        'recent_skip_count' => 0,
+        'last_event_at' => $timestamp,
+    ]);
+
+    $jobLabel = (string) ($definitions[$normalizedJobKey]['label'] ?? $normalizedJobKey);
+
+    return [
+        'ok' => true,
+        'message' => $jobLabel . ' is now stopped for investigation. Retry it from the job card after you resolve the issue.',
+    ];
+}
+
 function scheduler_reset_process_targets(): array
 {
     $paths = [


### PR DESCRIPTION
### Motivation

- Provide operators the ability to immediately retry a stopped sync job or stop it for investigation from the Settings > Data Sync UI so issues can be handled without direct DB access.
- Ensure scheduler state and observability metadata are updated when these admin actions are triggered to keep runtime telemetry consistent.

### Description

- Added UI controls in `public/settings/index.php` to show `Retry now` and `Stop & investigate` buttons on each sync job card and pass the `job_action_job_key` via the form action.
- Added request handling in `public/settings/index.php` for `data_sync_action` values `retry-job` and `stop-investigate-job` to call new action functions and redirect with flash messages.
- Implemented `retry_data_sync_job_now()` and `stop_data_sync_job_for_investigation()` in `src/functions.php` to validate the job key, update scheduler records, enqueue a run (for retry), and write scheduler event/tuning logs and current status entries.
- Added DB helpers in `src/db.php`: `db_sync_schedule_retry_by_job_key()` to reset scheduler state and requeue timing for an enabled job, and `db_sync_schedule_stop_for_investigation_by_job_key()` to mark a job as stopped/investigating with a degradations hold window and an operator message.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff10a18d8832fb132c9883c1b5d20)