### PR TITLE
Fix zKill worker checkpointing, add diagnostics, and improve logging

### DIFF
--- a/bin/python_scheduler_bridge.php
+++ b/bin/python_scheduler_bridge.php
@@ -164,6 +164,12 @@ try {
         python_scheduler_bridge_output(['ok' => true, 'result' => $result]);
     }
 
+    if ($action === 'sync-cursor-upsert') {
+        $input = python_scheduler_bridge_read_stdin_json();
+        $result = python_bridge_sync_cursor_upsert($input);
+        python_scheduler_bridge_output(['ok' => true, 'result' => $result]);
+    }
+
     if ($action === 'sync-run-finish') {
         $input = python_scheduler_bridge_read_stdin_json();
         $result = python_bridge_sync_run_finish($input);

--- a/ops/systemd/supplycore-zkill.service
+++ b/ops/systemd/supplycore-zkill.service
@@ -17,8 +17,8 @@ RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
 MemoryMax=768M
-StandardOutput=append:/var/www/SupplyCore/storage/logs/zkill.log
-StandardError=append:/var/www/SupplyCore/storage/logs/zkill.log
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -103,9 +103,9 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <p class="mt-1 text-sm text-muted">Last successful ingestion <?= htmlspecialchars((string) ($status['last_success_at'] ?? '—'), ENT_QUOTES) ?></p>
             </div>
             <div class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Latest worker pass</p>
-                <p class="mt-2 text-lg font-semibold text-slate-50"><?= number_format((int) ($status['last_run_written_rows'] ?? 0)) ?> written</p>
-                <p class="mt-1 text-sm text-muted">Seen <?= number_format((int) ($status['last_run_source_rows'] ?? 0)) ?> qualifying stream rows</p>
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Last rows written</p>
+                <p class="mt-2 text-lg font-semibold text-slate-50"><?= number_format((int) ($status['worker_rows_written'] ?? $status['last_run_written_rows'] ?? 0)) ?> written</p>
+                <p class="mt-1 text-sm text-muted">Seen <?= number_format((int) ($status['worker_rows_seen'] ?? $status['last_run_source_rows'] ?? 0)) ?> · matched <?= number_format((int) ($status['worker_rows_matched'] ?? 0)) ?> · skipped existing <?= number_format((int) ($status['worker_rows_skipped_existing'] ?? 0)) ?> · filtered <?= number_format((int) ($status['worker_rows_filtered_out'] ?? 0)) ?></p>
             </div>
             <div class="surface-tertiary">
                 <p class="text-xs uppercase tracking-[0.15em] text-muted">Current cursor</p>
@@ -113,9 +113,9 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <p class="mt-1 text-sm text-muted">Saved stream checkpoint used for the next pass.</p>
             </div>
             <div class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Live updates</p>
-                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($liveRefreshConfig === null ? 'Off' : (($pageFreshness['state'] ?? 'stale') === 'stale' ? 'Degraded' : 'On')), ENT_QUOTES) ?></p>
-                <p class="mt-1 text-sm text-muted">Last updated <?= htmlspecialchars((string) ($pageFreshness['computed_relative'] ?? 'Never'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($pageFreshness['computed_at'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Current ingestion state</p>
+                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($health['label'] ?? 'Unknown'), ENT_QUOTES) ?></p>
+                <p class="mt-1 text-sm text-muted">Worker <?= htmlspecialchars((string) ($status['worker_status'] ?? 'unknown'), ENT_QUOTES) ?> · checkpoint <?= htmlspecialchars((string) (($status['worker_checkpoint_state'] ?? '') !== '' ? $status['worker_checkpoint_state'] : 'unavailable'), ENT_QUOTES) ?></p>
             </div>
         </div>
         <?php if ((string) ($status['last_error'] ?? '') !== ''): ?>
@@ -128,10 +128,15 @@ include __DIR__ . '/../../src/views/partials/header.php';
             <div class="mt-3 grid gap-3 sm:grid-cols-2 text-sm text-slate-300">
                 <p><span class="text-slate-500">Worker heartbeat</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['worker_seen_relative'] ?? 'No heartbeat'), ENT_QUOTES) ?></span><br><span class="text-xs text-muted"><?= htmlspecialchars((string) ($status['worker_seen_at'] ?? 'No heartbeat recorded'), ENT_QUOTES) ?></span></p>
                 <p><span class="text-slate-500">Latest run outcome</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['last_sync_outcome'] ?? 'Unknown'), ENT_QUOTES) ?></span><br><span class="text-xs text-muted"><?= htmlspecialchars((string) ($status['last_run_finished_at'] ?? 'Unavailable'), ENT_QUOTES) ?></span></p>
-                <p><span class="text-slate-500">Worker rows</span><br><span class="mt-1 inline-block text-slate-100">seen <?= number_format((int) ($status['worker_rows_seen'] ?? 0)) ?> · matched <?= number_format((int) ($status['worker_rows_matched'] ?? 0)) ?> · skipped existing <?= number_format((int) ($status['worker_rows_skipped_existing'] ?? 0)) ?> · filtered <?= number_format((int) ($status['worker_rows_filtered_out'] ?? 0)) ?> · written <?= number_format((int) ($status['worker_rows_written'] ?? 0)) ?></span></p>
-                <p><span class="text-slate-500">Cursor movement</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) (($status['worker_cursor_before'] ?? '') !== '' ? $status['worker_cursor_before'] : '—'), ENT_QUOTES) ?> → <?= htmlspecialchars((string) (($status['worker_cursor_after'] ?? '') !== '' ? $status['worker_cursor_after'] : ($status['worker_cursor'] ?? '—')), ENT_QUOTES) ?></span></p>
+                <p><span class="text-slate-500">Worker rows</span><br><span class="mt-1 inline-block text-slate-100">seen <?= number_format((int) ($status['worker_rows_seen'] ?? 0)) ?> · matched <?= number_format((int) ($status['worker_rows_matched'] ?? 0)) ?> · skipped existing <?= number_format((int) ($status['worker_rows_skipped_existing'] ?? 0)) ?> · filtered <?= number_format((int) ($status['worker_rows_filtered_out'] ?? 0)) ?> · attempted <?= number_format((int) ($status['worker_rows_write_attempted'] ?? 0)) ?> · failed <?= number_format((int) ($status['worker_rows_failed'] ?? 0)) ?> · written <?= number_format((int) ($status['worker_rows_written'] ?? 0)) ?></span></p>
+                <p><span class="text-slate-500">Cursor movement</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) (($status['worker_cursor_before'] ?? '') !== '' ? $status['worker_cursor_before'] : '—'), ENT_QUOTES) ?> → <?= htmlspecialchars((string) (($status['worker_cursor_after'] ?? '') !== '' ? $status['worker_cursor_after'] : ($status['worker_cursor'] ?? '—')), ENT_QUOTES) ?></span><br><span class="text-xs text-muted">Sequences <?= htmlspecialchars((string) (($status['worker_first_sequence_seen'] ?? '') !== '' ? $status['worker_first_sequence_seen'] : '—'), ENT_QUOTES) ?> to <?= htmlspecialchars((string) (($status['worker_last_sequence_seen'] ?? '') !== '' ? $status['worker_last_sequence_seen'] : '—'), ENT_QUOTES) ?></span></p>
+                <p><span class="text-slate-500">No-progress guard</span><br><span class="mt-1 inline-block text-slate-100"><?= !empty($status['worker_stuck_detected']) ? 'Stuck condition detected' : 'No stuck condition' ?></span><br><span class="text-xs text-muted">Repeated same cursor <?= number_format((int) ($status['worker_same_cursor_no_progress_count'] ?? 0)) ?> times (threshold <?= number_format((int) ($status['worker_stuck_threshold'] ?? 0)) ?>).</span></p>
+                <p><span class="text-slate-500">Operator paths</span><br><span class="mt-1 inline-block text-slate-100 break-all"><?= htmlspecialchars((string) ($status['worker_log_file'] ?? 'Unavailable'), ENT_QUOTES) ?></span><br><span class="text-xs text-muted break-all"><?= htmlspecialchars((string) ($status['worker_state_file'] ?? 'Unavailable'), ENT_QUOTES) ?></span></p>
                 <?php if ((string) ($status['worker_outcome_reason'] ?? '') !== ''): ?>
                     <p class="sm:col-span-2"><span class="text-slate-500">Latest worker reason</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['worker_outcome_reason'] ?? ''), ENT_QUOTES) ?></span></p>
+                <?php endif; ?>
+                <?php if ((string) ($status['worker_no_write_reason'] ?? '') !== ''): ?>
+                    <p class="sm:col-span-2"><span class="text-slate-500">Zero-write reason</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['worker_no_write_reason'] ?? ''), ENT_QUOTES) ?></span></p>
                 <?php endif; ?>
             </div>
         </details>

--- a/python/orchestrator/jobs/killmail.py
+++ b/python/orchestrator/jobs/killmail.py
@@ -98,6 +98,138 @@ def _sync_run_finish(bridge: PhpBridge, job_context: dict[str, Any], run_id: int
     return dict(response.get("result") or {})
 
 
+def _sync_cursor_checkpoint(
+    bridge: PhpBridge,
+    job_context: dict[str, Any],
+    cursor: str,
+    *,
+    rows_written: int,
+    outcome_reason: str,
+) -> dict[str, Any]:
+    dataset_key = str(job_context.get("dataset_key") or "").strip()
+    if dataset_key == "" or cursor.strip() == "":
+        return {
+            "checkpoint_updated": False,
+            "cursor": cursor,
+            "reason": "missing_dataset_or_cursor",
+        }
+
+    response = bridge.call(
+        "sync-cursor-upsert",
+        payload={
+            "dataset_key": dataset_key,
+            "run_mode": "incremental",
+            "cursor": cursor,
+            "rows_written": rows_written,
+            "outcome_reason": outcome_reason,
+        },
+    )
+    result = dict(response.get("result") or {})
+    return {
+        "checkpoint_updated": bool(result.get("checkpoint_updated")),
+        "cursor": str(result.get("cursor") or cursor),
+        "reason": str(result.get("reason") or ""),
+    }
+
+
+def _zero_write_reason(
+    *,
+    rows_seen: int,
+    rows_matched: int,
+    rows_filtered_out: int,
+    rows_skipped_existing: int,
+    rows_failed: int,
+    rows_written: int,
+    checkpoint_updated: bool,
+    sequence_404s: int,
+    latest_remote_sequence: int | None,
+    cursor_before: str,
+    cursor_after: str,
+) -> str:
+    if rows_written > 0:
+        return ""
+    if rows_seen == 0 and sequence_404s > 0:
+        return "caught_up_to_live_tip"
+    if rows_seen == 0:
+        return "unknown"
+    if rows_failed > 0:
+        return "write_failed"
+    if rows_matched == 0 and rows_filtered_out == rows_seen:
+        return "no_tracked_entity_matches"
+    if rows_skipped_existing == rows_seen:
+        return "already_existed_locally"
+    if rows_filtered_out == rows_seen:
+        return "filter_excluded_all"
+    if cursor_after == cursor_before and latest_remote_sequence is not None and latest_remote_sequence > 0:
+        return "checkpoint_prevented_write"
+    if cursor_after != "" and not checkpoint_updated:
+        return "checkpoint_prevented_write"
+    if rows_matched > 0 and rows_written == 0:
+        return "downstream_persistence_blocked"
+    return "unknown"
+
+
+def _flush_pending_batch(
+    *,
+    bridge: PhpBridge,
+    job_context: dict[str, Any],
+    pending_payloads: list[dict[str, Any]],
+    batch_index: int,
+    last_processed_sequence: int | None,
+    logger_context: Any,
+    started_at: float,
+    totals: dict[str, int],
+) -> tuple[dict[str, Any], int | None]:
+    batch_result = _flush_batch(bridge, pending_payloads)
+    batch_meta = dict(batch_result.get("meta") or {})
+    batch_last_processed = batch_result.get("last_processed_sequence")
+    if batch_last_processed is not None:
+        last_processed_sequence = int(batch_last_processed)
+
+    checkpoint_state = {
+        "checkpoint_updated": False,
+        "cursor": "",
+        "reason": "no_processed_sequence",
+    }
+    if last_processed_sequence is not None and last_processed_sequence > 0:
+        checkpoint_state = _sync_cursor_checkpoint(
+            bridge,
+            job_context,
+            str(last_processed_sequence),
+            rows_written=int(batch_result.get("rows_written") or 0),
+            outcome_reason=str(batch_result.get("reason_for_zero_write") or "batch_processed"),
+        )
+
+    batch_result["meta"] = {
+        **batch_meta,
+        "checkpoint_state": checkpoint_state,
+    }
+    logger_context.emit(
+        "zkill.batch_completed",
+        {
+            "job_key": logger_context.job_key,
+            "batch_index": batch_index,
+            "rows_seen": batch_result.get("rows_seen"),
+            "rows_matched": batch_result.get("rows_matched"),
+            "rows_filtered_out": batch_result.get("rows_filtered_out"),
+            "rows_skipped_existing": batch_result.get("rows_skipped_existing"),
+            "rows_write_attempted": batch_result.get("rows_write_attempted"),
+            "rows_written": batch_result.get("rows_written"),
+            "rows_failed": batch_result.get("rows_failed"),
+            "cursor_after": str(last_processed_sequence or ""),
+            "first_sequence_seen": batch_meta.get("first_sequence_seen"),
+            "last_sequence_seen": batch_meta.get("last_sequence_seen"),
+            "reason_for_zero_write": batch_result.get("reason_for_zero_write"),
+            "checkpoint_state": checkpoint_state,
+            "duration_ms": int((time.monotonic() - started_at) * 1000),
+            "memory_usage_bytes": resident_memory_bytes(),
+            "running_rows_seen": totals["rows_seen"] + int(batch_result.get("rows_seen") or 0),
+            "running_rows_written": totals["rows_written"] + int(batch_result.get("rows_written") or 0),
+        },
+    )
+    return batch_result, last_processed_sequence
+
+
 class KillmailEntityResolver:
     def __init__(self, user_agent: str):
         self.user_agent = user_agent
@@ -220,6 +352,8 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
     total_rows_matched = 0
     total_rows_skipped_existing = 0
     total_rows_filtered_out = 0
+    total_rows_write_attempted = 0
+    total_rows_failed = 0
     total_duplicates = 0
     total_filtered = 0
     total_invalid = 0
@@ -227,8 +361,11 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
     total_sequence_404s = 0
     total_rate_limits = 0
     batches_flushed = 0
-    first_sequence_attempted: int | None = None
-    last_sequence_attempted: int | None = None
+    first_sequence_seen: int | None = None
+    last_sequence_seen: int | None = None
+    checkpoint_updates = 0
+    checkpoint_failures = 0
+    first_failure_message = ""
 
     try:
         while time.monotonic() < deadline and total_sequence_files_fetched < max_sequences:
@@ -249,9 +386,9 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                     raise RuntimeError(f"Unable to read killmail sequence.json, status={probe_status}")
 
             sequence_id = int(next_sequence)
-            if first_sequence_attempted is None:
-                first_sequence_attempted = sequence_id
-            last_sequence_attempted = sequence_id
+            if first_sequence_seen is None:
+                first_sequence_seen = sequence_id
+            last_sequence_seen = sequence_id
             status, payload = _http_json(f"{base_url}/{sequence_id}.json", user_agent)
 
             if status == 200:
@@ -262,51 +399,69 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 total_sequence_files_fetched += 1
                 next_sequence = sequence_id + 1
                 if len(pending_payloads) >= batch_size:
-                    batch_result = _flush_batch(bridge, pending_payloads)
+                    batch_result, last_processed_sequence = _flush_pending_batch(
+                        bridge=bridge,
+                        job_context=job_context,
+                        pending_payloads=pending_payloads,
+                        batch_index=batches_flushed + 1,
+                        last_processed_sequence=last_processed_sequence,
+                        logger_context=context,
+                        started_at=started_at,
+                        totals={
+                            "rows_seen": total_rows_seen,
+                            "rows_written": total_rows_written,
+                        },
+                    )
                     pending_payloads = []
                     batches_flushed += 1
                     total_rows_seen += int(batch_result.get("rows_seen") or 0)
                     total_rows_matched += int(batch_result.get("rows_matched") or 0)
                     total_rows_skipped_existing += int(batch_result.get("rows_skipped_existing") or 0)
                     total_rows_filtered_out += int(batch_result.get("rows_filtered_out") or 0)
+                    total_rows_write_attempted += int(batch_result.get("rows_write_attempted") or 0)
                     total_rows_written += int(batch_result.get("rows_written") or 0)
+                    total_rows_failed += int(batch_result.get("rows_failed") or 0)
                     total_duplicates += int(batch_result.get("duplicates") or 0)
                     total_filtered += int(batch_result.get("filtered") or 0)
                     total_invalid += int(batch_result.get("invalid") or 0)
-                    batch_last_processed = batch_result.get("last_processed_sequence")
-                    if batch_last_processed is not None:
-                        last_processed_sequence = int(batch_last_processed)
-                    context.emit(
-                        "python_worker.batch_progress",
-                        {
-                            "schedule_id": context.schedule_id,
-                            "job_key": context.job_key,
-                            "batches_completed": batches_flushed,
-                            "rows_processed": total_rows_seen,
-                            "rows_written": total_rows_written,
-                            "last_sequence_attempted": last_sequence_attempted,
-                            "last_processed_sequence": last_processed_sequence,
-                            "memory_usage_bytes": resident_memory_bytes(),
-                            "duration_ms": int((time.monotonic() - started_at) * 1000),
-                        },
-                    )
-                continue
+                    checkpoint_state = dict((batch_result.get("meta") or {}).get("checkpoint_state") or {})
+                    if checkpoint_state.get("checkpoint_updated"):
+                        checkpoint_updates += 1
+                    elif str(checkpoint_state.get("reason") or "") != "no_processed_sequence":
+                        checkpoint_failures += 1
+                    continue
 
             if pending_payloads:
-                batch_result = _flush_batch(bridge, pending_payloads)
+                batch_result, last_processed_sequence = _flush_pending_batch(
+                    bridge=bridge,
+                    job_context=job_context,
+                    pending_payloads=pending_payloads,
+                    batch_index=batches_flushed + 1,
+                    last_processed_sequence=last_processed_sequence,
+                    logger_context=context,
+                    started_at=started_at,
+                    totals={
+                        "rows_seen": total_rows_seen,
+                        "rows_written": total_rows_written,
+                    },
+                )
                 pending_payloads = []
                 batches_flushed += 1
                 total_rows_seen += int(batch_result.get("rows_seen") or 0)
                 total_rows_matched += int(batch_result.get("rows_matched") or 0)
                 total_rows_skipped_existing += int(batch_result.get("rows_skipped_existing") or 0)
                 total_rows_filtered_out += int(batch_result.get("rows_filtered_out") or 0)
+                total_rows_write_attempted += int(batch_result.get("rows_write_attempted") or 0)
                 total_rows_written += int(batch_result.get("rows_written") or 0)
+                total_rows_failed += int(batch_result.get("rows_failed") or 0)
                 total_duplicates += int(batch_result.get("duplicates") or 0)
                 total_filtered += int(batch_result.get("filtered") or 0)
                 total_invalid += int(batch_result.get("invalid") or 0)
-                batch_last_processed = batch_result.get("last_processed_sequence")
-                if batch_last_processed is not None:
-                    last_processed_sequence = int(batch_last_processed)
+                checkpoint_state = dict((batch_result.get("meta") or {}).get("checkpoint_state") or {})
+                if checkpoint_state.get("checkpoint_updated"):
+                    checkpoint_updates += 1
+                elif str(checkpoint_state.get("reason") or "") != "no_processed_sequence":
+                    checkpoint_failures += 1
 
             if status == 404:
                 total_sequence_404s += 1
@@ -325,20 +480,36 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
             raise RuntimeError(f"R2Z2 sequence fetch failed for {sequence_id} with status={status}")
 
         if pending_payloads:
-            batch_result = _flush_batch(bridge, pending_payloads)
+            batch_result, last_processed_sequence = _flush_pending_batch(
+                bridge=bridge,
+                job_context=job_context,
+                pending_payloads=pending_payloads,
+                batch_index=batches_flushed + 1,
+                last_processed_sequence=last_processed_sequence,
+                logger_context=context,
+                started_at=started_at,
+                totals={
+                    "rows_seen": total_rows_seen,
+                    "rows_written": total_rows_written,
+                },
+            )
             pending_payloads = []
             batches_flushed += 1
             total_rows_seen += int(batch_result.get("rows_seen") or 0)
             total_rows_matched += int(batch_result.get("rows_matched") or 0)
             total_rows_skipped_existing += int(batch_result.get("rows_skipped_existing") or 0)
             total_rows_filtered_out += int(batch_result.get("rows_filtered_out") or 0)
+            total_rows_write_attempted += int(batch_result.get("rows_write_attempted") or 0)
             total_rows_written += int(batch_result.get("rows_written") or 0)
+            total_rows_failed += int(batch_result.get("rows_failed") or 0)
             total_duplicates += int(batch_result.get("duplicates") or 0)
             total_filtered += int(batch_result.get("filtered") or 0)
             total_invalid += int(batch_result.get("invalid") or 0)
-            batch_last_processed = batch_result.get("last_processed_sequence")
-            if batch_last_processed is not None:
-                last_processed_sequence = int(batch_last_processed)
+            checkpoint_state = dict((batch_result.get("meta") or {}).get("checkpoint_state") or {})
+            if checkpoint_state.get("checkpoint_updated"):
+                checkpoint_updates += 1
+            elif str(checkpoint_state.get("reason") or "") != "no_processed_sequence":
+                checkpoint_failures += 1
 
         cursor_end = str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0))
         checksum = payload_checksum({
@@ -348,27 +519,34 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
             "batches_flushed": batches_flushed,
         })
 
-        no_write_reason = ""
+        checkpoint_updated = checkpoint_updates > 0 or cursor_end == str(last_saved_sequence or 0)
+        reason_for_zero_write = _zero_write_reason(
+            rows_seen=total_rows_seen,
+            rows_matched=total_rows_matched,
+            rows_filtered_out=total_rows_filtered_out,
+            rows_skipped_existing=total_rows_skipped_existing,
+            rows_failed=total_rows_failed,
+            rows_written=total_rows_written,
+            checkpoint_updated=checkpoint_updated,
+            sequence_404s=total_sequence_404s,
+            latest_remote_sequence=latest_remote_sequence,
+            cursor_before=str(last_saved_sequence or 0),
+            cursor_after=cursor_end,
+        )
         if total_rows_written > 0:
             outcome_reason = "Python streamed killmail ingestion batches and kept polling until the worker budget expired."
-        elif total_rows_seen > 0 and total_duplicates == total_rows_seen:
-            outcome_reason = "All fetched killmails were already present in storage."
-            no_write_reason = "all_rows_already_present"
-        elif total_rows_seen > 0 and total_filtered + total_invalid == total_rows_seen:
-            outcome_reason = "Fetched killmails did not pass tracked-entity filters or were invalid."
-            no_write_reason = "all_rows_filtered_or_invalid"
-        elif total_rows_seen > 0 and total_filtered == total_rows_seen:
-            outcome_reason = "Fetched killmails did not match any tracked alliance or corporation."
-            no_write_reason = "all_rows_filtered_out"
-        elif total_rows_seen > 0 and total_invalid == total_rows_seen:
-            outcome_reason = "Fetched killmails could not be normalized into valid persistence rows."
-            no_write_reason = "all_rows_invalid"
-        elif total_sequence_404s > 0:
-            outcome_reason = "Python worker caught up to the live R2Z2 tip and stayed in the documented poll/sleep loop."
-            no_write_reason = "caught_up_to_live_tip"
         else:
-            outcome_reason = "Python worker completed without new killmail inserts."
-            no_write_reason = "mixed_no_write_result"
+            outcome_reason = {
+                "no_tracked_entity_matches": "Fetched killmails did not match any tracked alliance or corporation.",
+                "already_existed_locally": "All fetched killmails were already present in local storage.",
+                "write_failed": "Fetched killmails reached persistence but a write failed before completion.",
+                "transaction_rolled_back": "The persistence transaction rolled back before any qualifying rows were committed.",
+                "filter_excluded_all": "Fetched killmails were excluded by tracked-entity filters.",
+                "checkpoint_prevented_write": "Cursor checkpointing did not advance after processing the batch.",
+                "downstream_persistence_blocked": "Qualifying killmails were matched but could not be persisted locally.",
+                "caught_up_to_live_tip": "Python worker caught up to the live R2Z2 tip and stayed in the documented poll/sleep loop.",
+                "unknown": "Python worker completed without new killmail inserts and the zero-write cause requires follow-up.",
+            }.get(reason_for_zero_write, "Python worker completed without new killmail inserts.")
 
         result = {
             "status": "success",
@@ -394,10 +572,12 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 "rows_matched": total_rows_matched,
                 "rows_skipped_existing": total_rows_skipped_existing,
                 "rows_filtered_out": total_rows_filtered_out,
+                "rows_write_attempted": total_rows_write_attempted,
+                "rows_failed": total_rows_failed,
                 "killmails_fetched": total_rows_seen,
                 "killmails_inserted": total_rows_written,
-                "first_sequence_attempted": first_sequence_attempted,
-                "last_sequence_attempted": last_sequence_attempted,
+                "first_sequence_seen": first_sequence_seen,
+                "last_sequence_seen": last_sequence_seen,
                 "cursor_before": str(last_saved_sequence or 0),
                 "cursor_after": cursor_end,
                 "last_saved_sequence_before_run": last_saved_sequence,
@@ -405,13 +585,19 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 "latest_remote_sequence": latest_remote_sequence,
                 "batches_flushed": batches_flushed,
                 "memory_usage_bytes": resident_memory_bytes(),
-                "no_write_reason": no_write_reason,
+                "checkpoint_updates": checkpoint_updates,
+                "checkpoint_failures": checkpoint_failures,
+                "checkpoint_state": "updated" if checkpoint_updated else "unchanged",
+                "reason_for_zero_write": reason_for_zero_write,
+                "no_write_reason": reason_for_zero_write,
                 "outcome_reason": outcome_reason,
             },
         }
         _sync_run_finish(bridge, job_context, run_id, result)
         return result
     except Exception as error:
+        if first_failure_message == "":
+            first_failure_message = str(error)
         _sync_run_finish(
             bridge,
             job_context,
@@ -424,6 +610,20 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 "cursor": str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0)),
                 "checksum": "",
                 "error": str(error),
+                "meta": {
+                    "rows_matched": total_rows_matched,
+                    "rows_filtered_out": total_rows_filtered_out,
+                    "rows_skipped_existing": total_rows_skipped_existing,
+                    "rows_write_attempted": total_rows_write_attempted,
+                    "rows_failed": max(1, total_rows_failed),
+                    "cursor_before": str(last_saved_sequence or 0),
+                    "cursor_after": str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0)),
+                    "first_sequence_seen": first_sequence_seen,
+                    "last_sequence_seen": last_sequence_seen,
+                    "reason_for_zero_write": "transaction_rolled_back",
+                    "checkpoint_state": "unchanged",
+                    "outcome_reason": first_failure_message,
+                },
             },
         )
         raise

--- a/python/orchestrator/logging_utils.py
+++ b/python/orchestrator/logging_utils.py
@@ -33,9 +33,17 @@ class LoggerAdapter(logging.LoggerAdapter):
         return msg, kwargs
 
 
-def configure_logging(verbose: bool = False, log_file: Path | None = None, stdout_enabled: bool = True) -> LoggerAdapter:
-    logger = logging.getLogger("supplycore.orchestrator")
-    logger.handlers.clear()
+def configure_logging(
+    *,
+    logger_name: str = "supplycore.orchestrator",
+    verbose: bool = False,
+    log_file: Path | None = None,
+    stdout_enabled: bool = True,
+) -> LoggerAdapter:
+    logger = logging.getLogger(logger_name)
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
     logger.setLevel(logging.DEBUG if verbose else logging.INFO)
 
     if stdout_enabled:

--- a/python/orchestrator/zkill_worker.py
+++ b/python/orchestrator/zkill_worker.py
@@ -6,6 +6,7 @@ import os
 import socket
 import time
 from pathlib import Path
+from typing import Any
 
 from .config import load_php_runtime_config
 from .jobs import run_killmail_r2z2_stream
@@ -42,19 +43,72 @@ def _write_state_file(path: Path, payload: dict[str, object]) -> None:
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
+def _read_state_file(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        decoded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _result_meta(result: dict[str, Any]) -> dict[str, Any]:
+    meta = result.get("meta")
+    return meta if isinstance(meta, dict) else {}
+
+
+def _no_progress_state(previous_state: dict[str, Any], result: dict[str, Any], threshold: int) -> dict[str, Any]:
+    meta = _result_meta(result)
+    cursor_after = str(meta.get("cursor_after") or result.get("cursor") or "").strip()
+    rows_written = int(result.get("rows_written") or 0)
+    previous_result = previous_state.get("result")
+    previous_meta = previous_result.get("meta") if isinstance(previous_result, dict) else {}
+    previous_cursor_after = ""
+    if isinstance(previous_meta, dict):
+        previous_cursor_after = str(previous_meta.get("cursor_after") or previous_result.get("cursor") or "").strip()
+    repeated_count = int(previous_state.get("same_cursor_no_progress_count") or 0)
+    if rows_written == 0 and cursor_after != "" and cursor_after == previous_cursor_after:
+        repeated_count += 1
+    else:
+        repeated_count = 0
+
+    stuck_detected = repeated_count >= max(1, threshold)
+    return {
+        "same_cursor_no_progress_count": repeated_count,
+        "stuck_threshold": max(1, threshold),
+        "stuck_detected": stuck_detected,
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     app_root = Path(args.app_root).resolve()
     runtime = load_php_runtime_config(app_root)
     worker_settings = runtime.raw.get("workers", {}) if isinstance(runtime.raw, dict) else {}
     log_file = Path(worker_settings.get("zkill_log_file", app_root / "storage/logs/zkill.log"))
-    logger = configure_logging(verbose=args.verbose, log_file=log_file, stdout_enabled=args.verbose or log_file is None)
+    logger = configure_logging(
+        logger_name="supplycore.zkill",
+        verbose=args.verbose,
+        log_file=log_file,
+        stdout_enabled=True,
+    )
     state_file = Path(worker_settings.get("zkill_state_file", app_root / "storage/run/zkill-heartbeat.json"))
     pause_threshold = max(128 * 1024 * 1024, int(worker_settings.get("memory_pause_threshold_bytes", 384 * 1024 * 1024)))
     abort_threshold = max(pause_threshold, int(worker_settings.get("memory_abort_threshold_bytes", 512 * 1024 * 1024)))
+    stuck_threshold = max(2, int(worker_settings.get("zkill_stuck_cursor_threshold", 3)))
     identity = f"{socket.gethostname()}-{os.getpid()}"
 
-    logger.info("zkill worker started", payload={"event": "zkill.started", "worker_id": identity})
+    logger.info(
+        "zkill worker started",
+        payload={
+            "event": "zkill.started",
+            "worker_id": identity,
+            "log_file": str(log_file),
+            "state_file": str(state_file),
+            "stuck_threshold": stuck_threshold,
+        },
+    )
 
     while True:
         memory_usage = resident_memory_bytes()
@@ -78,36 +132,72 @@ def main(argv: list[str] | None = None) -> int:
             memory_abort_threshold_bytes=abort_threshold,
             logger=logger,
         )
-        result = run_killmail_r2z2_stream(context)
-        _write_state_file(
-            state_file,
-            {
-                "ts": utc_now_iso(),
-                "worker_id": identity,
-                "result": result,
-                "memory_usage_bytes": resident_memory_bytes(),
-            },
-        )
+        previous_state = _read_state_file(state_file)
+        try:
+            result = run_killmail_r2z2_stream(context)
+        except Exception:
+            logger.exception(
+                "zkill loop failed",
+                payload={
+                    "event": "zkill.loop_failed",
+                    "worker_id": identity,
+                    "log_file": str(log_file),
+                    "state_file": str(state_file),
+                },
+            )
+            raise
+
+        no_progress = _no_progress_state(previous_state, result, stuck_threshold)
+        meta = _result_meta(result)
+        state_payload = {
+            "ts": utc_now_iso(),
+            "worker_id": identity,
+            "log_file": str(log_file),
+            "state_file": str(state_file),
+            "result": result,
+            "memory_usage_bytes": resident_memory_bytes(),
+            **no_progress,
+        }
+        _write_state_file(state_file, state_payload)
         logger.info(
             "zkill loop completed",
             payload={
                 "event": "zkill.loop_completed",
                 "worker_id": identity,
+                "log_file": str(log_file),
+                "state_file": str(state_file),
                 "status": result.get("status"),
                 "rows_seen": result.get("rows_seen"),
-                "rows_matched": (result.get("meta") or {}).get("rows_matched"),
-                "rows_skipped_existing": (result.get("meta") or {}).get("rows_skipped_existing"),
-                "rows_filtered_out": (result.get("meta") or {}).get("rows_filtered_out"),
+                "rows_matched": meta.get("rows_matched"),
+                "rows_filtered_out": meta.get("rows_filtered_out"),
+                "rows_skipped_existing": meta.get("rows_skipped_existing"),
+                "rows_write_attempted": meta.get("rows_write_attempted"),
                 "rows_written": result.get("rows_written"),
-                "cursor_before": (result.get("meta") or {}).get("cursor_before"),
-                "cursor_after": result.get("cursor"),
-                "duplicates": (result.get("meta") or {}).get("duplicates"),
-                "filtered": (result.get("meta") or {}).get("filtered"),
-                "invalid": (result.get("meta") or {}).get("invalid"),
-                "no_write_reason": (result.get("meta") or {}).get("no_write_reason"),
-                "outcome_reason": (result.get("meta") or {}).get("outcome_reason"),
+                "rows_failed": meta.get("rows_failed"),
+                "first_sequence_seen": meta.get("first_sequence_seen"),
+                "last_sequence_seen": meta.get("last_sequence_seen"),
+                "cursor_before": meta.get("cursor_before"),
+                "cursor_after": meta.get("cursor_after") or result.get("cursor"),
+                "reason_for_zero_write": meta.get("reason_for_zero_write"),
+                "checkpoint_state": meta.get("checkpoint_state"),
+                "same_cursor_no_progress_count": no_progress["same_cursor_no_progress_count"],
+                "stuck_detected": no_progress["stuck_detected"],
+                "stuck_threshold": no_progress["stuck_threshold"],
+                "outcome_reason": meta.get("outcome_reason"),
             },
         )
+        if no_progress["stuck_detected"]:
+            logger.warning(
+                "zkill worker detected repeated no-progress cursor state",
+                payload={
+                    "event": "zkill.no_progress_detected",
+                    "worker_id": identity,
+                    "cursor_after": meta.get("cursor_after") or result.get("cursor"),
+                    "same_cursor_no_progress_count": no_progress["same_cursor_no_progress_count"],
+                    "stuck_threshold": no_progress["stuck_threshold"],
+                    "reason_for_zero_write": meta.get("reason_for_zero_write"),
+                },
+            )
         if args.once:
             return 0
         sleep_for = max(3, args.poll_sleep if int(result.get("rows_written") or 0) == 0 else 3)

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -55,6 +55,7 @@ $config = [
         'memory_pause_threshold_bytes' => max(134217728, (int) (getenv('SUPPLYCORE_WORKER_MEMORY_PAUSE_THRESHOLD_BYTES') ?: 402653184)),
         'memory_abort_threshold_bytes' => max(268435456, (int) (getenv('SUPPLYCORE_WORKER_MEMORY_ABORT_THRESHOLD_BYTES') ?: 536870912)),
         'retry_backoff_seconds' => max(5, (int) (getenv('SUPPLYCORE_WORKER_RETRY_BACKOFF_SECONDS') ?: 30)),
+        'zkill_stuck_cursor_threshold' => max(2, (int) (getenv('SUPPLYCORE_ZKILL_STUCK_CURSOR_THRESHOLD') ?: 3)),
         'zkill_log_file' => getenv('SUPPLYCORE_ZKILL_LOG_FILE') ?: 'storage/logs/zkill.log',
         'worker_log_file' => getenv('SUPPLYCORE_WORKER_LOG_FILE') ?: 'storage/logs/worker.log',
         'compute_log_file' => getenv('SUPPLYCORE_COMPUTE_LOG_FILE') ?: 'storage/logs/compute.log',

--- a/src/functions.php
+++ b/src/functions.php
@@ -8080,6 +8080,7 @@ function zkill_worker_runtime_status(): array
 {
     $runtime = orchestrator_runtime_config_export();
     $stateFile = trim((string) ($runtime['workers']['zkill_state_file'] ?? ''));
+    $logFile = trim((string) ($runtime['workers']['zkill_log_file'] ?? ''));
     $state = $stateFile !== '' ? supplycore_runtime_json_file_read($stateFile) : [];
     $timestamp = trim((string) ($state['ts'] ?? ''));
     $status = trim((string) (($state['result']['status'] ?? '') ?: 'unknown'));
@@ -8087,6 +8088,7 @@ function zkill_worker_runtime_status(): array
 
     return [
         'state_file' => $stateFile !== '' ? $stateFile : null,
+        'log_file' => $logFile !== '' ? $logFile : null,
         'seen_at' => $timestamp !== '' ? $timestamp : null,
         'seen_at_display' => $timestamp !== '' ? killmail_format_datetime($timestamp) : 'No heartbeat recorded',
         'seen_at_relative' => $timestamp !== '' ? killmail_relative_datetime($timestamp) : 'No heartbeat',
@@ -8096,10 +8098,19 @@ function zkill_worker_runtime_status(): array
         'rows_matched' => (int) (($state['result']['meta']['rows_matched'] ?? 0)),
         'rows_skipped_existing' => (int) (($state['result']['meta']['rows_skipped_existing'] ?? 0)),
         'rows_filtered_out' => (int) (($state['result']['meta']['rows_filtered_out'] ?? 0)),
+        'rows_write_attempted' => (int) (($state['result']['meta']['rows_write_attempted'] ?? 0)),
         'rows_written' => (int) (($state['result']['rows_written'] ?? 0)),
+        'rows_failed' => (int) (($state['result']['meta']['rows_failed'] ?? 0)),
         'cursor' => isset($state['result']['cursor']) ? (string) $state['result']['cursor'] : null,
         'cursor_before' => isset($state['result']['meta']['cursor_before']) ? (string) $state['result']['meta']['cursor_before'] : null,
         'cursor_after' => isset($state['result']['meta']['cursor_after']) ? (string) $state['result']['meta']['cursor_after'] : null,
+        'first_sequence_seen' => isset($state['result']['meta']['first_sequence_seen']) ? (string) $state['result']['meta']['first_sequence_seen'] : null,
+        'last_sequence_seen' => isset($state['result']['meta']['last_sequence_seen']) ? (string) $state['result']['meta']['last_sequence_seen'] : null,
+        'checkpoint_state' => isset($state['result']['meta']['checkpoint_state']) ? (string) $state['result']['meta']['checkpoint_state'] : '',
+        'same_cursor_no_progress_count' => (int) ($state['same_cursor_no_progress_count'] ?? 0),
+        'stuck_detected' => (bool) ($state['stuck_detected'] ?? false),
+        'stuck_threshold' => (int) ($state['stuck_threshold'] ?? 0),
+        'reason_for_zero_write' => isset($state['result']['meta']['reason_for_zero_write']) ? (string) $state['result']['meta']['reason_for_zero_write'] : '',
         'no_write_reason' => isset($state['result']['meta']['no_write_reason']) ? (string) $state['result']['meta']['no_write_reason'] : '',
         'outcome_reason' => isset($state['result']['meta']['outcome_reason']) ? (string) $state['result']['meta']['outcome_reason'] : '',
         'memory_usage_bytes' => isset($state['memory_usage_bytes']) ? (int) $state['memory_usage_bytes'] : null,
@@ -8110,12 +8121,15 @@ function zkill_worker_runtime_status(): array
 function killmail_no_write_reason_label(string $reason): string
 {
     return match (trim($reason)) {
-        'all_rows_already_present' => 'Everything in the last worker pass was already stored.',
-        'all_rows_filtered_or_invalid' => 'The last worker pass saw rows, but all of them were filtered out or invalid.',
-        'all_rows_filtered_out' => 'The last worker pass did not match any tracked alliance or corporation.',
-        'all_rows_invalid' => 'The last worker pass could not normalize the fetched killmails.',
+        'already_existed_locally' => 'Everything in the last worker pass was already stored locally.',
+        'no_tracked_entity_matches' => 'The last worker pass did not match any tracked alliance or corporation.',
+        'filter_excluded_all' => 'The last worker pass was excluded by the current tracked-entity filters.',
+        'write_failed' => 'The last worker pass reached persistence, but local writes failed.',
+        'transaction_rolled_back' => 'The last worker pass rolled back before qualifying killmails could commit.',
+        'checkpoint_prevented_write' => 'The worker processed rows, but the checkpoint did not advance cleanly.',
+        'downstream_persistence_blocked' => 'The worker matched qualifying killmails, but downstream persistence blocked inserts.',
         'caught_up_to_live_tip' => 'The worker is caught up to the current zKill live tip.',
-        'mixed_no_write_result' => 'The last worker pass completed without inserting new rows.',
+        'unknown' => 'The last worker pass completed without inserting new rows and needs investigation.',
         default => '',
     };
 }
@@ -8128,12 +8142,14 @@ function killmail_ingestion_health_summary(array $status, array $workerStatus = 
     $lastError = trim((string) ($status['last_error'] ?? ''));
     $rowsWritten = (int) ($status['last_run_written_rows'] ?? 0);
     $rowsSeen = (int) ($status['last_run_source_rows'] ?? 0);
-    $workerNoWriteReason = killmail_no_write_reason_label((string) ($workerStatus['no_write_reason'] ?? ''));
+    $workerNoWriteReason = killmail_no_write_reason_label((string) ($workerStatus['reason_for_zero_write'] ?? $workerStatus['no_write_reason'] ?? ''));
 
     $state = 'healthy';
     if (!($status['ingestion_enabled'] ?? false)) {
         $state = 'disabled';
     } elseif ($lastError !== '') {
+        $state = 'stalled';
+    } elseif (!empty($workerStatus['stuck_detected'])) {
         $state = 'stalled';
     } elseif ($lastSuccessTimestamp === null) {
         $state = 'stalled';
@@ -8168,7 +8184,9 @@ function killmail_ingestion_health_summary(array $status, array $workerStatus = 
         'disabled' => 'Killmail ingestion is currently turned off.',
         'stalled' => $lastError !== ''
             ? ('The most recent sync error needs attention: ' . $lastError)
-            : 'Killmail freshness is outside the expected window or the worker is no longer checking in.',
+            : (!empty($workerStatus['stuck_detected'])
+                ? 'The worker is repeating the same cursor without progress. Review the zKill log and checkpoint state.'
+                : 'Killmail freshness is outside the expected window or the worker is no longer checking in.'),
         default => 'Killmail ingestion status is unavailable.',
     };
 
@@ -8180,6 +8198,7 @@ function killmail_ingestion_health_summary(array $status, array $workerStatus = 
         'last_rows_written' => $rowsWritten,
         'last_rows_seen' => $rowsSeen,
         'worker_no_write_reason' => $workerNoWriteReason,
+        'stuck_detected' => !empty($workerStatus['stuck_detected']),
     ];
 }
 
@@ -9824,9 +9843,13 @@ function killmail_overview_data(): array
         $lastIngestedAt = isset($summaryRow['last_ingested_at']) ? (string) $summaryRow['last_ingested_at'] : null;
         $latestUploadedAt = isset($summaryRow['latest_uploaded_at']) ? (string) $summaryRow['latest_uploaded_at'] : null;
         $cursor = isset($state['last_cursor']) ? trim((string) $state['last_cursor']) : '';
+        $workerSeenAt = isset($workerStatus['seen_at']) ? trim((string) $workerStatus['seen_at']) : '';
         $freshnessReferenceAt = $lastIngestedAt;
         if ($lastSuccessAt !== null && ($freshnessReferenceAt === null || strtotime($lastSuccessAt) > strtotime($freshnessReferenceAt))) {
             $freshnessReferenceAt = $lastSuccessAt;
+        }
+        if ($workerSeenAt !== '' && (($workerStatus['status'] ?? 'unknown') === 'success') && ($freshnessReferenceAt === null || strtotime($workerSeenAt) > strtotime($freshnessReferenceAt))) {
+            $freshnessReferenceAt = $workerSeenAt;
         }
 
         $overviewResolutionRequests = [
@@ -10012,13 +10035,23 @@ function killmail_overview_data(): array
             'worker_rows_matched' => (int) ($workerStatus['rows_matched'] ?? 0),
             'worker_rows_skipped_existing' => (int) ($workerStatus['rows_skipped_existing'] ?? 0),
             'worker_rows_filtered_out' => (int) ($workerStatus['rows_filtered_out'] ?? 0),
+            'worker_rows_write_attempted' => (int) ($workerStatus['rows_write_attempted'] ?? 0),
             'worker_rows_written' => (int) ($workerStatus['rows_written'] ?? 0),
+            'worker_rows_failed' => (int) ($workerStatus['rows_failed'] ?? 0),
             'worker_cursor' => isset($workerStatus['cursor']) ? (string) $workerStatus['cursor'] : '',
             'worker_cursor_before' => isset($workerStatus['cursor_before']) ? (string) $workerStatus['cursor_before'] : '',
             'worker_cursor_after' => isset($workerStatus['cursor_after']) ? (string) $workerStatus['cursor_after'] : '',
-            'worker_no_write_reason' => isset($workerStatus['no_write_reason']) ? (string) $workerStatus['no_write_reason'] : '',
+            'worker_first_sequence_seen' => isset($workerStatus['first_sequence_seen']) ? (string) $workerStatus['first_sequence_seen'] : '',
+            'worker_last_sequence_seen' => isset($workerStatus['last_sequence_seen']) ? (string) $workerStatus['last_sequence_seen'] : '',
+            'worker_checkpoint_state' => isset($workerStatus['checkpoint_state']) ? (string) $workerStatus['checkpoint_state'] : '',
+            'worker_same_cursor_no_progress_count' => (int) ($workerStatus['same_cursor_no_progress_count'] ?? 0),
+            'worker_stuck_detected' => (bool) ($workerStatus['stuck_detected'] ?? false),
+            'worker_stuck_threshold' => (int) ($workerStatus['stuck_threshold'] ?? 0),
+            'worker_no_write_reason' => isset($workerStatus['reason_for_zero_write']) ? (string) $workerStatus['reason_for_zero_write'] : (isset($workerStatus['no_write_reason']) ? (string) $workerStatus['no_write_reason'] : ''),
             'worker_outcome_reason' => isset($workerStatus['outcome_reason']) ? (string) $workerStatus['outcome_reason'] : '',
             'worker_memory_usage_bytes' => isset($workerStatus['memory_usage_bytes']) ? (int) $workerStatus['memory_usage_bytes'] : null,
+            'worker_log_file' => isset($workerStatus['log_file']) ? (string) $workerStatus['log_file'] : '',
+            'worker_state_file' => isset($workerStatus['state_file']) ? (string) $workerStatus['state_file'] : '',
         ];
         $statusView['health'] = killmail_ingestion_health_summary($statusView, $workerStatus);
 
@@ -13543,6 +13576,38 @@ function python_bridge_sync_run_start(string $datasetKey, string $runMode = 'inc
     ];
 }
 
+function python_bridge_sync_cursor_upsert(array $payload): array
+{
+    $datasetKey = trim((string) ($payload['dataset_key'] ?? ''));
+    if ($datasetKey === '') {
+        throw new InvalidArgumentException('dataset_key is required to checkpoint a sync cursor.');
+    }
+
+    $runMode = sync_mode_normalize((string) ($payload['run_mode'] ?? 'incremental'));
+    $cursor = isset($payload['cursor']) ? trim((string) $payload['cursor']) : '';
+    if ($cursor === '') {
+        return [
+            'dataset_key' => $datasetKey,
+            'run_mode' => $runMode,
+            'cursor' => null,
+            'checkpoint_updated' => false,
+            'reason' => 'missing_cursor',
+        ];
+    }
+
+    $updated = db_sync_cursor_upsert($datasetKey, $runMode, $cursor);
+
+    return [
+        'dataset_key' => $datasetKey,
+        'run_mode' => $runMode,
+        'cursor' => $cursor,
+        'checkpoint_updated' => $updated,
+        'reason' => $updated ? 'cursor_checkpointed' : 'checkpoint_write_failed',
+        'rows_written' => max(0, (int) ($payload['rows_written'] ?? 0)),
+        'outcome_reason' => trim((string) ($payload['outcome_reason'] ?? '')),
+    ];
+}
+
 function python_bridge_sync_run_finish(array $payload): array
 {
     $datasetKey = trim((string) ($payload['dataset_key'] ?? ''));
@@ -13647,17 +13712,35 @@ function python_bridge_process_killmail_batch(array $payloads): array
     $rowsSeen = 0;
     $rowsMatched = 0;
     $rowsWritten = 0;
+    $rowsWriteAttempted = 0;
+    $rowsFailed = 0;
     $duplicates = 0;
     $filtered = 0;
     $invalid = 0;
     $lastProcessedSequence = null;
+    $firstSequenceSeen = null;
+    $lastSequenceSeen = null;
+    $failureReason = '';
 
     foreach ($payloads as $payload) {
         $rowsSeen++;
         $requestedSequenceId = (int) ($payload['requested_sequence_id'] ?? $payload['sequence_id'] ?? 0);
-        $result = killmail_persist_r2z2_payload($payload, $trackedAllianceIds, $trackedCorporationIds, false, $requestedSequenceId > 0 ? $requestedSequenceId : null);
+        try {
+            $result = killmail_persist_r2z2_payload($payload, $trackedAllianceIds, $trackedCorporationIds, false, $requestedSequenceId > 0 ? $requestedSequenceId : null);
+        } catch (Throwable $exception) {
+            $rowsFailed++;
+            $failureReason = trim($exception->getMessage()) !== '' ? scheduler_normalize_error_message($exception->getMessage()) : 'Killmail write failed.';
+            $lastProcessedSequence = $requestedSequenceId > 0 ? $requestedSequenceId - 1 : $lastProcessedSequence;
+            break;
+        }
         $sequenceId = (int) ($result['sequence_id'] ?? 0);
         $status = (string) ($result['status'] ?? 'invalid');
+        if ($firstSequenceSeen === null && $sequenceId > 0) {
+            $firstSequenceSeen = $sequenceId;
+        }
+        if ($sequenceId > 0) {
+            $lastSequenceSeen = $sequenceId;
+        }
         if ($status === 'invalid') {
             $invalid++;
             if ($requestedSequenceId > 0) {
@@ -13672,6 +13755,7 @@ function python_bridge_process_killmail_batch(array $payloads): array
         } elseif ($status === 'filtered') {
             $filtered++;
         } elseif ($status === 'written') {
+            $rowsWriteAttempted++;
             $rowsWritten++;
             $rowsMatched++;
         }
@@ -13679,18 +13763,20 @@ function python_bridge_process_killmail_batch(array $payloads): array
         $lastProcessedSequence = $sequenceId;
     }
 
-    $noWriteReason = '';
+    $reasonForZeroWrite = '';
     if ($rowsWritten === 0) {
-        if ($duplicates === $rowsSeen && $rowsSeen > 0) {
-            $noWriteReason = 'all_rows_already_present';
+        if ($rowsFailed > 0) {
+            $reasonForZeroWrite = 'write_failed';
+        } elseif ($duplicates === $rowsSeen && $rowsSeen > 0) {
+            $reasonForZeroWrite = 'already_existed_locally';
         } elseif ($filtered === $rowsSeen && $rowsSeen > 0) {
-            $noWriteReason = 'all_rows_filtered_out';
+            $reasonForZeroWrite = 'no_tracked_entity_matches';
         } elseif ($invalid === $rowsSeen && $rowsSeen > 0) {
-            $noWriteReason = 'all_rows_invalid';
+            $reasonForZeroWrite = 'unknown';
         } elseif (($filtered + $invalid) === $rowsSeen && $rowsSeen > 0) {
-            $noWriteReason = 'all_rows_filtered_or_invalid';
+            $reasonForZeroWrite = 'filter_excluded_all';
         } else {
-            $noWriteReason = 'mixed_no_write_result';
+            $reasonForZeroWrite = 'unknown';
         }
     }
 
@@ -13699,13 +13785,30 @@ function python_bridge_process_killmail_batch(array $payloads): array
         'rows_matched' => $rowsMatched,
         'rows_skipped_existing' => $duplicates,
         'rows_filtered_out' => $filtered,
+        'rows_write_attempted' => $rowsWriteAttempted,
         'rows_written' => $rowsWritten,
+        'rows_failed' => $rowsFailed,
         'killmails_fetched' => $rowsSeen,
         'duplicates' => $duplicates,
         'filtered' => $filtered,
         'invalid' => $invalid,
         'last_processed_sequence' => $lastProcessedSequence,
-        'no_write_reason' => $noWriteReason,
+        'reason_for_zero_write' => $reasonForZeroWrite,
+        'no_write_reason' => $reasonForZeroWrite,
+        'failure_reason' => $failureReason,
+        'meta' => [
+            'first_sequence_seen' => $firstSequenceSeen,
+            'last_sequence_seen' => $lastSequenceSeen,
+            'rows_seen' => $rowsSeen,
+            'rows_matched' => $rowsMatched,
+            'rows_filtered_out' => $filtered,
+            'rows_skipped_existing' => $duplicates,
+            'rows_write_attempted' => $rowsWriteAttempted,
+            'rows_written' => $rowsWritten,
+            'rows_failed' => $rowsFailed,
+            'reason_for_zero_write' => $reasonForZeroWrite,
+            'failure_reason' => $failureReason,
+        ],
     ];
 }
 


### PR DESCRIPTION
### Motivation
- The dedicated Python zKill worker was repeatedly seeing rows but writing zero rows and replaying the same cursor window; logging was duplicated/insufficient for operations and the killmail board remained stale. 
- The intent is to add observability first, deterministically advance the cursor after safely processing batches, and surface concrete zero-write reasons so operators can diagnose and resolve no-op loops without broad architecture changes.

### Description
- Emit structured per-batch and per-loop diagnostics from the Python worker including `cursor_before`, `cursor_after`, `rows_seen`, `rows_matched`, `rows_write_attempted`, `rows_written`, `rows_failed`, `first_sequence_seen`, `last_sequence_seen`, `reason_for_zero_write`, `checkpoint_state`, and stuck/no-progress counters, and write them into the worker heartbeat file for UI use (`python/orchestrator/zkill_worker.py`, `python/orchestrator/jobs/killmail.py`).
- Add per-batch cursor checkpointing via a new bridge action `sync-cursor-upsert` so processed ranges advance deterministically and do not replay the same upstream slice (`bin/python_scheduler_bridge.php`, `src/functions.php`, `python/orchestrator/jobs/killmail.py`).
- Classify zero-write causes with explicit reasons (`no_tracked_entity_matches`, `already_existed_locally`, `write_failed`, `transaction_rolled_back`, `filter_excluded_all`, `checkpoint_prevented_write`, `downstream_persistence_blocked`, `caught_up_to_live_tip`, `unknown`) and surface them to the page and logs (`python/orchestrator/jobs/killmail.py`, `src/functions.php`).
- Add a no-progress/stuck guard that counts repeated zero-write loops with identical `cursor_after` and emits a `zkill.no_progress_detected` warning once the configured threshold is exceeded; threshold configurable via `SUPPLYCORE_ZKILL_STUCK_CURSOR_THRESHOLD` and defaulting to 3 (`src/config/app.php`, `python/orchestrator/zkill_worker.py`).
- Fix logging duplication/usability by ensuring Python logger handlers are cleaned up, using a dedicated `supplycore.zkill` logger that writes JSON to file and stdout, and route the systemd unit to journald instead of append-redirecting stderr/stdout to the same file (`python/orchestrator/logging_utils.py`, `ops/systemd/supplycore-zkill.service`).
- Expose the new diagnostics to the Killmail Loss Overview page and simplify the main status cards while moving low-level plumbing under Advanced diagnostics (`public/killmail-intelligence/index.php`, `src/functions.php`).

### Testing
- Python compilation: ran `python -m compileall python/orchestrator bin/python_orchestrator.py` and verified compiled modules (success).
- PHP linting: ran `php -l` on `src/functions.php`, `bin/python_scheduler_bridge.php`, `public/killmail-intelligence/index.php`, and `src/config/app.php` (no syntax errors).
- Logger harness: executed a synthetic logger payload via `configure_logging` to validate the new `zkill.loop_completed` JSON payload fields and confirmed output contains the new fields (success).
- No-progress harness: executed a synthetic `_no_progress_state` scenario and confirmed `same_cursor_no_progress_count` increments and `stuck_detected` becomes true at the configured threshold (success).
- End-to-end DB-backed verification: blocked in this environment due to `SQLSTATE[HY000] [2002] Connection refused`, so a live MariaDB write test could not be executed here (not verified in sandbox).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c7ff99d4832fab419070b0d6f100)