### PR TITLE
Fix killmail ingestion toggle persistence

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -76,7 +76,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             );
 
             $saved = save_settings([
-                'killmail_ingestion_enabled' => isset($_POST['killmail_ingestion_enabled']) ? '1' : '0',
+                'killmail_ingestion_enabled' => sanitize_enabled_flag($_POST['killmail_ingestion_enabled'] ?? null),
                 'killmail_ingestion_poll_sleep_seconds' => (string) max(6, min(300, (int) ($_POST['killmail_ingestion_poll_sleep_seconds'] ?? 6))),
                 'killmail_ingestion_max_sequences_per_run' => (string) max(1, min(5000, (int) ($_POST['killmail_ingestion_max_sequences_per_run'] ?? 120))),
                 'killmail_demand_prediction_mode' => trim((string) ($_POST['killmail_demand_prediction_mode'] ?? 'baseline')),


### PR DESCRIPTION
### Motivation
- The Killmail Intelligence ingest checkbox could not be turned off because the POST handler used `isset($_POST['killmail_ingestion_enabled']) ? '1' : '0'`, which interacted poorly with the hidden fallback field and caused the setting to be re-saved as enabled.

### Description
- Normalize the saved value by replacing the `isset(...)` expression with `sanitize_enabled_flag($_POST['killmail_ingestion_enabled'] ?? null)` in the Killmail Intelligence settings save flow so the persisted `killmail_ingestion_enabled` reflects the actual checkbox state.

### Testing
- Ran `php -l public/settings/index.php` and `php -l src/functions.php`, both reporting no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff96cfcbc832f8cbee6ebc0afcec5)