### PR TITLE
Fix zKill ingestion progress, add richer loop metrics, and simplify killmail UI

### DIFF
--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -14,16 +14,19 @@ $pagination = $data['pagination'] ?? [];
 $error = $data['error'] ?? null;
 $emptyMessage = (string) ($data['empty_message'] ?? 'No killmails available yet.');
 $lastSyncAt = trim((string) ($status['last_success_at_raw'] ?? ''));
-$lastSyncTimestamp = $lastSyncAt !== '' ? (strtotime($lastSyncAt) ?: null) : null;
+$freshnessReferenceAt = trim((string) ($status['freshness_reference_at_raw'] ?? $lastSyncAt));
+$lastSyncTimestamp = $freshnessReferenceAt !== '' ? (strtotime($freshnessReferenceAt) ?: null) : null;
 $lastSyncAgeSeconds = $lastSyncTimestamp !== null ? max(0, time() - $lastSyncTimestamp) : null;
 $pageFreshness = supplycore_page_freshness_view_model([
-    'computed_at' => $lastSyncAt !== '' ? $lastSyncAt : null,
+    'computed_at' => $freshnessReferenceAt !== '' ? $freshnessReferenceAt : null,
     'freshness_state' => $lastSyncAgeSeconds === null
         ? 'stale'
         : ($lastSyncAgeSeconds <= 15 * 60 ? 'fresh' : ($lastSyncAgeSeconds <= 45 * 60 ? 'updating' : 'stale')),
     'freshness_label' => $lastSyncAt === '' ? 'Awaiting sync' : 'Killmail sync',
 ]);
 $liveRefreshConfig = supplycore_live_refresh_page_config('killmail_intelligence');
+$health = is_array($status['health'] ?? null) ? $status['health'] : [];
+$workerNoWriteReason = trim((string) ($health['worker_no_write_reason'] ?? ''));
 
 $queryParams = $_GET;
 $buildPageUrl = static function (int $targetPage) use ($queryParams): string {
@@ -45,14 +48,14 @@ include __DIR__ . '/../../src/views/partials/header.php';
     <div>
         <p class="text-xs uppercase tracking-[0.2em] text-muted">Operational visibility</p>
         <h2 class="mt-1 text-lg font-medium text-slate-50">Tracked zKill loss feed</h2>
-        <p class="mt-2 max-w-3xl text-sm text-muted">Recent losses now emphasize the same core story you expect from zKill: victim, final blow, location, and estimated value, while still keeping SupplyCore’s tracked-entity context front and center.</p>
+        <p class="mt-2 max-w-3xl text-sm text-muted">Use this board to confirm that tracked losses are landing, see how fresh the data is, and review the latest killmails that matter to alliance logistics and trading.</p>
     </div>
     <div class="flex flex-wrap gap-2">
-        <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= ($status['ingestion_enabled'] ?? false) ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200' : 'border-amber-500/40 bg-amber-500/10 text-amber-100' ?>">
-            <?= ($status['ingestion_enabled'] ?? false) ? 'Ingestion enabled' : 'Ingestion disabled' ?>
+        <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= htmlspecialchars((string) ($health['tone'] ?? 'border-border bg-black/20 text-slate-200'), ENT_QUOTES) ?>">
+            <?= htmlspecialchars((string) ($health['label'] ?? 'Status unavailable'), ENT_QUOTES) ?>
         </span>
         <span class="rounded-full border border-border bg-black/20 px-3 py-1 text-xs uppercase tracking-[0.15em] text-slate-200">
-            Sync status: <?= htmlspecialchars((string) ($status['last_sync_outcome'] ?? 'Unknown'), ENT_QUOTES) ?>
+            Live updates: <?= htmlspecialchars((string) ($liveRefreshConfig === null ? 'Off' : (($pageFreshness['state'] ?? 'stale') === 'stale' ? 'Degraded' : 'On')), ENT_QUOTES) ?>
         </span>
     </div>
 </section>
@@ -69,34 +72,50 @@ include __DIR__ . '/../../src/views/partials/header.php';
 </section>
 <!-- ui-section:killmail-overview-summary:end -->
 
+<?php if (($health['state'] ?? '') !== 'healthy' || ($status['last_run_source_rows'] ?? 0) > 0 && (int) ($status['last_run_written_rows'] ?? 0) === 0): ?>
+    <section class="mt-6 rounded-2xl border px-4 py-4 text-sm <?= htmlspecialchars((string) ($health['tone'] ?? 'border-amber-500/40 bg-amber-500/10 text-amber-100'), ENT_QUOTES) ?>">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+            <div>
+                <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($health['label'] ?? 'Killmail attention needed'), ENT_QUOTES) ?></p>
+                <p class="mt-1 text-sm opacity-90"><?= htmlspecialchars((string) ($health['message'] ?? 'Review the latest worker pass and freshness.'), ENT_QUOTES) ?></p>
+            </div>
+            <div class="text-xs uppercase tracking-[0.14em] opacity-80">
+                Last updated <?= htmlspecialchars((string) ($status['freshness_reference_at'] ?? $status['last_success_at'] ?? 'Unavailable'), ENT_QUOTES) ?>
+            </div>
+        </div>
+        <?php if ($workerNoWriteReason !== ''): ?>
+            <p class="mt-3 text-xs opacity-90">Latest no-write reason: <?= htmlspecialchars($workerNoWriteReason, ENT_QUOTES) ?></p>
+        <?php endif; ?>
+    </section>
+<?php endif; ?>
+
 <!-- ui-section:killmail-overview-status:start -->
 <section class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]" data-ui-section="killmail-overview-status">
     <article class="surface-secondary">
         <div class="flex items-center justify-between gap-3">
-            <h2 class="text-base font-medium text-slate-50">Sync status</h2>
-            <span class="text-xs uppercase tracking-[0.15em] text-muted"><?= htmlspecialchars((string) ($status['sync_status'] ?? 'idle'), ENT_QUOTES) ?></span>
+            <h2 class="text-base font-medium text-slate-50">Ingestion status</h2>
+            <span class="text-xs uppercase tracking-[0.15em] text-muted"><?= htmlspecialchars((string) ($health['label'] ?? 'Unknown'), ENT_QUOTES) ?></span>
         </div>
         <div class="mt-4 grid gap-3 md:grid-cols-2">
             <div class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Cursor position</p>
-                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($status['current_cursor'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
-                <p class="mt-1 text-sm text-muted">Current saved stream cursor or last processed sequence.</p>
-            </div>
-            <div class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Latest run outcome</p>
-                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($status['last_sync_outcome'] ?? 'Unknown'), ENT_QUOTES) ?></p>
-                <p class="mt-1 text-sm text-muted">Source rows <?= number_format((int) ($status['last_run_source_rows'] ?? 0)) ?> · inserted <?= number_format((int) ($status['last_run_written_rows'] ?? 0)) ?></p>
-            </div>
-            <div class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Last successful sync</p>
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Freshness</p>
                 <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($status['last_sync_relative'] ?? 'Never'), ENT_QUOTES) ?></p>
-                <p class="mt-1 text-sm text-muted"><?= htmlspecialchars((string) ($status['last_success_at'] ?? '—'), ENT_QUOTES) ?></p>
+                <p class="mt-1 text-sm text-muted">Last successful ingestion <?= htmlspecialchars((string) ($status['last_success_at'] ?? '—'), ENT_QUOTES) ?></p>
             </div>
             <div class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Dedicated zKill worker</p>
-                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($status['worker_seen_relative'] ?? 'No heartbeat'), ENT_QUOTES) ?></p>
-                <p class="mt-1 text-sm text-muted"><?= htmlspecialchars((string) ($status['worker_seen_at'] ?? 'No heartbeat recorded'), ENT_QUOTES) ?></p>
-                <p class="mt-2 text-xs text-muted">Loop status <?= htmlspecialchars((string) ($status['worker_status'] ?? 'unknown'), ENT_QUOTES) ?> · rows <?= number_format((int) ($status['worker_rows_written'] ?? 0)) ?>/<?= number_format((int) ($status['worker_rows_seen'] ?? 0)) ?> written/seen</p>
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Latest worker pass</p>
+                <p class="mt-2 text-lg font-semibold text-slate-50"><?= number_format((int) ($status['last_run_written_rows'] ?? 0)) ?> written</p>
+                <p class="mt-1 text-sm text-muted">Seen <?= number_format((int) ($status['last_run_source_rows'] ?? 0)) ?> qualifying stream rows</p>
+            </div>
+            <div class="surface-tertiary">
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Current cursor</p>
+                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($status['current_cursor'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
+                <p class="mt-1 text-sm text-muted">Saved stream checkpoint used for the next pass.</p>
+            </div>
+            <div class="surface-tertiary">
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Live updates</p>
+                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($liveRefreshConfig === null ? 'Off' : (($pageFreshness['state'] ?? 'stale') === 'stale' ? 'Degraded' : 'On')), ENT_QUOTES) ?></p>
+                <p class="mt-1 text-sm text-muted">Last updated <?= htmlspecialchars((string) ($pageFreshness['computed_relative'] ?? 'Never'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($pageFreshness['computed_at'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
             </div>
         </div>
         <?php if ((string) ($status['last_error'] ?? '') !== ''): ?>
@@ -104,12 +123,24 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 Last sync error: <?= htmlspecialchars((string) $status['last_error'], ENT_QUOTES) ?>
             </div>
         <?php endif; ?>
+        <details class="mt-4 rounded-2xl border border-white/8 bg-black/20 p-3">
+            <summary class="cursor-pointer list-none text-sm font-medium text-slate-100">Advanced diagnostics</summary>
+            <div class="mt-3 grid gap-3 sm:grid-cols-2 text-sm text-slate-300">
+                <p><span class="text-slate-500">Worker heartbeat</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['worker_seen_relative'] ?? 'No heartbeat'), ENT_QUOTES) ?></span><br><span class="text-xs text-muted"><?= htmlspecialchars((string) ($status['worker_seen_at'] ?? 'No heartbeat recorded'), ENT_QUOTES) ?></span></p>
+                <p><span class="text-slate-500">Latest run outcome</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['last_sync_outcome'] ?? 'Unknown'), ENT_QUOTES) ?></span><br><span class="text-xs text-muted"><?= htmlspecialchars((string) ($status['last_run_finished_at'] ?? 'Unavailable'), ENT_QUOTES) ?></span></p>
+                <p><span class="text-slate-500">Worker rows</span><br><span class="mt-1 inline-block text-slate-100">seen <?= number_format((int) ($status['worker_rows_seen'] ?? 0)) ?> · matched <?= number_format((int) ($status['worker_rows_matched'] ?? 0)) ?> · skipped existing <?= number_format((int) ($status['worker_rows_skipped_existing'] ?? 0)) ?> · filtered <?= number_format((int) ($status['worker_rows_filtered_out'] ?? 0)) ?> · written <?= number_format((int) ($status['worker_rows_written'] ?? 0)) ?></span></p>
+                <p><span class="text-slate-500">Cursor movement</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) (($status['worker_cursor_before'] ?? '') !== '' ? $status['worker_cursor_before'] : '—'), ENT_QUOTES) ?> → <?= htmlspecialchars((string) (($status['worker_cursor_after'] ?? '') !== '' ? $status['worker_cursor_after'] : ($status['worker_cursor'] ?? '—')), ENT_QUOTES) ?></span></p>
+                <?php if ((string) ($status['worker_outcome_reason'] ?? '') !== ''): ?>
+                    <p class="sm:col-span-2"><span class="text-slate-500">Latest worker reason</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['worker_outcome_reason'] ?? ''), ENT_QUOTES) ?></span></p>
+                <?php endif; ?>
+            </div>
+        </details>
     </article>
 
     <article class="surface-secondary">
         <div class="flex items-center justify-between gap-3">
             <h2 class="text-base font-medium text-slate-50">Tracking context</h2>
-            <span class="text-xs text-muted">Victim + attacker coverage</span>
+            <span class="text-xs text-muted">What counts as relevant</span>
         </div>
         <div class="mt-4 space-y-3">
             <div class="surface-tertiary">
@@ -121,7 +152,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <p class="mt-2 text-xl font-semibold text-slate-50"><?= number_format((int) ($status['tracked_corporation_count'] ?? 0)) ?></p>
             </div>
             <div class="surface-tertiary text-sm text-slate-400">
-                Python ingestion now backfills missing corporation/alliance context before persistence so tracked-entity matches stay accurate even when R2Z2 omits victim alliance IDs.
+                Losses are retained when a tracked alliance or corporation appears on the victim side or among the attackers. That keeps the board focused on actionable activity without exposing worker plumbing by default.
             </div>
         </div>
     </article>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -312,6 +312,8 @@ if ($dbStatus['ok']) {
 $trackedAlliances = [];
 $trackedCorporations = [];
 $killmailStatus = null;
+$killmailWorkerStatus = [];
+$killmailStatusSummary = [];
 $itemScope = item_scope_view_model();
 $ollamaConfig = supplycore_ai_ollama_config();
 $ollamaStatus = supplycore_ai_status_summary();
@@ -320,11 +322,31 @@ if ($dbStatus['ok']) {
         $trackedAlliances = db_killmail_tracked_alliances_active();
         $trackedCorporations = db_killmail_tracked_corporations_active();
         $killmailStatus = db_killmail_ingestion_status();
+        $killmailWorkerStatus = zkill_worker_runtime_status();
     } catch (Throwable) {
         $trackedAlliances = [];
         $trackedCorporations = [];
         $killmailStatus = null;
+        $killmailWorkerStatus = [];
     }
+}
+
+if (is_array($killmailStatus)) {
+    $killmailState = is_array($killmailStatus['state'] ?? null) ? $killmailStatus['state'] : [];
+    $killmailLatestRun = is_array($killmailStatus['latest_run'] ?? null) ? $killmailStatus['latest_run'] : [];
+    $killmailStatusSummary = [
+        'ingestion_enabled' => ($settingValues['killmail_ingestion_enabled'] ?? '0') === '1',
+        'last_success_at_raw' => isset($killmailState['last_success_at']) ? (string) $killmailState['last_success_at'] : null,
+        'last_success_at' => killmail_format_datetime(isset($killmailState['last_success_at']) ? (string) $killmailState['last_success_at'] : null),
+        'last_sync_relative' => killmail_relative_datetime(isset($killmailState['last_success_at']) ? (string) $killmailState['last_success_at'] : null),
+        'current_cursor' => (string) ($killmailState['last_cursor'] ?? 'Unavailable'),
+        'last_run_source_rows' => (int) ($killmailLatestRun['source_rows'] ?? 0),
+        'last_run_written_rows' => (int) ($killmailLatestRun['written_rows'] ?? 0),
+        'last_error' => trim((string) ($killmailState['last_error_message'] ?? '')),
+        'tracked_alliance_count' => count($trackedAlliances),
+        'tracked_corporation_count' => count($trackedCorporations),
+    ];
+    $killmailStatusSummary['health'] = killmail_ingestion_health_summary($killmailStatusSummary, $killmailWorkerStatus);
 }
 
 foreach ($configuredSyncJobs as $schedule) {
@@ -1046,10 +1068,39 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 $corporationsText = implode("
 ", array_map(static fn (array $row): string => (string) $row['id'] . ' | ' . (string) $row['name'], $trackedCorporationSelections));
                 $statusState = is_array($killmailStatus['state'] ?? null) ? $killmailStatus['state'] : [];
+                $killmailHealth = is_array($killmailStatusSummary['health'] ?? null) ? $killmailStatusSummary['health'] : [];
             ?>
             <form class="mt-6 space-y-4" method="post">
                 <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
                 <input type="hidden" name="section" value="killmail-intelligence">
+
+                <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+                    <article class="rounded-xl border p-4 <?= htmlspecialchars((string) ($killmailHealth['tone'] ?? 'border-border bg-black/20 text-slate-200'), ENT_QUOTES) ?>">
+                        <p class="text-xs uppercase tracking-[0.16em] opacity-70">Status</p>
+                        <p class="mt-2 text-sm font-semibold text-slate-50"><?= htmlspecialchars((string) ($killmailHealth['label'] ?? 'Status unavailable'), ENT_QUOTES) ?></p>
+                        <p class="mt-2 text-xs opacity-90"><?= htmlspecialchars((string) ($killmailHealth['message'] ?? 'Killmail status is unavailable.'), ENT_QUOTES) ?></p>
+                    </article>
+                    <article class="rounded-xl border border-border bg-black/20 p-4">
+                        <p class="text-xs uppercase tracking-[0.16em] text-muted">Last success</p>
+                        <p class="mt-2 text-sm font-semibold text-slate-50"><?= htmlspecialchars((string) ($killmailStatusSummary['last_sync_relative'] ?? 'Never'), ENT_QUOTES) ?></p>
+                        <p class="mt-2 text-xs text-muted"><?= htmlspecialchars((string) ($killmailStatusSummary['last_success_at'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
+                    </article>
+                    <article class="rounded-xl border border-border bg-black/20 p-4">
+                        <p class="text-xs uppercase tracking-[0.16em] text-muted">Last rows written</p>
+                        <p class="mt-2 text-sm font-semibold text-slate-50"><?= number_format((int) ($killmailStatusSummary['last_run_written_rows'] ?? 0)) ?></p>
+                        <p class="mt-2 text-xs text-muted">Seen <?= number_format((int) ($killmailStatusSummary['last_run_source_rows'] ?? 0)) ?> rows in the latest pass</p>
+                    </article>
+                    <article class="rounded-xl border border-border bg-black/20 p-4">
+                        <p class="text-xs uppercase tracking-[0.16em] text-muted">Current cursor</p>
+                        <p class="mt-2 text-sm font-semibold text-slate-50"><?= htmlspecialchars((string) ($killmailStatusSummary['current_cursor'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
+                        <p class="mt-2 text-xs text-muted">Next worker pass resumes from this stream checkpoint.</p>
+                    </article>
+                    <article class="rounded-xl border border-border bg-black/20 p-4">
+                        <p class="text-xs uppercase tracking-[0.16em] text-muted">Tracked entities</p>
+                        <p class="mt-2 text-sm font-semibold text-slate-50"><?= number_format((int) ($killmailStatusSummary['tracked_alliance_count'] ?? 0)) ?> alliances · <?= number_format((int) ($killmailStatusSummary['tracked_corporation_count'] ?? 0)) ?> corporations</p>
+                        <p class="mt-2 text-xs text-muted">These determine which zKill activity is retained for business use.</p>
+                    </article>
+                </div>
 
                 <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
                     <input type="hidden" name="killmail_ingestion_enabled" value="0">
@@ -1453,20 +1504,33 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     })();
                 </script>
 
-                <label class="block space-y-2">
-                    <span class="text-sm text-muted">Demand Prediction Mode (future-facing)</span>
-                    <input type="text" name="killmail_demand_prediction_mode" value="<?= htmlspecialchars($settingValues['killmail_demand_prediction_mode'] ?? 'baseline', ENT_QUOTES) ?>" class="w-full field-input" />
-                </label>
+                <details class="rounded-xl border border-border bg-black/20 p-4">
+                    <summary class="cursor-pointer list-none text-sm font-medium text-slate-100">Advanced diagnostics</summary>
+                    <div class="mt-4 grid gap-4 lg:grid-cols-2 text-sm text-muted">
+                        <div class="space-y-1 rounded-lg border border-border bg-black/20 p-3">
+                            <p><span class="text-slate-100">Last cursor:</span> <?= htmlspecialchars((string) ($statusState['last_cursor'] ?? '-'), ENT_QUOTES) ?></p>
+                            <p><span class="text-slate-100">Last success:</span> <?= htmlspecialchars((string) ($statusState['last_success_at'] ?? '-'), ENT_QUOTES) ?></p>
+                            <p><span class="text-slate-100">Last status:</span> <?= htmlspecialchars((string) ($statusState['status'] ?? 'idle'), ENT_QUOTES) ?></p>
+                            <p><span class="text-slate-100">Latest ingested sequence:</span> <?= htmlspecialchars((string) ($killmailStatus['max_sequence_id'] ?? '-'), ENT_QUOTES) ?></p>
+                            <p><span class="text-slate-100">Latest uploaded_at:</span> <?= htmlspecialchars((string) ($killmailStatus['max_uploaded_at'] ?? '-'), ENT_QUOTES) ?></p>
+                        </div>
+                        <div class="space-y-1 rounded-lg border border-border bg-black/20 p-3">
+                            <p><span class="text-slate-100">Worker heartbeat:</span> <?= htmlspecialchars((string) ($killmailWorkerStatus['seen_at_relative'] ?? 'No heartbeat'), ENT_QUOTES) ?></p>
+                            <p><span class="text-slate-100">Worker rows:</span> seen <?= number_format((int) ($killmailWorkerStatus['rows_seen'] ?? 0)) ?> · matched <?= number_format((int) ($killmailWorkerStatus['rows_matched'] ?? 0)) ?> · skipped existing <?= number_format((int) ($killmailWorkerStatus['rows_skipped_existing'] ?? 0)) ?> · filtered <?= number_format((int) ($killmailWorkerStatus['rows_filtered_out'] ?? 0)) ?> · written <?= number_format((int) ($killmailWorkerStatus['rows_written'] ?? 0)) ?></p>
+                            <p><span class="text-slate-100">Cursor movement:</span> <?= htmlspecialchars((string) (($killmailWorkerStatus['cursor_before'] ?? '') !== '' ? $killmailWorkerStatus['cursor_before'] : '—'), ENT_QUOTES) ?> → <?= htmlspecialchars((string) (($killmailWorkerStatus['cursor_after'] ?? '') !== '' ? $killmailWorkerStatus['cursor_after'] : ($killmailWorkerStatus['cursor'] ?? '—')), ENT_QUOTES) ?></p>
+                            <?php if (trim((string) ($killmailWorkerStatus['outcome_reason'] ?? '')) !== ''): ?>
+                                <p><span class="text-slate-100">Latest worker reason:</span> <?= htmlspecialchars((string) ($killmailWorkerStatus['outcome_reason'] ?? ''), ENT_QUOTES) ?></p>
+                            <?php endif; ?>
+                        </div>
+                        <label class="block space-y-2 lg:col-span-2">
+                            <span class="text-sm text-muted">Demand Prediction Mode</span>
+                            <input type="text" name="killmail_demand_prediction_mode" value="<?= htmlspecialchars($settingValues['killmail_demand_prediction_mode'] ?? 'baseline', ENT_QUOTES) ?>" class="w-full field-input" />
+                            <span class="text-xs text-muted">Keep future-facing tuning here so the default settings view stays focused on freshness, tracked entities, and whether ingestion is working.</span>
+                        </label>
+                    </div>
+                </details>
 
-                <div class="rounded-lg border border-border bg-black/20 p-3 text-sm text-muted space-y-1">
-                    <p><span class="text-slate-100">Last cursor:</span> <?= htmlspecialchars((string) ($statusState['last_cursor'] ?? '-'), ENT_QUOTES) ?></p>
-                    <p><span class="text-slate-100">Last success:</span> <?= htmlspecialchars((string) ($statusState['last_success_at'] ?? '-'), ENT_QUOTES) ?></p>
-                    <p><span class="text-slate-100">Last status:</span> <?= htmlspecialchars((string) ($statusState['status'] ?? 'idle'), ENT_QUOTES) ?></p>
-                    <p><span class="text-slate-100">Latest ingested sequence:</span> <?= htmlspecialchars((string) ($killmailStatus['max_sequence_id'] ?? '-'), ENT_QUOTES) ?></p>
-                    <p><span class="text-slate-100">Latest uploaded_at:</span> <?= htmlspecialchars((string) ($killmailStatus['max_uploaded_at'] ?? '-'), ENT_QUOTES) ?></p>
-                </div>
-
-                <p class="text-sm text-muted">Ingestion consumes R2Z2 as an ordered stream. The worker now stores killmails when a tracked alliance or corporation appears on either the victim or attacker side, while victim-side matches continue to drive loss-demand analytics.</p>
+                <p class="text-sm text-muted">Ingestion consumes R2Z2 as an ordered stream and keeps killmails when a tracked alliance or corporation appears on either side of the fight. That gives you a concise, business-facing feed without losing deeper diagnostics when you need them.</p>
                 <button class="btn-primary">Save Killmail Intelligence Settings</button>
             </form>
         <?php elseif ($section === 'esi-login'): ?>

--- a/python/orchestrator/jobs/killmail.py
+++ b/python/orchestrator/jobs/killmail.py
@@ -217,6 +217,9 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
     pending_payloads: list[dict[str, Any]] = []
     total_rows_seen = 0
     total_rows_written = 0
+    total_rows_matched = 0
+    total_rows_skipped_existing = 0
+    total_rows_filtered_out = 0
     total_duplicates = 0
     total_filtered = 0
     total_invalid = 0
@@ -253,6 +256,8 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
 
             if status == 200:
                 payload = entity_resolver.enrich_payload(payload)
+                payload["requested_sequence_id"] = sequence_id
+                payload["sequence_id"] = int(payload.get("sequence_id") or sequence_id)
                 pending_payloads.append(payload)
                 total_sequence_files_fetched += 1
                 next_sequence = sequence_id + 1
@@ -261,6 +266,9 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                     pending_payloads = []
                     batches_flushed += 1
                     total_rows_seen += int(batch_result.get("rows_seen") or 0)
+                    total_rows_matched += int(batch_result.get("rows_matched") or 0)
+                    total_rows_skipped_existing += int(batch_result.get("rows_skipped_existing") or 0)
+                    total_rows_filtered_out += int(batch_result.get("rows_filtered_out") or 0)
                     total_rows_written += int(batch_result.get("rows_written") or 0)
                     total_duplicates += int(batch_result.get("duplicates") or 0)
                     total_filtered += int(batch_result.get("filtered") or 0)
@@ -289,6 +297,9 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 pending_payloads = []
                 batches_flushed += 1
                 total_rows_seen += int(batch_result.get("rows_seen") or 0)
+                total_rows_matched += int(batch_result.get("rows_matched") or 0)
+                total_rows_skipped_existing += int(batch_result.get("rows_skipped_existing") or 0)
+                total_rows_filtered_out += int(batch_result.get("rows_filtered_out") or 0)
                 total_rows_written += int(batch_result.get("rows_written") or 0)
                 total_duplicates += int(batch_result.get("duplicates") or 0)
                 total_filtered += int(batch_result.get("filtered") or 0)
@@ -318,6 +329,9 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
             pending_payloads = []
             batches_flushed += 1
             total_rows_seen += int(batch_result.get("rows_seen") or 0)
+            total_rows_matched += int(batch_result.get("rows_matched") or 0)
+            total_rows_skipped_existing += int(batch_result.get("rows_skipped_existing") or 0)
+            total_rows_filtered_out += int(batch_result.get("rows_filtered_out") or 0)
             total_rows_written += int(batch_result.get("rows_written") or 0)
             total_duplicates += int(batch_result.get("duplicates") or 0)
             total_filtered += int(batch_result.get("filtered") or 0)
@@ -334,16 +348,27 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
             "batches_flushed": batches_flushed,
         })
 
+        no_write_reason = ""
         if total_rows_written > 0:
             outcome_reason = "Python streamed killmail ingestion batches and kept polling until the worker budget expired."
         elif total_rows_seen > 0 and total_duplicates == total_rows_seen:
             outcome_reason = "All fetched killmails were already present in storage."
+            no_write_reason = "all_rows_already_present"
         elif total_rows_seen > 0 and total_filtered + total_invalid == total_rows_seen:
             outcome_reason = "Fetched killmails did not pass tracked-entity filters or were invalid."
+            no_write_reason = "all_rows_filtered_or_invalid"
+        elif total_rows_seen > 0 and total_filtered == total_rows_seen:
+            outcome_reason = "Fetched killmails did not match any tracked alliance or corporation."
+            no_write_reason = "all_rows_filtered_out"
+        elif total_rows_seen > 0 and total_invalid == total_rows_seen:
+            outcome_reason = "Fetched killmails could not be normalized into valid persistence rows."
+            no_write_reason = "all_rows_invalid"
         elif total_sequence_404s > 0:
             outcome_reason = "Python worker caught up to the live R2Z2 tip and stayed in the documented poll/sleep loop."
+            no_write_reason = "caught_up_to_live_tip"
         else:
             outcome_reason = "Python worker completed without new killmail inserts."
+            no_write_reason = "mixed_no_write_result"
 
         result = {
             "status": "success",
@@ -366,15 +391,21 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 "duplicates": total_duplicates,
                 "filtered": total_filtered,
                 "invalid": total_invalid,
+                "rows_matched": total_rows_matched,
+                "rows_skipped_existing": total_rows_skipped_existing,
+                "rows_filtered_out": total_rows_filtered_out,
                 "killmails_fetched": total_rows_seen,
                 "killmails_inserted": total_rows_written,
                 "first_sequence_attempted": first_sequence_attempted,
                 "last_sequence_attempted": last_sequence_attempted,
+                "cursor_before": str(last_saved_sequence or 0),
+                "cursor_after": cursor_end,
                 "last_saved_sequence_before_run": last_saved_sequence,
                 "last_processed_sequence": last_processed_sequence,
                 "latest_remote_sequence": latest_remote_sequence,
                 "batches_flushed": batches_flushed,
                 "memory_usage_bytes": resident_memory_bytes(),
+                "no_write_reason": no_write_reason,
                 "outcome_reason": outcome_reason,
             },
         }

--- a/python/orchestrator/logging_utils.py
+++ b/python/orchestrator/logging_utils.py
@@ -33,14 +33,15 @@ class LoggerAdapter(logging.LoggerAdapter):
         return msg, kwargs
 
 
-def configure_logging(verbose: bool = False, log_file: Path | None = None) -> LoggerAdapter:
+def configure_logging(verbose: bool = False, log_file: Path | None = None, stdout_enabled: bool = True) -> LoggerAdapter:
     logger = logging.getLogger("supplycore.orchestrator")
     logger.handlers.clear()
     logger.setLevel(logging.DEBUG if verbose else logging.INFO)
 
-    stream_handler = logging.StreamHandler(sys.stdout)
-    stream_handler.setFormatter(JsonFormatter())
-    logger.addHandler(stream_handler)
+    if stdout_enabled:
+        stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler.setFormatter(JsonFormatter())
+        logger.addHandler(stream_handler)
 
     if log_file is not None:
         log_file.parent.mkdir(parents=True, exist_ok=True)

--- a/python/orchestrator/zkill_worker.py
+++ b/python/orchestrator/zkill_worker.py
@@ -48,7 +48,7 @@ def main(argv: list[str] | None = None) -> int:
     runtime = load_php_runtime_config(app_root)
     worker_settings = runtime.raw.get("workers", {}) if isinstance(runtime.raw, dict) else {}
     log_file = Path(worker_settings.get("zkill_log_file", app_root / "storage/logs/zkill.log"))
-    logger = configure_logging(verbose=args.verbose, log_file=log_file)
+    logger = configure_logging(verbose=args.verbose, log_file=log_file, stdout_enabled=args.verbose or log_file is None)
     state_file = Path(worker_settings.get("zkill_state_file", app_root / "storage/run/zkill-heartbeat.json"))
     pause_threshold = max(128 * 1024 * 1024, int(worker_settings.get("memory_pause_threshold_bytes", 384 * 1024 * 1024)))
     abort_threshold = max(pause_threshold, int(worker_settings.get("memory_abort_threshold_bytes", 512 * 1024 * 1024)))
@@ -95,11 +95,16 @@ def main(argv: list[str] | None = None) -> int:
                 "worker_id": identity,
                 "status": result.get("status"),
                 "rows_seen": result.get("rows_seen"),
+                "rows_matched": (result.get("meta") or {}).get("rows_matched"),
+                "rows_skipped_existing": (result.get("meta") or {}).get("rows_skipped_existing"),
+                "rows_filtered_out": (result.get("meta") or {}).get("rows_filtered_out"),
                 "rows_written": result.get("rows_written"),
-                "cursor": result.get("cursor"),
+                "cursor_before": (result.get("meta") or {}).get("cursor_before"),
+                "cursor_after": result.get("cursor"),
                 "duplicates": (result.get("meta") or {}).get("duplicates"),
                 "filtered": (result.get("meta") or {}).get("filtered"),
                 "invalid": (result.get("meta") or {}).get("invalid"),
+                "no_write_reason": (result.get("meta") or {}).get("no_write_reason"),
                 "outcome_reason": (result.get("meta") or {}).get("outcome_reason"),
             },
         )

--- a/src/functions.php
+++ b/src/functions.php
@@ -8093,10 +8093,93 @@ function zkill_worker_runtime_status(): array
         'age_seconds' => $ageSeconds,
         'status' => $status !== '' ? $status : 'unknown',
         'rows_seen' => (int) (($state['result']['rows_seen'] ?? 0)),
+        'rows_matched' => (int) (($state['result']['meta']['rows_matched'] ?? 0)),
+        'rows_skipped_existing' => (int) (($state['result']['meta']['rows_skipped_existing'] ?? 0)),
+        'rows_filtered_out' => (int) (($state['result']['meta']['rows_filtered_out'] ?? 0)),
         'rows_written' => (int) (($state['result']['rows_written'] ?? 0)),
         'cursor' => isset($state['result']['cursor']) ? (string) $state['result']['cursor'] : null,
+        'cursor_before' => isset($state['result']['meta']['cursor_before']) ? (string) $state['result']['meta']['cursor_before'] : null,
+        'cursor_after' => isset($state['result']['meta']['cursor_after']) ? (string) $state['result']['meta']['cursor_after'] : null,
+        'no_write_reason' => isset($state['result']['meta']['no_write_reason']) ? (string) $state['result']['meta']['no_write_reason'] : '',
+        'outcome_reason' => isset($state['result']['meta']['outcome_reason']) ? (string) $state['result']['meta']['outcome_reason'] : '',
         'memory_usage_bytes' => isset($state['memory_usage_bytes']) ? (int) $state['memory_usage_bytes'] : null,
         'worker_id' => isset($state['worker_id']) ? (string) $state['worker_id'] : null,
+    ];
+}
+
+function killmail_no_write_reason_label(string $reason): string
+{
+    return match (trim($reason)) {
+        'all_rows_already_present' => 'Everything in the last worker pass was already stored.',
+        'all_rows_filtered_or_invalid' => 'The last worker pass saw rows, but all of them were filtered out or invalid.',
+        'all_rows_filtered_out' => 'The last worker pass did not match any tracked alliance or corporation.',
+        'all_rows_invalid' => 'The last worker pass could not normalize the fetched killmails.',
+        'caught_up_to_live_tip' => 'The worker is caught up to the current zKill live tip.',
+        'mixed_no_write_result' => 'The last worker pass completed without inserting new rows.',
+        default => '',
+    };
+}
+
+function killmail_ingestion_health_summary(array $status, array $workerStatus = []): array
+{
+    $lastSuccessAt = trim((string) ($status['last_success_at_raw'] ?? $status['last_success_at'] ?? ''));
+    $lastSuccessTimestamp = $lastSuccessAt !== '' ? (strtotime($lastSuccessAt) ?: null) : null;
+    $workerAgeSeconds = isset($workerStatus['age_seconds']) ? (int) $workerStatus['age_seconds'] : null;
+    $lastError = trim((string) ($status['last_error'] ?? ''));
+    $rowsWritten = (int) ($status['last_run_written_rows'] ?? 0);
+    $rowsSeen = (int) ($status['last_run_source_rows'] ?? 0);
+    $workerNoWriteReason = killmail_no_write_reason_label((string) ($workerStatus['no_write_reason'] ?? ''));
+
+    $state = 'healthy';
+    if (!($status['ingestion_enabled'] ?? false)) {
+        $state = 'disabled';
+    } elseif ($lastError !== '') {
+        $state = 'stalled';
+    } elseif ($lastSuccessTimestamp === null) {
+        $state = 'stalled';
+    } elseif ((time() - $lastSuccessTimestamp) > 45 * 60) {
+        $state = 'stalled';
+    } elseif ((time() - $lastSuccessTimestamp) > 15 * 60) {
+        $state = 'delayed';
+    } elseif ($workerAgeSeconds !== null && $workerAgeSeconds > 20 * 60) {
+        $state = 'delayed';
+    }
+
+    $tone = match ($state) {
+        'healthy' => 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100',
+        'delayed' => 'border-amber-500/40 bg-amber-500/10 text-amber-100',
+        'disabled', 'stalled' => 'border-rose-500/40 bg-rose-500/10 text-rose-100',
+        default => 'border-slate-500/40 bg-slate-500/10 text-slate-200',
+    };
+
+    $label = match ($state) {
+        'healthy' => 'Ingestion healthy',
+        'delayed' => 'Ingestion delayed',
+        'disabled' => 'Ingestion disabled',
+        'stalled' => 'Ingestion stalled',
+        default => 'Status unknown',
+    };
+
+    $message = match ($state) {
+        'healthy' => $rowsWritten > 0
+            ? 'The worker is writing qualifying killmails and the board should stay current.'
+            : ($workerNoWriteReason !== '' ? $workerNoWriteReason : 'The worker is current and no new qualifying killmails were written in the latest pass.'),
+        'delayed' => 'Freshness is drifting beyond the normal operating window. Confirm the worker heartbeat and latest successful sync.',
+        'disabled' => 'Killmail ingestion is currently turned off.',
+        'stalled' => $lastError !== ''
+            ? ('The most recent sync error needs attention: ' . $lastError)
+            : 'Killmail freshness is outside the expected window or the worker is no longer checking in.',
+        default => 'Killmail ingestion status is unavailable.',
+    };
+
+    return [
+        'state' => $state,
+        'label' => $label,
+        'tone' => $tone,
+        'message' => $message,
+        'last_rows_written' => $rowsWritten,
+        'last_rows_seen' => $rowsSeen,
+        'worker_no_write_reason' => $workerNoWriteReason,
     ];
 }
 
@@ -9741,6 +9824,10 @@ function killmail_overview_data(): array
         $lastIngestedAt = isset($summaryRow['last_ingested_at']) ? (string) $summaryRow['last_ingested_at'] : null;
         $latestUploadedAt = isset($summaryRow['latest_uploaded_at']) ? (string) $summaryRow['latest_uploaded_at'] : null;
         $cursor = isset($state['last_cursor']) ? trim((string) $state['last_cursor']) : '';
+        $freshnessReferenceAt = $lastIngestedAt;
+        if ($lastSuccessAt !== null && ($freshnessReferenceAt === null || strtotime($lastSuccessAt) > strtotime($freshnessReferenceAt))) {
+            $freshnessReferenceAt = $lastSuccessAt;
+        }
 
         $overviewResolutionRequests = [
             'alliance' => [],
@@ -9899,6 +9986,41 @@ function killmail_overview_data(): array
         $emptyMessage = $totalCount === 0
             ? 'No killmails have been stored yet. Enable killmail ingestion, run the sync worker, and this view will populate as local killmails arrive.'
             : 'No killmails matched the current filters. Try clearing search or filter controls.';
+        $statusView = [
+            'ingestion_enabled' => killmail_ingestion_enabled(),
+            'current_cursor' => $cursor !== '' ? $cursor : 'Unavailable',
+            'last_sync_outcome' => killmail_last_sync_outcome_label($latestRun),
+            'last_success_at_raw' => $lastSuccessAt,
+            'last_success_at' => killmail_format_datetime($lastSuccessAt),
+            'last_sync_relative' => killmail_relative_datetime($lastSuccessAt),
+            'last_uploaded_at' => killmail_format_datetime($latestUploadedAt),
+            'last_ingested_at' => killmail_format_datetime($lastIngestedAt),
+            'freshness_reference_at_raw' => $freshnessReferenceAt,
+            'freshness_reference_at' => killmail_format_datetime($freshnessReferenceAt),
+            'tracked_alliance_count' => (int) ($status['tracked_alliance_count'] ?? 0),
+            'tracked_corporation_count' => (int) ($status['tracked_corporation_count'] ?? 0),
+            'sync_status' => (string) ($state['status'] ?? 'idle'),
+            'last_run_status' => (string) ($latestRun['run_status'] ?? 'not_run'),
+            'last_run_source_rows' => (int) ($latestRun['source_rows'] ?? 0),
+            'last_run_written_rows' => (int) ($latestRun['written_rows'] ?? 0),
+            'last_run_finished_at' => killmail_format_datetime(isset($latestRun['finished_at']) ? (string) $latestRun['finished_at'] : null),
+            'last_error' => trim((string) ($state['last_error_message'] ?? '')),
+            'worker_status' => (string) ($workerStatus['status'] ?? 'unknown'),
+            'worker_seen_at' => (string) ($workerStatus['seen_at_display'] ?? 'No heartbeat recorded'),
+            'worker_seen_relative' => (string) ($workerStatus['seen_at_relative'] ?? 'No heartbeat'),
+            'worker_rows_seen' => (int) ($workerStatus['rows_seen'] ?? 0),
+            'worker_rows_matched' => (int) ($workerStatus['rows_matched'] ?? 0),
+            'worker_rows_skipped_existing' => (int) ($workerStatus['rows_skipped_existing'] ?? 0),
+            'worker_rows_filtered_out' => (int) ($workerStatus['rows_filtered_out'] ?? 0),
+            'worker_rows_written' => (int) ($workerStatus['rows_written'] ?? 0),
+            'worker_cursor' => isset($workerStatus['cursor']) ? (string) $workerStatus['cursor'] : '',
+            'worker_cursor_before' => isset($workerStatus['cursor_before']) ? (string) $workerStatus['cursor_before'] : '',
+            'worker_cursor_after' => isset($workerStatus['cursor_after']) ? (string) $workerStatus['cursor_after'] : '',
+            'worker_no_write_reason' => isset($workerStatus['no_write_reason']) ? (string) $workerStatus['no_write_reason'] : '',
+            'worker_outcome_reason' => isset($workerStatus['outcome_reason']) ? (string) $workerStatus['outcome_reason'] : '',
+            'worker_memory_usage_bytes' => isset($workerStatus['memory_usage_bytes']) ? (int) $workerStatus['memory_usage_bytes'] : null,
+        ];
+        $statusView['health'] = killmail_ingestion_health_summary($statusView, $workerStatus);
 
         return [
             'error' => null,
@@ -9909,31 +10031,7 @@ function killmail_overview_data(): array
                 ['label' => 'Last Processed Sequence', 'value' => $maxSequenceId > 0 ? number_format($maxSequenceId) : '—', 'context' => $cursor !== '' ? ('Cursor ' . $cursor) : 'Cursor not recorded yet'],
                 ['label' => 'Sync Freshness', 'value' => killmail_relative_datetime($lastSuccessAt), 'context' => $lastSuccessAt !== null ? ('Last success ' . killmail_format_datetime($lastSuccessAt)) : 'No successful sync recorded'],
             ],
-            'status' => [
-                'ingestion_enabled' => killmail_ingestion_enabled(),
-                'current_cursor' => $cursor !== '' ? $cursor : 'Unavailable',
-                'last_sync_outcome' => killmail_last_sync_outcome_label($latestRun),
-                'last_success_at_raw' => $lastSuccessAt,
-                'last_success_at' => killmail_format_datetime($lastSuccessAt),
-                'last_sync_relative' => killmail_relative_datetime($lastSuccessAt),
-                'last_uploaded_at' => killmail_format_datetime($latestUploadedAt),
-                'last_ingested_at' => killmail_format_datetime($lastIngestedAt),
-                'tracked_alliance_count' => (int) ($status['tracked_alliance_count'] ?? 0),
-                'tracked_corporation_count' => (int) ($status['tracked_corporation_count'] ?? 0),
-                'sync_status' => (string) ($state['status'] ?? 'idle'),
-                'last_run_status' => (string) ($latestRun['run_status'] ?? 'not_run'),
-                'last_run_source_rows' => (int) ($latestRun['source_rows'] ?? 0),
-                'last_run_written_rows' => (int) ($latestRun['written_rows'] ?? 0),
-                'last_run_finished_at' => killmail_format_datetime(isset($latestRun['finished_at']) ? (string) $latestRun['finished_at'] : null),
-                'last_error' => trim((string) ($state['last_error_message'] ?? '')),
-                'worker_status' => (string) ($workerStatus['status'] ?? 'unknown'),
-                'worker_seen_at' => (string) ($workerStatus['seen_at_display'] ?? 'No heartbeat recorded'),
-                'worker_seen_relative' => (string) ($workerStatus['seen_at_relative'] ?? 'No heartbeat'),
-                'worker_rows_written' => (int) ($workerStatus['rows_written'] ?? 0),
-                'worker_rows_seen' => (int) ($workerStatus['rows_seen'] ?? 0),
-                'worker_cursor' => isset($workerStatus['cursor']) ? (string) $workerStatus['cursor'] : '',
-                'worker_memory_usage_bytes' => isset($workerStatus['memory_usage_bytes']) ? (int) $workerStatus['memory_usage_bytes'] : null,
-            ],
+            'status' => $statusView,
             'rows' => $rows,
             'filters' => $filters + [
                 'page_size_options' => $allowedPageSizes,
@@ -13530,12 +13628,16 @@ function python_bridge_process_killmail_batch(array $payloads): array
     if ($payloads === []) {
         return [
             'rows_seen' => 0,
+            'rows_matched' => 0,
+            'rows_skipped_existing' => 0,
+            'rows_filtered_out' => 0,
             'rows_written' => 0,
             'killmails_fetched' => 0,
             'duplicates' => 0,
             'filtered' => 0,
             'invalid' => 0,
             'last_processed_sequence' => null,
+            'no_write_reason' => 'empty_batch',
         ];
     }
 
@@ -13543,6 +13645,7 @@ function python_bridge_process_killmail_batch(array $payloads): array
     ['alliance_ids' => $trackedAllianceIds, 'corporation_ids' => $trackedCorporationIds] = killmail_active_tracked_entity_ids();
 
     $rowsSeen = 0;
+    $rowsMatched = 0;
     $rowsWritten = 0;
     $duplicates = 0;
     $filtered = 0;
@@ -13551,33 +13654,58 @@ function python_bridge_process_killmail_batch(array $payloads): array
 
     foreach ($payloads as $payload) {
         $rowsSeen++;
-        $result = killmail_persist_r2z2_payload($payload, $trackedAllianceIds, $trackedCorporationIds);
+        $requestedSequenceId = (int) ($payload['requested_sequence_id'] ?? $payload['sequence_id'] ?? 0);
+        $result = killmail_persist_r2z2_payload($payload, $trackedAllianceIds, $trackedCorporationIds, false, $requestedSequenceId > 0 ? $requestedSequenceId : null);
         $sequenceId = (int) ($result['sequence_id'] ?? 0);
         $status = (string) ($result['status'] ?? 'invalid');
         if ($status === 'invalid') {
             $invalid++;
+            if ($requestedSequenceId > 0) {
+                $lastProcessedSequence = $requestedSequenceId;
+            }
             continue;
         }
 
         if ($status === 'duplicate') {
             $duplicates++;
+            $rowsMatched++;
         } elseif ($status === 'filtered') {
             $filtered++;
         } elseif ($status === 'written') {
             $rowsWritten++;
+            $rowsMatched++;
         }
 
         $lastProcessedSequence = $sequenceId;
     }
 
+    $noWriteReason = '';
+    if ($rowsWritten === 0) {
+        if ($duplicates === $rowsSeen && $rowsSeen > 0) {
+            $noWriteReason = 'all_rows_already_present';
+        } elseif ($filtered === $rowsSeen && $rowsSeen > 0) {
+            $noWriteReason = 'all_rows_filtered_out';
+        } elseif ($invalid === $rowsSeen && $rowsSeen > 0) {
+            $noWriteReason = 'all_rows_invalid';
+        } elseif (($filtered + $invalid) === $rowsSeen && $rowsSeen > 0) {
+            $noWriteReason = 'all_rows_filtered_or_invalid';
+        } else {
+            $noWriteReason = 'mixed_no_write_result';
+        }
+    }
+
     return [
         'rows_seen' => $rowsSeen,
+        'rows_matched' => $rowsMatched,
+        'rows_skipped_existing' => $duplicates,
+        'rows_filtered_out' => $filtered,
         'rows_written' => $rowsWritten,
         'killmails_fetched' => $rowsSeen,
         'duplicates' => $duplicates,
         'filtered' => $filtered,
         'invalid' => $invalid,
         'last_processed_sequence' => $lastProcessedSequence,
+        'no_write_reason' => $noWriteReason,
     ];
 }
 
@@ -17091,7 +17219,7 @@ function killmail_transform_r2z2_payload(array $payload): array
         : (is_array($payload['killmail'] ?? null) ? $payload['killmail'] : []);
     $victim = is_array($killmail['victim'] ?? null) ? $killmail['victim'] : [];
     $zkb = is_array($payload['zkb'] ?? null) ? $payload['zkb'] : [];
-    $sequenceId = (int) ($payload['sequence_id'] ?? 0);
+    $sequenceId = (int) ($payload['sequence_id'] ?? $payload['requested_sequence_id'] ?? 0);
     $systemId = isset($killmail['solar_system_id']) ? (int) $killmail['solar_system_id'] : null;
 
     $event = [


### PR DESCRIPTION
### Motivation
- The zKill Python worker repeatedly reported `rows_seen > 0` but `rows_written == 0` and kept re-reading the same sequence window, leaving the UI stale and producing duplicate loop log lines.
- Operators need a concise, business-facing killmail view that highlights freshness and whether ingestion is working, while detailed diagnostics live in an advanced panel.

### Description
- Ensure each fetched sequence carries its requested sequence id and a fallback sequence id by stamping `requested_sequence_id` and backfilling `sequence_id` in `python/orchestrator/jobs/killmail.py`, so the checkpoint can advance even when normalization would otherwise drop the row.
- Add richer per-loop counters and reasons in the Python worker: `rows_matched`, `rows_skipped_existing`, `rows_filtered_out`, `cursor_before`, `cursor_after`, and `no_write_reason` and surface them in the `meta` returned by `run_killmail_r2z2_stream`. 
- Reduce duplicate logging noise by making stdout emission optional in `python/orchestrator/logging_utils.py` and using `stdout_enabled` from `python/orchestrator/zkill_worker.py`. 
- Extend the PHP bridge and server-side logic in `src/functions.php` with `python_bridge_process_killmail_batch` changes to return the new counters and `no_write_reason`, accept `requested_sequence_id`, and update `killmail_transform_r2z2_payload`/`killmail_persist_r2z2_payload` to accept a fallback/requested sequence id. 
- Expose the richer worker view through `zkill_worker_runtime_status()` and add `killmail_ingestion_health_summary()` to produce a concise operator-friendly ingestion health card. 
- Simplify user-facing pages by focusing `public/killmail-intelligence/index.php` and `public/settings/index.php` on freshness, ingestion health, tracked entities, last successful ingestion, and recent inserted rows, while moving low-level diagnostics into collapsed "Advanced diagnostics" panels. 
- Files changed: `python/orchestrator/jobs/killmail.py`, `python/orchestrator/zkill_worker.py`, `python/orchestrator/logging_utils.py`, `src/functions.php`, `public/killmail-intelligence/index.php`, and `public/settings/index.php`.

### Testing
- Linted PHP templates with `php -l public/killmail-intelligence/index.php`, `php -l public/settings/index.php`, and `php -l src/functions.php`, and they all passed. (success)
- Compiled the Python orchestrator modules with `python -m py_compile python/orchestrator/logging_utils.py python/orchestrator/zkill_worker.py python/orchestrator/jobs/killmail.py` to assert syntax validity, and compilation succeeded. (success)
- Verified `killmail_transform_r2z2_payload` accepts `requested_sequence_id` via a probe script (`php /tmp/killmail_transform_probe.php`) which returned the expected `sequence_id`, confirming normalization fallback behavior. (success)
- Ran a targeted Python harness with a fake PHP bridge (`PYTHONPATH=/workspace/SupplyCore python /tmp/zkill_worker_harness.py`) that exercised two successive runs against the live R2Z2 sequence probe and confirmed forward cursor movement and inserted rows (example output: first run `cursor_before: 96567474 -> cursor_after: 96567476` with `rows_written=2`, second run `cursor_before: 96567476 -> cursor_after: 96567478` with `rows_written=2`). (success)
- Note: a full DB-backed end-to-end page render could not be executed in this environment due to the local MySQL instance being unavailable (`SQLSTATE[HY000] [2002] Connection refused`), so UI rendering checks used linting and the code-level harnesses above as automated verification. (environment limitation)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0bca509e8832fa2a19ac73b6188c4)