### PR TITLE
Backfill missing corp/alliance from ESI and revamp killmail overview

### DIFF
--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -44,8 +44,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
 <section class="mb-6 flex flex-wrap items-center justify-between gap-4 surface-secondary">
     <div>
         <p class="text-xs uppercase tracking-[0.2em] text-muted">Operational visibility</p>
-        <h2 class="mt-1 text-lg font-medium text-slate-50">Human-readable loss intelligence</h2>
-        <p class="mt-2 max-w-3xl text-sm text-muted">Scan recent tracked losses by ship, location, signal strength, and estimated supply impact without hunting through raw identifiers.</p>
+        <h2 class="mt-1 text-lg font-medium text-slate-50">Tracked zKill loss feed</h2>
+        <p class="mt-2 max-w-3xl text-sm text-muted">Recent losses now emphasize the same core story you expect from zKill: victim, final blow, location, and estimated value, while still keeping SupplyCore’s tracked-entity context front and center.</p>
     </div>
     <div class="flex flex-wrap gap-2">
         <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= ($status['ingestion_enabled'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-amber-500/40 bg-amber-500/10 text-amber-100' ?>">
@@ -108,7 +108,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
     <article class="surface-secondary">
         <div class="flex items-center justify-between gap-3">
             <h2 class="text-base font-medium text-slate-50">Tracking context</h2>
-            <span class="text-xs text-muted">Victim-side coverage</span>
+            <span class="text-xs text-muted">Victim + attacker coverage</span>
         </div>
         <div class="mt-4 space-y-3">
             <div class="surface-tertiary">
@@ -120,7 +120,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <p class="mt-2 text-xl font-semibold text-slate-50"><?= number_format((int) ($status['tracked_corporation_count'] ?? 0)) ?></p>
             </div>
             <div class="surface-tertiary text-sm text-slate-400">
-                This view prioritizes victim losses that matter to alliance logistics, while deeper ingestion details remain secondary.
+                Python ingestion now backfills missing corporation/alliance context before persistence so tracked-entity matches stay accurate even when R2Z2 omits victim alliance IDs.
             </div>
         </div>
     </article>
@@ -182,19 +182,18 @@ include __DIR__ . '/../../src/views/partials/header.php';
         <table class="table-ui">
             <thead>
             <tr class="border-b border-border/80 bg-white/[0.03] text-left text-xs uppercase tracking-[0.15em] text-muted">
-                <th class="px-3 py-2 font-medium">Loss</th>
                 <th class="px-3 py-2 font-medium">Victim</th>
-                <th class="px-3 py-2 font-medium">Ship & place</th>
+                <th class="px-3 py-2 font-medium">Final blow</th>
+                <th class="px-3 py-2 font-medium">Ship & location</th>
                 <th class="px-3 py-2 font-medium">Signals</th>
-                <th class="px-3 py-2 font-medium">Value</th>
-                <th class="px-3 py-2 font-medium">Recorded</th>
+                <th class="px-3 py-2 font-medium">Value & time</th>
                 <th class="px-3 py-2 font-medium">Inspect</th>
             </tr>
             </thead>
             <tbody>
             <?php if ($rows === []): ?>
                 <tr>
-                    <td colspan="7" class="px-4 py-8">
+                    <td colspan="6" class="px-4 py-8">
                         <div class="surface-tertiary">
                             <p class="text-base font-medium text-slate-50">No killmails to show yet.</p>
                             <p class="mt-2 text-sm text-muted"><?= htmlspecialchars($emptyMessage, ENT_QUOTES) ?></p>
@@ -205,13 +204,21 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <?php foreach ($rows as $index => $row): ?>
                     <tr class="border-b border-border/60 text-slate-200 transition hover:bg-accent/10 <?= $index % 2 === 1 ? 'bg-white/[0.01]' : '' ?>">
                         <td class="px-3 py-3 align-top">
-                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
-                            <p class="mt-1 text-xs text-muted">Recorded loss event</p>
-                        </td>
-                        <td class="px-3 py-3 align-top">
                             <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['victim_corporation'] ?? '—'), ENT_QUOTES) ?></p>
                             <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($row['victim_alliance'] ?? '—'), ENT_QUOTES) ?></p>
-                            <p class="mt-2 max-w-xs text-xs text-muted"><?= htmlspecialchars((string) ($row['match_context'] ?? ''), ENT_QUOTES) ?></p>
+                            <p class="mt-2 text-xs text-muted"><?= htmlspecialchars((string) ($row['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
+                        </td>
+                        <td class="px-3 py-3 align-top">
+                            <div class="flex items-start gap-3">
+                                <?php if ((string) ($row['final_blow_portrait_url'] ?? '') !== ''): ?>
+                                    <img src="<?= htmlspecialchars((string) $row['final_blow_portrait_url'], ENT_QUOTES) ?>" alt="" class="h-10 w-10 rounded-xl object-cover">
+                                <?php endif; ?>
+                                <div>
+                                    <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['final_blow_character'] ?? 'Unknown character'), ENT_QUOTES) ?></p>
+                                    <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($row['final_blow_corporation'] ?? '—'), ENT_QUOTES) ?></p>
+                                    <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['final_blow_alliance'] ?? '—'), ENT_QUOTES) ?></p>
+                                </div>
+                            </div>
                         </td>
                         <td class="px-3 py-3 align-top">
                             <div class="flex items-start gap-3">
@@ -222,10 +229,14 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                     <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['ship_type'] ?? '—'), ENT_QUOTES) ?></p>
                                     <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($row['system'] ?? '—'), ENT_QUOTES) ?></p>
                                     <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['region'] ?? '—'), ENT_QUOTES) ?></p>
+                                    <?php if ((string) ($row['final_blow_ship'] ?? '') !== '' && (string) ($row['final_blow_ship'] ?? '') !== 'Ship unavailable'): ?>
+                                        <p class="mt-2 text-xs text-muted">Final blow ship: <?= htmlspecialchars((string) ($row['final_blow_ship'] ?? '—'), ENT_QUOTES) ?></p>
+                                    <?php endif; ?>
                                 </div>
                             </div>
                         </td>
                         <td class="px-3 py-3 align-top">
+                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['killmail_flags_display'] ?? 'No special flags'), ENT_QUOTES) ?></p>
                             <div class="flex max-w-xs flex-wrap gap-2">
                                 <span class="rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] <?= ($row['matched_tracked'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-slate-500/40 bg-slate-500/10 text-slate-300' ?>">
                                     <?= ($row['matched_tracked'] ?? false) ? 'Tracked entity' : 'Recorded loss' ?>
@@ -237,12 +248,14 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                     <?= htmlspecialchars((string) (($row['supply_impact']['label'] ?? 'Impact')), ENT_QUOTES) ?>
                                 </span>
                             </div>
+                            <p class="mt-2 max-w-xs text-xs text-muted"><?= htmlspecialchars((string) ($row['match_context'] ?? ''), ENT_QUOTES) ?></p>
                         </td>
                         <td class="px-3 py-3 align-top">
                             <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['estimated_value_display'] ?? 'Value unavailable'), ENT_QUOTES) ?></p>
-                        </td>
-                        <td class="px-3 py-3 align-top">
-                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['created_at_display'] ?? '—'), ENT_QUOTES) ?></p>
+                            <?php if ((string) ($row['final_blow_weapon'] ?? '') !== '' && (string) ($row['final_blow_weapon'] ?? '') !== 'Weapon unavailable'): ?>
+                                <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($row['final_blow_weapon'] ?? '—'), ENT_QUOTES) ?></p>
+                            <?php endif; ?>
+                            <p class="mt-2 text-xs text-muted"><?= htmlspecialchars((string) ($row['created_at_display'] ?? '—'), ENT_QUOTES) ?></p>
                             <p class="mt-1 text-xs text-muted">Uploaded <?= htmlspecialchars((string) ($row['uploaded_at_display'] ?? '—'), ENT_QUOTES) ?></p>
                         </td>
                         <td class="px-3 py-3 align-top">

--- a/python/orchestrator/jobs/killmail.py
+++ b/python/orchestrator/jobs/killmail.py
@@ -59,6 +59,77 @@ def _flush_batch(bridge: PhpBridge, pending_payloads: list[dict[str, Any]]) -> d
     return dict(response.get("result") or {})
 
 
+class KillmailEntityResolver:
+    def __init__(self, user_agent: str):
+        self.user_agent = user_agent
+        self._character_cache: dict[int, dict[str, Any] | None] = {}
+        self._corporation_cache: dict[int, dict[str, Any] | None] = {}
+
+    def _fetch_profile(self, url: str) -> dict[str, Any] | None:
+        status, payload = _http_json(url, self.user_agent)
+        if status != 200:
+            return None
+
+        return payload
+
+    def _character_profile(self, character_id: int) -> dict[str, Any] | None:
+        if character_id <= 0:
+            return None
+
+        if character_id not in self._character_cache:
+            self._character_cache[character_id] = self._fetch_profile(
+                f"https://esi.evetech.net/latest/characters/{character_id}/?datasource=tranquility"
+            )
+
+        return self._character_cache[character_id]
+
+    def _corporation_profile(self, corporation_id: int) -> dict[str, Any] | None:
+        if corporation_id <= 0:
+            return None
+
+        if corporation_id not in self._corporation_cache:
+            self._corporation_cache[corporation_id] = self._fetch_profile(
+                f"https://esi.evetech.net/latest/corporations/{corporation_id}/?datasource=tranquility"
+            )
+
+        return self._corporation_cache[corporation_id]
+
+    def _enrich_actor(self, actor: dict[str, Any]) -> None:
+        character_id = int(actor.get("character_id") or 0)
+        corporation_id = int(actor.get("corporation_id") or 0)
+        alliance_id = int(actor.get("alliance_id") or 0)
+
+        if corporation_id <= 0 and character_id > 0:
+            character_profile = self._character_profile(character_id) or {}
+            corporation_id = int(character_profile.get("corporation_id") or 0)
+            if corporation_id > 0:
+                actor["corporation_id"] = corporation_id
+
+        if alliance_id <= 0 and corporation_id > 0:
+            corporation_profile = self._corporation_profile(corporation_id) or {}
+            alliance_id = int(corporation_profile.get("alliance_id") or 0)
+            if alliance_id > 0:
+                actor["alliance_id"] = alliance_id
+
+    def enrich_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        for payload_key in ("esi", "killmail"):
+            killmail = payload.get(payload_key)
+            if not isinstance(killmail, dict):
+                continue
+
+            victim = killmail.get("victim")
+            if isinstance(victim, dict):
+                self._enrich_actor(victim)
+
+            attackers = killmail.get("attackers")
+            if isinstance(attackers, list):
+                for attacker in attackers:
+                    if isinstance(attacker, dict):
+                        self._enrich_actor(attacker)
+
+        return payload
+
+
 def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
     bridge = PhpBridge(context.php_binary, context.app_root)
     bridge_response = bridge.call("killmail-context")
@@ -88,6 +159,7 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
     poll_sleep_seconds = max(10, int(job_context.get("poll_sleep_seconds") or 10))
     max_sequences = max(1, int(job_context.get("max_sequences_per_run") or 120))
     batch_size = max(1, min(50, context.batch_size // 20 or 25))
+    entity_resolver = KillmailEntityResolver(user_agent)
 
     if sequence_url == "" or base_url == "":
         raise RuntimeError("Killmail Python worker requires both sequence and base R2Z2 URLs.")
@@ -139,6 +211,7 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
         status, payload = _http_json(f"{base_url}/{sequence_id}.json", user_agent)
 
         if status == 200:
+            payload = entity_resolver.enrich_payload(payload)
             pending_payloads.append(payload)
             total_sequence_files_fetched += 1
             next_sequence = sequence_id + 1

--- a/src/db.php
+++ b/src/db.php
@@ -9699,6 +9699,14 @@ function db_killmail_overview_page(array $filters = []): array
     $fromSql = " FROM killmail_events e
         {$trackedJoinType} {$trackedMatchesSql} tracked
           ON tracked.sequence_id = e.sequence_id
+        LEFT JOIN killmail_attackers final_blow_attacker
+          ON final_blow_attacker.sequence_id = e.sequence_id
+         AND final_blow_attacker.attacker_index = (
+             SELECT MIN(fb.attacker_index)
+               FROM killmail_attackers fb
+              WHERE fb.sequence_id = e.sequence_id
+                AND fb.final_blow = 1
+         )
         LEFT JOIN ref_item_types ship ON ship.type_id = e.victim_ship_type_id
         LEFT JOIN ref_systems system_ref ON system_ref.system_id = e.solar_system_id
         LEFT JOIN ref_regions region_ref ON region_ref.region_id = e.region_id
@@ -9764,6 +9772,11 @@ function db_killmail_overview_page(array $filters = []): array
             e.victim_ship_type_id,
             e.solar_system_id,
             e.region_id,
+            final_blow_attacker.character_id AS final_blow_character_id,
+            final_blow_attacker.corporation_id AS final_blow_corporation_id,
+            final_blow_attacker.alliance_id AS final_blow_alliance_id,
+            final_blow_attacker.ship_type_id AS final_blow_ship_type_id,
+            final_blow_attacker.weapon_type_id AS final_blow_weapon_type_id,
             e.zkb_total_value,
             e.zkb_points,
             e.zkb_npc,

--- a/src/functions.php
+++ b/src/functions.php
@@ -9732,6 +9732,11 @@ function killmail_overview_data(): array
             $shipTypeId = (int) ($row['victim_ship_type_id'] ?? 0);
             $systemId = (int) ($row['solar_system_id'] ?? 0);
             $regionId = (int) ($row['region_id'] ?? 0);
+            $finalBlowCharacterId = (int) ($row['final_blow_character_id'] ?? 0);
+            $finalBlowCorporationId = (int) ($row['final_blow_corporation_id'] ?? 0);
+            $finalBlowAllianceId = (int) ($row['final_blow_alliance_id'] ?? 0);
+            $finalBlowShipTypeId = (int) ($row['final_blow_ship_type_id'] ?? 0);
+            $finalBlowWeaponTypeId = (int) ($row['final_blow_weapon_type_id'] ?? 0);
 
             if ($allianceId > 0) {
                 $overviewResolutionRequests['alliance'][$allianceId] = $allianceId;
@@ -9747,6 +9752,21 @@ function killmail_overview_data(): array
             }
             if ($regionId > 0) {
                 $overviewResolutionRequests['region'][$regionId] = $regionId;
+            }
+            if ($finalBlowCharacterId > 0) {
+                $overviewResolutionRequests['character'][$finalBlowCharacterId] = $finalBlowCharacterId;
+            }
+            if ($finalBlowCorporationId > 0) {
+                $overviewResolutionRequests['corporation'][$finalBlowCorporationId] = $finalBlowCorporationId;
+            }
+            if ($finalBlowAllianceId > 0) {
+                $overviewResolutionRequests['alliance'][$finalBlowAllianceId] = $finalBlowAllianceId;
+            }
+            if ($finalBlowShipTypeId > 0) {
+                $overviewResolutionRequests['type'][$finalBlowShipTypeId] = $finalBlowShipTypeId;
+            }
+            if ($finalBlowWeaponTypeId > 0) {
+                $overviewResolutionRequests['type'][$finalBlowWeaponTypeId] = $finalBlowWeaponTypeId;
             }
         }
 
@@ -9793,6 +9813,11 @@ function killmail_overview_data(): array
             $estimatedValue = killmail_overview_value_amount($row);
             $points = killmail_overview_points($row);
             $shipTypeId = isset($row['victim_ship_type_id']) ? (int) $row['victim_ship_type_id'] : null;
+            $finalBlowCharacterId = isset($row['final_blow_character_id']) ? (int) $row['final_blow_character_id'] : null;
+            $finalBlowCorporationId = isset($row['final_blow_corporation_id']) ? (int) $row['final_blow_corporation_id'] : null;
+            $finalBlowAllianceId = isset($row['final_blow_alliance_id']) ? (int) $row['final_blow_alliance_id'] : null;
+            $finalBlowShipTypeId = isset($row['final_blow_ship_type_id']) ? (int) $row['final_blow_ship_type_id'] : null;
+            $finalBlowWeaponTypeId = isset($row['final_blow_weapon_type_id']) ? (int) $row['final_blow_weapon_type_id'] : null;
             $signalStrength = killmail_signal_strength_meta(0, 0, killmail_row_matches_tracked_victim($row));
             $supplyImpact = killmail_supply_impact_meta($estimatedValue, 0, 0, 0);
             $killmailFlags = array_values(array_filter([
@@ -9812,9 +9837,16 @@ function killmail_overview_data(): array
                 'ship_type' => killmail_entity_preferred_name($resolvedOverviewEntities, 'type', isset($row['victim_ship_type_id']) ? (int) $row['victim_ship_type_id'] : null, isset($row['ship_type_name']) ? (string) $row['ship_type_name'] : '', 'Ship'),
                 'system' => killmail_entity_preferred_name($resolvedOverviewEntities, 'system', isset($row['solar_system_id']) ? (int) $row['solar_system_id'] : null, isset($row['system_name']) ? (string) $row['system_name'] : '', 'System'),
                 'region' => killmail_entity_preferred_name($resolvedOverviewEntities, 'region', isset($row['region_id']) ? (int) $row['region_id'] : null, isset($row['region_name']) ? (string) $row['region_name'] : '', 'Region'),
+                'final_blow_character' => killmail_entity_preferred_name($resolvedOverviewEntities, 'character', $finalBlowCharacterId, '', 'Character'),
+                'final_blow_corporation' => killmail_entity_preferred_name($resolvedOverviewEntities, 'corporation', $finalBlowCorporationId, '', 'Corporation'),
+                'final_blow_alliance' => killmail_entity_preferred_name($resolvedOverviewEntities, 'alliance', $finalBlowAllianceId, '', 'Alliance'),
+                'final_blow_ship' => killmail_entity_preferred_name($resolvedOverviewEntities, 'type', $finalBlowShipTypeId, '', 'Ship'),
+                'final_blow_weapon' => killmail_entity_preferred_name($resolvedOverviewEntities, 'type', $finalBlowWeaponTypeId, '', 'Weapon'),
                 'matched_tracked' => (int) ($row['matched_tracked'] ?? 0) === 1,
                 'match_context' => $matchSources === [] ? 'No tracked entity currently matches this stored killmail.' : ('Matched on ' . implode(', ', $matchSources) . '.'),
                 'ship_icon_url' => $shipTypeId !== null ? killmail_entity_image_url('type', $shipTypeId, 'icon', 64) : null,
+                'final_blow_portrait_url' => $finalBlowCharacterId !== null && $finalBlowCharacterId > 0 ? killmail_entity_image_url('character', $finalBlowCharacterId, 'portrait', 64) : null,
+                'final_blow_ship_icon_url' => $finalBlowShipTypeId !== null && $finalBlowShipTypeId > 0 ? killmail_entity_image_url('type', $finalBlowShipTypeId, 'icon', 64) : null,
                 'estimated_value_display' => $estimatedValue !== null ? number_format($estimatedValue, 0) . ' ISK' : 'Value unavailable',
                 'points_display' => $points !== null ? number_format($points) : 'Unavailable',
                 'killmail_flags' => $killmailFlags,


### PR DESCRIPTION
### Motivation
- zKill R2Z2 sometimes omits corporation/alliance context which causes tracked-entity matching to miss attacker/victim orgs and stalls useful UI signals.  
- The killmail overview UI should present victim + final-blow context (who scored the kill) like zKill so operators can scan losses quickly.  

### Description
- Add a Python-side enrichment step (`KillmailEntityResolver`) in `python/orchestrator/jobs/killmail.py` that queries ESI to backfill `corporation_id` from a `character_id` and `alliance_id` from a `corporation_id`, with simple per-run caching and `enrich_payload()` applied before batching.  
- Persist enriched payloads through the existing PHP bridge so persisted rows include the corrected attacker/victim corp/alliance fields.  
- Extend the killmail overview read query in `src/db.php` to LEFT JOIN the final-blow attacker (selecting the final-blow attacker row) and expose `final_blow_*` columns (character_id, corporation_id, alliance_id, ship_type_id, weapon_type_id).  
- Resolve those final-blow IDs in `src/functions.php` and include them in the overview model so templates can display readable names and icons.  
- Redesign `public/killmail-intelligence/index.php` to show Victim and Final-blow columns, display final-blow portrait, final-blow org names, final-blow ship/weapon, and clearer ship/location/value/time grouping; update explanatory copy about Python-side backfilling.  

### Testing
- Compiled Python module with `python3 -m py_compile python/orchestrator/jobs/killmail.py` (success).  
- Linted PHP templates and core with `php -l src/functions.php && php -l src/db.php && php -l public/killmail-intelligence/index.php` (no syntax errors).  
- Ran an inline Python smoke test that stubs `_http_json` to validate character -> corporation -> alliance enrichment logic in `KillmailEntityResolver` (assertions passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0730c5f78832fa648d98dc55c7709)