### PR TITLE
Add interactive install-services script and single-instance systemd units

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,23 +191,35 @@ SupplyCore now runs three long-lived worker classes:
 
 ### Systemd deployment
 
-Install and enable the continuous services instead of cron:
+Use the interactive installer to build/update the Python virtualenv, install the current orchestrator package, copy the unit files, and enable the selected services:
 
 ```bash
+sudo ./scripts/install-services.sh
+```
+
+The script asks for the app root, runtime user/group, worker counts, whether to enable the dedicated zKill worker, and whether to also install the legacy compatibility service. It also re-runs `pip install --upgrade ./python`, which fixes hosts where `python -m orchestrator zkill-worker ...` still points at an older package build that does not know about the `zkill-worker` subcommand yet.
+
+If you prefer manual installation, copy the units and env file yourself:
+
+```bash
+sudo cp ops/systemd/supplycore-sync-worker.service /etc/systemd/system/
 sudo cp ops/systemd/supplycore-sync-worker@.service /etc/systemd/system/
+sudo cp ops/systemd/supplycore-compute-worker.service /etc/systemd/system/
 sudo cp ops/systemd/supplycore-compute-worker@.service /etc/systemd/system/
 sudo cp ops/systemd/supplycore-zkill.service /etc/systemd/system/
 sudo cp ops/systemd/supplycore-worker.env.example /etc/default/supplycore-worker
 sudo systemctl daemon-reload
-sudo systemctl enable --now supplycore-sync-worker@1.service
-sudo systemctl enable --now supplycore-compute-worker@1.service
+sudo systemctl enable --now supplycore-sync-worker.service
+sudo systemctl enable --now supplycore-compute-worker.service
 sudo systemctl enable --now supplycore-zkill.service
 ```
 
 Recommended scaling pattern:
 
-- `supplycore-sync-worker@N.service` → queues/classes tuned for `sync`
-- `supplycore-compute-worker@N.service` → queues/classes tuned for `compute`
+- `supplycore-sync-worker.service` → single sync worker with a convenient non-templated unit name
+- `supplycore-sync-worker@N.service` → scaled sync workers when you want more than one instance
+- `supplycore-compute-worker.service` → single compute worker with a convenient non-templated unit name
+- `supplycore-compute-worker@N.service` → scaled compute workers when you want more than one instance
 - `supplycore-zkill.service` → dedicated infinite stream worker
 
 ### Logs
@@ -380,6 +392,7 @@ Validation:
 
 ```bash
 .venv-orchestrator/bin/python -m orchestrator --help
+.venv-orchestrator/bin/python -m orchestrator zkill-worker --help
 php bin/orchestrator_config.php
 ```
 

--- a/ops/systemd/supplycore-compute-worker.service
+++ b/ops/systemd/supplycore-compute-worker.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=SupplyCore compute worker
+After=network.target mariadb.service
+Wants=network.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+WorkingDirectory=/var/www/SupplyCore
+EnvironmentFile=-/etc/default/supplycore-worker
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python -m orchestrator worker-pool --app-root /var/www/SupplyCore --worker-id %H-compute --queues compute --workload-classes compute
+Restart=always
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=90
+MemoryMax=1G
+StandardOutput=append:/var/www/SupplyCore/storage/logs/compute.log
+StandardError=append:/var/www/SupplyCore/storage/logs/compute.log
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/supplycore-sync-worker.service
+++ b/ops/systemd/supplycore-sync-worker.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=SupplyCore sync worker
+After=network.target mariadb.service
+Wants=network.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+WorkingDirectory=/var/www/SupplyCore
+EnvironmentFile=-/etc/default/supplycore-worker
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python -m orchestrator worker-pool --app-root /var/www/SupplyCore --worker-id %H-sync --queues sync --workload-classes sync
+Restart=always
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=90
+MemoryMax=768M
+StandardOutput=append:/var/www/SupplyCore/storage/logs/worker.log
+StandardError=append:/var/www/SupplyCore/storage/logs/worker.log
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+APP_ROOT_DEFAULT=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+REPO_ROOT="${APP_ROOT_DEFAULT}"
+
+if [[ ${EUID} -ne 0 ]]; then
+  echo "This script must be run as root so it can write systemd units and manage services." >&2
+  exit 1
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  echo "systemctl is required to install SupplyCore services." >&2
+  exit 1
+fi
+
+prompt() {
+  local message=$1
+  local default=${2-}
+  local value
+  if [[ -n ${default} ]]; then
+    read -r -p "${message} [${default}]: " value
+    printf '%s\n' "${value:-$default}"
+  else
+    read -r -p "${message}: " value
+    printf '%s\n' "${value}"
+  fi
+}
+
+prompt_yes_no() {
+  local message=$1
+  local default=${2:-Y}
+  local reply
+  local suffix="[y/N]"
+  if [[ ${default^^} == Y ]]; then
+    suffix="[Y/n]"
+  fi
+
+  while true; do
+    read -r -p "${message} ${suffix}: " reply
+    reply=${reply:-$default}
+    case ${reply,,} in
+      y|yes) return 0 ;;
+      n|no) return 1 ;;
+    esac
+    echo "Please answer yes or no." >&2
+  done
+}
+
+prompt_number() {
+  local message=$1
+  local default=${2:-1}
+  local value
+  while true; do
+    value=$(prompt "${message}" "${default}")
+    if [[ ${value} =~ ^[0-9]+$ ]]; then
+      printf '%s\n' "${value}"
+      return 0
+    fi
+    echo "Please enter a whole number." >&2
+  done
+}
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+render_unit() {
+  local template=$1
+  local destination=$2
+  local app_root_escaped user_escaped group_escaped venv_escaped env_file_escaped
+  app_root_escaped=$(escape_sed_replacement "${APP_ROOT}")
+  user_escaped=$(escape_sed_replacement "${RUN_USER}")
+  group_escaped=$(escape_sed_replacement "${RUN_GROUP}")
+  venv_escaped=$(escape_sed_replacement "${VENV_PATH}")
+  env_file_escaped=$(escape_sed_replacement "${ENV_FILE}")
+
+  sed \
+    -e "s|/var/www/SupplyCore/.venv-orchestrator|${venv_escaped}|g" \
+    -e "s|/var/www/SupplyCore|${app_root_escaped}|g" \
+    -e "s|/etc/default/supplycore-worker|${env_file_escaped}|g" \
+    -e "s|User=www-data|User=${user_escaped}|" \
+    -e "s|Group=www-data|Group=${group_escaped}|" \
+    "${template}" > "${destination}"
+}
+
+start_services() {
+  local service
+  local -a services=("$@")
+
+  systemctl daemon-reload
+  if ((${#services[@]} == 0)); then
+    return 0
+  fi
+
+  for service in "${services[@]}"; do
+    echo "Enabling and starting ${service}"
+    systemctl enable --now "${service}"
+  done
+}
+
+APP_ROOT=$(prompt "SupplyCore app root" "${APP_ROOT_DEFAULT}")
+RUN_USER=$(prompt "System user for services" "www-data")
+RUN_GROUP=$(prompt "System group for services" "${RUN_USER}")
+PYTHON_BIN=$(prompt "Python 3.11+ executable for the orchestrator venv" "python3")
+VENV_PATH=$(prompt "Python virtualenv path" "${APP_ROOT}/.venv-orchestrator")
+SYSTEMD_DIR=$(prompt "systemd unit directory" "/etc/systemd/system")
+ENV_FILE=$(prompt "Worker environment file" "/etc/default/supplycore-worker")
+SYNC_COUNT=$(prompt_number "How many sync workers should be enabled?" "1")
+COMPUTE_COUNT=$(prompt_number "How many compute workers should be enabled?" "1")
+INSTALL_ZKILL=false
+if prompt_yes_no "Install and enable the dedicated zKill worker?" "Y"; then
+  INSTALL_ZKILL=true
+fi
+INSTALL_COMPAT_ORCHESTRATOR=false
+if prompt_yes_no "Install the legacy compatibility worker-pool service (supplycore-orchestrator.service)?" "N"; then
+  INSTALL_COMPAT_ORCHESTRATOR=true
+fi
+
+if [[ ! -d ${APP_ROOT} ]]; then
+  echo "App root does not exist: ${APP_ROOT}" >&2
+  exit 1
+fi
+
+if [[ ! -f ${APP_ROOT}/python/pyproject.toml ]]; then
+  echo "Expected Python package metadata at ${APP_ROOT}/python/pyproject.toml" >&2
+  exit 1
+fi
+
+install -d -m 0755 "${SYSTEMD_DIR}"
+install -d -m 0755 "${APP_ROOT}/storage/logs" "${APP_ROOT}/storage/run"
+chown -R "${RUN_USER}:${RUN_GROUP}" "${APP_ROOT}/storage"
+chmod -R u+rwX "${APP_ROOT}/storage"
+
+if [[ ! -x ${VENV_PATH}/bin/python ]]; then
+  echo "Creating orchestrator virtualenv at ${VENV_PATH}"
+  "${PYTHON_BIN}" -m venv "${VENV_PATH}"
+fi
+
+"${VENV_PATH}/bin/python" -m pip install --upgrade pip
+"${VENV_PATH}/bin/python" -m pip install --upgrade "${APP_ROOT}/python"
+"${VENV_PATH}/bin/python" -m orchestrator worker-pool --help >/dev/null
+"${VENV_PATH}/bin/python" -m orchestrator zkill-worker --help >/dev/null
+
+if [[ ! -f ${ENV_FILE} ]]; then
+  install -D -m 0644 "${REPO_ROOT}/ops/systemd/supplycore-worker.env.example" "${ENV_FILE}"
+else
+  echo "Keeping existing worker environment file at ${ENV_FILE}"
+fi
+
+render_unit "${REPO_ROOT}/ops/systemd/supplycore-sync-worker.service" "${SYSTEMD_DIR}/supplycore-sync-worker.service"
+render_unit "${REPO_ROOT}/ops/systemd/supplycore-sync-worker@.service" "${SYSTEMD_DIR}/supplycore-sync-worker@.service"
+render_unit "${REPO_ROOT}/ops/systemd/supplycore-compute-worker.service" "${SYSTEMD_DIR}/supplycore-compute-worker.service"
+render_unit "${REPO_ROOT}/ops/systemd/supplycore-compute-worker@.service" "${SYSTEMD_DIR}/supplycore-compute-worker@.service"
+render_unit "${REPO_ROOT}/ops/systemd/supplycore-zkill.service" "${SYSTEMD_DIR}/supplycore-zkill.service"
+if [[ ${INSTALL_COMPAT_ORCHESTRATOR} == true ]]; then
+  render_unit "${REPO_ROOT}/ops/systemd/supplycore-orchestrator.service" "${SYSTEMD_DIR}/supplycore-orchestrator.service"
+fi
+
+services_to_enable=()
+if (( SYNC_COUNT == 1 )); then
+  services_to_enable+=("supplycore-sync-worker.service")
+elif (( SYNC_COUNT > 1 )); then
+  for ((i = 1; i <= SYNC_COUNT; i++)); do
+    services_to_enable+=("supplycore-sync-worker@${i}.service")
+  done
+fi
+
+if (( COMPUTE_COUNT == 1 )); then
+  services_to_enable+=("supplycore-compute-worker.service")
+elif (( COMPUTE_COUNT > 1 )); then
+  for ((i = 1; i <= COMPUTE_COUNT; i++)); do
+    services_to_enable+=("supplycore-compute-worker@${i}.service")
+  done
+fi
+
+if [[ ${INSTALL_ZKILL} == true ]]; then
+  services_to_enable+=("supplycore-zkill.service")
+fi
+
+if [[ ${INSTALL_COMPAT_ORCHESTRATOR} == true ]]; then
+  services_to_enable+=("supplycore-orchestrator.service")
+fi
+
+start_services "${services_to_enable[@]}"
+
+echo
+echo "SupplyCore services installed successfully."
+echo "Worker environment: ${ENV_FILE}"
+echo "Virtualenv: ${VENV_PATH}"
+echo "Helpful status commands:"
+if (( SYNC_COUNT == 1 )); then
+  echo "  systemctl status supplycore-sync-worker.service"
+elif (( SYNC_COUNT > 1 )); then
+  echo "  systemctl status supplycore-sync-worker@1.service"
+fi
+if (( COMPUTE_COUNT == 1 )); then
+  echo "  systemctl status supplycore-compute-worker.service"
+elif (( COMPUTE_COUNT > 1 )); then
+  echo "  systemctl status supplycore-compute-worker@1.service"
+fi
+if [[ ${INSTALL_ZKILL} == true ]]; then
+  echo "  systemctl status supplycore-zkill.service"
+fi


### PR DESCRIPTION
### Motivation
- Provide a single interactive workflow to install and configure the Python orchestrator and systemd units so operators can reliably deploy services without manual steps.
- Fix two deployment issues: the absent non-templated `supplycore-sync-worker` unit and stale orchestrator venvs that lack the `zkill-worker` subcommand.

### Description
- Add `scripts/install-services.sh`, an interactive installer that prompts for app root, runtime user/group, Python binary, venv path, systemd directory, env file path, and worker counts, then creates/updates the venv, reinstalls the local `./python` package, renders systemd units with chosen paths, and enables the selected services via `systemctl`.
- Add non-templated single-instance units `ops/systemd/supplycore-sync-worker.service` and `ops/systemd/supplycore-compute-worker.service` so single-worker installs have stable service names (`supplycore-sync-worker.service` / `supplycore-compute-worker.service`).
- Update `README.md` to recommend the new installer, document the new single-instance unit names, and add an explicit validation step `venv/bin/python -m orchestrator zkill-worker --help` to catch stale venvs that miss the `zkill-worker` subcommand.
- Installer renders units substituting the chosen venv path and env file and optionally installs the legacy `supplycore-orchestrator.service` compatibility unit.

### Testing
- Ran a shell syntax check with `bash -n scripts/install-services.sh` which succeeded.
- Compiled the Python orchestrator package with `python -m compileall python/orchestrator` which succeeded.
- Executed the installer in a controlled test by stubbing `systemctl` (via `PATH` override) and answering prompts programmatically to validate virtualenv creation, `pip install --upgrade ./python`, unit rendering, and that the script calls `systemctl daemon-reload` / `systemctl enable --now` for the expected services; this test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03d5cb95c832f84e02c0f2a8548ec)