### PR TITLE
Prevent killmail schema migration during stream transactions

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -15433,6 +15433,9 @@ function sync_killmail_r2z2_stream(string $runMode = 'incremental'): array
     $runId = db_sync_run_start($datasetKey, $runMode, db_sync_cursor_get($datasetKey));
 
     try {
+        // Ensure any one-time killmail schema migrations run before per-row write transactions begin.
+        db_killmail_payload_schema_ensure();
+
         $trackedAllianceRows = db_killmail_tracked_alliances_active();
         $trackedCorporationRows = db_killmail_tracked_corporations_active();
         $trackedAllianceIds = [];


### PR DESCRIPTION
### Motivation
- Avoid implicit-commit failures where one-time killmail schema DDL runs inside per-row transactional callbacks and causes errors like "The active database transaction ended before db_transaction() could commit."

### Description
- Ensure `db_killmail_payload_schema_ensure()` is invoked at the start of `sync_killmail_r2z2_stream()` so any one-time killmail schema migrations run before the stream begins per-row transactional writes.

### Testing
- Ran `php -l src/functions.php` to verify PHP syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bffaeb7a44832fb19af9733cacbef4)