### PR TITLE
Fix zKill R2Z2 sequence dedupe (stop cross-sequence killmail deduplication)

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1047,7 +1047,7 @@ CREATE TABLE IF NOT EXISTS killmail_event_payloads (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (sequence_id),
-    UNIQUE KEY uniq_killmail_event_payloads_killmail (killmail_id, killmail_hash),
+    KEY idx_killmail_event_payloads_killmail (killmail_id, killmail_hash),
     CONSTRAINT fk_killmail_event_payloads_sequence
         FOREIGN KEY (sequence_id) REFERENCES killmail_events (sequence_id)
         ON DELETE CASCADE

--- a/src/db.php
+++ b/src/db.php
@@ -499,14 +499,18 @@ function db_killmail_payload_schema_ensure(): void
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         PRIMARY KEY (sequence_id),
-        UNIQUE KEY uniq_killmail_event_payloads_killmail (killmail_id, killmail_hash),
+        KEY idx_killmail_event_payloads_killmail (killmail_id, killmail_hash),
         CONSTRAINT fk_killmail_event_payloads_sequence
             FOREIGN KEY (sequence_id) REFERENCES killmail_events (sequence_id)
             ON DELETE CASCADE
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
-    if (!db_table_has_index('killmail_event_payloads', 'uniq_killmail_event_payloads_killmail')) {
-        db()->exec('ALTER TABLE killmail_event_payloads ADD UNIQUE KEY uniq_killmail_event_payloads_killmail (killmail_id, killmail_hash)');
+    if (db_table_has_index('killmail_event_payloads', 'uniq_killmail_event_payloads_killmail')) {
+        db()->exec('ALTER TABLE killmail_event_payloads DROP INDEX uniq_killmail_event_payloads_killmail');
+    }
+
+    if (!db_table_has_index('killmail_event_payloads', 'idx_killmail_event_payloads_killmail')) {
+        db()->exec('ALTER TABLE killmail_event_payloads ADD KEY idx_killmail_event_payloads_killmail (killmail_id, killmail_hash)');
     }
 
     if (db_table_has_column('killmail_events', 'zkb_json') && db_table_has_column('killmail_events', 'raw_killmail_json')) {
@@ -547,7 +551,7 @@ function db_killmail_overview_schema_ensure(): void
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         PRIMARY KEY (sequence_id),
-        UNIQUE KEY uniq_killmail_event_payloads_killmail (killmail_id, killmail_hash),
+        KEY idx_killmail_event_payloads_killmail (killmail_id, killmail_hash),
         CONSTRAINT fk_killmail_event_payloads_sequence
             FOREIGN KEY (sequence_id) REFERENCES killmail_events (sequence_id)
             ON DELETE CASCADE
@@ -9197,9 +9201,8 @@ function db_killmail_event_exists(int $sequenceId, int $killmailId, string $kill
         'SELECT sequence_id
            FROM killmail_events
           WHERE sequence_id = ?
-             OR (killmail_id = ? AND killmail_hash = ?)
           LIMIT 1',
-        [$sequenceId, $killmailId, $killmailHash]
+        [$sequenceId]
     );
 
     return $row !== null;


### PR DESCRIPTION
### Motivation
- The R2Z2 feed can re-emit the same killmail under a new `sequence_id` when zKillboard reprocesses entries, and those should be storable per-sequence for correct analytics and tracked-entity matching.  
- The existing payload schema enforced a unique `(killmail_id, killmail_hash)` constraint and the duplicate guard also checked that pair, which caused reprocessed killmails to be skipped.  
- This change aligns ingestion with the R2Z2 contract by treating `sequence_id` as the authoritative dedupe key so reprocessed entries are preserved and tracked alliance/corporation matches are not lost.  

### Description
- Replace the unique payload constraint on `killmail_event_payloads (killmail_id, killmail_hash)` with a non-unique index by updating `database/schema.sql` and `src/db.php`.  
- Add a runtime migration step in `db_killmail_payload_schema_ensure()` that drops the old unique index if present and adds the non-unique index so existing installs migrate without manual intervention.  
- Restrict duplicate detection in `db_killmail_event_exists()` to only check `sequence_id` so ingest will not treat the same killmail/hash from a different `sequence_id` as a duplicate.  

### Testing
- Ran PHP syntax checks with `php -l src/db.php` and `php -l src/functions.php`, both reported no syntax errors.  
- Fetched the live R2Z2 `sequence.json` and corresponding `{sequence}.json` and validated the existing transformer `killmail_transform_r2z2_payload()` and matcher `killmail_event_matches_tracked_entities()` correctly extract alliance and corporation IDs and return expected matches.  
- Exercised the end-to-end transform locally by saving a live payload to `storage/tmp/r2z2-sample.json` and running a PHP one-liner to confirm `sequence_id`, victim alliance/corporation, attacker corp IDs, and match booleans, all returning expected values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c06e27b4d8832f97648082c98129ab)