### PR TITLE
Fix zKill HTTP 200 sequence handling

### DIFF
--- a/python/orchestrator/jobs/killmail.py
+++ b/python/orchestrator/jobs/killmail.py
@@ -9,7 +9,7 @@ from ..bridge import PhpBridge
 from ..worker_runtime import payload_checksum, resident_memory_bytes, utc_now_iso
 
 
-def _http_json(url: str, user_agent: str, timeout_seconds: int = 25) -> tuple[int, dict[str, Any]]:
+def _http_json(url: str, user_agent: str, timeout_seconds: int = 25) -> tuple[int, Any]:
     request = urllib.request.Request(
         url,
         headers={
@@ -29,10 +29,64 @@ def _http_json(url: str, user_agent: str, timeout_seconds: int = 25) -> tuple[in
 
     import json
 
-    decoded = json.loads(payload) if payload.strip() else {}
-    if not isinstance(decoded, dict):
+    if not payload.strip():
+        return status, {}
+
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError as error:
+        if status == 200:
+            raise RuntimeError(
+                f"R2Z2 response from {url} with status=200 contained invalid JSON: {error.msg}"
+            ) from error
         decoded = {}
     return status, decoded
+
+
+def _classify_sequence_payload(payload: Any) -> tuple[str, dict[str, Any], bool]:
+    if not isinstance(payload, dict):
+        return "malformed_non_object_payload", {}, False
+    if payload == {}:
+        return "valid_empty_payload", {}, True
+    return "valid_payload", payload, False
+
+
+def _accumulate_batch_result(
+    *,
+    batch_result: dict[str, Any],
+    totals: dict[str, int],
+) -> tuple[int, int]:
+    totals["rows_seen"] += int(batch_result.get("rows_seen") or 0)
+    totals["rows_matched"] += int(batch_result.get("rows_matched") or 0)
+    totals["rows_skipped_existing"] += int(batch_result.get("rows_skipped_existing") or 0)
+    totals["rows_filtered_out"] += int(batch_result.get("rows_filtered_out") or 0)
+    totals["rows_write_attempted"] += int(batch_result.get("rows_write_attempted") or 0)
+    totals["rows_written"] += int(batch_result.get("rows_written") or 0)
+    totals["rows_failed"] += int(batch_result.get("rows_failed") or 0)
+    totals["duplicates"] += int(batch_result.get("duplicates") or 0)
+    totals["filtered"] += int(batch_result.get("filtered") or 0)
+    totals["invalid"] += int(batch_result.get("invalid") or 0)
+
+    checkpoint_state = dict((batch_result.get("meta") or {}).get("checkpoint_state") or {})
+    if checkpoint_state.get("checkpoint_updated"):
+        return 1, 0
+    if str(checkpoint_state.get("reason") or "") != "no_processed_sequence":
+        return 0, 1
+    return 0, 0
+
+
+def _sequence_outcome_from_batch_result(batch_result: dict[str, Any]) -> str:
+    if int(batch_result.get("rows_written") or 0) > 0:
+        return "inserted"
+    if int(batch_result.get("rows_skipped_existing") or 0) > 0:
+        return "already_existing"
+    if int(batch_result.get("rows_filtered_out") or 0) > 0:
+        return "filtered_out"
+    if int(batch_result.get("invalid") or 0) > 0:
+        return "invalid_payload"
+    if int(batch_result.get("rows_failed") or 0) > 0:
+        return "write_failed"
+    return "non_actionable"
 
 
 def _sleep_with_budget(seconds: int, deadline: float) -> bool:
@@ -238,7 +292,7 @@ class KillmailEntityResolver:
 
     def _fetch_profile(self, url: str) -> dict[str, Any] | None:
         status, payload = _http_json(url, self.user_agent)
-        if status != 200:
+        if status != 200 or not isinstance(payload, dict):
             return None
 
         return payload
@@ -347,16 +401,18 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
 
     warnings: list[str] = []
     pending_payloads: list[dict[str, Any]] = []
-    total_rows_seen = 0
-    total_rows_written = 0
-    total_rows_matched = 0
-    total_rows_skipped_existing = 0
-    total_rows_filtered_out = 0
-    total_rows_write_attempted = 0
-    total_rows_failed = 0
-    total_duplicates = 0
-    total_filtered = 0
-    total_invalid = 0
+    totals = {
+        "rows_seen": 0,
+        "rows_written": 0,
+        "rows_matched": 0,
+        "rows_skipped_existing": 0,
+        "rows_filtered_out": 0,
+        "rows_write_attempted": 0,
+        "rows_failed": 0,
+        "duplicates": 0,
+        "filtered": 0,
+        "invalid": 0,
+    }
     total_sequence_files_fetched = 0
     total_sequence_404s = 0
     total_rate_limits = 0
@@ -372,6 +428,8 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
             if next_sequence is None:
                 probe_status, probe_payload = _http_json(sequence_url, user_agent)
                 if probe_status == 200:
+                    if not isinstance(probe_payload, dict):
+                        raise RuntimeError("R2Z2 sequence probe returned a non-object JSON payload.")
                     latest_remote_sequence = int(probe_payload.get("sequence") or 0)
                     if latest_remote_sequence <= 0:
                         raise RuntimeError("R2Z2 sequence probe returned an invalid sequence value.")
@@ -392,10 +450,27 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
             status, payload = _http_json(f"{base_url}/{sequence_id}.json", user_agent)
 
             if status == 200:
-                payload = entity_resolver.enrich_payload(payload)
-                payload["requested_sequence_id"] = sequence_id
-                payload["sequence_id"] = int(payload.get("sequence_id") or sequence_id)
-                pending_payloads.append(payload)
+                payload_classification, normalized_payload, valid_non_actionable = _classify_sequence_payload(payload)
+                context.emit(
+                    "zkill.sequence_fetch",
+                    {
+                        "job_key": context.job_key,
+                        "sequence_id": sequence_id,
+                        "http_status": status,
+                        "payload_classification": payload_classification,
+                        "fetch_outcome": "valid_http_200",
+                        "valid_non_actionable": valid_non_actionable,
+                    },
+                )
+                if payload_classification == "malformed_non_object_payload":
+                    raise RuntimeError(
+                        f"R2Z2 sequence {sequence_id} returned HTTP 200 with malformed non-object JSON payload."
+                    )
+
+                normalized_payload = entity_resolver.enrich_payload(normalized_payload)
+                normalized_payload["requested_sequence_id"] = sequence_id
+                normalized_payload["sequence_id"] = int(normalized_payload.get("sequence_id") or sequence_id)
+                pending_payloads.append(normalized_payload)
                 total_sequence_files_fetched += 1
                 next_sequence = sequence_id + 1
                 if len(pending_payloads) >= batch_size:
@@ -408,28 +483,79 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                         logger_context=context,
                         started_at=started_at,
                         totals={
-                            "rows_seen": total_rows_seen,
-                            "rows_written": total_rows_written,
+                            "rows_seen": totals["rows_seen"],
+                            "rows_written": totals["rows_written"],
                         },
                     )
                     pending_payloads = []
                     batches_flushed += 1
-                    total_rows_seen += int(batch_result.get("rows_seen") or 0)
-                    total_rows_matched += int(batch_result.get("rows_matched") or 0)
-                    total_rows_skipped_existing += int(batch_result.get("rows_skipped_existing") or 0)
-                    total_rows_filtered_out += int(batch_result.get("rows_filtered_out") or 0)
-                    total_rows_write_attempted += int(batch_result.get("rows_write_attempted") or 0)
-                    total_rows_written += int(batch_result.get("rows_written") or 0)
-                    total_rows_failed += int(batch_result.get("rows_failed") or 0)
-                    total_duplicates += int(batch_result.get("duplicates") or 0)
-                    total_filtered += int(batch_result.get("filtered") or 0)
-                    total_invalid += int(batch_result.get("invalid") or 0)
-                    checkpoint_state = dict((batch_result.get("meta") or {}).get("checkpoint_state") or {})
-                    if checkpoint_state.get("checkpoint_updated"):
-                        checkpoint_updates += 1
-                    elif str(checkpoint_state.get("reason") or "") != "no_processed_sequence":
-                        checkpoint_failures += 1
+                    checkpoint_update_increment, checkpoint_failure_increment = _accumulate_batch_result(
+                        batch_result=batch_result,
+                        totals=totals,
+                    )
+                    checkpoint_updates += checkpoint_update_increment
+                    checkpoint_failures += checkpoint_failure_increment
+                    context.emit(
+                        "zkill.sequence_processed",
+                        {
+                            "job_key": context.job_key,
+                            "sequence_id": sequence_id,
+                            "http_status": status,
+                            "payload_classification": payload_classification,
+                            "processing_outcome": _sequence_outcome_from_batch_result(batch_result),
+                            "rows_matched": batch_result.get("rows_matched"),
+                            "rows_filtered_out": batch_result.get("rows_filtered_out"),
+                            "rows_skipped_existing": batch_result.get("rows_skipped_existing"),
+                            "rows_written": batch_result.get("rows_written"),
+                            "rows_failed": batch_result.get("rows_failed"),
+                            "valid_non_actionable": valid_non_actionable
+                            or int(batch_result.get("rows_written") or 0) == 0,
+                            "checkpoint_state": dict((batch_result.get("meta") or {}).get("checkpoint_state") or {}),
+                        },
+                    )
                     continue
+
+                if pending_payloads:
+                    batch_result, last_processed_sequence = _flush_pending_batch(
+                        bridge=bridge,
+                        job_context=job_context,
+                        pending_payloads=pending_payloads,
+                        batch_index=batches_flushed + 1,
+                        last_processed_sequence=last_processed_sequence,
+                        logger_context=context,
+                        started_at=started_at,
+                        totals={
+                            "rows_seen": totals["rows_seen"],
+                            "rows_written": totals["rows_written"],
+                        },
+                    )
+                    pending_payloads = []
+                    batches_flushed += 1
+                    checkpoint_update_increment, checkpoint_failure_increment = _accumulate_batch_result(
+                        batch_result=batch_result,
+                        totals=totals,
+                    )
+                    checkpoint_updates += checkpoint_update_increment
+                    checkpoint_failures += checkpoint_failure_increment
+                    context.emit(
+                        "zkill.sequence_processed",
+                        {
+                            "job_key": context.job_key,
+                            "sequence_id": sequence_id,
+                            "http_status": status,
+                            "payload_classification": payload_classification,
+                            "processing_outcome": _sequence_outcome_from_batch_result(batch_result),
+                            "rows_matched": batch_result.get("rows_matched"),
+                            "rows_filtered_out": batch_result.get("rows_filtered_out"),
+                            "rows_skipped_existing": batch_result.get("rows_skipped_existing"),
+                            "rows_written": batch_result.get("rows_written"),
+                            "rows_failed": batch_result.get("rows_failed"),
+                            "valid_non_actionable": valid_non_actionable
+                            or int(batch_result.get("rows_written") or 0) == 0,
+                            "checkpoint_state": dict((batch_result.get("meta") or {}).get("checkpoint_state") or {}),
+                        },
+                    )
+                continue
 
             if pending_payloads:
                 batch_result, last_processed_sequence = _flush_pending_batch(
@@ -441,30 +567,32 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                     logger_context=context,
                     started_at=started_at,
                     totals={
-                        "rows_seen": total_rows_seen,
-                        "rows_written": total_rows_written,
+                        "rows_seen": totals["rows_seen"],
+                        "rows_written": totals["rows_written"],
                     },
                 )
                 pending_payloads = []
                 batches_flushed += 1
-                total_rows_seen += int(batch_result.get("rows_seen") or 0)
-                total_rows_matched += int(batch_result.get("rows_matched") or 0)
-                total_rows_skipped_existing += int(batch_result.get("rows_skipped_existing") or 0)
-                total_rows_filtered_out += int(batch_result.get("rows_filtered_out") or 0)
-                total_rows_write_attempted += int(batch_result.get("rows_write_attempted") or 0)
-                total_rows_written += int(batch_result.get("rows_written") or 0)
-                total_rows_failed += int(batch_result.get("rows_failed") or 0)
-                total_duplicates += int(batch_result.get("duplicates") or 0)
-                total_filtered += int(batch_result.get("filtered") or 0)
-                total_invalid += int(batch_result.get("invalid") or 0)
-                checkpoint_state = dict((batch_result.get("meta") or {}).get("checkpoint_state") or {})
-                if checkpoint_state.get("checkpoint_updated"):
-                    checkpoint_updates += 1
-                elif str(checkpoint_state.get("reason") or "") != "no_processed_sequence":
-                    checkpoint_failures += 1
+                checkpoint_update_increment, checkpoint_failure_increment = _accumulate_batch_result(
+                    batch_result=batch_result,
+                    totals=totals,
+                )
+                checkpoint_updates += checkpoint_update_increment
+                checkpoint_failures += checkpoint_failure_increment
 
             if status == 404:
                 total_sequence_404s += 1
+                context.emit(
+                    "zkill.sequence_fetch",
+                    {
+                        "job_key": context.job_key,
+                        "sequence_id": sequence_id,
+                        "http_status": status,
+                        "payload_classification": "not_found",
+                        "fetch_outcome": "sleep_and_retry",
+                        "valid_non_actionable": True,
+                    },
+                )
                 warnings.append(f"R2Z2 returned 404 for sequence {sequence_id}; sleeping {poll_sleep_seconds}s before retry.")
                 if not _sleep_with_budget(poll_sleep_seconds, deadline):
                     break
@@ -472,11 +600,33 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
 
             if status in (403, 429):
                 total_rate_limits += 1
+                context.emit(
+                    "zkill.sequence_fetch",
+                    {
+                        "job_key": context.job_key,
+                        "sequence_id": sequence_id,
+                        "http_status": status,
+                        "payload_classification": "retryable_http_status",
+                        "fetch_outcome": "sleep_and_retry",
+                        "valid_non_actionable": False,
+                    },
+                )
                 warnings.append(f"R2Z2 returned status {status} for sequence {sequence_id}; sleeping {poll_sleep_seconds}s before retry.")
                 if not _sleep_with_budget(poll_sleep_seconds, deadline):
                     break
                 continue
 
+            context.emit(
+                "zkill.sequence_fetch",
+                {
+                    "job_key": context.job_key,
+                    "sequence_id": sequence_id,
+                    "http_status": status,
+                    "payload_classification": "unexpected_http_status",
+                    "fetch_outcome": "fatal_fetch_error",
+                    "valid_non_actionable": False,
+                },
+            )
             raise RuntimeError(f"R2Z2 sequence fetch failed for {sequence_id} with status={status}")
 
         if pending_payloads:
@@ -489,51 +639,42 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 logger_context=context,
                 started_at=started_at,
                 totals={
-                    "rows_seen": total_rows_seen,
-                    "rows_written": total_rows_written,
+                    "rows_seen": totals["rows_seen"],
+                    "rows_written": totals["rows_written"],
                 },
             )
             pending_payloads = []
             batches_flushed += 1
-            total_rows_seen += int(batch_result.get("rows_seen") or 0)
-            total_rows_matched += int(batch_result.get("rows_matched") or 0)
-            total_rows_skipped_existing += int(batch_result.get("rows_skipped_existing") or 0)
-            total_rows_filtered_out += int(batch_result.get("rows_filtered_out") or 0)
-            total_rows_write_attempted += int(batch_result.get("rows_write_attempted") or 0)
-            total_rows_written += int(batch_result.get("rows_written") or 0)
-            total_rows_failed += int(batch_result.get("rows_failed") or 0)
-            total_duplicates += int(batch_result.get("duplicates") or 0)
-            total_filtered += int(batch_result.get("filtered") or 0)
-            total_invalid += int(batch_result.get("invalid") or 0)
-            checkpoint_state = dict((batch_result.get("meta") or {}).get("checkpoint_state") or {})
-            if checkpoint_state.get("checkpoint_updated"):
-                checkpoint_updates += 1
-            elif str(checkpoint_state.get("reason") or "") != "no_processed_sequence":
-                checkpoint_failures += 1
+            checkpoint_update_increment, checkpoint_failure_increment = _accumulate_batch_result(
+                batch_result=batch_result,
+                totals=totals,
+            )
+            checkpoint_updates += checkpoint_update_increment
+            checkpoint_failures += checkpoint_failure_increment
 
         cursor_end = str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0))
         checksum = payload_checksum({
-            "rows_seen": total_rows_seen,
-            "rows_written": total_rows_written,
+            "rows_seen": totals["rows_seen"],
+            "rows_written": totals["rows_written"],
             "cursor": cursor_end,
             "batches_flushed": batches_flushed,
         })
 
         checkpoint_updated = checkpoint_updates > 0 or cursor_end == str(last_saved_sequence or 0)
         reason_for_zero_write = _zero_write_reason(
-            rows_seen=total_rows_seen,
-            rows_matched=total_rows_matched,
-            rows_filtered_out=total_rows_filtered_out,
-            rows_skipped_existing=total_rows_skipped_existing,
-            rows_failed=total_rows_failed,
-            rows_written=total_rows_written,
+            rows_seen=totals["rows_seen"],
+            rows_matched=totals["rows_matched"],
+            rows_filtered_out=totals["rows_filtered_out"],
+            rows_skipped_existing=totals["rows_skipped_existing"],
+            rows_failed=totals["rows_failed"],
+            rows_written=totals["rows_written"],
             checkpoint_updated=checkpoint_updated,
             sequence_404s=total_sequence_404s,
             latest_remote_sequence=latest_remote_sequence,
             cursor_before=str(last_saved_sequence or 0),
             cursor_after=cursor_end,
         )
-        if total_rows_written > 0:
+        if totals["rows_written"] > 0:
             outcome_reason = "Python streamed killmail ingestion batches and kept polling until the worker budget expired."
         else:
             outcome_reason = {
@@ -551,8 +692,8 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
         result = {
             "status": "success",
             "summary": "Killmail R2Z2 ingestion ran in Python with continuous polling and bridge-backed batch persistence.",
-            "rows_seen": total_rows_seen,
-            "rows_written": total_rows_written,
+            "rows_seen": totals["rows_seen"],
+            "rows_written": totals["rows_written"],
             "cursor": cursor_end,
             "checksum": checksum,
             "duration_ms": int((time.monotonic() - started_at) * 1000),
@@ -566,16 +707,16 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 "sequence_files_fetched": total_sequence_files_fetched,
                 "sequence_404s_encountered": total_sequence_404s,
                 "rate_limit_responses": total_rate_limits,
-                "duplicates": total_duplicates,
-                "filtered": total_filtered,
-                "invalid": total_invalid,
-                "rows_matched": total_rows_matched,
-                "rows_skipped_existing": total_rows_skipped_existing,
-                "rows_filtered_out": total_rows_filtered_out,
-                "rows_write_attempted": total_rows_write_attempted,
-                "rows_failed": total_rows_failed,
-                "killmails_fetched": total_rows_seen,
-                "killmails_inserted": total_rows_written,
+                "duplicates": totals["duplicates"],
+                "filtered": totals["filtered"],
+                "invalid": totals["invalid"],
+                "rows_matched": totals["rows_matched"],
+                "rows_skipped_existing": totals["rows_skipped_existing"],
+                "rows_filtered_out": totals["rows_filtered_out"],
+                "rows_write_attempted": totals["rows_write_attempted"],
+                "rows_failed": totals["rows_failed"],
+                "killmails_fetched": totals["rows_seen"],
+                "killmails_inserted": totals["rows_written"],
                 "first_sequence_seen": first_sequence_seen,
                 "last_sequence_seen": last_sequence_seen,
                 "cursor_before": str(last_saved_sequence or 0),
@@ -605,17 +746,17 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
             {
                 "status": "failed",
                 "summary": str(error),
-                "rows_seen": total_rows_seen,
-                "rows_written": total_rows_written,
+                "rows_seen": totals["rows_seen"],
+                "rows_written": totals["rows_written"],
                 "cursor": str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0)),
                 "checksum": "",
                 "error": str(error),
                 "meta": {
-                    "rows_matched": total_rows_matched,
-                    "rows_filtered_out": total_rows_filtered_out,
-                    "rows_skipped_existing": total_rows_skipped_existing,
-                    "rows_write_attempted": total_rows_write_attempted,
-                    "rows_failed": max(1, total_rows_failed),
+                    "rows_matched": totals["rows_matched"],
+                    "rows_filtered_out": totals["rows_filtered_out"],
+                    "rows_skipped_existing": totals["rows_skipped_existing"],
+                    "rows_write_attempted": totals["rows_write_attempted"],
+                    "rows_failed": max(1, totals["rows_failed"]),
                     "cursor_before": str(last_saved_sequence or 0),
                     "cursor_after": str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0)),
                     "first_sequence_seen": first_sequence_seen,

--- a/python/tests/test_killmail_r2z2_stream.py
+++ b/python/tests/test_killmail_r2z2_stream.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from orchestrator.jobs import killmail
+
+
+class FakeBridge:
+    def __init__(self, php_binary: str, app_root: Path):
+        self.php_binary = php_binary
+        self.app_root = app_root
+        self.calls: list[tuple[str, dict | None]] = []
+
+    def call(self, action: str, payload: dict | None = None) -> dict:
+        self.calls.append((action, payload))
+        if action == "killmail-context":
+            return {
+                "context": {
+                    "enabled": True,
+                    "sequence_url": "https://example.test/sequence.json",
+                    "base_url": "https://example.test/killmails",
+                    "user_agent": "test-agent",
+                    "poll_sleep_seconds": 10,
+                    "max_sequences_per_run": 3,
+                    "cursor": "100",
+                    "dataset_key": "killmail",
+                    "job_key": "killmail_r2z2_sync",
+                }
+            }
+        if action == "sync-run-start":
+            return {"result": {"run_id": 1}}
+        if action == "process-killmail-batch":
+            payloads = list((payload or {}).get("payloads") or [])
+            sequence_id = int(payloads[-1].get("sequence_id") or 0) if payloads else 0
+            requested_sequence_id = int(payloads[-1].get("requested_sequence_id") or sequence_id) if payloads else 0
+            result = self._batch_result_for_payload(payloads[-1] if payloads else {}, requested_sequence_id)
+            result["last_processed_sequence"] = requested_sequence_id
+            result["meta"] = {
+                **dict(result.get("meta") or {}),
+                "checkpoint_state": {
+                    "checkpoint_updated": True,
+                    "cursor": str(requested_sequence_id),
+                    "reason": "updated",
+                },
+                "first_sequence_seen": requested_sequence_id,
+                "last_sequence_seen": requested_sequence_id,
+            }
+            return {"result": result}
+        if action == "sync-cursor-upsert":
+            cursor = str((payload or {}).get("cursor") or "")
+            return {
+                "result": {
+                    "checkpoint_updated": True,
+                    "cursor": cursor,
+                    "reason": "updated",
+                }
+            }
+        if action == "sync-run-finish":
+            return {"result": {"ok": True}}
+        raise AssertionError(f"Unexpected bridge action: {action}")
+
+    @staticmethod
+    def _batch_result_for_payload(item: dict, requested_sequence_id: int) -> dict:
+        classification = item.get("test_result")
+        base = {
+            "rows_seen": 1,
+            "rows_matched": 0,
+            "rows_skipped_existing": 0,
+            "rows_filtered_out": 0,
+            "rows_write_attempted": 0,
+            "rows_written": 0,
+            "rows_failed": 0,
+            "duplicates": 0,
+            "filtered": 0,
+            "invalid": 0,
+            "reason_for_zero_write": "unknown",
+        }
+        if classification == "inserted":
+            return {
+                **base,
+                "rows_matched": 1,
+                "rows_write_attempted": 1,
+                "rows_written": 1,
+                "reason_for_zero_write": "",
+            }
+        if classification == "existing":
+            return {
+                **base,
+                "rows_matched": 1,
+                "rows_skipped_existing": 1,
+                "duplicates": 1,
+                "reason_for_zero_write": "already_existed_locally",
+            }
+        if classification == "filtered":
+            return {
+                **base,
+                "rows_filtered_out": 1,
+                "filtered": 1,
+                "reason_for_zero_write": "no_tracked_entity_matches",
+            }
+        if classification == "empty":
+            return {
+                **base,
+                "invalid": 1,
+                "reason_for_zero_write": "unknown",
+            }
+        return {
+            **base,
+            "invalid": 1,
+            "reason_for_zero_write": "unknown",
+        }
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.php_binary = "php"
+        self.app_root = Path("/tmp/supplycore")
+        self.timeout_seconds = 60
+        self.batch_size = 1000
+        self.job_key = "killmail_r2z2_sync"
+        self.emitted: list[tuple[str, dict]] = []
+
+    def emit(self, event: str, payload: dict) -> None:
+        self.emitted.append((event, payload))
+
+
+class KillmailStreamTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.context = FakeContext()
+
+    def test_http_200_sequences_do_not_raise_and_checkpoint_advances(self) -> None:
+        responses = [
+            (200, {"esi": {"killmail_id": 1}, "test_result": "filtered"}),
+            (200, {"esi": {"killmail_id": 2}, "test_result": "existing"}),
+            (200, {"esi": {"killmail_id": 3}, "test_result": "inserted"}),
+        ]
+
+        def fake_http_json(url: str, user_agent: str, timeout_seconds: int = 25):
+            self.assertEqual(user_agent, "test-agent")
+            if url.endswith("/101.json"):
+                return responses[0]
+            if url.endswith("/102.json"):
+                return responses[1]
+            if url.endswith("/103.json"):
+                return responses[2]
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        with patch.object(killmail, "PhpBridge", FakeBridge), patch.object(killmail, "_http_json", side_effect=fake_http_json):
+            result = killmail.run_killmail_r2z2_stream(self.context)
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["rows_seen"], 3)
+        self.assertEqual(result["rows_written"], 1)
+        self.assertEqual(result["cursor"], "103")
+        self.assertEqual(result["meta"]["rows_filtered_out"], 1)
+        self.assertEqual(result["meta"]["rows_skipped_existing"], 1)
+        self.assertEqual(result["meta"]["rows_matched"], 2)
+        self.assertEqual(result["meta"]["checkpoint_updates"], 3)
+        sequence_processed = [payload for event, payload in self.context.emitted if event == "zkill.sequence_processed"]
+        self.assertEqual(len(sequence_processed), 3)
+        self.assertEqual([item["processing_outcome"] for item in sequence_processed], ["filtered_out", "already_existing", "inserted"])
+
+    def test_empty_http_200_payload_is_valid_non_actionable(self) -> None:
+        def fake_http_json(url: str, user_agent: str, timeout_seconds: int = 25):
+            if url.endswith("/101.json"):
+                return 200, {}
+            if url.endswith("/102.json"):
+                return 404, {}
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        with (
+            patch.object(killmail, "PhpBridge", FakeBridge),
+            patch.object(killmail, "_http_json", side_effect=fake_http_json),
+            patch.object(killmail, "_sleep_with_budget", return_value=False),
+        ):
+            result = killmail.run_killmail_r2z2_stream(self.context)
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["rows_seen"], 1)
+        self.assertEqual(result["rows_written"], 0)
+        self.assertEqual(result["cursor"], "101")
+        sequence_fetch = [payload for event, payload in self.context.emitted if event == "zkill.sequence_fetch"]
+        self.assertEqual(sequence_fetch[0]["payload_classification"], "valid_empty_payload")
+        self.assertTrue(sequence_fetch[0]["valid_non_actionable"])
+        sequence_processed = [payload for event, payload in self.context.emitted if event == "zkill.sequence_processed"]
+        self.assertEqual(sequence_processed[0]["processing_outcome"], "invalid_payload")
+        self.assertTrue(sequence_processed[0]["valid_non_actionable"])
+
+    def test_http_200_non_object_payload_raises_precise_error(self) -> None:
+        def fake_http_json(url: str, user_agent: str, timeout_seconds: int = 25):
+            if url.endswith("/101.json"):
+                return 200, []
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        with patch.object(killmail, "PhpBridge", FakeBridge), patch.object(killmail, "_http_json", side_effect=fake_http_json):
+            with self.assertRaisesRegex(RuntimeError, "HTTP 200 with malformed non-object JSON payload"):
+                killmail.run_killmail_r2z2_stream(self.context)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The zKill worker was crashing because the sequence fetch path incorrectly treated an HTTP 200 response as a fatal fetch error due to control-flow falling through to the generic error branch.  The goal is to fix that without redesigning the worker flow.
- The change must correctly distinguish fetch outcomes (successful, empty-but-valid, malformed payload, retryable status, not-found) and preserve checkpointing and batch diagnostics.
- Improve per-sequence diagnostics so the worker can log `sequence_id`, `http_status`, `payload_classification`, processing outcome, and checkpoint state for each sequence.

### Description
- Fix `python/orchestrator/jobs/killmail.py` ` _http_json` to return {} for blank bodies, parse JSON safely, and raise a precise error only when an HTTP 200 contains invalid JSON.
- Add `_classify_sequence_payload` to classify payloads as `valid_payload`, `valid_empty_payload`, or `malformed_non_object_payload`, and update the sequence loop to use that classification and emit `zkill.sequence_fetch` events.
- Stop treating `status == 200` as a fatal error; process valid 200 responses (including empty-but-valid payloads) and only raise for malformed non-object 200 payloads or truly unexpected HTTP statuses; emit `zkill.sequence_processed` with outcome details after batch persistence.
- Consolidate totals accumulation via `_accumulate_batch_result`, ensure `_fetch_profile` only returns a profile when the HTTP 200 payload is an object, and keep existing checkpointing/bridge batch behavior intact.
- Files changed: `python/orchestrator/jobs/killmail.py` and added unit tests in `python/tests/test_killmail_r2z2_stream.py`.

### Testing
- Ran unit tests with `PYTHONPATH=python python -m unittest discover -s python/tests -v`, which executed the new targeted tests and reported all tests OK (3 tests).
- Compiled the module and tests with `python -m compileall python/orchestrator/jobs/killmail.py python/tests/test_killmail_r2z2_stream.py`, which succeeded.
- Automated tests cover: multiple consecutive HTTP 200 sequence fetches with mixed outcomes, empty HTTP 200 payload handling as valid non-actionable, and malformed non-object HTTP 200 payload raising a precise error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0cebb65d4832fbe12822fcb084cd0)