### PR TITLE
Make "Start now" immediately clear stopped jobs and wake scheduler

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -112,7 +112,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $requestedJob = trim((string) (($_POST['job_action_job_key'] ?? $_GET['job_action_job_key'] ?? '')));
                 $retry = retry_data_sync_job_now($requestedJob);
                 $saved = (bool) ($retry['ok'] ?? false);
-                flash('success', (string) ($retry['message'] ?? 'Retry submitted.'));
+                flash('success', (string) ($retry['message'] ?? 'Start now submitted.'));
                 header('Location: /settings?section=' . urlencode($submittedSection));
                 exit;
             }
@@ -1698,7 +1698,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                     ? 'border-sky-400/40 bg-sky-500/10 text-sky-100'
                                     : ($state === 'stopped' ? 'border-rose-400/40 bg-rose-500/10 text-rose-100' : 'border-amber-400/40 bg-amber-500/10 text-amber-100');
                                 $jobKey = (string) ($schedule['job_key'] ?? '');
-                                $canRetry = !empty($schedule['enabled']) && $state === 'stopped';
+                                $canStartNow = !empty($schedule['enabled']) && $state === 'stopped';
                                 $canStopForInvestigation = !empty($schedule['enabled']) && $state !== 'stopped';
                             ?>
                             <div class="rounded-xl border border-border bg-black/20 p-4">
@@ -1708,9 +1708,9 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                             <p class="text-sm font-medium text-slate-100"><?= htmlspecialchars((string) ($schedule['label'] ?? $schedule['job_key']), ENT_QUOTES) ?></p>
                                             <span class="inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.14em] <?= $stateClass ?>"><?= htmlspecialchars($state, ENT_QUOTES) ?></span>
                                             <?php if (!empty($schedule['allow_backfill'])): ?><span class="inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-emerald-100">idle backfill</span><?php endif; ?>
-                                            <?php if ($canRetry): ?>
+                                            <?php if ($canStartNow): ?>
                                                 <button type="submit" name="data_sync_action" value="retry-job" class="inline-flex items-center rounded-full border border-emerald-400/40 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-emerald-100 hover:bg-emerald-500/20" formaction="/settings?section=data-sync&amp;job_action_job_key=<?= urlencode($jobKey) ?>" formnovalidate>
-                                                    <span>Retry now</span>
+                                                    <span>Start now</span>
                                                 </button>
                                             <?php endif; ?>
                                             <?php if ($canStopForInvestigation): ?>

--- a/src/db.php
+++ b/src/db.php
@@ -7140,6 +7140,9 @@ function db_sync_schedule_retry_by_job_key(string $jobKey): bool
              failure_streak = 0,
              degraded_until = NULL,
              consecutive_deferrals = 0,
+             last_status = CASE WHEN enabled = 1 THEN \'queued\' ELSE last_status END,
+             last_result = CASE WHEN enabled = 1 THEN \'queued\' ELSE last_result END,
+             last_error = CASE WHEN enabled = 1 THEN NULL ELSE last_error END,
              updated_at = CURRENT_TIMESTAMP
          WHERE job_key = ?
          LIMIT 1',

--- a/src/functions.php
+++ b/src/functions.php
@@ -2404,6 +2404,34 @@ function data_sync_backfill_start_date(string $settingKey, bool $pipelineEnabled
     return $pipelineEnabled ? $fallbackDate : '';
 }
 
+function scheduler_mark_manual_job_start_requested(string $jobKey, string $eventType = 'manual_start_requested', string $actionType = 'manual_start'): void
+{
+    $timestamp = gmdate('Y-m-d H:i:s');
+    db_scheduler_job_event_insert($jobKey, $eventType, ['actor' => 'operator'], 0, null);
+    db_scheduler_tuning_action_log(
+        $jobKey,
+        'admin',
+        $actionType,
+        'Operator queued the job to start immediately and cleared any stopped/investigation state.',
+        [],
+        ['current_state' => 'waiting'],
+        ['source' => 'settings']
+    );
+    db_scheduler_job_current_status_upsert($jobKey, [
+        'latest_status' => 'queued',
+        'latest_event_type' => $eventType,
+        'last_failure_at' => null,
+        'last_failure_message' => null,
+        'current_pressure_state' => 'healthy',
+        'last_pressure_state' => 'healthy',
+        'recent_timeout_count' => 0,
+        'recent_lock_conflict_count' => 0,
+        'recent_deferral_count' => 0,
+        'recent_skip_count' => 0,
+        'last_event_at' => $timestamp,
+    ]);
+}
+
 function run_data_sync_now(?string $jobKey = null): array
 {
     $lockName = 'cron_tick_runner';
@@ -2418,17 +2446,37 @@ function run_data_sync_now(?string $jobKey = null): array
         ];
     }
 
+    $jobLabel = $normalizedJobKey === ''
+        ? 'all enabled jobs'
+        : ((string) ($definitions[$normalizedJobKey]['label'] ?? $normalizedJobKey) . ' job');
+
     try {
+        if ($normalizedJobKey !== '') {
+            $scheduleRow = db_sync_schedule_fetch_by_job_keys([$normalizedJobKey])[0] ?? null;
+            if (!is_array($scheduleRow) || (int) ($scheduleRow['enabled'] ?? 0) !== 1) {
+                return [
+                    'ok' => false,
+                    'message' => 'Run now failed: the selected sync job is not enabled.',
+                ];
+            }
+
+            if (!db_sync_schedule_retry_by_job_key($normalizedJobKey)) {
+                return [
+                    'ok' => false,
+                    'message' => 'Run now failed: scheduler state could not be reset.',
+                ];
+            }
+
+            scheduler_mark_manual_job_start_requested($normalizedJobKey);
+        }
+
+        $forcedJobs = $normalizedJobKey === ''
+            ? db_sync_schedule_force_due_all_enabled()
+            : db_sync_schedule_force_due_by_job_keys([$normalizedJobKey]);
+
         $daemonState = scheduler_daemon_state_view();
         if (!empty($daemonState['is_healthy'])) {
-            $forcedJobs = $normalizedJobKey === ''
-                ? db_sync_schedule_force_due_all_enabled()
-                : db_sync_schedule_force_due_by_job_keys([$normalizedJobKey]);
             db_scheduler_daemon_request_wake(scheduler_daemon_key());
-
-            $jobLabel = $normalizedJobKey === ''
-                ? 'all enabled jobs'
-                : ((string) ($definitions[$normalizedJobKey]['label'] ?? $normalizedJobKey) . ' job');
 
             return [
                 'ok' => true,
@@ -2437,22 +2485,26 @@ function run_data_sync_now(?string $jobKey = null): array
             ];
         }
 
+        $startResult = scheduler_watchdog_start_daemon();
+        if (!empty($startResult['ok'])) {
+            db_scheduler_daemon_request_wake(scheduler_daemon_key());
+
+            return [
+                'ok' => true,
+                'message' => 'Run now queued for ' . $jobLabel . '. Forced ' . $forcedJobs . ' schedule(s) and requested an immediate scheduler daemon start (' . ($startResult['mode'] ?? 'watchdog') . ').',
+                'summary' => ['jobs_forced' => $forcedJobs, 'mode' => $startResult['mode'] ?? 'watchdog_start'],
+            ];
+        }
+
         $lockAcquired = runner_lock_acquire($lockName, 0);
         if (!$lockAcquired) {
             return [
                 'ok' => false,
-                'message' => 'Data sync is already running from cron. Please wait a minute and try again.',
+                'message' => 'Run now failed: the scheduler daemon could not be started and the cron runner lock is currently busy.',
             ];
         }
 
-        $forcedJobs = $normalizedJobKey === ''
-            ? db_sync_schedule_force_due_all_enabled()
-            : db_sync_schedule_force_due_by_job_keys([$normalizedJobKey]);
         $summary = cron_tick_run();
-
-        $jobLabel = $normalizedJobKey === ''
-            ? 'all enabled jobs'
-            : ((string) ($definitions[$normalizedJobKey]['label'] ?? $normalizedJobKey) . ' job');
 
         return [
             'ok' => true,
@@ -2473,50 +2525,7 @@ function run_data_sync_now(?string $jobKey = null): array
 
 function retry_data_sync_job_now(string $jobKey): array
 {
-    $definitions = data_sync_schedule_job_definitions();
-    $normalizedJobKey = trim($jobKey);
-    if ($normalizedJobKey === '' || !isset($definitions[$normalizedJobKey])) {
-        return [
-            'ok' => false,
-            'message' => 'Retry failed: unknown sync job selected.',
-        ];
-    }
-
-    $scheduleRow = db_sync_schedule_fetch_by_job_keys([$normalizedJobKey])[0] ?? null;
-    if (!is_array($scheduleRow) || (int) ($scheduleRow['enabled'] ?? 0) !== 1) {
-        return [
-            'ok' => false,
-            'message' => 'Retry failed: the selected sync job is not enabled.',
-        ];
-    }
-
-    if (!db_sync_schedule_retry_by_job_key($normalizedJobKey)) {
-        return [
-            'ok' => false,
-            'message' => 'Retry failed: scheduler state could not be reset.',
-        ];
-    }
-
-    $queued = run_data_sync_now($normalizedJobKey);
-    if (!empty($queued['ok'])) {
-        $timestamp = gmdate('Y-m-d H:i:s');
-        db_scheduler_job_event_insert($normalizedJobKey, 'manual_retry_requested', ['actor' => 'operator'], 0, null);
-        db_scheduler_tuning_action_log($normalizedJobKey, 'admin', 'manual_retry', 'Cleared scheduler quarantine state and re-queued the job.', [], ['current_state' => 'waiting'], ['source' => 'settings']);
-        db_scheduler_job_current_status_upsert($normalizedJobKey, [
-            'latest_status' => 'queued',
-            'latest_event_type' => 'manual_retry_requested',
-            'last_failure_message' => null,
-            'current_pressure_state' => 'healthy',
-            'last_pressure_state' => 'healthy',
-            'recent_timeout_count' => 0,
-            'recent_lock_conflict_count' => 0,
-            'recent_deferral_count' => 0,
-            'recent_skip_count' => 0,
-            'last_event_at' => $timestamp,
-        ]);
-    }
-
-    return $queued;
+    return run_data_sync_now(trim($jobKey));
 }
 
 function stop_data_sync_job_for_investigation(string $jobKey): array
@@ -2538,7 +2547,7 @@ function stop_data_sync_job_for_investigation(string $jobKey): array
         ];
     }
 
-    $reason = 'Stopped by operator for investigation. Use Retry now after resolving the issue.';
+    $reason = 'Stopped by operator for investigation. Use Start now after resolving the issue.';
     if (!db_sync_schedule_stop_for_investigation_by_job_key($normalizedJobKey, $reason)) {
         return [
             'ok' => false,
@@ -2566,7 +2575,7 @@ function stop_data_sync_job_for_investigation(string $jobKey): array
 
     return [
         'ok' => true,
-        'message' => $jobLabel . ' is now stopped for investigation. Retry it from the job card after you resolve the issue.',
+        'message' => $jobLabel . ' is now stopped for investigation. Use Start now from the job card after you resolve the issue.',
     ];
 }
 


### PR DESCRIPTION
### Motivation

- Operators expect a manual "Start now" action to take effect immediately and clear any stopped/investigation state so work can begin without waiting for cron. 
- The scheduler had an older path that left stopped metadata in place and relied on cron or passive retries, causing confusion when starting jobs manually.

### Description

- Added `scheduler_mark_manual_job_start_requested()` to record a manual start event, log a tuning action, and upsert a queued status into `scheduler_job_current_status` so the status projection reflects an immediate start request. 
- Enhanced `run_data_sync_now()` to reset per-job scheduler state for a targeted job, force schedules (`db_sync_schedule_force_due_*`), attempt to wake a healthy daemon (`db_scheduler_daemon_request_wake`), request watchdog-triggered daemon start (`scheduler_watchdog_start_daemon`) before falling back to inline `cron_tick_run()`, and to use the new manual-start marker for single-job starts. 
- Updated `db_sync_schedule_retry_by_job_key()` to clear stale stopped metadata in `sync_schedules` for retries by setting `last_status`/`last_result` to `queued`, clearing `last_error`, and zeroing failure/degraded counters so a restarted schedule is clean. 
- Updated the settings UI to relabel the per-job stopped action from "Retry now" to "Start now", adjusted flash copy, and changed stop-for-investigation messaging to instruct operators to use "Start now" after investigation. 

### Testing

- Ran PHP linting on modified files with `php -l src/functions.php`, `php -l src/db.php`, and `php -l public/settings/index.php`, and all reported no syntax errors. 
- Verified repository diff checks with `git diff --check` which produced no warnings.
- Performed local file validations and quick code inspection for the changed SQL and function calls (no automated unit tests existed for these paths in the repository).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff570b7c4832f9b16d8f80cc384d9)