### PR TITLE
Fix zKill tracked-entity matching to include attacker-side mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,8 @@ SupplyCore now includes a first-pass killmail intelligence ingestion foundation 
   - treat feed as an ordered stream (not query API)
   - resume from last processed sequence cursor
   - iterate forward until 404 (no new sequence yet)
-  - filtering happens **after** local storage
+  - store killmails when a tracked alliance or corporation appears on the victim or attacker side
+  - keep victim-side tracked matches available for loss-demand analytics
 - Local persistence tables:
   - `killmail_events`
   - `killmail_attackers`

--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -147,7 +147,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
             <label class="flex items-center gap-3 surface-tertiary text-sm text-slate-200">
                 <input type="hidden" name="tracked_only" value="0">
                 <input type="checkbox" name="tracked_only" value="1" <?= ($filters['tracked_only'] ?? false) ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
-                <span>Tracked victim losses only</span>
+                <span>Tracked entity killmails only</span>
             </label>
         </div>
         <div class="mt-4 flex flex-wrap items-center justify-between gap-3">
@@ -212,7 +212,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <td class="px-3 py-3 align-top">
                             <div class="flex max-w-xs flex-wrap gap-2">
                                 <span class="rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] <?= ($row['matched_tracked'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-slate-500/40 bg-slate-500/10 text-slate-300' ?>">
-                                    <?= ($row['matched_tracked'] ?? false) ? 'Tracked victim' : 'Recorded loss' ?>
+                                    <?= ($row['matched_tracked'] ?? false) ? 'Tracked entity' : 'Recorded loss' ?>
                                 </span>
                                 <span class="rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] <?= htmlspecialchars((string) (($row['signal_strength']['tone'] ?? 'border-slate-500/40 bg-slate-500/10 text-slate-300')), ENT_QUOTES) ?>">
                                     <?= htmlspecialchars((string) (($row['signal_strength']['label'] ?? 'Signal')), ENT_QUOTES) ?>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1370,7 +1370,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <p><span class="text-slate-100">Latest uploaded_at:</span> <?= htmlspecialchars((string) ($killmailStatus['max_uploaded_at'] ?? '-'), ENT_QUOTES) ?></p>
                 </div>
 
-                <p class="text-sm text-muted">Ingestion consumes R2Z2 as an ordered stream. Filtering for alliances/corporations happens after local persistence, enabling future module-demand prediction and restock analytics.</p>
+                <p class="text-sm text-muted">Ingestion consumes R2Z2 as an ordered stream. The worker now stores killmails when a tracked alliance or corporation appears on either the victim or attacker side, while victim-side matches continue to drive loss-demand analytics.</p>
                 <button class="btn-primary">Save Killmail Intelligence Settings</button>
             </form>
         <?php elseif ($section === 'esi-login'): ?>

--- a/src/db.php
+++ b/src/db.php
@@ -9320,6 +9320,22 @@ function db_killmail_tracked_match_sql(string $eventAlias = 'e'): string
             FROM killmail_tracked_corporations tc
             WHERE tc.is_active = 1
         )
+        OR EXISTS (
+            SELECT 1
+            FROM killmail_attackers attacker
+            INNER JOIN killmail_tracked_alliances ta
+                ON ta.alliance_id = attacker.alliance_id
+               AND ta.is_active = 1
+            WHERE attacker.sequence_id = {$eventAlias}.sequence_id
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM killmail_attackers attacker
+            INNER JOIN killmail_tracked_corporations tc
+                ON tc.corporation_id = attacker.corporation_id
+               AND tc.is_active = 1
+            WHERE attacker.sequence_id = {$eventAlias}.sequence_id
+        )
     )";
 }
 
@@ -9336,12 +9352,16 @@ function db_killmail_tracked_matches_sql(?string $effectiveAfterSql = null, ?str
         SELECT
             matched.sequence_id,
             MAX(matched.matches_victim_alliance) AS matches_victim_alliance,
-            MAX(matched.matches_victim_corporation) AS matches_victim_corporation
+            MAX(matched.matches_victim_corporation) AS matches_victim_corporation,
+            MAX(matched.matches_attacker_alliance) AS matches_attacker_alliance,
+            MAX(matched.matches_attacker_corporation) AS matches_attacker_corporation
         FROM (
             SELECT
                 e.sequence_id,
                 1 AS matches_victim_alliance,
-                0 AS matches_victim_corporation
+                0 AS matches_victim_corporation,
+                0 AS matches_attacker_alliance,
+                0 AS matches_attacker_corporation
             FROM killmail_tracked_alliances ta
             INNER JOIN killmail_events e
                 ON e.victim_alliance_id = ta.alliance_id{$effectiveFilterSql}{$sequenceFilterSql}
@@ -9352,10 +9372,42 @@ function db_killmail_tracked_matches_sql(?string $effectiveAfterSql = null, ?str
             SELECT
                 e.sequence_id,
                 0 AS matches_victim_alliance,
-                1 AS matches_victim_corporation
+                1 AS matches_victim_corporation,
+                0 AS matches_attacker_alliance,
+                0 AS matches_attacker_corporation
             FROM killmail_tracked_corporations tc
             INNER JOIN killmail_events e
                 ON e.victim_corporation_id = tc.corporation_id{$effectiveFilterSql}{$sequenceFilterSql}
+            WHERE tc.is_active = 1
+
+            UNION ALL
+
+            SELECT
+                a.sequence_id,
+                0 AS matches_victim_alliance,
+                0 AS matches_victim_corporation,
+                1 AS matches_attacker_alliance,
+                0 AS matches_attacker_corporation
+            FROM killmail_tracked_alliances ta
+            INNER JOIN killmail_attackers a
+                ON a.alliance_id = ta.alliance_id
+            INNER JOIN killmail_events e
+                ON e.sequence_id = a.sequence_id{$effectiveFilterSql}{$sequenceFilterSql}
+            WHERE ta.is_active = 1
+
+            UNION ALL
+
+            SELECT
+                a.sequence_id,
+                0 AS matches_victim_alliance,
+                0 AS matches_victim_corporation,
+                0 AS matches_attacker_alliance,
+                1 AS matches_attacker_corporation
+            FROM killmail_tracked_corporations tc
+            INNER JOIN killmail_attackers a
+                ON a.corporation_id = tc.corporation_id
+            INNER JOIN killmail_events e
+                ON e.sequence_id = a.sequence_id{$effectiveFilterSql}{$sequenceFilterSql}
             WHERE tc.is_active = 1
         ) matched
         GROUP BY matched.sequence_id
@@ -9459,6 +9511,7 @@ function db_killmail_overview_row(int $sequenceId): ?array
     }
 
     $matchSql = db_killmail_tracked_match_sql('e');
+    $trackedMatchesSql = db_killmail_tracked_matches_sql();
 
     return db_select_one(
         "SELECT
@@ -9488,8 +9541,12 @@ function db_killmail_overview_row(int $sequenceId): ?array
             COALESCE(NULLIF(region_ref.region_name, ''), '') AS region_name,
             CASE WHEN victim_ta.alliance_id IS NULL THEN 0 ELSE 1 END AS matches_victim_alliance,
             CASE WHEN victim_tc.corporation_id IS NULL THEN 0 ELSE 1 END AS matches_victim_corporation,
+            COALESCE(tracked.matches_attacker_alliance, 0) AS matches_attacker_alliance,
+            COALESCE(tracked.matches_attacker_corporation, 0) AS matches_attacker_corporation,
             CASE WHEN {$matchSql} THEN 1 ELSE 0 END AS matched_tracked
          FROM killmail_events e
+         LEFT JOIN {$trackedMatchesSql} tracked
+           ON tracked.sequence_id = e.sequence_id
          LEFT JOIN ref_item_types ship ON ship.type_id = e.victim_ship_type_id
          LEFT JOIN ref_systems system_ref ON system_ref.system_id = e.solar_system_id
          LEFT JOIN ref_regions region_ref ON region_ref.region_id = e.region_id
@@ -9673,6 +9730,8 @@ function db_killmail_overview_page(array $filters = []): array
             COALESCE(NULLIF(region_ref.region_name, ''), CONCAT('Region #', e.region_id)) AS region_name,
             COALESCE(tracked.matches_victim_alliance, 0) AS matches_victim_alliance,
             COALESCE(tracked.matches_victim_corporation, 0) AS matches_victim_corporation,
+            COALESCE(tracked.matches_attacker_alliance, 0) AS matches_attacker_alliance,
+            COALESCE(tracked.matches_attacker_corporation, 0) AS matches_attacker_corporation,
             CASE WHEN tracked.sequence_id IS NULL THEN 0 ELSE 1 END AS matched_tracked
             {$fromSql}
             {$whereSql}

--- a/src/functions.php
+++ b/src/functions.php
@@ -8064,7 +8064,21 @@ function killmail_match_sources(array $row): array
         $sources[] = 'tracked victim corporation';
     }
 
+    if ((int) ($row['matches_attacker_alliance'] ?? 0) === 1) {
+        $sources[] = 'tracked attacker alliance';
+    }
+
+    if ((int) ($row['matches_attacker_corporation'] ?? 0) === 1) {
+        $sources[] = 'tracked attacker corporation';
+    }
+
     return $sources;
+}
+
+function killmail_row_matches_tracked_victim(array $row): bool
+{
+    return (int) ($row['matches_victim_alliance'] ?? 0) === 1
+        || (int) ($row['matches_victim_corporation'] ?? 0) === 1;
 }
 
 function killmail_entity_display_name(?string $label, string $fallbackPrefix, ?int $id): string
@@ -9545,7 +9559,7 @@ function killmail_detail_data(): array
             'fitted' => (int) ($groupedItems['fitted']['total_quantity'] ?? 0),
         ];
         $storedItemCount = array_sum(array_map(static fn (array $group): int => count((array) ($group['rows'] ?? [])), $groupedItems));
-        $signalStrength = killmail_signal_strength_meta($storedItemCount, count($formattedAttackers), (int) ($event['matched_tracked'] ?? 0) === 1);
+        $signalStrength = killmail_signal_strength_meta($storedItemCount, count($formattedAttackers), killmail_row_matches_tracked_victim($event));
         $supplyImpact = killmail_supply_impact_meta($estimatedValue, $itemTotals['dropped'], $itemTotals['destroyed'], $itemTotals['fitted']);
 
         return [
@@ -9588,8 +9602,8 @@ function killmail_detail_data(): array
             'items' => $groupedItems,
             'item_totals' => $itemTotals,
             'stored_item_count' => $storedItemCount,
-            'tracked_victim_loss' => (int) ($event['matched_tracked'] ?? 0) === 1,
-            'match_context' => $matchSources === [] ? 'No tracked victim entity currently matches this stored loss.' : ('Matched on ' . implode(' and ', $matchSources) . '.'),
+            'tracked_victim_loss' => killmail_row_matches_tracked_victim($event),
+            'match_context' => $matchSources === [] ? 'No tracked entity currently matches this stored killmail.' : ('Matched on ' . implode(' and ', $matchSources) . '.'),
             'signal_strength' => $signalStrength,
             'supply_impact' => $supplyImpact,
             'doctrine_impact' => $doctrineImpact,
@@ -9767,7 +9781,7 @@ function killmail_overview_data(): array
             $estimatedValue = killmail_overview_value_amount($row);
             $points = killmail_overview_points($row);
             $shipTypeId = isset($row['victim_ship_type_id']) ? (int) $row['victim_ship_type_id'] : null;
-            $signalStrength = killmail_signal_strength_meta(0, 0, (int) ($row['matched_tracked'] ?? 0) === 1);
+            $signalStrength = killmail_signal_strength_meta(0, 0, killmail_row_matches_tracked_victim($row));
             $supplyImpact = killmail_supply_impact_meta($estimatedValue, 0, 0, 0);
             $killmailFlags = array_values(array_filter([
                 killmail_overview_flag_enabled($row, 'zkb_npc') ? 'NPC' : null,
@@ -9787,7 +9801,7 @@ function killmail_overview_data(): array
                 'system' => killmail_entity_preferred_name($resolvedOverviewEntities, 'system', isset($row['solar_system_id']) ? (int) $row['solar_system_id'] : null, isset($row['system_name']) ? (string) $row['system_name'] : '', 'System'),
                 'region' => killmail_entity_preferred_name($resolvedOverviewEntities, 'region', isset($row['region_id']) ? (int) $row['region_id'] : null, isset($row['region_name']) ? (string) $row['region_name'] : '', 'Region'),
                 'matched_tracked' => (int) ($row['matched_tracked'] ?? 0) === 1,
-                'match_context' => $matchSources === [] ? 'No tracked victim entity currently matches this stored loss.' : ('Matched on ' . implode(', ', $matchSources) . '.'),
+                'match_context' => $matchSources === [] ? 'No tracked entity currently matches this stored killmail.' : ('Matched on ' . implode(', ', $matchSources) . '.'),
                 'ship_icon_url' => $shipTypeId !== null ? killmail_entity_image_url('type', $shipTypeId, 'icon', 64) : null,
                 'estimated_value_display' => $estimatedValue !== null ? number_format($estimatedValue, 0) . ' ISK' : 'Value unavailable',
                 'points_display' => $points !== null ? number_format($points) : 'Unavailable',
@@ -9808,7 +9822,7 @@ function killmail_overview_data(): array
             'summary' => [
                 ['label' => 'Total Ingested', 'value' => number_format($totalCount), 'context' => 'Killmails stored locally'],
                 ['label' => 'Recent Ingestion', 'value' => number_format($recentCount), 'context' => 'Stored in the last ' . $recentHours . ' hours'],
-                ['label' => 'Tracked Victim Losses', 'value' => number_format($trackedMatchCount), 'context' => 'Stored losses where the victim matches a tracked alliance or corporation'],
+                ['label' => 'Tracked Entity Killmails', 'value' => number_format($trackedMatchCount), 'context' => 'Stored killmails where a tracked alliance or corporation appears on the victim or attacker side'],
                 ['label' => 'Last Processed Sequence', 'value' => $maxSequenceId > 0 ? number_format($maxSequenceId) : '—', 'context' => $cursor !== '' ? ('Cursor ' . $cursor) : 'Cursor not recorded yet'],
                 ['label' => 'Sync Freshness', 'value' => killmail_relative_datetime($lastSuccessAt), 'context' => $lastSuccessAt !== null ? ('Last success ' . killmail_format_datetime($lastSuccessAt)) : 'No successful sync recorded'],
             ],
@@ -16785,7 +16799,27 @@ function killmail_event_matches_tracked_entities(array $event, array $attackers,
 
     $victimCorporationId = (int) ($event['victim_corporation_id'] ?? 0);
 
-    return $victimCorporationId > 0 && isset($trackedCorporationIds[$victimCorporationId]);
+    if ($victimCorporationId > 0 && isset($trackedCorporationIds[$victimCorporationId])) {
+        return true;
+    }
+
+    foreach ($attackers as $attacker) {
+        if (!is_array($attacker)) {
+            continue;
+        }
+
+        $attackerAllianceId = (int) ($attacker['alliance_id'] ?? 0);
+        if ($attackerAllianceId > 0 && isset($trackedAllianceIds[$attackerAllianceId])) {
+            return true;
+        }
+
+        $attackerCorporationId = (int) ($attacker['corporation_id'] ?? 0);
+        if ($attackerCorporationId > 0 && isset($trackedCorporationIds[$attackerCorporationId])) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 function killmail_transform_r2z2_payload(array $payload): array


### PR DESCRIPTION
### Motivation

- The zKill ingestion path only persisted killmails when tracked alliances/corporations appeared on the victim side, so attacker-side mentions were ignored and some relevant killmails were never stored.
- The goal is to broaden ingestion so tracked entities on either the victim or attacker side cause a killmail to be stored while preserving victim-only semantics for loss-demand analytics and scoring.

### Description

- Extend the in-PHP matcher `killmail_event_matches_tracked_entities` to check attacker rows for tracked `alliance_id` and `corporation_id` in addition to victim IDs so the Python/bridge and PHP batch processor will accept killmails where tracked entities appear on the attacker side. (`src/functions.php`)
- Add attacker-side checks to the SQL tracked-match expression `db_killmail_tracked_match_sql` so SQL filters/expressions can detect attacker matches using `EXISTS` against `killmail_attackers`. (`src/db.php`)
- Expand `db_killmail_tracked_matches_sql` to report `matches_attacker_alliance` and `matches_attacker_corporation` and surface those columns in overview/detail queries; join the tracked-match subquery in relevant `SELECT`s so UI/listing rows include attacker match badges. (`src/db.php`)
- Add helper `killmail_row_matches_tracked_victim()` and surface attacker match badges in `killmail_match_sources()` while preserving the `tracked_victim_loss` semantics used for demand analytics and signal scoring. (`src/functions.php`)
- Update UI copy and README to reflect that ingestion stores killmails when tracked alliances/corporations appear on either the victim or attacker side and that victim-side matches still drive loss-demand analytics. (`public/killmail-intelligence/index.php`, `public/settings/index.php`, `README.md`)

### Testing

- Ran PHP syntax checks: `php -l src/functions.php && php -l src/db.php && php -l public/settings/index.php && php -l public/killmail-intelligence/index.php` and they reported no syntax errors.
- Compiled Python orchestrator: `python -m compileall python/orchestrator` with no compile errors.
- Performed a small runtime sanity check via `php -r 'require "src/bootstrap.php"; ...'` that exercised `killmail_event_matches_tracked_entities` for attacker and victim cases and `killmail_row_matches_tracked_victim`; the checks returned the expected `true` results.
- All automated checks completed successfully in this environment (note: full integration requires a live DB and running worker processes which were not exercised here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04eea17b4832f86177b03f2a5fcd2)