### PR TITLE
Fix systemd worker environment expansion

### DIFF
--- a/ops/systemd/supplycore-orchestrator.service
+++ b/ops/systemd/supplycore-orchestrator.service
@@ -8,9 +8,11 @@ Type=simple
 User=www-data
 Group=www-data
 WorkingDirectory=/var/www/SupplyCore
+Environment=SUPPLYCORE_WORKER_QUEUES=sync,compute
+Environment=SUPPLYCORE_WORKER_CLASSES=sync,compute
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python -m orchestrator worker-pool --app-root /var/www/SupplyCore --queues ${SUPPLYCORE_WORKER_QUEUES:-sync,compute} --workload-classes ${SUPPLYCORE_WORKER_CLASSES:-sync,compute}
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python -m orchestrator worker-pool --app-root /var/www/SupplyCore --queues ${SUPPLYCORE_WORKER_QUEUES} --workload-classes ${SUPPLYCORE_WORKER_CLASSES}
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM

--- a/ops/systemd/supplycore-worker@.service
+++ b/ops/systemd/supplycore-worker@.service
@@ -8,9 +8,11 @@ Type=simple
 User=www-data
 Group=www-data
 WorkingDirectory=/var/www/SupplyCore
+Environment=SUPPLYCORE_WORKER_QUEUES=sync,compute
+Environment=SUPPLYCORE_WORKER_CLASSES=sync,compute
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python -m orchestrator worker-pool --app-root /var/www/SupplyCore --worker-id %H-%i --queues ${SUPPLYCORE_WORKER_QUEUES:-sync,compute} --workload-classes ${SUPPLYCORE_WORKER_CLASSES:-sync,compute}
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python -m orchestrator worker-pool --app-root /var/www/SupplyCore --worker-id %H-%i --queues ${SUPPLYCORE_WORKER_QUEUES} --workload-classes ${SUPPLYCORE_WORKER_CLASSES}
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM

--- a/ops/systemd/supplycore-zkill.service
+++ b/ops/systemd/supplycore-zkill.service
@@ -8,9 +8,10 @@ Type=simple
 User=www-data
 Group=www-data
 WorkingDirectory=/var/www/SupplyCore
+Environment=SUPPLYCORE_ZKILL_POLL_SLEEP=10
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python -m orchestrator zkill-worker --app-root /var/www/SupplyCore --poll-sleep ${SUPPLYCORE_ZKILL_POLL_SLEEP:-10}
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python -m orchestrator zkill-worker --app-root /var/www/SupplyCore --poll-sleep ${SUPPLYCORE_ZKILL_POLL_SLEEP}
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM


### PR DESCRIPTION
### Motivation
- Systemd unit files used shell-style default expansion (`${VAR:-default}`) in `ExecStart`, which systemd does not support and could leave invalid literals passed to the Python worker CLI causing `argparse` errors and `INVALIDARGUMENT` exits.

### Description
- Update `ops/systemd/supplycore-worker@.service` and `ops/systemd/supplycore-orchestrator.service` to set explicit defaults via `Environment=SUPPLYCORE_WORKER_QUEUES=sync,compute` and `Environment=SUPPLYCORE_WORKER_CLASSES=sync,compute` and switch `ExecStart` to use plain `${SUPPLYCORE_WORKER_QUEUES}` / `${SUPPLYCORE_WORKER_CLASSES}` (removed `:-default`).
- Update `ops/systemd/supplycore-zkill.service` to set `Environment=SUPPLYCORE_ZKILL_POLL_SLEEP=10` and pass `--poll-sleep ${SUPPLYCORE_ZKILL_POLL_SLEEP}` instead of the unsupported `${...:-10}` form.
- Preserve `EnvironmentFile=-/etc/default/supplycore-worker` so operator overrides continue to work.

### Testing
- Ran `rg -n '\$\{[^}]+:-[^}]+' ops/systemd -S || true` to assert no shell-style default expansions remain, and it returned no matches.
- Ran `systemd-analyze verify ops/systemd/supplycore-worker@.service ops/systemd/supplycore-orchestrator.service ops/systemd/supplycore-zkill.service` to validate unit parsing; the units parse but the verifier in this container warns about the missing production venv interpreter path (`/var/www/SupplyCore/.venv-orchestrator/bin/python`).
- Committed the change with `git commit` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03a5c6da0832f96cae17a226065f9)