### PR TITLE
Stabilize zKill worker settings and victim-only ingestion

### DIFF
--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -157,7 +157,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <p class="mt-2 text-xl font-semibold text-slate-50"><?= number_format((int) ($status['tracked_corporation_count'] ?? 0)) ?></p>
             </div>
             <div class="surface-tertiary text-sm text-slate-400">
-                Losses are retained when a tracked alliance or corporation appears on the victim side or among the attackers. That keeps the board focused on actionable activity without exposing worker plumbing by default.
+                Losses are retained only when a tracked alliance or corporation appears on the victim side. That keeps the board focused on tracked losses without exposing worker plumbing by default.
             </div>
         </div>
     </article>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -70,27 +70,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 
         case 'killmail-intelligence':
-            $resolvedEntities = killmail_resolve_tracked_entities(
-                (string) ($_POST['tracked_alliance_names'] ?? ''),
-                (string) ($_POST['tracked_corporation_names'] ?? '')
-            );
-
-            $saved = save_settings([
-                'killmail_ingestion_enabled' => sanitize_enabled_flag($_POST['killmail_ingestion_enabled'] ?? null),
-                'killmail_ingestion_poll_sleep_seconds' => (string) max(6, min(300, (int) ($_POST['killmail_ingestion_poll_sleep_seconds'] ?? 10))),
-                'killmail_ingestion_max_sequences_per_run' => (string) max(1, min(5000, (int) ($_POST['killmail_ingestion_max_sequences_per_run'] ?? 120))),
-                'killmail_demand_prediction_mode' => trim((string) ($_POST['killmail_demand_prediction_mode'] ?? 'baseline')),
-            ]);
-
-            if ($saved) {
-                $saved = db_killmail_tracked_alliances_replace(array_map(static fn (array $row): array => ['alliance_id' => $row['id'], 'label' => $row['label']], (array) ($resolvedEntities['alliances'] ?? [])))
-                    && db_killmail_tracked_corporations_replace(array_map(static fn (array $row): array => ['corporation_id' => $row['id'], 'label' => $row['label']], (array) ($resolvedEntities['corporations'] ?? [])));
-                if ($saved) {
-                    supplycore_cache_bust(['dashboard', 'killmail_overview', 'killmail_detail']);
-                }
-            }
-
-            $unresolved = array_slice((array) ($resolvedEntities['unresolved'] ?? []), 0, 8);
+            $killmailSave = save_killmail_intelligence_settings($_POST);
+            $saved = (bool) ($killmailSave['ok'] ?? false);
+            $unresolved = (array) ($killmailSave['unresolved'] ?? []);
             if ($unresolved !== []) {
                 $saveMessage = 'Some names were not resolved: ' . implode('; ', $unresolved);
             }
@@ -1098,7 +1080,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <article class="rounded-xl border border-border bg-black/20 p-4">
                         <p class="text-xs uppercase tracking-[0.16em] text-muted">Tracked entities</p>
                         <p class="mt-2 text-sm font-semibold text-slate-50"><?= number_format((int) ($killmailStatusSummary['tracked_alliance_count'] ?? 0)) ?> alliances · <?= number_format((int) ($killmailStatusSummary['tracked_corporation_count'] ?? 0)) ?> corporations</p>
-                        <p class="mt-2 text-xs text-muted">These determine which zKill activity is retained for business use.</p>
+                        <p class="mt-2 text-xs text-muted">These determine which victim-side losses are retained for the tracked loss board.</p>
                     </article>
                 </div>
 
@@ -1168,6 +1150,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
                 <div class="rounded-lg border border-border bg-black/20 p-3 text-sm text-muted space-y-2">
                     <p>Add alliances and corporations from the lookup, or enter exact numeric IDs when you already know them.</p>
+                    <p>The continuous zKill worker keeps a killmail only when the victim belongs to one of these tracked entities. Attacker-only matches are ignored for the tracked loss board.</p>
                     <p>Each saved entry is stored locally as <span class="text-slate-100">ID + name</span>, and you can remove anything here before saving if an alliance or corporation leaves the group you care about.</p>
                 </div>
 
@@ -1530,7 +1513,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     </div>
                 </details>
 
-                <p class="text-sm text-muted">Ingestion consumes R2Z2 as an ordered stream and keeps killmails when a tracked alliance or corporation appears on either side of the fight. That gives you a concise, business-facing feed without losing deeper diagnostics when you need them.</p>
+                <p class="text-sm text-muted">Ingestion consumes R2Z2 as an ordered stream and keeps killmails only when a tracked alliance or corporation appears on the victim side. That keeps the board focused on tracked losses while leaving attacker details available only inside each stored loss.</p>
                 <button class="btn-primary">Save Killmail Intelligence Settings</button>
             </form>
         <?php elseif ($section === 'esi-login'): ?>
@@ -1812,7 +1795,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
                     <div>
                         <p class="text-sm text-slate-100">Continuous worker runtime</p>
-                        <p class="mt-1 text-xs text-muted">The Python worker pool owns recurring cadence, retries, and schedule rows now. This page saves sync behavior settings, while the cards below show the currently active runtime profile.</p>
+                        <p class="mt-1 text-xs text-muted">The Python worker pool owns recurring cadence, retries, and schedule rows now. The zKill stream is tracked separately as a dedicated continuous worker, while the cards below show the currently active scheduler runtime profile for normal jobs.</p>
                     </div>
 
                     <div class="rounded-xl border border-border bg-black/20 p-4 space-y-4">

--- a/src/db.php
+++ b/src/db.php
@@ -238,6 +238,18 @@ function db_execute(string $sql, array $params = []): bool
     return $stmt->execute($params);
 }
 
+function db_app_settings_upsert_many(array $settings): bool
+{
+    foreach ($settings as $key => $value) {
+        db_execute(
+            'INSERT INTO app_settings (setting_key, setting_value) VALUES (?, ?) ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), updated_at = CURRENT_TIMESTAMP',
+            [(string) $key, (string) $value]
+        );
+    }
+
+    return true;
+}
+
 function db_transaction(callable $callback): mixed
 {
     db_query_cache_clear();
@@ -9310,6 +9322,13 @@ function db_killmail_items_replace(int $sequenceId, array $rows): int
 function db_killmail_tracked_alliances_replace(array $rows): bool
 {
     return db_transaction(static function () use ($rows): bool {
+        db_execute('CREATE TABLE IF NOT EXISTS killmail_tracked_alliances (
+            alliance_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+            label VARCHAR(255) DEFAULT NULL,
+            is_active TINYINT(1) NOT NULL DEFAULT 1,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
         db_execute('DELETE FROM killmail_tracked_alliances');
 
         foreach ($rows as $row) {
@@ -9327,6 +9346,13 @@ function db_killmail_tracked_alliances_replace(array $rows): bool
 function db_killmail_tracked_corporations_replace(array $rows): bool
 {
     return db_transaction(static function () use ($rows): bool {
+        db_execute('CREATE TABLE IF NOT EXISTS killmail_tracked_corporations (
+            corporation_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+            label VARCHAR(255) DEFAULT NULL,
+            is_active TINYINT(1) NOT NULL DEFAULT 1,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
         db_execute('DELETE FROM killmail_tracked_corporations');
 
         foreach ($rows as $row) {
@@ -9351,6 +9377,22 @@ function db_killmail_tracked_corporations_active(): array
     return db_select('SELECT corporation_id, label FROM killmail_tracked_corporations WHERE is_active = 1 ORDER BY corporation_id ASC');
 }
 
+function db_sync_schedule_delete_by_job_keys(array $jobKeys): int
+{
+    $safeJobKeys = array_values(array_filter(array_map(static fn (mixed $jobKey): string => trim((string) $jobKey), $jobKeys), static fn (string $jobKey): bool => $jobKey !== ''));
+    if ($safeJobKeys === []) {
+        return 0;
+    }
+
+    db_sync_schedule_registry_columns_ensure();
+    $placeholders = implode(',', array_fill(0, count($safeJobKeys), '?'));
+    $stmt = db()->prepare("DELETE FROM sync_schedules WHERE job_key IN ({$placeholders})");
+    $stmt->execute($safeJobKeys);
+    db_query_cache_clear();
+
+    return (int) $stmt->rowCount();
+}
+
 function db_killmail_tracked_match_sql(string $eventAlias = 'e'): string
 {
     $eventAlias = preg_replace('/[^a-zA-Z0-9_]/', '', $eventAlias) ?: 'e';
@@ -9365,22 +9407,6 @@ function db_killmail_tracked_match_sql(string $eventAlias = 'e'): string
             SELECT tc.corporation_id
             FROM killmail_tracked_corporations tc
             WHERE tc.is_active = 1
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM killmail_attackers attacker
-            INNER JOIN killmail_tracked_alliances ta
-                ON ta.alliance_id = attacker.alliance_id
-               AND ta.is_active = 1
-            WHERE attacker.sequence_id = {$eventAlias}.sequence_id
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM killmail_attackers attacker
-            INNER JOIN killmail_tracked_corporations tc
-                ON tc.corporation_id = attacker.corporation_id
-               AND tc.is_active = 1
-            WHERE attacker.sequence_id = {$eventAlias}.sequence_id
         )
     )";
 }
@@ -9424,36 +9450,6 @@ function db_killmail_tracked_matches_sql(?string $effectiveAfterSql = null, ?str
             FROM killmail_tracked_corporations tc
             INNER JOIN killmail_events e
                 ON e.victim_corporation_id = tc.corporation_id{$effectiveFilterSql}{$sequenceFilterSql}
-            WHERE tc.is_active = 1
-
-            UNION ALL
-
-            SELECT
-                a.sequence_id,
-                0 AS matches_victim_alliance,
-                0 AS matches_victim_corporation,
-                1 AS matches_attacker_alliance,
-                0 AS matches_attacker_corporation
-            FROM killmail_tracked_alliances ta
-            INNER JOIN killmail_attackers a
-                ON a.alliance_id = ta.alliance_id
-            INNER JOIN killmail_events e
-                ON e.sequence_id = a.sequence_id{$effectiveFilterSql}{$sequenceFilterSql}
-            WHERE ta.is_active = 1
-
-            UNION ALL
-
-            SELECT
-                a.sequence_id,
-                0 AS matches_victim_alliance,
-                0 AS matches_victim_corporation,
-                0 AS matches_attacker_alliance,
-                1 AS matches_attacker_corporation
-            FROM killmail_tracked_corporations tc
-            INNER JOIN killmail_attackers a
-                ON a.corporation_id = tc.corporation_id
-            INNER JOIN killmail_events e
-                ON e.sequence_id = a.sequence_id{$effectiveFilterSql}{$sequenceFilterSql}
             WHERE tc.is_active = 1
         ) matched
         GROUP BY matched.sequence_id

--- a/src/functions.php
+++ b/src/functions.php
@@ -203,12 +203,7 @@ function save_settings(array $settings): bool
 {
     try {
         db_transaction(function () use ($settings): void {
-            foreach ($settings as $key => $value) {
-                db_execute(
-                    'INSERT INTO app_settings (setting_key, setting_value) VALUES (?, ?) ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), updated_at = CURRENT_TIMESTAMP',
-                    [$key, (string) $value]
-                );
-            }
+            db_app_settings_upsert_many($settings);
         });
     } catch (Throwable) {
         return false;
@@ -2117,11 +2112,6 @@ function scheduler_operational_profile_matrix(string $profile): array
             'medium' => ['interval_minutes' => 6, 'timeout_seconds' => 180, 'priority' => 'medium'],
             'high' => ['interval_minutes' => 4, 'timeout_seconds' => 240, 'priority' => 'high'],
         ],
-        'killmail_r2z2_sync' => [
-            'low' => ['interval_minutes' => 5, 'timeout_seconds' => 120, 'priority' => 'high'],
-            'medium' => ['interval_minutes' => 2, 'timeout_seconds' => 120, 'priority' => 'highest'],
-            'high' => ['interval_minutes' => 1, 'timeout_seconds' => 150, 'priority' => 'highest'],
-        ],
         'current_state_refresh_sync' => [
             'low' => ['interval_minutes' => 15, 'timeout_seconds' => 120, 'priority' => 'medium'],
             'medium' => ['interval_minutes' => 8, 'timeout_seconds' => 120, 'priority' => 'medium'],
@@ -3548,13 +3538,24 @@ function worker_job_registry_definitions(): array
     ];
 }
 
+function dedicated_worker_job_keys(): array
+{
+    return [
+        'killmail_r2z2_sync',
+    ];
+}
+
+function scheduler_is_dedicated_worker_job(string $jobKey): bool
+{
+    return in_array(trim($jobKey), dedicated_worker_job_keys(), true);
+}
+
 function scheduler_registry_definitions(): array
 {
     return [
         'market_hub_current_sync' => ['label' => 'Market Hub Current', 'default_interval_minutes' => 8, 'default_offset_minutes' => 0, 'priority' => 'high', 'timeout_seconds' => 240, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'min_interval_minutes' => 1, 'max_interval_minutes' => 8, 'workload_class' => 'lightweight'],
         'deal_alerts_sync' => ['label' => 'Deal Alerts', 'default_interval_minutes' => 5, 'default_offset_minutes' => 1, 'priority' => 'high', 'timeout_seconds' => 90, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'latency_sensitive' => true, 'user_facing' => true, 'workload_class' => 'lightweight'],
         'alliance_current_sync' => ['label' => 'Alliance Current', 'default_interval_minutes' => 4, 'default_offset_minutes' => 2, 'priority' => 'medium', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'lightweight'],
-        'killmail_r2z2_sync' => ['label' => 'Killmail R2Z2 Stream', 'default_interval_minutes' => 1, 'default_offset_minutes' => 3, 'priority' => 'highest', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'min_interval_minutes' => 1, 'max_interval_minutes' => 3, 'workload_class' => 'heavy'],
         'configured_structure_destination_id_for_esi_sync' => ['label' => 'Configured Structure Destination for ESI', 'default_interval_minutes' => 30, 'default_offset_minutes' => 4, 'priority' => 'normal', 'timeout_seconds' => 120, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => false, 'workload_class' => 'lightweight'],
         'current_state_refresh_sync' => ['label' => 'Current-State Refresh', 'default_interval_minutes' => 12, 'default_offset_minutes' => 6, 'priority' => 'medium', 'timeout_seconds' => 120, 'concurrency_policy' => 'single', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
         'doctrine_intelligence_sync' => ['label' => 'Doctrine Intelligence', 'default_interval_minutes' => 15, 'default_offset_minutes' => 8, 'priority' => 'normal', 'timeout_seconds' => 180, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'allow_backfill' => true, 'backfill_priority' => 'normal', 'min_backfill_gap_seconds' => 300, 'max_early_start_seconds' => 900, 'workload_class' => 'lightweight'],
@@ -3611,7 +3612,6 @@ function scheduler_internal_mechanic_job_keys(): array
 function scheduler_protected_job_keys(): array
 {
     return [
-        'killmail_r2z2_sync',
         'market_hub_current_sync',
         'deal_alerts_sync',
         'alliance_current_sync',
@@ -5598,7 +5598,7 @@ function scheduler_console_pipeline_health(array $jobs, array $pipelineSettings)
             'key' => 'current',
             'label' => 'Current sync',
             'enabled' => ($pipelineSettings['alliance_current_pipeline_enabled'] ?? '1') === '1',
-            'jobs' => ['alliance_current_sync', 'market_hub_current_sync', 'killmail_r2z2_sync'],
+            'jobs' => ['alliance_current_sync', 'market_hub_current_sync'],
         ],
         [
             'key' => 'alliance_history',
@@ -5768,6 +5768,10 @@ function sync_schedule_settings_view_model(): array
     foreach ($rows as $row) {
         $jobKey = trim((string) ($row['job_key'] ?? ''));
         if ($jobKey === '') {
+            continue;
+        }
+
+        if (scheduler_is_dedicated_worker_job($jobKey)) {
             continue;
         }
 
@@ -8214,14 +8218,6 @@ function killmail_match_sources(array $row): array
         $sources[] = 'tracked victim corporation';
     }
 
-    if ((int) ($row['matches_attacker_alliance'] ?? 0) === 1) {
-        $sources[] = 'tracked attacker alliance';
-    }
-
-    if ((int) ($row['matches_attacker_corporation'] ?? 0) === 1) {
-        $sources[] = 'tracked attacker corporation';
-    }
-
     return $sources;
 }
 
@@ -10060,7 +10056,7 @@ function killmail_overview_data(): array
             'summary' => [
                 ['label' => 'Total Ingested', 'value' => number_format($totalCount), 'context' => 'Killmails stored locally'],
                 ['label' => 'Recent Ingestion', 'value' => number_format($recentCount), 'context' => 'Stored in the last ' . $recentHours . ' hours'],
-                ['label' => 'Tracked Entity Killmails', 'value' => number_format($trackedMatchCount), 'context' => 'Stored killmails where a tracked alliance or corporation appears on the victim or attacker side'],
+                ['label' => 'Tracked Entity Killmails', 'value' => number_format($trackedMatchCount), 'context' => 'Stored killmails where a tracked alliance or corporation appears on the victim side'],
                 ['label' => 'Last Processed Sequence', 'value' => $maxSequenceId > 0 ? number_format($maxSequenceId) : '—', 'context' => $cursor !== '' ? ('Cursor ' . $cursor) : 'Cursor not recorded yet'],
                 ['label' => 'Sync Freshness', 'value' => killmail_relative_datetime($lastSuccessAt), 'context' => $lastSuccessAt !== null ? ('Last success ' . killmail_format_datetime($lastSuccessAt)) : 'No successful sync recorded'],
             ],
@@ -11624,6 +11620,9 @@ function scheduler_discover_jobs(): array
     $discovered = [];
     $known = scheduler_registry_definitions();
     foreach ($known as $jobKey => $definition) {
+        if (scheduler_is_dedicated_worker_job($jobKey)) {
+            continue;
+        }
         $discovered[$jobKey] = $definition + [
             'job_key' => $jobKey,
             'discovered_from_code' => true,
@@ -11685,6 +11684,10 @@ function scheduler_discover_jobs(): array
 
             foreach (scheduler_extract_php_function_names($contents) as $candidate) {
                 if (!preg_match('/(?:_sync|_job)$/', $candidate)) {
+                    continue;
+                }
+
+                if (scheduler_is_dedicated_worker_job($candidate)) {
                     continue;
                 }
 
@@ -11798,10 +11801,14 @@ function scheduler_registry_bootstrap(): void
     }
 
     scheduler_reconcile_baseline_rows($definitions, $existingRows);
+    db_sync_schedule_delete_by_job_keys(dedicated_worker_job_keys());
 
     $handlers = scheduler_job_definitions();
 
     foreach ($definitions as $jobKey => $definition) {
+        if (scheduler_is_dedicated_worker_job($jobKey)) {
+            continue;
+        }
         $enabled = array_key_exists($jobKey, $handlers) ? 1 : 0;
         $wasKnown = array_key_exists($jobKey, $existingRows);
         db_sync_schedule_ensure_job(
@@ -13156,12 +13163,46 @@ function http_post_form(string $url, array $headers, array $formData): array
         throw new RuntimeException('HTTP request failed: ' . $error);
     }
 
-    $decoded = json_decode($response, true);
-    if (!is_array($decoded)) {
-        throw new RuntimeException('Invalid JSON response from ' . $url);
+    $decoded = http_json_decode_response_body($url, (int) $status, (string) $response);
+
+    return [
+        'status' => $status,
+        'json' => $decoded['json'],
+        'body' => (string) $response,
+        'payload_classification' => $decoded['classification'],
+        'valid_empty_body' => $decoded['valid_empty_body'],
+    ];
+}
+
+function http_json_decode_response_body(string $url, int $status, string $body): array
+{
+    $trimmed = trim($body);
+    if ($trimmed === '') {
+        return [
+            'json' => [],
+            'classification' => $status >= 400 ? 'empty_error_body' : 'empty_body',
+            'valid_empty_body' => $status < 400,
+        ];
     }
 
-    return ['status' => $status, 'json' => $decoded];
+    $decoded = json_decode($body, true);
+    if (is_array($decoded)) {
+        return [
+            'json' => $decoded,
+            'classification' => 'json_object',
+            'valid_empty_body' => false,
+        ];
+    }
+
+    if ($status >= 400) {
+        return [
+            'json' => [],
+            'classification' => 'non_json_error_body',
+            'valid_empty_body' => false,
+        ];
+    }
+
+    throw new RuntimeException('Invalid JSON response from ' . $url . ' (status=' . $status . ').');
 }
 
 function http_post_json(string $url, array $headers, array $payload, int $timeoutSeconds = 25): array
@@ -13189,12 +13230,15 @@ function http_post_json(string $url, array $headers, array $payload, int $timeou
         throw new RuntimeException('HTTP request failed: ' . $error);
     }
 
-    $decoded = json_decode($response, true);
-    if (!is_array($decoded)) {
-        throw new RuntimeException('Invalid JSON response from ' . $url);
-    }
+    $decoded = http_json_decode_response_body($url, (int) $status, (string) $response);
 
-    return ['status' => $status, 'json' => $decoded];
+    return [
+        'status' => $status,
+        'json' => $decoded['json'],
+        'body' => (string) $response,
+        'payload_classification' => $decoded['classification'],
+        'valid_empty_body' => $decoded['valid_empty_body'],
+    ];
 }
 
 function http_get_json(string $url, array $headers = [], int $timeoutSeconds = 25): array
@@ -13243,12 +13287,16 @@ function http_get_json(string $url, array $headers = [], int $timeoutSeconds = 2
         throw new RuntimeException('HTTP request failed: ' . $error);
     }
 
-    $decoded = json_decode($response, true);
-    if (!is_array($decoded)) {
-        throw new RuntimeException('Invalid JSON response from ' . $url);
-    }
+    $decoded = http_json_decode_response_body($url, (int) $status, (string) $response);
 
-    return ['status' => $status, 'json' => $decoded, 'headers' => $responseHeaders];
+    return [
+        'status' => $status,
+        'json' => $decoded['json'],
+        'headers' => $responseHeaders,
+        'body' => (string) $response,
+        'payload_classification' => $decoded['classification'],
+        'valid_empty_body' => $decoded['valid_empty_body'],
+    ];
 }
 
 function sync_http_retryable_status_codes(): array
@@ -13376,14 +13424,13 @@ function http_get_json_multi(array $requests, int $timeoutSeconds = 25): array
             $error = curl_error($handle);
             $decoded = null;
             $errorMessage = null;
+            $payloadMeta = null;
 
             if ($body === false || $error !== '') {
                 $errorMessage = 'HTTP request failed: ' . ($error !== '' ? $error : ('Unable to fetch ' . $entry['url']));
             } else {
-                $decoded = json_decode($body, true);
-                if (!is_array($decoded)) {
-                    $errorMessage = 'Invalid JSON response from ' . $entry['url'];
-                }
+                $payloadMeta = http_json_decode_response_body($entry['url'], $status, (string) $body);
+                $decoded = $payloadMeta['json'];
             }
 
             $responses[$key] = [
@@ -13391,6 +13438,9 @@ function http_get_json_multi(array $requests, int $timeoutSeconds = 25): array
                 'json' => $decoded,
                 'headers' => $responseHeadersByKey[$key] ?? [],
                 'error' => $errorMessage,
+                'body' => $body === false ? '' : (string) $body,
+                'payload_classification' => $payloadMeta['classification'] ?? ($errorMessage === null ? 'json_object' : 'transport_error'),
+                'valid_empty_body' => (bool) ($payloadMeta['valid_empty_body'] ?? false),
             ];
 
             curl_multi_remove_handle($multiHandle, $handle);
@@ -17119,6 +17169,79 @@ function killmail_resolve_tracked_entities(string $allianceText, string $corpora
     ];
 }
 
+function killmail_settings_from_request(array $request): array
+{
+    $resolvedEntities = killmail_resolve_tracked_entities(
+        (string) ($request['tracked_alliance_names'] ?? ''),
+        (string) ($request['tracked_corporation_names'] ?? '')
+    );
+
+    return [
+        'settings' => [
+            'killmail_ingestion_enabled' => sanitize_enabled_flag($request['killmail_ingestion_enabled'] ?? null),
+            'killmail_ingestion_poll_sleep_seconds' => (string) max(6, min(300, (int) ($request['killmail_ingestion_poll_sleep_seconds'] ?? 10))),
+            'killmail_ingestion_max_sequences_per_run' => (string) max(1, min(5000, (int) ($request['killmail_ingestion_max_sequences_per_run'] ?? 120))),
+            'killmail_demand_prediction_mode' => trim((string) ($request['killmail_demand_prediction_mode'] ?? 'baseline')),
+        ],
+        'alliances' => array_map(
+            static fn (array $row): array => ['alliance_id' => (int) ($row['id'] ?? 0), 'label' => $row['label'] ?? null],
+            (array) ($resolvedEntities['alliances'] ?? [])
+        ),
+        'corporations' => array_map(
+            static fn (array $row): array => ['corporation_id' => (int) ($row['id'] ?? 0), 'label' => $row['label'] ?? null],
+            (array) ($resolvedEntities['corporations'] ?? [])
+        ),
+        'unresolved' => array_values((array) ($resolvedEntities['unresolved'] ?? [])),
+    ];
+}
+
+function save_killmail_intelligence_settings(array $request): array
+{
+    $payload = killmail_settings_from_request($request);
+    $saved = false;
+
+    try {
+        db_transaction(static function () use ($payload): void {
+            db_app_settings_upsert_many((array) ($payload['settings'] ?? []));
+            db_killmail_tracked_alliances_replace((array) ($payload['alliances'] ?? []));
+            db_killmail_tracked_corporations_replace((array) ($payload['corporations'] ?? []));
+        });
+        $reloadedSettings = get_settings(array_keys((array) ($payload['settings'] ?? [])));
+        foreach ((array) ($payload['settings'] ?? []) as $key => $value) {
+            if ((string) ($reloadedSettings[$key] ?? '') !== (string) $value) {
+                throw new RuntimeException('Killmail settings readback mismatch for key ' . $key . '.');
+            }
+        }
+
+        $reloadedAllianceIds = array_values(array_map(static fn (array $row): int => (int) ($row['alliance_id'] ?? 0), db_killmail_tracked_alliances_active()));
+        $reloadedCorporationIds = array_values(array_map(static fn (array $row): int => (int) ($row['corporation_id'] ?? 0), db_killmail_tracked_corporations_active()));
+        $expectedAllianceIds = array_values(array_map(static fn (array $row): int => (int) ($row['alliance_id'] ?? 0), (array) ($payload['alliances'] ?? [])));
+        $expectedCorporationIds = array_values(array_map(static fn (array $row): int => (int) ($row['corporation_id'] ?? 0), (array) ($payload['corporations'] ?? [])));
+        sort($reloadedAllianceIds);
+        sort($reloadedCorporationIds);
+        sort($expectedAllianceIds);
+        sort($expectedCorporationIds);
+        if ($reloadedAllianceIds !== $expectedAllianceIds || $reloadedCorporationIds !== $expectedCorporationIds) {
+            throw new RuntimeException('Killmail tracked entity readback mismatch after save.');
+        }
+        $saved = true;
+    } catch (Throwable) {
+        $saved = false;
+    }
+
+    if ($saved) {
+        supplycore_cache_bust(['dashboard', 'killmail_overview', 'killmail_detail']);
+    }
+
+    return [
+        'ok' => $saved,
+        'settings' => (array) ($payload['settings'] ?? []),
+        'alliances' => (array) ($payload['alliances'] ?? []),
+        'corporations' => (array) ($payload['corporations'] ?? []),
+        'unresolved' => array_slice((array) ($payload['unresolved'] ?? []), 0, 8),
+    ];
+}
+
 function killmail_r2z2_fetch_json(string $url): array
 {
     $userAgent = trim((string) get_setting('app_name', 'SupplyCore'));
@@ -17200,6 +17323,8 @@ function killmail_region_id_from_system(?int $systemId): ?int
 
 function killmail_event_matches_tracked_entities(array $event, array $attackers, array $trackedAllianceIds, array $trackedCorporationIds): bool
 {
+    unset($attackers);
+
     if ($trackedAllianceIds === [] && $trackedCorporationIds === []) {
         return true;
     }
@@ -17213,22 +17338,6 @@ function killmail_event_matches_tracked_entities(array $event, array $attackers,
 
     if ($victimCorporationId > 0 && isset($trackedCorporationIds[$victimCorporationId])) {
         return true;
-    }
-
-    foreach ($attackers as $attacker) {
-        if (!is_array($attacker)) {
-            continue;
-        }
-
-        $attackerAllianceId = (int) ($attacker['alliance_id'] ?? 0);
-        if ($attackerAllianceId > 0 && isset($trackedAllianceIds[$attackerAllianceId])) {
-            return true;
-        }
-
-        $attackerCorporationId = (int) ($attacker['corporation_id'] ?? 0);
-        if ($attackerCorporationId > 0 && isset($trackedCorporationIds[$attackerCorporationId])) {
-            return true;
-        }
     }
 
     return false;


### PR DESCRIPTION
### Motivation
- Fix incorrect classification of valid HTTP/JSON responses in the fetch pipeline so 2xx empty bodies and non-JSON error bodies are handled precisely instead of being treated as transport failures.
- Make killmail settings and tracked-entity persistence reliable end-to-end with transactional save and immediate readback validation.
- Remove leftover scheduler semantics for the zKill stream so it behaves as a dedicated continuous worker rather than a cadence-scheduled job.
- Restrict zKill ingestion to victim-side matching only so the tracked-loss board only retains victim losses (attacker-only matches no longer qualify).

### Description
- Harden shared HTTP helpers by adding `http_json_decode_response_body()` and returning structured payload metadata (classification, valid-empty flag, body) from `http_get_json`, `http_post_json`, `http_post_form`, and multi-request helpers; this prevents valid empty 2xx bodies and non-JSON error bodies from being misclassified.
- Centralize app-settings upserts with `db_app_settings_upsert_many()` and switch `save_settings()` to use it, improving atomicity and reusability.
- Add a dedicated killmail save flow: `killmail_settings_from_request()` and `save_killmail_intelligence_settings()` perform a transactional save of settings and tracked entities, create tracked-entity tables if missing, and perform immediate readback validation of settings and tracked IDs.
- Treat zKill as a dedicated worker by introducing `dedicated_worker_job_keys()` and `scheduler_is_dedicated_worker_job()`; remove `killmail_r2z2_sync` from schedule discovery/bootstrap and delete any lingering schedule rows for it during registry bootstrap so it is represented only via worker runtime state.
- Restrict tracked matching to victim-only by removing attacker-side matching from SQL helpers and PHP match functions, and update UI copy to remove wording implying attacker-side retention.
- Files changed: `src/functions.php`, `src/db.php`, `public/settings/index.php`, `public/killmail-intelligence/index.php`, and small additions to existing Python unit tests usage were exercised.

### Testing
- PHP syntax checks: `php -l src/functions.php`, `php -l src/db.php`, `php -l public/settings/index.php`, and `php -l public/killmail-intelligence/index.php` all succeeded.
- Unit tests: `PYTHONPATH=python python -m unittest python/tests/test_killmail_r2z2_stream.py` ran and passed (3 tests, OK).
- Targeted runtime checks: ad-hoc `php -r` validations were run to confirm victim-only matching, dedicated-worker classification, settings payload sanitization, and HTTP response classification; all checks returned expected results.
- Note: full live DB integration (web form save + end-to-end worker) could not be exercised here because the environment could not connect to the database, but transactional save + immediate readback validation is implemented to detect save/read mismatches at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d4a1bfcc832f98a93790e35e217f)