### PR TITLE
Fix Data Sync settings persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ mysql -u "$DB_USERNAME" -p"$DB_PASSWORD" -h "$DB_HOST" -P "$DB_PORT" "$DB_DATABA
 
 ### Migration note (old per-job crontabs)
 
-If you previously had one cron line per pipeline/job, remove those entries and keep only the single `bin/cron_tick.php` timer entry. Job-specific cadence is now managed in Data Sync settings, and due-job selection is centralized in the scheduler.
+If you previously had one cron line per pipeline/job, remove those entries and keep only the single `bin/cron_tick.php` timer entry. Recurring job registration and due-job selection are now centralized in the worker/scheduler control plane; the Data Sync page focuses on shared app settings and runtime observability instead of rewriting schedule rows manually.
 
 ### Rollout plan
 

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1747,32 +1747,35 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     </div>
 
                     <div>
-                        <p class="text-sm text-slate-100">Business configuration</p>
-                        <p class="mt-1 text-xs text-muted">Use this area to choose how aggressively SupplyCore refreshes data and recovers from delays.</p>
+                        <p class="text-sm text-slate-100">Continuous worker runtime</p>
+                        <p class="mt-1 text-xs text-muted">The Python worker pool owns recurring cadence, retries, and schedule rows now. This page saves sync behavior settings, while the cards below show the currently active runtime profile.</p>
                     </div>
 
-                    <div class="rounded-xl border border-border bg-black/20 p-4">
+                    <div class="rounded-xl border border-border bg-black/20 p-4 space-y-4">
                         <div class="flex flex-wrap items-start justify-between gap-3">
                             <div>
-                                <p class="text-sm text-slate-100">Update profile</p>
-                                <p class="mt-1 text-xs text-muted">Profiles control how quickly updates run without surfacing every runtime knob.</p>
+                                <p class="text-sm text-slate-100">Active runtime profile</p>
+                                <p class="mt-1 text-xs text-muted">Profile registration happens automatically from code/bootstrap, so there is nothing to save manually here anymore.</p>
                             </div>
                             <span class="inline-flex items-center rounded-full border border-cyan-400/30 bg-cyan-500/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.16em] text-cyan-100"><?= htmlspecialchars($selectedProfile, ENT_QUOTES) ?></span>
                         </div>
-                        <div class="mt-4 grid gap-3 lg:grid-cols-3">
+                        <div class="grid gap-3 lg:grid-cols-3">
                             <?php foreach ($profileOptions as $profileValue => $profileMeta): ?>
-                                <label class="rounded-xl border p-4 text-sm <?= $selectedProfile === $profileValue ? 'border-cyan-400/40 bg-cyan-500/10' : 'border-border bg-black/30' ?>">
-                                    <div class="flex items-start gap-3">
-                                        <input type="radio" name="scheduler_operational_profile" value="<?= htmlspecialchars($profileValue, ENT_QUOTES) ?>" <?= $selectedProfile === $profileValue ? 'checked' : '' ?> class="mt-1 size-4 border-border bg-black text-cyan-300">
-                                        <div>
+                                <?php $isActiveProfile = $selectedProfile === $profileValue; ?>
+                                <div class="rounded-xl border p-4 text-sm <?= $isActiveProfile ? 'border-cyan-400/40 bg-cyan-500/10' : 'border-border bg-black/30' ?>">
+                                    <div>
+                                        <div class="flex items-center justify-between gap-3">
                                             <p class="font-medium text-slate-100"><?= htmlspecialchars((string) ($profileMeta['label'] ?? ucfirst($profileValue)), ENT_QUOTES) ?></p>
-                                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($profileMeta['description'] ?? ''), ENT_QUOTES) ?></p>
+                                            <?php if ($isActiveProfile): ?>
+                                                <span class="inline-flex items-center rounded-full border border-cyan-400/30 bg-cyan-500/10 px-2 py-0.5 text-[11px] font-medium uppercase tracking-[0.14em] text-cyan-100">active</span>
+                                            <?php endif; ?>
                                         </div>
+                                        <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($profileMeta['description'] ?? ''), ENT_QUOTES) ?></p>
                                     </div>
-                                </label>
+                                </div>
                             <?php endforeach; ?>
                         </div>
-                        <div class="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4 text-sm">
+                        <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4 text-sm">
                             <div class="rounded-lg border border-border bg-black/30 p-3"><p class="text-xs uppercase tracking-[0.16em] text-muted">Auto concurrency</p><p class="mt-2 font-semibold text-white"><?= (int) ($profileRuntime['max_concurrent_jobs'] ?? 0) ?> workers</p></div>
                             <div class="rounded-lg border border-border bg-black/30 p-3"><p class="text-xs uppercase tracking-[0.16em] text-muted">CPU budget</p><p class="mt-2 font-semibold text-white"><?= htmlspecialchars(number_format((float) ($profileRuntime['cpu_budget_percent'] ?? 0), 0), ENT_QUOTES) ?>%</p></div>
                             <div class="rounded-lg border border-border bg-black/30 p-3"><p class="text-xs uppercase tracking-[0.16em] text-muted">Daemon poll</p><p class="mt-2 font-semibold text-white"><?= (int) ($profileRuntime['daemon_poll_interval_seconds'] ?? 0) ?>s idle · <?= (int) ($profileRuntime['daemon_running_poll_interval_seconds'] ?? 0) ?>s active</p></div>
@@ -2156,7 +2159,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <div class="space-y-3">
                     <div>
                         <p class="text-sm text-muted">Pipeline toggles</p>
-                        <p class="mt-1 text-xs text-muted">Use these defaults to keep related sync pipelines enabled alongside the scheduler cadence above.</p>
+                        <p class="mt-1 text-xs text-muted">Use these defaults to keep related sync pipelines enabled alongside the continuous worker automation shown above.</p>
                     </div>
                     <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
                         <input type="hidden" name="alliance_current_pipeline_enabled" value="0">

--- a/src/functions.php
+++ b/src/functions.php
@@ -6093,37 +6093,20 @@ function scheduler_apply_operational_profile(string $profile): bool
     return true;
 }
 
-function save_data_sync_schedule_settings(array $request): bool
-{
-    return scheduler_apply_operational_profile((string) ($request['scheduler_operational_profile'] ?? 'medium'));
-}
-
 function save_data_sync_settings(array $request): array
 {
     $settingsSaved = save_settings(data_sync_settings_from_request($request));
-    $schedulesSaved = save_data_sync_schedule_settings($request);
-
-    if ($settingsSaved && $schedulesSaved) {
-        return ['ok' => true, 'message' => 'Settings saved successfully.'];
-    }
 
     if ($settingsSaved) {
         return [
-            'ok' => false,
-            'message' => 'Core sync settings were saved, but the scheduler registry could not be updated. If this keeps happening, apply the latest database schema update and try again.',
-        ];
-    }
-
-    if ($schedulesSaved) {
-        return [
-            'ok' => false,
-            'message' => 'The scheduler profile was applied, but the core sync settings could not be saved to app_settings.',
+            'ok' => true,
+            'message' => 'Settings saved successfully. Continuous worker services keep their own recurring job registry, so this page now saves only the shared app settings used by sync jobs.',
         ];
     }
 
     return [
         'ok' => false,
-        'message' => 'Settings were not persisted. Please verify the database schema is up to date and that the web app can write to the SupplyCore tables.',
+        'message' => 'Settings were not persisted. Please verify the database schema is up to date and that the web app can write to app_settings.',
     ];
 }
 


### PR DESCRIPTION
### Motivation

- Saving Data Sync settings was failing intermittently because the web form attempted to rewrite the scheduler registry rows on every save, which can fail in deployments where the Python worker pool owns cadence and job registration. 
- The codebase now uses a continuous Python worker pool that self-registers recurring jobs, so the Settings page should only persist shared app settings and be informational about runtime profiles. 

### Description

- Stop trying to update scheduler rows from the web form by removing the scheduler-registry apply step from the save path and no longer invoking schedule-upsert logic during Data Sync saves (`src/functions.php` now returns only app-settings persistence results). 
- Make the Data Sync UI profile area informational (showing the active runtime profile) rather than offering/expecting a manual profile write, and adjust explanatory copy to reflect the continuous Python worker model (`public/settings/index.php`). 
- Update documentation text to state that recurring job registration and due-job selection live in the worker/scheduler control plane instead of being rewritten from the Data Sync page (`README.md`).

### Testing

- Ran PHP linter on modified PHP sources with `php -l src/functions.php` and `php -l public/settings/index.php`, both reported no syntax errors. 
- Performed a repository consistency check with `git diff --check` (no whitespace/patch issues reported). 
- No automated unit tests exist for the settings flow in this change, so validation consisted of linting and ensuring the Settings save path no longer attempts scheduler registry updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c069b23d44832f8bd91ffb9c8e6174)