### PR TITLE
Handle missing systemd @.service templates in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ sudo ./scripts/install-services.sh
 
 The script asks for the app root, runtime user/group, worker counts, whether to enable the dedicated zKill worker, and whether to also install the legacy compatibility service. It also re-runs `pip install --upgrade ./python`, which fixes hosts where `python -m orchestrator zkill-worker ...` still points at an older package build that does not know about the `zkill-worker` subcommand yet.
 
+If your deployed checkout is missing the newer `supplycore-sync-worker@.service` or `supplycore-compute-worker@.service` template files, the installer now falls back to the single-worker units and generates compatible instance templates automatically during installation.
+
 If you prefer manual installation, copy the units and env file yourself:
 
 ```bash

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -85,6 +85,62 @@ render_unit() {
     "${template}" > "${destination}"
 }
 
+resolve_unit_template() {
+  local requested_template=$1
+  local fallback_template=${2-}
+
+  if [[ -f ${requested_template} ]]; then
+    printf '%s\n' "${requested_template}"
+    return 0
+  fi
+
+  if [[ -n ${fallback_template} && -f ${fallback_template} ]]; then
+    echo "Warning: missing unit template ${requested_template}; generating it from ${fallback_template}" >&2
+    printf '%s\n' "${fallback_template}"
+    return 0
+  fi
+
+  echo "Missing required unit template: ${requested_template}" >&2
+  if [[ -n ${fallback_template} ]]; then
+    echo "Fallback template was also unavailable: ${fallback_template}" >&2
+  fi
+  exit 1
+}
+
+render_sync_instance_unit() {
+  local template
+  local destination=$1
+
+  template=$(resolve_unit_template \
+    "${REPO_ROOT}/ops/systemd/supplycore-sync-worker@.service" \
+    "${REPO_ROOT}/ops/systemd/supplycore-sync-worker.service")
+
+  render_unit "${template}" "${destination}"
+  if [[ ${template} != *"@.service" ]]; then
+    sed -i \
+      -e 's|Description=SupplyCore sync worker$|Description=SupplyCore sync worker %i|' \
+      -e 's|--worker-id %H-sync --queues|--worker-id %H-sync-%i --queues|' \
+      "${destination}"
+  fi
+}
+
+render_compute_instance_unit() {
+  local template
+  local destination=$1
+
+  template=$(resolve_unit_template \
+    "${REPO_ROOT}/ops/systemd/supplycore-compute-worker@.service" \
+    "${REPO_ROOT}/ops/systemd/supplycore-compute-worker.service")
+
+  render_unit "${template}" "${destination}"
+  if [[ ${template} != *"@.service" ]]; then
+    sed -i \
+      -e 's|Description=SupplyCore compute worker$|Description=SupplyCore compute worker %i|' \
+      -e 's|--worker-id %H-compute --queues|--worker-id %H-compute-%i --queues|' \
+      "${destination}"
+  fi
+}
+
 start_services() {
   local service
   local -a services=("$@")
@@ -150,9 +206,9 @@ else
 fi
 
 render_unit "${REPO_ROOT}/ops/systemd/supplycore-sync-worker.service" "${SYSTEMD_DIR}/supplycore-sync-worker.service"
-render_unit "${REPO_ROOT}/ops/systemd/supplycore-sync-worker@.service" "${SYSTEMD_DIR}/supplycore-sync-worker@.service"
 render_unit "${REPO_ROOT}/ops/systemd/supplycore-compute-worker.service" "${SYSTEMD_DIR}/supplycore-compute-worker.service"
-render_unit "${REPO_ROOT}/ops/systemd/supplycore-compute-worker@.service" "${SYSTEMD_DIR}/supplycore-compute-worker@.service"
+render_sync_instance_unit "${SYSTEMD_DIR}/supplycore-sync-worker@.service"
+render_compute_instance_unit "${SYSTEMD_DIR}/supplycore-compute-worker@.service"
 render_unit "${REPO_ROOT}/ops/systemd/supplycore-zkill.service" "${SYSTEMD_DIR}/supplycore-zkill.service"
 if [[ ${INSTALL_COMPAT_ORCHESTRATOR} == true ]]; then
   render_unit "${REPO_ROOT}/ops/systemd/supplycore-orchestrator.service" "${SYSTEMD_DIR}/supplycore-orchestrator.service"


### PR DESCRIPTION
### Motivation

- The interactive `scripts/install-services.sh` installer failed on older checkouts that did not include the templated `@.service` unit files, causing `sed: can't read ...@.service` errors during deployment.

### Description

- Add `resolve_unit_template` to prefer the requested instance template and fall back to a single-worker unit when the `@.service` template is missing.
- Add `render_sync_instance_unit` and `render_compute_instance_unit` helpers to generate instance templates and rewrite the `Description` and `--worker-id` fields when synthesizing from the non-templated unit.
- Switch the installer flow to call `render_sync_instance_unit` and `render_compute_instance_unit` instead of directly rendering the `@.service` files, and preserve the original `render_unit` behavior for normal cases.
- Document the fallback behavior in `README.md` so operators know the installer will generate compatible instance templates when the newer files are absent.

### Testing

- Ran a syntax check with `bash -n scripts/install-services.sh`, which succeeded.
- Executed an integration test in a temporary repo copy that intentionally omitted the `@.service` templates and ran the installer, which produced valid `supplycore-sync-worker@.service` and `supplycore-compute-worker@.service` files and invoked the expected `systemctl enable --now supplycore-*-worker@N.service` commands; the test succeeded.
- A reusable temp test script (`/tmp/supplycore-install-fallback-test.sh`) was created during verification and exercised the fallback path successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0416dddb0832faf4606c81ffd7b23)