### PR TITLE
Add scheduler memory guards, DB streaming, and Python worker plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 - Clean recycle exits are now also **self-respawning**. If the daemon exits because of a memory recycle threshold, loop ceiling, runtime ceiling, or an explicit restart request, it immediately spawns a replacement process before relying on cron/systemd. This prevents the “stopped after recycle” gap you were seeing when the external supervisor did not relaunch it quickly enough.
 - `bin/scheduler_health.php` prints the daemon health JSON and exits non-zero when the daemon is degraded or stopped, which makes it suitable for `systemd` health probes or manual checks.
 - The continuous daemon still reuses the existing scheduler intelligence: it claims due jobs from `sync_schedules`, preserves priority/fairness/latest-allowed-start behavior, keeps protected-job and incompatibility rules, uses the same resource-aware concurrency planner, and still dispatches async-capable AI jobs to `bin/scheduler_job_runner.php` background workers so long-polling providers do not block the rest of the queue.
+- Each schedule row now carries an explicit `execution_mode` (`php` or `python`). Lightweight control-plane jobs stay in PHP, while heavy market aggregation, snapshot-generation, history rebuild, and killmail workloads can be routed to the Python `python_worker` runner without changing scheduler cadence or lock semantics.
 - The daemon does not busy-spin. When nothing is due it can now opportunistically claim a single **idle backfill** job (for example dashboard/summary warmers that are explicitly marked backfill-safe) so the app keeps refreshing useful derived data while otherwise idle. If no due or backfill-safe work is runnable, it sleeps until the earliest of the next due timestamp, a short fallback poll interval, or a wake signal recorded by the watchdog/background workers after completions.
 - Scheduler cadence controls in **Settings → Data Sync** are intentionally simplified to one selector:
   - **Low**: conservative cadence, lower concurrency, wider poll intervals, and more headroom for smaller VPS/container deployments.
@@ -258,6 +259,7 @@ SupplyCore sync pipelines depend on the `cron` daemon being present and running 
 - The optimizer changes one thing at a time with cooldowns: it first shifts congested offsets, then raises timeouts when repeated timeout pressure is observed, then adjusts intervals while protecting the freshness ceilings for `killmail_r2z2_sync` and `market_hub_current_sync`. Every automatic or admin change is written to `scheduler_tuning_actions`, while lock conflicts, skips, dispatches, and timeout pressure are written to `scheduler_job_events`.
 - Resource-aware concurrency now extends that scheduler baseline instead of replacing it: every completed job records per-run CPU, wall time, queue delay, approximate lock handoff delay, overlap count, and process memory high-water marks in `scheduler_job_resource_metrics`, while planner allow/defer/promote decisions are persisted in `scheduler_planner_decisions`.
 - CPU telemetry is derived from PHP process user+system CPU time (`getrusage()`) divided by wall-clock seconds, so the recorded percentage represents how much of one CPU core the job consumed on average during the run. Memory telemetry uses PHP's process memory usage and peak high-water mark (`memory_get_usage(true)` / `memory_get_peak_usage(true)`), with the stored run cost preferring the peak delta observed while the job was executing.
+- Scheduler-run PHP entrypoints now enforce `memory_limit=512M`, log current and peak memory usage in scheduler events/resource metrics, and abort a job if runtime memory crosses 400 MiB or the resolved timeout is exceeded.
 - The planner learns a rolling light/medium/heavy class for each job from recent CPU, memory, duration, timeout/failure, and lock-wait behavior. Unknown jobs stay in learning mode and are projected conservatively until enough telemetry samples accumulate.
 - Capacity decisions combine current running-job projections, per-job p95 resource costs, fairness/urgency toward `latest_allowed_start_at`, explicit incompatibility rules, reserved headroom for critical jobs, and the pressure states `healthy`, `busy`, `congested`, and `overload_protection`.
 - Lease recovery and stale-state cleanup now happen during daemon startup and watchdog intervention. The daemon clears expired/stale running markers, updates the last recovery event in `scheduler_daemon_state`, and resumes scheduling without waiting for the next cron minute.
@@ -310,6 +312,7 @@ python/
     __main__.py          # python -m orchestrator
     config.py            # loads PHP-exported runtime config JSON
     health.py            # scheduler health probe wrapper
+    job_runner.py        # python_worker skeleton for heavy scheduler jobs
     logging_utils.py     # journald-friendly JSON logs
     main.py              # CLI entrypoint
     php_runner.py        # supervised PHP child process runner
@@ -323,7 +326,7 @@ python/
 - `systemd` runs the Python orchestrator.
 - Python launches `bin/scheduler_daemon.php` as a child process.
 - Python captures stdout/stderr, polls `bin/scheduler_health.php`, enforces graceful stop/kill behavior, writes a heartbeat file, and restarts the PHP daemon after crashes or repeated health failures.
-- PHP background workers remain PHP-owned, preserving scheduler/business logic.
+- PHP remains the default execution engine, but heavy jobs can now be routed to a dedicated Python `python_worker` skeleton through the per-job `execution_mode` flag.
 
 **Phase 2: optional later**
 
@@ -335,6 +338,7 @@ python/
 - `bin/orchestrator_config.php` — export resolved runtime config as JSON.
 - `bin/scheduler_daemon.php` — primary managed PHP child process.
 - `bin/scheduler_health.php` — health/heartbeat probe used by Python.
+- `bin/python_job_runner.py` — bootstrap the Python `python_worker` runner for heavy `execution_mode=python` jobs.
 - `bin/scheduler_watchdog.php` / `bin/cron_tick.php` — still available during transition, but when `scheduler.supervisor_mode=python` they target the Python-managed service instead of spawning a standalone PHP daemon directly.
 
 #### Duplicate-master safety
@@ -373,6 +377,7 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
+MemoryMax=1G
 StandardOutput=append:/var/www/SupplyCore/storage/logs/cron.log
 StandardError=append:/var/www/SupplyCore/storage/logs/cron.log
 

--- a/bin/python_job_runner.py
+++ b/bin/python_job_runner.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    python_root = repo_root / "python"
+    if str(python_root) not in sys.path:
+        sys.path.insert(0, str(python_root))
+
+    from orchestrator.job_runner import main as job_runner_main
+
+    return job_runner_main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/scheduler_daemon.php
+++ b/bin/scheduler_daemon.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../src/bootstrap.php';
 
+scheduler_enforce_php_runtime_limits();
+
 try {
     exit(scheduler_daemon_run('scheduler_daemon_output'));
 } catch (Throwable $exception) {

--- a/bin/scheduler_job_runner.php
+++ b/bin/scheduler_job_runner.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../src/bootstrap.php';
 
+scheduler_enforce_php_runtime_limits();
+
 function scheduler_job_runner_output(string $event, array $payload = [], $stream = STDOUT): void
 {
     $line = ['event' => $event, 'ts' => gmdate(DATE_ATOM)] + $payload;
@@ -31,7 +33,7 @@ function scheduler_job_runner_main(): int
     }
 
     $jobKey = trim((string) ($job['job_key'] ?? 'unknown_job'));
-    $jobType = scheduler_job_type($jobKey);
+    $jobType = scheduler_job_runtime_type($job);
     $status = trim((string) ($job['last_status'] ?? ''));
     $lockedUntil = trim((string) ($job['locked_until'] ?? ''));
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -143,6 +143,7 @@ CREATE TABLE IF NOT EXISTS sync_schedules (
     backfill_priority VARCHAR(20) NOT NULL DEFAULT 'normal',
     min_backfill_gap_seconds INT UNSIGNED NOT NULL DEFAULT 900,
     max_early_start_seconds INT UNSIGNED NOT NULL DEFAULT 0,
+    execution_mode VARCHAR(16) NOT NULL DEFAULT 'php',
     last_execution_mode VARCHAR(32) NOT NULL DEFAULT 'scheduled',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -540,10 +541,30 @@ PREPARE sync_schedules_timeout_count_stmt FROM @sync_schedules_timeout_count_sql
 EXECUTE sync_schedules_timeout_count_stmt;
 DEALLOCATE PREPARE sync_schedules_timeout_count_stmt;
 
+SET @sync_schedules_execution_mode_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'sync_schedules'
+      AND COLUMN_NAME = 'execution_mode'
+);
+SET @sync_schedules_execution_mode_sql := IF(
+    @sync_schedules_execution_mode_exists = 0,
+    'ALTER TABLE sync_schedules ADD COLUMN execution_mode VARCHAR(16) NOT NULL DEFAULT ''php'' AFTER max_early_start_seconds',
+    'SELECT 1'
+);
+PREPARE sync_schedules_execution_mode_stmt FROM @sync_schedules_execution_mode_sql;
+EXECUTE sync_schedules_execution_mode_stmt;
+DEALLOCATE PREPARE sync_schedules_execution_mode_stmt;
+
 UPDATE sync_schedules
 SET interval_minutes = GREATEST(1, CEIL(interval_seconds / 60)),
     offset_minutes = FLOOR(offset_seconds / 60),
     next_due_at = COALESCE(next_due_at, next_run_at),
+    execution_mode = CASE
+        WHEN LOWER(COALESCE(NULLIF(execution_mode, ''), 'php')) = 'python' THEN 'python'
+        ELSE 'php'
+    END,
     current_state = CASE
         WHEN enabled = 0 THEN 'stopped'
         WHEN locked_until IS NOT NULL AND locked_until > UTC_TIMESTAMP() THEN 'running'
@@ -2102,6 +2123,7 @@ INSERT INTO sync_schedules (
     offset_minutes,
     priority,
     concurrency_policy,
+    execution_mode,
     timeout_seconds,
     next_run_at,
     next_due_at,
@@ -2114,23 +2136,23 @@ INSERT INTO sync_schedules (
     last_error,
     locked_until
 ) VALUES
-    ('market_hub_current_sync', 1, 8, 480, 0, 0, 'high', 'single', 240, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('alliance_current_sync', 1, 4, 240, 120, 2, 'medium', 'single', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('current_state_refresh_sync', 1, 12, 720, 360, 6, 'medium', 'single', 120, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('market_hub_local_history_sync', 1, 20, 1200, 840, 14, 'normal', 'background', 1800, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('doctrine_intelligence_sync', 1, 15, 900, 480, 8, 'normal', 'single', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('market_comparison_summary_sync', 1, 15, 900, 540, 9, 'normal', 'single', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('loss_demand_summary_sync', 1, 15, 900, 600, 10, 'normal', 'single', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('dashboard_summary_sync', 1, 15, 900, 660, 11, 'normal', 'single', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('rebuild_ai_briefings', 1, 20, 1200, 720, 12, 'normal', 'background', 300, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('killmail_r2z2_sync', 1, 3, 180, 180, 3, 'highest', 'single', 90, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('alliance_historical_sync', 1, 360, 21600, 300, 5, 'normal', 'background', 3600, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('market_hub_historical_sync', 1, 360, 21600, 0, 0, 'normal', 'background', 3600, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('forecasting_ai_sync', 1, 60, 3600, 0, 0, 'normal', 'background', 300, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('deal_alerts_sync', 1, 5, 300, 60, 1, 'high', 'single', 90, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('activity_priority_summary_sync', 1, 15, 900, 780, 13, 'normal', 'single', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 0, NULL, NULL, NULL, NULL),
-    ('analytics_bucket_1h_sync', 1, 15, 900, 900, 15, 'normal', 'single', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 0, NULL, NULL, NULL, NULL),
-    ('analytics_bucket_1d_sync', 1, 60, 3600, 960, 16, 'normal', 'single', 240, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 0, NULL, NULL, NULL, NULL)
+    ('market_hub_current_sync', 1, 8, 480, 0, 0, 'high', 'single', 'php', 240, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('alliance_current_sync', 1, 4, 240, 120, 2, 'medium', 'single', 'php', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('current_state_refresh_sync', 1, 12, 720, 360, 6, 'medium', 'single', 'php', 120, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('market_hub_local_history_sync', 1, 20, 1200, 840, 14, 'normal', 'background', 'php', 1800, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('doctrine_intelligence_sync', 1, 15, 900, 480, 8, 'normal', 'single', 'php', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('market_comparison_summary_sync', 1, 15, 900, 540, 9, 'normal', 'single', 'php', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('loss_demand_summary_sync', 1, 15, 900, 600, 10, 'normal', 'single', 'php', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('dashboard_summary_sync', 1, 15, 900, 660, 11, 'normal', 'single', 'php', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('rebuild_ai_briefings', 1, 20, 1200, 720, 12, 'normal', 'background', 'php', 300, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('killmail_r2z2_sync', 1, 3, 180, 180, 3, 'highest', 'single', 'php', 90, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('alliance_historical_sync', 1, 360, 21600, 300, 5, 'normal', 'background', 'php', 3600, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('market_hub_historical_sync', 1, 360, 21600, 0, 0, 'normal', 'background', 'php', 3600, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('forecasting_ai_sync', 1, 60, 3600, 0, 0, 'normal', 'background', 'php', 300, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('deal_alerts_sync', 1, 5, 300, 60, 1, 'high', 'single', 'php', 90, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('activity_priority_summary_sync', 1, 15, 900, 780, 13, 'normal', 'single', 'php', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 0, NULL, NULL, NULL, NULL),
+    ('analytics_bucket_1h_sync', 1, 15, 900, 900, 15, 'normal', 'single', 'php', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 0, NULL, NULL, NULL, NULL),
+    ('analytics_bucket_1d_sync', 1, 60, 3600, 960, 16, 'normal', 'single', 'php', 240, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 0, NULL, NULL, NULL, NULL)
 ON DUPLICATE KEY UPDATE
     enabled = VALUES(enabled),
     interval_minutes = VALUES(interval_minutes),
@@ -2139,6 +2161,7 @@ ON DUPLICATE KEY UPDATE
     offset_minutes = VALUES(offset_minutes),
     priority = VALUES(priority),
     concurrency_policy = VALUES(concurrency_policy),
+    execution_mode = VALUES(execution_mode),
     timeout_seconds = VALUES(timeout_seconds),
     next_due_at = COALESCE(sync_schedules.next_due_at, VALUES(next_due_at)),
     discovered_from_code = VALUES(discovered_from_code),

--- a/ops/systemd/supplycore-orchestrator.env.example
+++ b/ops/systemd/supplycore-orchestrator.env.example
@@ -4,6 +4,8 @@ APP_TIMEZONE=UTC
 SCHEDULER_SUPERVISOR_MODE=python
 # Optional: pin the PHP CLI binary used by the orchestrator bridge if `php` is not PHP 8+.
 # SUPPLYCORE_PHP_BINARY=/usr/bin/php8.3
+# Optional: pin the Python binary used for python_worker background jobs.
+# SUPPLYCORE_PYTHON_BINARY=/var/www/SupplyCore/.venv-orchestrator/bin/python
 ORCHESTRATOR_HEALTH_CHECK_INTERVAL_SECONDS=15
 ORCHESTRATOR_WORKER_GRACE_SECONDS=45
 ORCHESTRATOR_WORKER_START_BACKOFF_SECONDS=5

--- a/ops/systemd/supplycore-orchestrator.service
+++ b/ops/systemd/supplycore-orchestrator.service
@@ -16,6 +16,7 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
+MemoryMax=1G
 StandardOutput=append:/var/www/SupplyCore/storage/logs/cron.log
 StandardError=append:/var/www/SupplyCore/storage/logs/cron.log
 

--- a/python/orchestrator/job_runner.py
+++ b/python/orchestrator/job_runner.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .config import load_php_runtime_config
+
+
+@dataclass(slots=True)
+class PythonWorkerContext:
+    schedule_id: int
+    app_root: Path
+    raw_config: dict[str, Any]
+
+    @property
+    def db_config(self) -> dict[str, Any]:
+        return dict(self.raw_config.get("db", {}))
+
+    @property
+    def scheduler_config(self) -> dict[str, Any]:
+        return dict(self.raw_config.get("scheduler", {}))
+
+    @property
+    def batch_size(self) -> int:
+        return 1_000
+
+    @property
+    def timeout_seconds(self) -> int:
+        return int(self.scheduler_config.get("default_timeout_seconds", 300))
+
+    @property
+    def memory_abort_threshold_bytes(self) -> int:
+        return int(self.scheduler_config.get("memory_abort_threshold_bytes", 400 * 1024 * 1024))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a SupplyCore scheduler job in Python worker mode.")
+    parser.add_argument("--schedule-id", type=int, required=True, help="Claimed sync_schedules.id to execute.")
+    parser.add_argument(
+        "--app-root",
+        default=str(Path(__file__).resolve().parents[2]),
+        help="Path to the SupplyCore repository/app root.",
+    )
+    return parser.parse_args()
+
+
+def emit(event: str, payload: dict[str, Any]) -> None:
+    print(json.dumps({"event": event, "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), **payload}))
+
+
+def process_job(context: PythonWorkerContext) -> dict[str, Any]:
+    start = time.time()
+    emit(
+        "python_worker.started",
+        {
+            "schedule_id": context.schedule_id,
+            "batch_size": context.batch_size,
+            "timeout_seconds": context.timeout_seconds,
+            "memory_abort_threshold_bytes": context.memory_abort_threshold_bytes,
+            "db_host": context.db_config.get("host"),
+            "db_port": context.db_config.get("port"),
+            "db_database": context.db_config.get("database"),
+        },
+    )
+
+    # Skeleton only: this worker intentionally does not implement concrete heavy-job processors yet.
+    # The scheduler execution_mode flag can be set to python now, and processors can be added incrementally
+    # around this stable contract without further scheduler/plumbing changes.
+    duration_ms = int((time.time() - start) * 1000)
+    return {
+        "status": "skipped",
+        "summary": "Python worker skeleton initialized successfully; no concrete job processor is registered yet.",
+        "duration_ms": duration_ms,
+        "rows_seen": 0,
+        "rows_written": 0,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    app_root = Path(args.app_root).resolve()
+    config = load_php_runtime_config(app_root)
+    context = PythonWorkerContext(schedule_id=max(0, args.schedule_id), app_root=app_root, raw_config=config.raw)
+
+    if context.schedule_id <= 0:
+        emit("python_worker.error", {"error": "Argument --schedule-id must be a positive integer."})
+        return 1
+
+    os.environ.setdefault("APP_ENV", str(config.raw.get("app", {}).get("env", "development")))
+    os.environ.setdefault("APP_TIMEZONE", str(config.raw.get("app", {}).get("timezone", "UTC")))
+
+    result = process_job(context)
+    emit("python_worker.finished", {"schedule_id": context.schedule_id, **result})
+    return 0 if result.get("status") != "failed" else 1

--- a/src/db.php
+++ b/src/db.php
@@ -165,6 +165,62 @@ function db_select(string $sql, array $params = []): array
     return $stmt->fetchAll();
 }
 
+function db_select_stream(string $sql, array $params, callable $callback): int
+{
+    $driverOptions = [];
+    if (defined('PDO::MYSQL_ATTR_USE_BUFFERED_QUERY')) {
+        $driverOptions[PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = false;
+    }
+
+    $stmt = db()->prepare($sql, $driverOptions);
+    $stmt->execute($params);
+    $stmt->setFetchMode(PDO::FETCH_ASSOC);
+
+    $rowCount = 0;
+
+    try {
+        while (($row = $stmt->fetch()) !== false) {
+            $rowCount++;
+            $callback($row, $rowCount);
+        }
+    } finally {
+        $stmt->closeCursor();
+    }
+
+    return $rowCount;
+}
+
+function db_select_stream_batches(string $sql, array $params, callable $callback, ?int $batchSize = null): int
+{
+    $limit = $batchSize ?? db_incremental_chunk_size();
+    $limit = max(1, $limit);
+    $batch = [];
+    $rowCount = 0;
+
+    db_select_stream($sql, $params, static function (array $row) use (&$batch, $limit, $callback, &$rowCount): void {
+        $batch[] = $row;
+        $rowCount++;
+
+        if (count($batch) < $limit) {
+            return;
+        }
+
+        $callback($batch, $rowCount);
+        $batch = [];
+    });
+
+    if ($batch !== []) {
+        $callback($batch, $rowCount);
+    }
+
+    unset($batch);
+    if (function_exists('gc_collect_cycles')) {
+        gc_collect_cycles();
+    }
+
+    return $rowCount;
+}
+
 function db_select_one(string $sql, array $params = []): ?array
 {
     $stmt = db()->prepare($sql);
@@ -6343,6 +6399,7 @@ function db_sync_schedule_registry_columns_ensure(): void
     db_ensure_table_column('sync_schedules', 'backfill_priority', "VARCHAR(20) NOT NULL DEFAULT 'normal'");
     db_ensure_table_column('sync_schedules', 'min_backfill_gap_seconds', 'INT UNSIGNED NOT NULL DEFAULT 900');
     db_ensure_table_column('sync_schedules', 'max_early_start_seconds', 'INT UNSIGNED NOT NULL DEFAULT 0');
+    db_ensure_table_column('sync_schedules', 'execution_mode', "VARCHAR(16) NOT NULL DEFAULT 'php'");
     db_ensure_table_column('sync_schedules', 'last_execution_mode', "VARCHAR(32) NOT NULL DEFAULT 'scheduled'");
 
     db_execute(
@@ -6356,6 +6413,10 @@ function db_sync_schedule_registry_columns_ensure(): void
              latest_allowed_start_at = COALESCE(latest_allowed_start_at, DATE_ADD(COALESCE(next_due_at, next_run_at, UTC_TIMESTAMP()), INTERVAL GREATEST(1, interval_minutes) MINUTE)),
              resource_class = COALESCE(NULLIF(resource_class, ''), 'learning'),
              current_pressure_state = COALESCE(NULLIF(current_pressure_state, ''), 'healthy'),
+             execution_mode = CASE
+                WHEN LOWER(COALESCE(NULLIF(execution_mode, ''), 'php')) = 'python' THEN 'python'
+                ELSE 'php'
+             END,
              allow_parallel = IFNULL(allow_parallel, 1),
              prefers_solo = IFNULL(prefers_solo, 0),
              must_run_alone = IFNULL(must_run_alone, 0),
@@ -6381,7 +6442,7 @@ function db_sync_schedule_select_columns_sql(): string
 {
     db_sync_schedule_registry_columns_ensure();
 
-    return 'id, job_key, enabled, interval_minutes, interval_seconds, offset_seconds, offset_minutes, priority, concurrency_policy, timeout_seconds, next_run_at, next_due_at, latest_allowed_start_at, last_run_at, last_started_at, last_finished_at, latency_sensitive, user_facing, consecutive_deferrals, last_duration_seconds, average_duration_seconds, p95_duration_seconds, last_status, last_result, last_error, current_state, tuning_mode, discovered_from_code, explicitly_configured, last_auto_tuned_at, last_auto_tune_reason, degraded_until, failure_streak, lock_conflict_count, timeout_count, resource_class, resource_class_confidence, telemetry_sample_count, learning_mode, allow_parallel, prefers_solo, must_run_alone, preferred_max_parallelism, last_cpu_percent, average_cpu_percent, p95_cpu_percent, last_memory_peak_bytes, average_memory_peak_bytes, p95_memory_peak_bytes, last_queue_wait_seconds, last_lock_wait_seconds, average_lock_wait_seconds, last_overlap_count, last_overlapped, recent_timeout_rate, recent_failure_rate, current_projected_cpu_percent, current_projected_memory_bytes, current_pressure_state, last_capacity_reason, allow_backfill, backfill_priority, min_backfill_gap_seconds, max_early_start_seconds, last_execution_mode, locked_until, created_at, updated_at';
+    return 'id, job_key, enabled, interval_minutes, interval_seconds, offset_seconds, offset_minutes, priority, concurrency_policy, timeout_seconds, next_run_at, next_due_at, latest_allowed_start_at, last_run_at, last_started_at, last_finished_at, latency_sensitive, user_facing, consecutive_deferrals, last_duration_seconds, average_duration_seconds, p95_duration_seconds, last_status, last_result, last_error, current_state, tuning_mode, discovered_from_code, explicitly_configured, last_auto_tuned_at, last_auto_tune_reason, degraded_until, failure_streak, lock_conflict_count, timeout_count, resource_class, resource_class_confidence, telemetry_sample_count, learning_mode, allow_parallel, prefers_solo, must_run_alone, preferred_max_parallelism, last_cpu_percent, average_cpu_percent, p95_cpu_percent, last_memory_peak_bytes, average_memory_peak_bytes, p95_memory_peak_bytes, last_queue_wait_seconds, last_lock_wait_seconds, average_lock_wait_seconds, last_overlap_count, last_overlapped, recent_timeout_rate, recent_failure_rate, current_projected_cpu_percent, current_projected_memory_bytes, current_pressure_state, last_capacity_reason, allow_backfill, backfill_priority, min_backfill_gap_seconds, max_early_start_seconds, execution_mode, last_execution_mode, locked_until, created_at, updated_at';
 }
 
 function db_sync_schedule_priority_rank_sql(string $column = 'priority'): string
@@ -6877,6 +6938,7 @@ function db_sync_schedule_ensure_job(string $jobKey, int $enabled, int $interval
     $maxEarlyStartSeconds = max(0, min(86400, (int) ($options['max_early_start_seconds'] ?? 0)));
     $latencySensitive = !empty($options['latency_sensitive']) ? 1 : 0;
     $userFacing = !empty($options['user_facing']) ? 1 : 0;
+    $executionMode = strtolower(trim((string) ($options['execution_mode'] ?? 'php'))) === 'python' ? 'python' : 'php';
     $tuningMode = ($options['tuning_mode'] ?? 'automatic') === 'manual' ? 'manual' : 'automatic';
     $discoveredFromCode = !empty($options['discovered_from_code']) ? 1 : 0;
     $explicitlyConfigured = array_key_exists('explicitly_configured', $options) && !$options['explicitly_configured'] ? 0 : 1;
@@ -6900,6 +6962,7 @@ function db_sync_schedule_ensure_job(string $jobKey, int $enabled, int $interval
             max_early_start_seconds,
             latency_sensitive,
             user_facing,
+            execution_mode,
             next_run_at,
             next_due_at,
             current_state,
@@ -6911,7 +6974,7 @@ function db_sync_schedule_ensure_job(string $jobKey, int $enabled, int $interval
             last_error,
             locked_until
          ) VALUES (
-            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL
          )
          ON DUPLICATE KEY UPDATE
             enabled = sync_schedules.enabled,
@@ -6930,6 +6993,7 @@ function db_sync_schedule_ensure_job(string $jobKey, int $enabled, int $interval
             max_early_start_seconds = COALESCE(sync_schedules.max_early_start_seconds, VALUES(max_early_start_seconds)),
             latency_sensitive = GREATEST(sync_schedules.latency_sensitive, VALUES(latency_sensitive)),
             user_facing = GREATEST(sync_schedules.user_facing, VALUES(user_facing)),
+            execution_mode = COALESCE(NULLIF(sync_schedules.execution_mode, \'\'), VALUES(execution_mode)),
             tuning_mode = COALESCE(sync_schedules.tuning_mode, VALUES(tuning_mode)),
             next_run_at = CASE
                 WHEN sync_schedules.enabled = 1 AND sync_schedules.next_run_at IS NULL THEN VALUES(next_run_at)
@@ -6945,7 +7009,7 @@ function db_sync_schedule_ensure_job(string $jobKey, int $enabled, int $interval
                 ELSE VALUES(current_state)
             END,
             updated_at = CURRENT_TIMESTAMP',
-        [$normalizedKey, $enabled, $intervalMinutes, $safeIntervalSeconds, $safeOffsetSeconds, $offsetMinutes, $priority, $concurrencyPolicy, $timeoutSeconds, $allowBackfill, $backfillPriority, $minBackfillGapSeconds, $maxEarlyStartSeconds, $latencySensitive, $userFacing, $nextDueAt, $nextDueAt, $currentState, $tuningMode, $discoveredFromCode, $explicitlyConfigured]
+        [$normalizedKey, $enabled, $intervalMinutes, $safeIntervalSeconds, $safeOffsetSeconds, $offsetMinutes, $priority, $concurrencyPolicy, $timeoutSeconds, $allowBackfill, $backfillPriority, $minBackfillGapSeconds, $maxEarlyStartSeconds, $latencySensitive, $userFacing, $executionMode, $nextDueAt, $nextDueAt, $currentState, $tuningMode, $discoveredFromCode, $explicitlyConfigured]
     );
 }
 
@@ -6959,7 +7023,7 @@ function db_sync_schedule_upsert(string $jobKey, int $enabled, int $intervalSeco
     }
 
     $existing = db_select_one(
-        'SELECT offset_minutes, priority, concurrency_policy, timeout_seconds, tuning_mode, discovered_from_code, explicitly_configured, allow_backfill, backfill_priority, min_backfill_gap_seconds, max_early_start_seconds, latency_sensitive, user_facing
+        'SELECT offset_minutes, priority, concurrency_policy, timeout_seconds, tuning_mode, discovered_from_code, explicitly_configured, allow_backfill, backfill_priority, min_backfill_gap_seconds, max_early_start_seconds, latency_sensitive, user_facing, execution_mode
          FROM sync_schedules
          WHERE job_key = ?
          LIMIT 1',
@@ -6980,6 +7044,7 @@ function db_sync_schedule_upsert(string $jobKey, int $enabled, int $intervalSeco
     $maxEarlyStartSeconds = max(0, min(86400, (int) ($options['max_early_start_seconds'] ?? ($existing['max_early_start_seconds'] ?? 0))));
     $latencySensitive = !empty($options['latency_sensitive'] ?? $existing['latency_sensitive'] ?? 0) ? 1 : 0;
     $userFacing = !empty($options['user_facing'] ?? $existing['user_facing'] ?? 0) ? 1 : 0;
+    $executionMode = strtolower(trim((string) ($options['execution_mode'] ?? ($existing['execution_mode'] ?? 'php')))) === 'python' ? 'python' : 'php';
     $tuningMode = ($options['tuning_mode'] ?? ($existing['tuning_mode'] ?? 'automatic')) === 'manual' ? 'manual' : 'automatic';
     $discoveredFromCode = !empty($options['discovered_from_code'] ?? $existing['discovered_from_code'] ?? 0) ? 1 : 0;
     $explicitlyConfigured = array_key_exists('explicitly_configured', $options)
@@ -7005,6 +7070,7 @@ function db_sync_schedule_upsert(string $jobKey, int $enabled, int $intervalSeco
             max_early_start_seconds,
             latency_sensitive,
             user_facing,
+            execution_mode,
             next_run_at,
             next_due_at,
             current_state,
@@ -7016,7 +7082,7 @@ function db_sync_schedule_upsert(string $jobKey, int $enabled, int $intervalSeco
             last_error,
             locked_until
          ) VALUES (
-            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL
          )
          ON DUPLICATE KEY UPDATE
             enabled = VALUES(enabled),
@@ -7033,6 +7099,7 @@ function db_sync_schedule_upsert(string $jobKey, int $enabled, int $intervalSeco
             max_early_start_seconds = VALUES(max_early_start_seconds),
             latency_sensitive = VALUES(latency_sensitive),
             user_facing = VALUES(user_facing),
+            execution_mode = VALUES(execution_mode),
             tuning_mode = VALUES(tuning_mode),
             discovered_from_code = VALUES(discovered_from_code),
             explicitly_configured = VALUES(explicitly_configured),
@@ -7045,7 +7112,7 @@ function db_sync_schedule_upsert(string $jobKey, int $enabled, int $intervalSeco
             END,
             locked_until = CASE WHEN VALUES(enabled) = 1 THEN sync_schedules.locked_until ELSE NULL END,
             updated_at = CURRENT_TIMESTAMP',
-        [$normalizedKey, $enabled, $intervalMinutes, $safeIntervalSeconds, $safeOffsetSeconds, $offsetMinutes, $priority, $concurrencyPolicy, $timeoutSeconds, $allowBackfill, $backfillPriority, $minBackfillGapSeconds, $maxEarlyStartSeconds, $latencySensitive, $userFacing, $nextDueAt, $nextDueAt, $currentState, $tuningMode, $discoveredFromCode, $explicitlyConfigured]
+        [$normalizedKey, $enabled, $intervalMinutes, $safeIntervalSeconds, $safeOffsetSeconds, $offsetMinutes, $priority, $concurrencyPolicy, $timeoutSeconds, $allowBackfill, $backfillPriority, $minBackfillGapSeconds, $maxEarlyStartSeconds, $latencySensitive, $userFacing, $executionMode, $nextDueAt, $nextDueAt, $currentState, $tuningMode, $discoveredFromCode, $explicitlyConfigured]
     );
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -3450,6 +3450,8 @@ function orchestrator_runtime_config_export(): array
             'lease_ttl_seconds' => scheduler_daemon_lease_ttl_seconds(),
             'watchdog_grace_seconds' => scheduler_daemon_watchdog_grace_seconds(),
             'default_timeout_seconds' => scheduler_global_timeout_default_seconds(),
+            'php_memory_limit' => scheduler_php_memory_limit(),
+            'memory_abort_threshold_bytes' => scheduler_memory_abort_threshold_bytes(),
             'daemon_poll_interval_seconds' => scheduler_daemon_poll_interval_seconds(),
             'daemon_running_poll_interval_seconds' => scheduler_daemon_running_poll_interval_seconds(),
             'daemon_max_runtime_seconds' => scheduler_daemon_max_runtime_seconds(),
@@ -3490,24 +3492,24 @@ function scheduler_tuning_mode_options(): array
 function scheduler_registry_definitions(): array
 {
     return [
-        'market_hub_current_sync' => ['label' => 'Market Hub Current', 'default_interval_minutes' => 8, 'default_offset_minutes' => 0, 'priority' => 'high', 'timeout_seconds' => 240, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'min_interval_minutes' => 1, 'max_interval_minutes' => 8],
-        'deal_alerts_sync' => ['label' => 'Deal Alerts', 'default_interval_minutes' => 5, 'default_offset_minutes' => 1, 'priority' => 'high', 'timeout_seconds' => 90, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'latency_sensitive' => true, 'user_facing' => true],
-        'alliance_current_sync' => ['label' => 'Alliance Current', 'default_interval_minutes' => 4, 'default_offset_minutes' => 2, 'priority' => 'medium', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => true],
-        'killmail_r2z2_sync' => ['label' => 'Killmail R2Z2 Stream', 'default_interval_minutes' => 3, 'default_offset_minutes' => 3, 'priority' => 'highest', 'timeout_seconds' => 90, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'min_interval_minutes' => 1, 'max_interval_minutes' => 3],
-        'configured_structure_destination_id_for_esi_sync' => ['label' => 'Configured Structure Destination for ESI', 'default_interval_minutes' => 30, 'default_offset_minutes' => 4, 'priority' => 'normal', 'timeout_seconds' => 120, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => false],
-        'current_state_refresh_sync' => ['label' => 'Current-State Refresh', 'default_interval_minutes' => 12, 'default_offset_minutes' => 6, 'priority' => 'medium', 'timeout_seconds' => 120, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => true],
-        'doctrine_intelligence_sync' => ['label' => 'Doctrine Intelligence', 'default_interval_minutes' => 15, 'default_offset_minutes' => 8, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'normal', 'min_backfill_gap_seconds' => 300, 'max_early_start_seconds' => 900],
-        'market_comparison_summary_sync' => ['label' => 'Market Comparison Summary', 'default_interval_minutes' => 15, 'default_offset_minutes' => 9, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'high', 'min_backfill_gap_seconds' => 300, 'max_early_start_seconds' => 900],
-        'loss_demand_summary_sync' => ['label' => 'Loss Demand Summary', 'default_interval_minutes' => 15, 'default_offset_minutes' => 10, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'high', 'min_backfill_gap_seconds' => 300, 'max_early_start_seconds' => 900],
-        'dashboard_summary_sync' => ['label' => 'Dashboard Summary', 'default_interval_minutes' => 15, 'default_offset_minutes' => 11, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'highest', 'min_backfill_gap_seconds' => 240, 'max_early_start_seconds' => 900],
-        'rebuild_ai_briefings' => ['label' => 'Rebuild AI Briefings', 'default_interval_minutes' => 20, 'default_offset_minutes' => 12, 'priority' => 'normal', 'timeout_seconds' => 300, 'concurrency_policy' => 'background', 'tuning_mode' => 'automatic', 'explicitly_configured' => true],
-        'activity_priority_summary_sync' => ['label' => 'Activity Priority Summary', 'default_interval_minutes' => 15, 'default_offset_minutes' => 13, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => false],
-        'market_hub_local_history_sync' => ['label' => 'Market Hub Local History', 'default_interval_minutes' => 20, 'default_offset_minutes' => 14, 'priority' => 'normal', 'timeout_seconds' => 1800, 'concurrency_policy' => 'background', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'normal', 'min_backfill_gap_seconds' => 900, 'max_early_start_seconds' => 900],
-        'analytics_bucket_1h_sync' => ['label' => 'Analytics Buckets (1h)', 'default_interval_minutes' => 15, 'default_offset_minutes' => 15, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => false, 'allow_backfill' => true, 'backfill_priority' => 'normal', 'min_backfill_gap_seconds' => 600, 'max_early_start_seconds' => 900],
-        'analytics_bucket_1d_sync' => ['label' => 'Analytics Buckets (1d)', 'default_interval_minutes' => 60, 'default_offset_minutes' => 16, 'priority' => 'normal', 'timeout_seconds' => 240, 'concurrency_policy' => 'single', 'tuning_mode' => 'automatic', 'explicitly_configured' => false],
-        'alliance_historical_sync' => ['label' => 'Alliance Historical', 'default_interval_minutes' => 360, 'default_offset_minutes' => 5, 'priority' => 'normal', 'timeout_seconds' => 3600, 'concurrency_policy' => 'background', 'tuning_mode' => 'automatic', 'explicitly_configured' => true],
-        'market_hub_historical_sync' => ['label' => 'Market Hub Historical', 'default_interval_minutes' => 360, 'default_offset_minutes' => 0, 'priority' => 'normal', 'timeout_seconds' => 3600, 'concurrency_policy' => 'background', 'tuning_mode' => 'automatic', 'explicitly_configured' => true],
-        'forecasting_ai_sync' => ['label' => 'Forecasting AI', 'default_interval_minutes' => 60, 'default_offset_minutes' => 0, 'priority' => 'normal', 'timeout_seconds' => 300, 'concurrency_policy' => 'background', 'tuning_mode' => 'automatic', 'explicitly_configured' => true],
+        'market_hub_current_sync' => ['label' => 'Market Hub Current', 'default_interval_minutes' => 8, 'default_offset_minutes' => 0, 'priority' => 'high', 'timeout_seconds' => 240, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'min_interval_minutes' => 1, 'max_interval_minutes' => 8, 'workload_class' => 'lightweight'],
+        'deal_alerts_sync' => ['label' => 'Deal Alerts', 'default_interval_minutes' => 5, 'default_offset_minutes' => 1, 'priority' => 'high', 'timeout_seconds' => 90, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'latency_sensitive' => true, 'user_facing' => true, 'workload_class' => 'lightweight'],
+        'alliance_current_sync' => ['label' => 'Alliance Current', 'default_interval_minutes' => 4, 'default_offset_minutes' => 2, 'priority' => 'medium', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'lightweight'],
+        'killmail_r2z2_sync' => ['label' => 'Killmail R2Z2 Stream', 'default_interval_minutes' => 3, 'default_offset_minutes' => 3, 'priority' => 'highest', 'timeout_seconds' => 90, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'min_interval_minutes' => 1, 'max_interval_minutes' => 3, 'workload_class' => 'heavy'],
+        'configured_structure_destination_id_for_esi_sync' => ['label' => 'Configured Structure Destination for ESI', 'default_interval_minutes' => 30, 'default_offset_minutes' => 4, 'priority' => 'normal', 'timeout_seconds' => 120, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => false, 'workload_class' => 'lightweight'],
+        'current_state_refresh_sync' => ['label' => 'Current-State Refresh', 'default_interval_minutes' => 12, 'default_offset_minutes' => 6, 'priority' => 'medium', 'timeout_seconds' => 120, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
+        'doctrine_intelligence_sync' => ['label' => 'Doctrine Intelligence', 'default_interval_minutes' => 15, 'default_offset_minutes' => 8, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'normal', 'min_backfill_gap_seconds' => 300, 'max_early_start_seconds' => 900, 'workload_class' => 'lightweight'],
+        'market_comparison_summary_sync' => ['label' => 'Market Comparison Summary', 'default_interval_minutes' => 15, 'default_offset_minutes' => 9, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'high', 'min_backfill_gap_seconds' => 300, 'max_early_start_seconds' => 900, 'workload_class' => 'heavy'],
+        'loss_demand_summary_sync' => ['label' => 'Loss Demand Summary', 'default_interval_minutes' => 15, 'default_offset_minutes' => 10, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'high', 'min_backfill_gap_seconds' => 300, 'max_early_start_seconds' => 900, 'workload_class' => 'lightweight'],
+        'dashboard_summary_sync' => ['label' => 'Dashboard Summary', 'default_interval_minutes' => 15, 'default_offset_minutes' => 11, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'highest', 'min_backfill_gap_seconds' => 240, 'max_early_start_seconds' => 900, 'workload_class' => 'lightweight'],
+        'rebuild_ai_briefings' => ['label' => 'Rebuild AI Briefings', 'default_interval_minutes' => 20, 'default_offset_minutes' => 12, 'priority' => 'normal', 'timeout_seconds' => 300, 'concurrency_policy' => 'background', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'lightweight'],
+        'activity_priority_summary_sync' => ['label' => 'Activity Priority Summary', 'default_interval_minutes' => 15, 'default_offset_minutes' => 13, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => false, 'workload_class' => 'heavy'],
+        'market_hub_local_history_sync' => ['label' => 'Market Hub Local History', 'default_interval_minutes' => 20, 'default_offset_minutes' => 14, 'priority' => 'normal', 'timeout_seconds' => 1800, 'concurrency_policy' => 'background', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'normal', 'min_backfill_gap_seconds' => 900, 'max_early_start_seconds' => 900, 'workload_class' => 'heavy'],
+        'analytics_bucket_1h_sync' => ['label' => 'Analytics Buckets (1h)', 'default_interval_minutes' => 15, 'default_offset_minutes' => 15, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => false, 'allow_backfill' => true, 'backfill_priority' => 'normal', 'min_backfill_gap_seconds' => 600, 'max_early_start_seconds' => 900, 'workload_class' => 'lightweight'],
+        'analytics_bucket_1d_sync' => ['label' => 'Analytics Buckets (1d)', 'default_interval_minutes' => 60, 'default_offset_minutes' => 16, 'priority' => 'normal', 'timeout_seconds' => 240, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => false, 'workload_class' => 'lightweight'],
+        'alliance_historical_sync' => ['label' => 'Alliance Historical', 'default_interval_minutes' => 360, 'default_offset_minutes' => 5, 'priority' => 'normal', 'timeout_seconds' => 3600, 'concurrency_policy' => 'background', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
+        'market_hub_historical_sync' => ['label' => 'Market Hub Historical', 'default_interval_minutes' => 360, 'default_offset_minutes' => 0, 'priority' => 'normal', 'timeout_seconds' => 3600, 'concurrency_policy' => 'background', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
+        'forecasting_ai_sync' => ['label' => 'Forecasting AI', 'default_interval_minutes' => 60, 'default_offset_minutes' => 0, 'priority' => 'normal', 'timeout_seconds' => 300, 'concurrency_policy' => 'background', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'lightweight'],
     ];
 }
 
@@ -3522,6 +3524,7 @@ function data_sync_schedule_job_definitions(): array
             'offset_minutes_key' => $jobKey . '_offset_minutes',
             'priority_key' => $jobKey . '_priority',
             'timeout_key' => $jobKey . '_timeout_seconds',
+            'execution_mode_key' => $jobKey . '_execution_mode',
             'mode_key' => $jobKey . '_tuning_mode',
         ];
     }
@@ -3885,6 +3888,83 @@ function scheduler_resource_usage_snapshot(): array
         'memory_usage' => function_exists('memory_get_usage') ? memory_get_usage(true) : null,
         'memory_peak_usage' => function_exists('memory_get_peak_usage') ? memory_get_peak_usage(true) : null,
         'wall_time' => microtime(true),
+    ];
+}
+
+function scheduler_php_memory_limit(): string
+{
+    return '512M';
+}
+
+function scheduler_memory_abort_threshold_bytes(): int
+{
+    return 400 * 1024 * 1024;
+}
+
+function scheduler_enforce_php_runtime_limits(): void
+{
+    if (function_exists('ini_set')) {
+        @ini_set('memory_limit', scheduler_php_memory_limit());
+    }
+
+    if (function_exists('gc_enable')) {
+        @gc_enable();
+    }
+}
+
+function scheduler_runtime_guard(float $startedAtUnix, int $timeoutSeconds, string $context = ''): void
+{
+    $safeTimeout = max(1, $timeoutSeconds);
+    $memoryUsage = function_exists('memory_get_usage') ? (int) memory_get_usage(true) : 0;
+    $memoryPeak = function_exists('memory_get_peak_usage') ? (int) memory_get_peak_usage(true) : $memoryUsage;
+    $threshold = scheduler_memory_abort_threshold_bytes();
+    $elapsed = max(0.0, microtime(true) - $startedAtUnix);
+
+    if ($memoryUsage > $threshold || $memoryPeak > $threshold) {
+        throw new RuntimeException(sprintf(
+            'Job exceeded scheduler memory guard%s (usage=%d bytes, peak=%d bytes, threshold=%d bytes).',
+            $context !== '' ? ' during ' . $context : '',
+            $memoryUsage,
+            $memoryPeak,
+            $threshold
+        ));
+    }
+
+    if ($elapsed > $safeTimeout) {
+        throw new RuntimeException(sprintf(
+            'Job exceeded scheduler timeout guard%s (elapsed=%.2fs, timeout=%ds).',
+            $context !== '' ? ' during ' . $context : '',
+            $elapsed,
+            $safeTimeout
+        ));
+    }
+}
+
+function scheduler_job_execution_mode(array $job, ?array $definition = null): string
+{
+    $resolvedDefinition = is_array($definition) ? $definition : (scheduler_registry_definitions()[(string) ($job['job_key'] ?? '')] ?? []);
+    $configured = strtolower(trim((string) ($job['execution_mode'] ?? $resolvedDefinition['execution_mode'] ?? 'php')));
+
+    return $configured === 'python' ? 'python' : 'php';
+}
+
+function scheduler_job_workload_profile(string $jobKey): array
+{
+    $definition = scheduler_registry_definitions()[$jobKey] ?? [];
+    $class = (string) ($definition['workload_class'] ?? 'lightweight');
+
+    $reason = match ($jobKey) {
+        'market_comparison_summary_sync' => 'heavy market aggregation over large current-order projections; prefer SQL plus Python batch execution',
+        'current_state_refresh_sync' => 'heavy snapshot generation that assembles multiple materialized summary layers',
+        'market_hub_local_history_sync', 'alliance_historical_sync', 'market_hub_historical_sync' => 'heavy snapshot/history rebuild over large market windows; prefer batched execution outside PHP request memory',
+        'killmail_r2z2_sync', 'activity_priority_summary_sync' => 'heavy killmail ingestion and derived activity recomputation with large append-only tables',
+        default => 'lightweight control-plane or summary job that is safe to keep in PHP',
+    };
+
+    return [
+        'workload_class' => $class === 'heavy' ? 'heavy' : 'lightweight',
+        'recommended_execution_mode' => $class === 'heavy' ? 'python' : 'php',
+        'reason' => $reason,
     ];
 }
 
@@ -5753,11 +5833,18 @@ function market_comparison_refresh_summary(string $reason = 'manual'): array
 {
     supplycore_materialized_snapshot_mark_updating(market_comparison_snapshot_key(), $reason);
     $snapshot = market_comparison_outcomes_build();
-
-    return supplycore_materialized_snapshot_store(market_comparison_snapshot_key(), $snapshot, [
+    $rowCount = count((array) ($snapshot['rows'] ?? []));
+    $stored = supplycore_materialized_snapshot_store(market_comparison_snapshot_key(), $snapshot, [
         'reason' => $reason,
-        'row_count' => count((array) ($snapshot['rows'] ?? [])),
+        'row_count' => $rowCount,
     ]);
+
+    unset($snapshot);
+    if (function_exists('gc_collect_cycles')) {
+        gc_collect_cycles();
+    }
+
+    return $stored;
 }
 
 function market_comparison_refresh_summary_job_result(string $reason = 'manual'): array
@@ -10112,6 +10199,23 @@ function scheduler_job_runner_script_path(): string
     return dirname(__DIR__) . '/bin/scheduler_job_runner.php';
 }
 
+function scheduler_python_job_runner_script_path(): string
+{
+    return dirname(__DIR__) . '/bin/python_job_runner.py';
+}
+
+function scheduler_python_binary(): string
+{
+    foreach (['SUPPLYCORE_PYTHON_BINARY', 'ORCHESTRATOR_PYTHON_BINARY', 'PYTHON_BINARY'] as $envKey) {
+        $candidate = trim((string) getenv($envKey));
+        if ($candidate !== '') {
+            return $candidate;
+        }
+    }
+
+    return 'python3';
+}
+
 function scheduler_cron_log_path(): string
 {
     return dirname(__DIR__) . '/storage/logs/cron.log';
@@ -10125,11 +10229,24 @@ function scheduler_job_runs_in_background(string $jobKey): bool
     return ($definition['execution'] ?? 'inline') === 'background';
 }
 
+function scheduler_job_runtime_type(array $job, ?array $definition = null): string
+{
+    $executionMode = scheduler_job_execution_mode($job, $definition);
+    if ($executionMode === 'python') {
+        return 'python_worker';
+    }
+
+    return scheduler_job_type((string) ($job['job_key'] ?? ''));
+}
+
 function scheduler_dispatch_background_job(array $job): array
 {
     $scheduleId = (int) ($job['id'] ?? 0);
     $jobKey = trim((string) ($job['job_key'] ?? ''));
-    $jobType = scheduler_job_type($jobKey);
+    $definitions = scheduler_job_definitions();
+    $definition = $definitions[$jobKey] ?? null;
+    $executionMode = scheduler_job_execution_mode($job, $definition);
+    $jobType = scheduler_job_runtime_type($job, $definition);
     $scheduledFor = (string) ($job['next_due_at'] ?? $job['next_run_at'] ?? '');
     $dispatchStartedAt = microtime(true);
     $startedAt = gmdate(DATE_ATOM);
@@ -10138,19 +10255,23 @@ function scheduler_dispatch_background_job(array $job): array
         throw new RuntimeException('Background scheduler dispatch requires a valid claimed job.');
     }
 
-    $definitions = scheduler_job_definitions();
-    $timeout = scheduler_resolve_job_timeout($jobKey, $job, $definitions[$jobKey] ?? null);
-
-    $phpBinary = PHP_BINARY !== '' ? PHP_BINARY : 'php';
-    $scriptPath = scheduler_job_runner_script_path();
+    $timeout = scheduler_resolve_job_timeout($jobKey, $job, $definition);
     $logPath = scheduler_cron_log_path();
-    $command = sprintf(
-        '%s %s --schedule-id=%d >> %s 2>&1 &',
-        escapeshellarg($phpBinary),
-        escapeshellarg($scriptPath),
-        $scheduleId,
-        escapeshellarg($logPath)
-    );
+    $command = $executionMode === 'python'
+        ? sprintf(
+            '%s %s --schedule-id=%d >> %s 2>&1 &',
+            escapeshellarg(scheduler_python_binary()),
+            escapeshellarg(scheduler_python_job_runner_script_path()),
+            $scheduleId,
+            escapeshellarg($logPath)
+        )
+        : sprintf(
+            '%s %s --schedule-id=%d >> %s 2>&1 &',
+            escapeshellarg(PHP_BINARY !== '' ? PHP_BINARY : 'php'),
+            escapeshellarg(scheduler_job_runner_script_path()),
+            $scheduleId,
+            escapeshellarg($logPath)
+        );
 
     exec($command, $output, $exitCode);
     $dispatchDurationMs = (int) round((microtime(true) - $dispatchStartedAt) * 1000);
@@ -10173,13 +10294,16 @@ function scheduler_dispatch_background_job(array $job): array
         'warnings' => [],
         'meta' => [
             'execution' => 'background',
+            'execution_mode' => $executionMode,
             'dispatch_duration_ms' => $dispatchDurationMs,
             'resolved_timeout_seconds' => (int) ($timeout['resolved_timeout_seconds'] ?? 0),
             'enforced_timeout_seconds' => (int) ($timeout['enforced_timeout_seconds'] ?? 0),
             'timeout_source' => (string) ($timeout['timeout_source'] ?? 'unknown'),
-            'outcome_reason' => 'Job was dispatched to a background PHP worker so other due jobs can continue immediately.',
+            'outcome_reason' => $executionMode === 'python'
+                ? 'Job was dispatched to a background Python worker for controlled heavy-workload execution.'
+                : 'Job was dispatched to a background PHP worker so other due jobs can continue immediately.',
         ],
-        'summary' => 'Dispatched to a background worker.',
+        'summary' => $executionMode === 'python' ? 'Dispatched to a background Python worker.' : 'Dispatched to a background PHP worker.',
     ];
 }
 
@@ -10212,6 +10336,7 @@ function scheduler_background_dispatch_failure_result(array $job, Throwable $exc
         'warnings' => [],
         'meta' => [
             'execution' => 'background',
+            'execution_mode' => scheduler_job_execution_mode($job),
         ],
         'summary' => $message,
     ];
@@ -11329,7 +11454,8 @@ function scheduler_run_job(array $job): array
     $definitions = scheduler_job_definitions();
     $definition = $definitions[$jobKey] ?? null;
     $datasetKey = scheduler_job_dataset_key($jobKey !== '' ? $jobKey : 'unknown');
-    $jobType = scheduler_job_type($jobKey);
+    $executionMode = scheduler_job_execution_mode($job, $definition);
+    $jobType = scheduler_job_runtime_type($job, $definition);
     $scheduledFor = (string) ($job['next_due_at'] ?? $job['next_run_at'] ?? '');
     $startedAtUnix = microtime(true);
     $startedAtIso = gmdate(DATE_ATOM, (int) $startedAtUnix);
@@ -11399,9 +11525,11 @@ function scheduler_run_job(array $job): array
     $startedAt = microtime(true);
 
     try {
+        scheduler_enforce_php_runtime_limits();
         if (function_exists('set_time_limit')) {
             @set_time_limit($timeoutSeconds + 5);
         }
+        scheduler_runtime_guard($startedAtUnix, $timeoutSeconds, 'startup');
 
         if (is_array($changeDecision) && !$changeDecision['run']) {
             $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
@@ -11512,12 +11640,15 @@ function scheduler_run_job(array $job): array
         }
 
         db_scheduler_job_event_insert($jobKey, 'started', [
+            'execution_mode' => $executionMode,
             'queue_wait_seconds' => round($queueWaitSeconds, 2),
             'lock_wait_seconds' => round($lockWaitSeconds, 2),
             'overlap_count' => $overlapCount,
             'projected_cpu_percent' => $projectedCpuPercent,
             'projected_memory_bytes' => $projectedMemoryBytes,
             'pressure_state' => $pressureState,
+            'memory_usage_bytes' => memory_get_usage(true),
+            'memory_peak_bytes' => memory_get_peak_usage(true),
             'resolved_timeout_seconds' => $timeoutResolution['resolved_timeout_seconds'] ?? null,
             'enforced_timeout_seconds' => $timeoutResolution['enforced_timeout_seconds'] ?? null,
             'timeout_source' => $timeoutResolution['timeout_source'] ?? null,
@@ -11529,6 +11660,7 @@ function scheduler_run_job(array $job): array
         $handler = $definition['handler'];
         $syncResult = $handler();
         $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
+        scheduler_runtime_guard($startedAtUnix, $timeoutSeconds, 'handler completion');
         if ($durationMs > ($timeoutSeconds * 1000)) {
             throw new RuntimeException('Job exceeded timeout of ' . $timeoutSeconds . ' seconds.');
         }
@@ -11651,6 +11783,7 @@ function scheduler_run_job(array $job): array
                     'cpu_system_seconds' => $resourceMetric['cpu_system_seconds'] ?? null,
                     'memory_peak_bytes' => $resourceMetric['memory_peak_bytes'] ?? null,
                     'memory_peak_delta_bytes' => $resourceMetric['memory_peak_delta_bytes'] ?? null,
+                    'memory_usage_bytes' => memory_get_usage(true),
                     'queue_wait_seconds' => $resourceMetric['queue_wait_seconds'] ?? null,
                     'lock_wait_seconds' => $resourceMetric['lock_wait_seconds'] ?? null,
                     'overlap_count' => $resourceMetric['overlap_count'] ?? null,
@@ -11662,6 +11795,7 @@ function scheduler_run_job(array $job): array
                     'timeout_source' => $timeoutResolution['timeout_source'] ?? null,
                 ],
                 'scheduler_result_status' => $status,
+                'execution_mode' => $executionMode,
                 'change_aware' => !empty($changeDecision['change_aware']),
                 'trigger' => $changeDecision['trigger'] ?? null,
                 'dependencies' => $dependencyMetadata,
@@ -11762,6 +11896,7 @@ function scheduler_run_job(array $job): array
                     'cpu_percent' => $resourceMetric['cpu_percent'] ?? null,
                     'memory_peak_bytes' => $resourceMetric['memory_peak_bytes'] ?? null,
                     'memory_peak_delta_bytes' => $resourceMetric['memory_peak_delta_bytes'] ?? null,
+                    'memory_usage_bytes' => memory_get_usage(true),
                     'queue_wait_seconds' => $resourceMetric['queue_wait_seconds'] ?? null,
                     'lock_wait_seconds' => $resourceMetric['lock_wait_seconds'] ?? null,
                     'overlap_count' => $resourceMetric['overlap_count'] ?? null,
@@ -11772,6 +11907,7 @@ function scheduler_run_job(array $job): array
                     'enforced_timeout_seconds' => $timeoutResolution['enforced_timeout_seconds'] ?? null,
                     'timeout_source' => $timeoutResolution['timeout_source'] ?? null,
                 ],
+                'execution_mode' => $executionMode,
             ],
             'summary' => $message,
         ];
@@ -12074,7 +12210,7 @@ function cron_tick_run(?callable $logger = null): array
         }
 
         try {
-            $result = ($forceBackground || scheduler_job_runs_in_background($jobKey))
+            $result = ($forceBackground || scheduler_job_runs_in_background($jobKey) || scheduler_job_execution_mode($job) === 'python')
                 ? scheduler_dispatch_background_job($job)
                 : scheduler_run_job($job);
             if (($result['status'] ?? '') === 'dispatched') {
@@ -13872,8 +14008,11 @@ function sync_market_history_from_snapshots(
     $safeWindowDays = market_hub_local_history_window_days_normalize($windowDays);
     $windowStartObservedAt = market_hub_local_history_window_start_observed_at($safeWindowDays);
     $runId = db_sync_run_start($datasetKey, $syncMode, sync_watermark($datasetKey));
+    $runtimeStartedAt = microtime(true);
+    $runtimeTimeoutSeconds = max(30, (int) ($context['timeout_seconds'] ?? (scheduler_registry_definitions()['market_hub_local_history_sync']['timeout_seconds'] ?? 1800)));
 
     try {
+        scheduler_runtime_guard($runtimeStartedAt, $runtimeTimeoutSeconds, $syncLabel . ' bootstrap');
         if ($sourceId <= 0) {
             $sourceName = (string) ($context['source_name'] ?? $context['reference_market_hub'] ?? $context['operational_market'] ?? ('Source #' . $sourceId));
             $warning = $syncLabel . ' skipped: could not resolve a valid local source id for ' . $sourceName . '.';
@@ -13908,6 +14047,7 @@ function sync_market_history_from_snapshots(
         $snapshotMetrics = is_array($snapshotMetricResult['rows'] ?? null) ? $snapshotMetricResult['rows'] : [];
         $summaryRowsWritten = max(0, (int) ($snapshotMetricResult['summary_rows_written'] ?? 0));
         $result['rows_seen'] = count($snapshotMetrics);
+        scheduler_runtime_guard($runtimeStartedAt, $runtimeTimeoutSeconds, $syncLabel . ' metrics load');
 
         if ($snapshotMetrics === []) {
             $sourceName = (string) ($context['source_name'] ?? $context['reference_market_hub'] ?? $context['operational_market'] ?? ('Source #' . $sourceId));
@@ -13941,10 +14081,15 @@ function sync_market_history_from_snapshots(
         }
 
         $rebuilt = market_history_daily_rebuild_from_snapshot_metrics($snapshotMetrics, $normalizedSourceType);
+        unset($snapshotMetrics, $snapshotMetricResult);
+        if (function_exists('gc_collect_cycles')) {
+            gc_collect_cycles();
+        }
         $canonicalRows = is_array($rebuilt['rows'] ?? null) ? $rebuilt['rows'] : [];
         $historyRowCount = count($canonicalRows);
         $tradeDates = is_array($rebuilt['trade_dates'] ?? null) ? $rebuilt['trade_dates'] : [];
         $latestObservedAt = $canonicalRows === [] ? '' : (string) ($canonicalRows[array_key_last($canonicalRows)]['observed_at'] ?? '');
+        scheduler_runtime_guard($runtimeStartedAt, $runtimeTimeoutSeconds, $syncLabel . ' daily rebuild');
 
         if ($canonicalRows === []) {
             $sourceName = (string) ($context['source_name'] ?? $context['reference_market_hub'] ?? $context['operational_market'] ?? ('Source #' . $sourceId));
@@ -13978,8 +14123,13 @@ function sync_market_history_from_snapshots(
         }
 
         $result['rows_written'] = db_market_history_daily_bulk_upsert($canonicalRows);
-        $result['cursor'] = 'source_type:' . $normalizedSourceType . ';source_id:' . $sourceId . ';window_days:' . $safeWindowDays . ';observed_at:' . $latestObservedAt;
         $result['checksum'] = sync_checksum($canonicalRows);
+        unset($canonicalRows, $rebuilt);
+        if (function_exists('gc_collect_cycles')) {
+            gc_collect_cycles();
+        }
+        scheduler_runtime_guard($runtimeStartedAt, $runtimeTimeoutSeconds, $syncLabel . ' bulk upsert');
+        $result['cursor'] = 'source_type:' . $normalizedSourceType . ';source_id:' . $sourceId . ';window_days:' . $safeWindowDays . ';observed_at:' . $latestObservedAt;
         $result['meta'] = $context + [
             'source_type' => $normalizedSourceType,
             'source_id' => $sourceId,
@@ -14039,6 +14189,7 @@ function sync_alliance_market_history(int $structureId, string $runMode = 'incre
             'operational_market_id' => $structureId,
             'operational_market' => selected_station_name('alliance_station_id') ?? ('Structure ' . $structureId),
             'source_name' => selected_station_name('alliance_station_id') ?? ('Structure ' . $structureId),
+            'timeout_seconds' => (int) (scheduler_registry_definitions()['alliance_historical_sync']['timeout_seconds'] ?? 3600),
         ],
         'Alliance history sync'
     );
@@ -14075,6 +14226,7 @@ function sync_market_hub_history(string|int $hubRef, string $runMode = 'incremen
             'resolved_region_id' => isset($hubContext['region_id']) && $hubContext['region_id'] !== null ? (int) $hubContext['region_id'] : null,
             'resolved_structure_id' => isset($hubContext['structure_id']) && $hubContext['structure_id'] !== null ? (int) $hubContext['structure_id'] : null,
             'source_name' => (string) ($hubContext['hub_name'] ?? market_hub_reference_name()),
+            'timeout_seconds' => (int) (scheduler_registry_definitions()['market_hub_historical_sync']['timeout_seconds'] ?? 3600),
         ],
         'Hub history sync'
     );
@@ -14111,6 +14263,7 @@ function sync_market_hub_local_history(string|int $hubRef, string $runMode = 'in
             'resolved_region_id' => isset($hubContext['region_id']) && $hubContext['region_id'] !== null ? (int) $hubContext['region_id'] : null,
             'resolved_structure_id' => isset($hubContext['structure_id']) && $hubContext['structure_id'] !== null ? (int) $hubContext['structure_id'] : null,
             'source_name' => (string) ($hubContext['hub_name'] ?? market_hub_reference_name()),
+            'timeout_seconds' => (int) (scheduler_registry_definitions()['market_hub_local_history_sync']['timeout_seconds'] ?? 1800),
         ],
         'Hub snapshot history sync'
     );
@@ -15951,8 +16104,11 @@ function sync_killmail_r2z2_stream(string $runMode = 'incremental'): array
     $runMode = sync_mode_normalize($runMode);
     $datasetKey = killmail_sync_dataset_key();
     $runId = db_sync_run_start($datasetKey, $runMode, db_sync_cursor_get($datasetKey));
+    $runtimeStartedAt = microtime(true);
+    $runtimeTimeoutSeconds = max(30, min(3600, killmail_max_sequences_per_run() * 3));
 
     try {
+        scheduler_runtime_guard($runtimeStartedAt, $runtimeTimeoutSeconds, 'killmail stream bootstrap');
         // Ensure any one-time killmail schema migrations run before per-row write transactions begin.
         db_killmail_payload_schema_ensure();
 
@@ -16032,6 +16188,7 @@ function sync_killmail_r2z2_stream(string $runMode = 'incremental'): array
         $lastSequenceAttempted = null;
 
         for ($step = 0; $step < $maxSteps; $step++) {
+            scheduler_runtime_guard($runtimeStartedAt, $runtimeTimeoutSeconds, 'killmail sequence loop');
             if ($firstSequenceAttempted === null) {
                 $firstSequenceAttempted = $nextSequence;
             }
@@ -16099,6 +16256,10 @@ function sync_killmail_r2z2_stream(string $runMode = 'incremental'): array
                 db_killmail_items_replace($sequenceId, $transformed['items']);
                 $rowsWritten++;
             });
+            unset($transformed, $event, $response);
+            if (function_exists('gc_collect_cycles')) {
+                gc_collect_cycles();
+            }
 
             $lastProcessed = $sequenceId;
             $nextSequence = $sequenceId + 1;


### PR DESCRIPTION
### Motivation

- Prevent PHP OOM crashes by moving heavy, memory-hungry work out of the inline PHP execution path and make heavy processing safer via streaming/batched reads and a Python worker option. 
- Provide per-job routing so operators can mark heavy workloads to run in a memory-controlled Python worker while keeping lightweight jobs in PHP. 
- Add explicit runtime guards and telemetry so runs are aborted before they destabilize the host and so resource profiles can be learned and used by the scheduler.

### Description

- Introduce streaming DB helpers `db_select_stream()` and `db_select_stream_batches()` in `src/db.php` to avoid `fetchAll()` on large result sets and to support batch callbacks. 
- Add per-schedule `execution_mode` plumbing (schema + bootstrap + `sync_schedules` insert/upsert changes) and expose `execution_mode` in runtime exports so each schedule can be `php` or `python` (schema change in `database/schema.sql`, support in `src/db.php` and `src/functions.php`). 
- Enforce PHP runtime limits and guards: `scheduler_enforce_php_runtime_limits()` sets `memory_limit=512M`, `scheduler_runtime_guard()` aborts a job when memory > 400MiB or elapsed time > resolved timeout, and memory telemetry (`memory_usage_bytes` / `memory_peak_bytes`) is added to scheduler events/metrics; entrypoints call these guards (`bin/scheduler_daemon.php`, `bin/scheduler_job_runner.php`, `bin/scheduler_job_runner` flow). 
- Route background dispatch to a Python runner when configured: new `execution_mode` aware dispatch in `src/functions.php` and `scheduler_job_runtime_type()`; `scheduler_dispatch_background_job()` now starts `bin/python_job_runner.py` when `execution_mode=python`. 
- Add a Python worker skeleton and bootstrap: `bin/python_job_runner.py` and `python/orchestrator/job_runner.py` that load the PHP-exported runtime config and provide a stable contract for implementing heavy-job processors (skeleton intentionally does not implement job logic yet). 
- Add memory / GC checkpoints and explicit `unset()` plus `gc_collect_cycles()` calls in heavy paths (market snapshot rebuild, killmail stream ingestion) and convert large in-memory snapshot flows to use batch/stream patterns where practical. 
- Orchestrator/systemd updates: `ops/systemd/supplycore-orchestrator.service` adds `MemoryMax=1G` and `ops/systemd/supplycore-orchestrator.env.example` documents `SUPPLYCORE_PYTHON_BINARY`. 
- Docs: `README.md` updated to document `execution_mode`, PHP memory guard behavior, Python worker skeleton, and systemd memory cap.

### Testing

- Ran PHP syntax checks: `php -l src/db.php`, `php -l src/functions.php`, `php -l bin/scheduler_daemon.php`, `php -l bin/scheduler_job_runner.php`, and `php -l bin/orchestrator_config.php`; all returned “No syntax errors detected.”
- Validated Python side by byte-compiling the orchestrator/workflow modules: `python3 -m py_compile bin/python_job_runner.py python/orchestrator/job_runner.py python/orchestrator/config.py python/orchestrator/main.py python/orchestrator/supervisor.py python/orchestrator/php_runner.py`; compilation succeeded with no syntax errors.
- Performed repository-level checks and committed the changes; automated checks above succeeded. No behavioral unit tests were modified or required for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0098fe3c0832fb4f6a8545fa26b41)