### PR TITLE
Wire killmail overview into live-refresh so the page updates on new ingest

### DIFF
--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -13,6 +13,17 @@ $filters = $data['filters'] ?? [];
 $pagination = $data['pagination'] ?? [];
 $error = $data['error'] ?? null;
 $emptyMessage = (string) ($data['empty_message'] ?? 'No killmails available yet.');
+$lastSyncAt = trim((string) ($status['last_success_at_raw'] ?? ''));
+$lastSyncTimestamp = $lastSyncAt !== '' ? (strtotime($lastSyncAt) ?: null) : null;
+$lastSyncAgeSeconds = $lastSyncTimestamp !== null ? max(0, time() - $lastSyncTimestamp) : null;
+$pageFreshness = supplycore_page_freshness_view_model([
+    'computed_at' => $lastSyncAt !== '' ? $lastSyncAt : null,
+    'freshness_state' => $lastSyncAgeSeconds === null
+        ? 'stale'
+        : ($lastSyncAgeSeconds <= 15 * 60 ? 'fresh' : ($lastSyncAgeSeconds <= 45 * 60 ? 'updating' : 'stale')),
+    'freshness_label' => $lastSyncAt === '' ? 'Awaiting sync' : 'Killmail sync',
+]);
+$liveRefreshConfig = supplycore_live_refresh_page_config('killmail_intelligence');
 
 $queryParams = $_GET;
 $buildPageUrl = static function (int $targetPage) use ($queryParams): string {
@@ -46,7 +57,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
     </div>
 </section>
 
-<section class="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+<!-- ui-section:killmail-overview-summary:start -->
+<section class="grid gap-4 md:grid-cols-2 xl:grid-cols-5" data-ui-section="killmail-overview-summary">
     <?php foreach ($summary as $card): ?>
         <article class="surface-secondary">
             <p class="text-xs uppercase tracking-[0.2em] text-muted"><?= htmlspecialchars((string) ($card['label'] ?? ''), ENT_QUOTES) ?></p>
@@ -55,8 +67,10 @@ include __DIR__ . '/../../src/views/partials/header.php';
         </article>
     <?php endforeach; ?>
 </section>
+<!-- ui-section:killmail-overview-summary:end -->
 
-<section class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
+<!-- ui-section:killmail-overview-status:start -->
+<section class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]" data-ui-section="killmail-overview-status">
     <article class="surface-secondary">
         <div class="flex items-center justify-between gap-3">
             <h2 class="text-base font-medium text-slate-50">Sync status</h2>
@@ -111,8 +125,10 @@ include __DIR__ . '/../../src/views/partials/header.php';
         </div>
     </article>
 </section>
+<!-- ui-section:killmail-overview-status:end -->
 
-<section class="mt-6 surface-secondary shadow-lg shadow-black/20">
+<!-- ui-section:killmail-overview-table:start -->
+<section class="mt-6 surface-secondary shadow-lg shadow-black/20" data-ui-section="killmail-overview-table">
     <form method="get" action="<?= htmlspecialchars(current_path(), ENT_QUOTES) ?>" class="surface-tertiary">
         <div class="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto] xl:items-end">
             <label class="block text-sm text-muted">
@@ -247,5 +263,6 @@ include __DIR__ . '/../../src/views/partials/header.php';
         </div>
     </div>
 </section>
+<!-- ui-section:killmail-overview-table:end -->
 
 <?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/src/functions.php
+++ b/src/functions.php
@@ -9859,6 +9859,7 @@ function killmail_overview_data(): array
                 'ingestion_enabled' => killmail_ingestion_enabled(),
                 'current_cursor' => $cursor !== '' ? $cursor : 'Unavailable',
                 'last_sync_outcome' => killmail_last_sync_outcome_label($latestRun),
+                'last_success_at_raw' => $lastSuccessAt,
                 'last_success_at' => killmail_format_datetime($lastSuccessAt),
                 'last_sync_relative' => killmail_relative_datetime($lastSuccessAt),
                 'last_uploaded_at' => killmail_format_datetime($latestUploadedAt),
@@ -21796,6 +21797,13 @@ function supplycore_ui_refresh_section_version_definitions(): array
                 return supplycore_ui_refresh_version_from_sync_state('killmail_activity_version', [sync_dataset_key_killmail_r2z2_stream()], ['doctrine_activity', 'loss_aware_views'], ['activity-doctrines', 'activity-sidebar', 'activity-items', 'doctrine-fit-history']);
             },
         ],
+        'killmail_overview_version' => [
+            'domains' => ['killmail_overview', 'loss_aware_views'],
+            'ui_sections' => ['killmail-overview-summary', 'killmail-overview-status', 'killmail-overview-table'],
+            'resolver' => static function (): array {
+                return supplycore_ui_refresh_version_from_sync_state('killmail_overview_version', [sync_dataset_key_killmail_r2z2_stream()], ['killmail_overview', 'loss_aware_views'], ['killmail-overview-summary', 'killmail-overview-status', 'killmail-overview-table']);
+            },
+        ],
     ];
 }
 
@@ -21803,9 +21811,9 @@ function supplycore_ui_refresh_job_domain_map(): array
 {
     return [
         'killmail_r2z2_sync' => [
-            'domains' => ['doctrine_activity', 'loss_aware_views', 'activity_priority'],
-            'ui_sections' => ['activity-doctrines', 'activity-sidebar', 'activity-items', 'doctrine-fit-history'],
-            'version_keys' => ['killmail_activity_version', 'activity_priority_version'],
+            'domains' => ['doctrine_activity', 'loss_aware_views', 'activity_priority', 'killmail_overview'],
+            'ui_sections' => ['activity-doctrines', 'activity-sidebar', 'activity-items', 'doctrine-fit-history', 'killmail-overview-summary', 'killmail-overview-status', 'killmail-overview-table'],
+            'version_keys' => ['killmail_activity_version', 'activity_priority_version', 'killmail_overview_version'],
         ],
         'alliance_current_sync' => [
             'domains' => ['alliance_stock', 'doctrine_readiness', 'fit_availability', 'buyall'],
@@ -22192,6 +22200,18 @@ function supplycore_live_refresh_page_registry(): array
             'version_keys' => ['market_comparison_version', 'alliance_stock_version', 'market_prices_version'],
             'sections' => [
                 'price-deviations-main' => ['version_keys' => ['market_comparison_version', 'alliance_stock_version', 'market_prices_version']],
+            ],
+        ],
+        'killmail_intelligence' => [
+            'path' => '/killmail-intelligence/index.php',
+            'public_path' => '/killmail-intelligence',
+            'script' => dirname(__DIR__) . '/public/killmail-intelligence/index.php',
+            'domains' => ['killmail_overview', 'loss_aware_views'],
+            'version_keys' => ['killmail_overview_version'],
+            'sections' => [
+                'killmail-overview-summary' => ['version_keys' => ['killmail_overview_version']],
+                'killmail-overview-status' => ['version_keys' => ['killmail_overview_version']],
+                'killmail-overview-table' => ['version_keys' => ['killmail_overview_version']],
             ],
         ],
     ];


### PR DESCRIPTION
### Motivation

- The killmail overview page was not receiving live refresh events when new killmails were ingested, so its summary/status/table regions stayed stale. 
- The intent is to publish killmail ingestion activity into the UI-refresh system and make the overview derive freshness from the actual sync timestamp so the page reflects new data automatically.

### Description

- Added a dedicated live-refresh version `killmail_overview_version` and resolver in `src/functions.php` to represent the overview output fingerprint and freshness. 
- Published the overview version from the `killmail_r2z2_sync` job by extending `supplycore_ui_refresh_job_domain_map()` to include the `killmail_overview` domain, `killmail_overview_version` key, and the overview UI sections. 
- Registered the overview page in the live-refresh page registry via `supplycore_live_refresh_page_registry()` so `/killmail-intelligence` can be targeted by refresh events. 
- Exposed the raw last-success timestamp as `last_success_at_raw` from `killmail_overview_data()` and updated `public/killmail-intelligence/index.php` to compute `pageFreshness`, initialize `liveRefreshConfig`, and mark the summary, status, and table blocks with `data-ui-section` markers so the existing `ui-live-refresh.js` can refresh them.

### Testing

- Ran PHP syntax checks with `php -l public/killmail-intelligence/index.php` which reported no syntax errors. 
- Ran PHP syntax checks with `php -l src/functions.php` which reported no syntax errors. 
- No additional automated unit tests exist for this area; the change is limited to wiring live-refresh metadata and page fragments so runtime verification is done via the application UI and refresh event flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c067cf7488832fbe3542c7bf05fb01)