### PR TITLE
Harden rebuild workflow and dedupe recent/history views

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,54 @@ php bin/partition_health.php
 
 The command prints both raw partitioned tables, their read/write cutover modes, the current monthly partitions, the retention cutoff derived from Settings → Data Sync, and any missing future partitions. It also lists deferred candidates that were evaluated but intentionally left unpartitioned in this pass.
 
+### Rebuild / reset CLI
+
+Use the rebuild helper when you need to re-materialize the current/latest tables and history-derived summaries from authoritative local data without touching the raw history/event store:
+
+```bash
+php bin/rebuild_data_model.php --mode=rebuild-current-only
+php bin/rebuild_data_model.php --mode=rebuild-rollups-only --window-days=30
+php bin/rebuild_data_model.php --mode=rebuild-all-derived --window-days=30
+php bin/rebuild_data_model.php --mode=full-reset --window-days=30
+```
+
+Modes:
+
+- `rebuild-current-only` resets and rebuilds the latest/current projection layer (`market_order_current_projection`, `market_source_snapshot_state`) from `market_orders_current`.
+- `rebuild-rollups-only` rebuilds history-derived summaries for the retained raw window from `market_orders_history` plus the live gap in `market_orders_current`, then refreshes current-state materialized summaries.
+- `rebuild-all-derived` runs both rebuild passes in sequence.
+- `full-reset` is the explicit destructive mode for non-authoritative derived tables only. It truncates current/derived layers first, but still preserves raw history and killmail event history.
+
+Authoritative sources vs derived targets:
+
+- Authoritative append-only history:
+  - `market_orders_history` / `market_orders_history_p`
+  - `killmail_events`
+  - `killmail_event_payloads`
+- Authoritative latest/current:
+  - `market_orders_current`
+- Derived / rebuildable:
+  - `market_order_current_projection`
+  - `market_source_snapshot_state`
+  - `market_order_snapshots_summary` / `market_order_snapshots_summary_p`
+  - `market_order_snapshot_rollup_1h`
+  - `market_order_snapshot_rollup_1d`
+  - `market_history_daily`
+  - `market_hub_local_history_daily`
+  - current-state Redis/materialized summary payloads (`market comparison`, `loss demand`, `dashboard`, `activity priority`, `doctrine`)
+
+Partition handling during rebuild:
+
+- The rebuild CLI ensures the monthly partitioned raw-history companions exist.
+- It backfills the retained raw window into `market_orders_history_p` and `market_order_snapshots_summary_p`.
+- It then switches those tables to `read=partitioned` and `write=dual`, so reads prefer the monthly partitions while writes still keep the legacy table in sync during cutover.
+
+Safety notes:
+
+- History tables are preserved unless you explicitly choose `--mode=full-reset`.
+- `full-reset` does **not** delete `market_orders_history`, `market_orders_history_p`, `killmail_events`, or `killmail_event_payloads`.
+- Rebuilds are idempotent for the selected window: the script clears the affected derived window and writes it back from authoritative data.
+
 ### Troubleshooting
 
 If the UI says the scheduler daemon is **stopped** while no jobs are running:

--- a/bin/rebuild_data_model.php
+++ b/bin/rebuild_data_model.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+function rebuild_cli_bool(string $value): bool
+{
+    return in_array(strtolower(trim($value)), ['1', 'true', 'yes', 'on'], true);
+}
+
+$options = getopt('', [
+    'mode::',
+    'window-days::',
+    'full-reset::',
+    'enable-partitioned-history::',
+]);
+
+$mode = trim((string) ($options['mode'] ?? 'rebuild-all-derived'));
+$windowDays = isset($options['window-days']) ? max(1, (int) $options['window-days']) : null;
+$fullReset = isset($options['full-reset']) ? rebuild_cli_bool((string) $options['full-reset']) : false;
+$enablePartitionedHistory = isset($options['enable-partitioned-history'])
+    ? rebuild_cli_bool((string) $options['enable-partitioned-history'])
+    : true;
+
+$allowedModes = [
+    'rebuild-current-only',
+    'rebuild-rollups-only',
+    'rebuild-all-derived',
+    'full-reset',
+];
+
+if (!in_array($mode, $allowedModes, true)) {
+    fwrite(STDERR, "Unsupported --mode value. Use one of: " . implode(', ', $allowedModes) . PHP_EOL);
+    exit(1);
+}
+
+if ($mode === 'full-reset') {
+    $fullReset = true;
+    $mode = 'rebuild-all-derived';
+}
+
+$result = [
+    'mode' => $mode,
+    'window' => supplycore_rebuild_window_bounds($windowDays),
+    'full_reset' => $fullReset,
+    'enable_partitioned_history' => $enablePartitionedHistory,
+    'steps' => [],
+];
+
+try {
+    if ($enablePartitionedHistory) {
+        $result['steps']['partitioned_history'] = supplycore_rebuild_partitioned_market_history($result['window']);
+    }
+
+    if (in_array($mode, ['rebuild-current-only', 'rebuild-all-derived'], true)) {
+        $result['steps']['current'] = supplycore_rebuild_current_layers('cli-rebuild', $fullReset);
+    }
+
+    if (in_array($mode, ['rebuild-rollups-only', 'rebuild-all-derived'], true)) {
+        $result['steps']['rollups'] = supplycore_rebuild_rollup_layers('cli-rebuild', $windowDays, $fullReset);
+    }
+
+    echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    exit(0);
+} catch (Throwable $exception) {
+    $result['error'] = $exception->getMessage();
+    fwrite(STDERR, json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+    exit(1);
+}

--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -44,22 +44,6 @@ include __DIR__ . '/../../src/views/partials/header.php';
     </section>
 <?php endif; ?>
 
-<section class="mb-6 flex flex-wrap items-center justify-between gap-4 surface-secondary">
-    <div>
-        <p class="text-xs uppercase tracking-[0.2em] text-muted">Operational visibility</p>
-        <h2 class="mt-1 text-lg font-medium text-slate-50">Tracked zKill loss feed</h2>
-        <p class="mt-2 max-w-3xl text-sm text-muted">Use this board to confirm that tracked losses are landing, see how fresh the data is, and review the latest killmails that matter to alliance logistics and trading.</p>
-    </div>
-    <div class="flex flex-wrap gap-2">
-        <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= htmlspecialchars((string) ($health['tone'] ?? 'border-border bg-black/20 text-slate-200'), ENT_QUOTES) ?>">
-            <?= htmlspecialchars((string) ($health['label'] ?? 'Status unavailable'), ENT_QUOTES) ?>
-        </span>
-        <span class="rounded-full border border-border bg-black/20 px-3 py-1 text-xs uppercase tracking-[0.15em] text-slate-200">
-            Live updates: <?= htmlspecialchars((string) ($liveRefreshConfig === null ? 'Off' : (($pageFreshness['state'] ?? 'stale') === 'stale' ? 'Degraded' : 'On')), ENT_QUOTES) ?>
-        </span>
-    </div>
-</section>
-
 <!-- ui-section:killmail-overview-summary:start -->
 <section class="grid gap-4 md:grid-cols-2 xl:grid-cols-5" data-ui-section="killmail-overview-summary">
     <?php foreach ($summary as $card): ?>
@@ -90,13 +74,23 @@ include __DIR__ . '/../../src/views/partials/header.php';
 <?php endif; ?>
 
 <!-- ui-section:killmail-overview-status:start -->
-<section class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]" data-ui-section="killmail-overview-status">
+<section class="mt-6 grid gap-4" data-ui-section="killmail-overview-status">
     <article class="surface-secondary">
-        <div class="flex items-center justify-between gap-3">
-            <h2 class="text-base font-medium text-slate-50">Ingestion status</h2>
-            <span class="text-xs uppercase tracking-[0.15em] text-muted"><?= htmlspecialchars((string) ($health['label'] ?? 'Unknown'), ENT_QUOTES) ?></span>
+        <div class="flex flex-wrap items-start justify-between gap-3">
+            <div>
+                <h2 class="text-base font-medium text-slate-50">Current ingestion status</h2>
+                <p class="mt-1 text-sm text-muted"><?= htmlspecialchars((string) ($health['message'] ?? 'Review the latest worker pass and freshness.'), ENT_QUOTES) ?></p>
+            </div>
+            <div class="flex flex-wrap gap-2">
+                <span class="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.15em] <?= htmlspecialchars((string) ($health['tone'] ?? 'border-border bg-black/20 text-slate-200'), ENT_QUOTES) ?>">
+                    <?= htmlspecialchars((string) ($health['label'] ?? 'Status unavailable'), ENT_QUOTES) ?>
+                </span>
+                <span class="rounded-full border border-border bg-black/20 px-3 py-1 text-xs uppercase tracking-[0.15em] text-slate-200">
+                    Live updates <?= htmlspecialchars((string) ($liveRefreshConfig === null ? 'Off' : (($pageFreshness['state'] ?? 'stale') === 'stale' ? 'Degraded' : 'On')), ENT_QUOTES) ?>
+                </span>
+            </div>
         </div>
-        <div class="mt-4 grid gap-3 md:grid-cols-2">
+        <div class="mt-4 grid gap-3 md:grid-cols-4">
             <div class="surface-tertiary">
                 <p class="text-xs uppercase tracking-[0.15em] text-muted">Freshness</p>
                 <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($status['last_sync_relative'] ?? 'Never'), ENT_QUOTES) ?></p>
@@ -117,14 +111,23 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($health['label'] ?? 'Unknown'), ENT_QUOTES) ?></p>
                 <p class="mt-1 text-sm text-muted">Worker <?= htmlspecialchars((string) ($status['worker_status'] ?? 'unknown'), ENT_QUOTES) ?> · checkpoint <?= htmlspecialchars((string) (($status['worker_checkpoint_state'] ?? '') !== '' ? $status['worker_checkpoint_state'] : 'unavailable'), ENT_QUOTES) ?></p>
             </div>
+            <div class="surface-tertiary">
+                <p class="text-xs uppercase tracking-[0.15em] text-muted">Tracked scope</p>
+                <p class="mt-2 text-lg font-semibold text-slate-50"><?= number_format((int) ($status['tracked_alliance_count'] ?? 0)) ?>A · <?= number_format((int) ($status['tracked_corporation_count'] ?? 0)) ?>C</p>
+                <p class="mt-1 text-sm text-muted">Losses only surface when tracked victim entities match.</p>
+            </div>
         </div>
-        <?php if ((string) ($status['last_error'] ?? '') !== ''): ?>
+        <?php if (($health['state'] ?? '') !== 'healthy' || (($status['last_run_source_rows'] ?? 0) > 0 && (int) ($status['last_run_written_rows'] ?? 0) === 0) || (string) ($status['last_error'] ?? '') !== ''): ?>
             <div class="mt-4 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
-                Last sync error: <?= htmlspecialchars((string) $status['last_error'], ENT_QUOTES) ?>
+                <p class="font-medium text-slate-50">Action needed</p>
+                <p class="mt-1"><?= htmlspecialchars((string) ($status['last_error'] !== '' ? ('Last sync error: ' . $status['last_error']) : ($health['message'] ?? 'Review the latest worker pass and freshness.')), ENT_QUOTES) ?></p>
+                <?php if ($workerNoWriteReason !== ''): ?>
+                    <p class="mt-2 text-xs opacity-90">Latest no-write reason: <?= htmlspecialchars($workerNoWriteReason, ENT_QUOTES) ?></p>
+                <?php endif; ?>
             </div>
         <?php endif; ?>
         <details class="mt-4 rounded-2xl border border-white/8 bg-black/20 p-3">
-            <summary class="cursor-pointer list-none text-sm font-medium text-slate-100">Advanced diagnostics</summary>
+            <summary class="cursor-pointer list-none text-sm font-medium text-slate-100">Diagnostics</summary>
             <div class="mt-3 grid gap-3 sm:grid-cols-2 text-sm text-slate-300">
                 <p><span class="text-slate-500">Worker heartbeat</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['worker_seen_relative'] ?? 'No heartbeat'), ENT_QUOTES) ?></span><br><span class="text-xs text-muted"><?= htmlspecialchars((string) ($status['worker_seen_at'] ?? 'No heartbeat recorded'), ENT_QUOTES) ?></span></p>
                 <p><span class="text-slate-500">Latest run outcome</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['last_sync_outcome'] ?? 'Unknown'), ENT_QUOTES) ?></span><br><span class="text-xs text-muted"><?= htmlspecialchars((string) ($status['last_run_finished_at'] ?? 'Unavailable'), ENT_QUOTES) ?></span></p>
@@ -140,26 +143,6 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <?php endif; ?>
             </div>
         </details>
-    </article>
-
-    <article class="surface-secondary">
-        <div class="flex items-center justify-between gap-3">
-            <h2 class="text-base font-medium text-slate-50">Tracking context</h2>
-            <span class="text-xs text-muted">What counts as relevant</span>
-        </div>
-        <div class="mt-4 space-y-3">
-            <div class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Tracked alliances</p>
-                <p class="mt-2 text-xl font-semibold text-slate-50"><?= number_format((int) ($status['tracked_alliance_count'] ?? 0)) ?></p>
-            </div>
-            <div class="surface-tertiary">
-                <p class="text-xs uppercase tracking-[0.15em] text-muted">Tracked corporations</p>
-                <p class="mt-2 text-xl font-semibold text-slate-50"><?= number_format((int) ($status['tracked_corporation_count'] ?? 0)) ?></p>
-            </div>
-            <div class="surface-tertiary text-sm text-slate-400">
-                Losses are retained only when a tracked alliance or corporation appears on the victim side. That keeps the board focused on tracked losses without exposing worker plumbing by default.
-            </div>
-        </div>
     </article>
 </section>
 <!-- ui-section:killmail-overview-status:end -->

--- a/src/db.php
+++ b/src/db.php
@@ -574,6 +574,7 @@ function db_killmail_overview_schema_ensure(): void
     db_ensure_table_column('killmail_events', 'zkb_npc', 'TINYINT(1) DEFAULT NULL AFTER zkb_points');
     db_ensure_table_column('killmail_events', 'zkb_solo', 'TINYINT(1) DEFAULT NULL AFTER zkb_npc');
     db_ensure_table_column('killmail_events', 'zkb_awox', 'TINYINT(1) DEFAULT NULL AFTER zkb_solo');
+    db_ensure_table_index('killmail_events', 'idx_killmail_natural_sequence', 'INDEX idx_killmail_natural_sequence (killmail_id, killmail_hash, sequence_id)');
 
     $legacyEventJsonSql = db_table_has_column('killmail_events', 'zkb_json') ? "NULLIF(e.zkb_json, '')" : 'NULL';
     $zkbJsonSql = "COALESCE(NULLIF(p.zkb_json, ''), {$legacyEventJsonSql}, '{}')";
@@ -615,6 +616,16 @@ function db_killmail_overview_schema_ensure(): void
     );
 
     $ensured = true;
+}
+
+function db_killmail_latest_sequences_sql(): string
+{
+    return "(
+        SELECT
+            MAX(e.sequence_id) AS sequence_id
+        FROM killmail_events e
+        GROUP BY e.killmail_id, e.killmail_hash
+    )";
 }
 
 function db_killmail_event_has_legacy_payload_columns(): bool
@@ -3857,6 +3868,103 @@ function db_market_snapshot_rollup_bulk_upsert(string $resolution, array $rows, 
         ],
         $chunkSize
     );
+}
+
+function db_market_rebuild_source_keys(): array
+{
+    db_market_snapshot_optimization_ensure();
+
+    $historyTable = db_validate_identifier(db_market_orders_history_read_table());
+    $summaryTable = db_validate_identifier(db_market_order_snapshots_summary_read_table());
+
+    return db_select(
+        "SELECT source_type, source_id
+         FROM (
+            SELECT source_type, source_id FROM market_orders_current
+            UNION
+            SELECT source_type, source_id FROM {$historyTable}
+            UNION
+            SELECT source_type, source_id FROM {$summaryTable}
+            UNION
+            SELECT source_type, source_id FROM market_source_snapshot_state
+         ) sources
+         WHERE source_type <> ''
+           AND source_id > 0
+         ORDER BY source_type ASC, source_id ASC"
+    );
+}
+
+function db_truncate_tables(array $tables): int
+{
+    $truncated = 0;
+
+    foreach ($tables as $table) {
+        db_execute('TRUNCATE TABLE ' . db_validate_identifier((string) $table));
+        $truncated++;
+    }
+
+    return $truncated;
+}
+
+function db_market_order_snapshots_summary_delete_window(string $sourceType, int $sourceId, string $startDate, string $endDate): int
+{
+    $deleted = 0;
+
+    foreach (db_market_order_snapshots_summary_known_tables() as $table) {
+        db_execute(
+            'DELETE FROM ' . db_validate_identifier($table) . '
+             WHERE source_type = ?
+               AND source_id = ?
+               AND observed_date BETWEEN ? AND ?',
+            [$sourceType, $sourceId, $startDate, $endDate]
+        );
+        $deleted += (int) db()->query('SELECT ROW_COUNT()')->fetchColumn();
+    }
+
+    return $deleted;
+}
+
+function db_market_snapshot_rollup_delete_window(string $resolution, string $sourceType, int $sourceId, string $startDate, string $endDate): int
+{
+    $table = db_validate_identifier(db_market_snapshot_rollup_table_name($resolution));
+    $startValue = $resolution === '1d' ? $startDate : ($startDate . ' 00:00:00');
+    $endValue = $resolution === '1d' ? $endDate : ($endDate . ' 23:59:59');
+
+    db_execute(
+        "DELETE FROM {$table}
+         WHERE source_type = ?
+           AND source_id = ?
+           AND bucket_start BETWEEN ? AND ?",
+        [$sourceType, $sourceId, $startValue, $endValue]
+    );
+
+    return (int) db()->query('SELECT ROW_COUNT()')->fetchColumn();
+}
+
+function db_market_history_daily_delete_window(string $sourceType, int $sourceId, string $startDate, string $endDate): int
+{
+    db_execute(
+        'DELETE FROM market_history_daily
+         WHERE source_type = ?
+           AND source_id = ?
+           AND trade_date BETWEEN ? AND ?',
+        [$sourceType, $sourceId, $startDate, $endDate]
+    );
+
+    return (int) db()->query('SELECT ROW_COUNT()')->fetchColumn();
+}
+
+function db_market_hub_local_history_daily_delete_window(string $source, int $sourceId, string $startDate, string $endDate): int
+{
+    db_execute(
+        'DELETE FROM market_hub_local_history_daily
+         WHERE source = ?
+           AND source_id = ?
+           AND trade_date BETWEEN ? AND ?',
+        [$source, $sourceId, $startDate, $endDate]
+    );
+
+    return (int) db()->query('SELECT ROW_COUNT()')->fetchColumn();
 }
 
 function db_market_snapshot_optimization_ensure(): void
@@ -9913,8 +10021,9 @@ function db_killmail_event_exists(int $sequenceId, int $killmailId, string $kill
         'SELECT sequence_id
            FROM killmail_events
           WHERE sequence_id = ?
+             OR (killmail_id = ? AND killmail_hash = ?)
           LIMIT 1',
-        [$sequenceId]
+        [$sequenceId, $killmailId, $killmailHash]
     );
 
     return $row !== null;
@@ -10182,13 +10291,15 @@ function db_killmail_filtered_recent(int $limit = 50): array
 {
     $limit = max(1, min(500, $limit));
     $trackedMatchesSql = db_killmail_tracked_matches_sql();
+    $latestSequencesSql = db_killmail_latest_sequences_sql();
 
     return db_select(
         "SELECT e.sequence_id, e.killmail_id, e.killmail_hash, e.uploaded_at, e.killmail_time,
                 e.victim_alliance_id, e.victim_corporation_id, e.victim_ship_type_id, e.solar_system_id, e.region_id
          FROM {$trackedMatchesSql} tracked
+         INNER JOIN {$latestSequencesSql} latest ON latest.sequence_id = tracked.sequence_id
          INNER JOIN killmail_events e ON e.sequence_id = tracked.sequence_id
-         ORDER BY e.sequence_id DESC
+         ORDER BY e.effective_killmail_at DESC, e.sequence_id DESC, e.killmail_id DESC
          LIMIT {$limit}"
     );
 }
@@ -10197,16 +10308,22 @@ function db_killmail_overview_summary(int $recentHours = 24): array
 {
     $safeRecentHours = max(1, min(24 * 30, $recentHours));
     $trackedMatchesSql = db_killmail_tracked_matches_sql();
+    $latestSequencesSql = db_killmail_latest_sequences_sql();
     $summary = db_select_one(
         "SELECT
             COUNT(*) AS total_count,
-            SUM(CASE WHEN e.created_at >= (UTC_TIMESTAMP() - INTERVAL {$safeRecentHours} HOUR) THEN 1 ELSE 0 END) AS recent_count,
+            SUM(CASE WHEN e.effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL {$safeRecentHours} HOUR) THEN 1 ELSE 0 END) AS recent_count,
             MAX(e.sequence_id) AS max_sequence_id,
             MAX(e.created_at) AS last_ingested_at,
             MAX(e.uploaded_at) AS latest_uploaded_at
-         FROM killmail_events e"
+         FROM {$latestSequencesSql} latest
+         INNER JOIN killmail_events e ON e.sequence_id = latest.sequence_id"
     ) ?? [];
-    $trackedCountRow = db_select_one("SELECT COUNT(*) AS tracked_match_count FROM {$trackedMatchesSql} tracked") ?? [];
+    $trackedCountRow = db_select_one(
+        "SELECT COUNT(*) AS tracked_match_count
+         FROM {$trackedMatchesSql} tracked
+         INNER JOIN {$latestSequencesSql} latest ON latest.sequence_id = tracked.sequence_id"
+    ) ?? [];
     $summary['tracked_match_count'] = (int) ($trackedCountRow['tracked_match_count'] ?? 0);
 
     return $summary;
@@ -10214,11 +10331,13 @@ function db_killmail_overview_summary(int $recentHours = 24): array
 
 function db_killmail_overview_filter_options(): array
 {
+    $latestSequencesSql = db_killmail_latest_sequences_sql();
     $alliances = db_select(
         "SELECT DISTINCT
             e.victim_alliance_id AS entity_id,
             COALESCE(NULLIF(ta.label, ''), CONCAT('Alliance #', e.victim_alliance_id)) AS entity_label
-         FROM killmail_events e
+         FROM {$latestSequencesSql} latest
+         INNER JOIN killmail_events e ON e.sequence_id = latest.sequence_id
          LEFT JOIN killmail_tracked_alliances ta
            ON ta.alliance_id = e.victim_alliance_id
           AND ta.is_active = 1
@@ -10231,7 +10350,8 @@ function db_killmail_overview_filter_options(): array
         "SELECT DISTINCT
             e.victim_corporation_id AS entity_id,
             COALESCE(NULLIF(tc.label, ''), CONCAT('Corporation #', e.victim_corporation_id)) AS entity_label
-         FROM killmail_events e
+         FROM {$latestSequencesSql} latest
+         INNER JOIN killmail_events e ON e.sequence_id = latest.sequence_id
          LEFT JOIN killmail_tracked_corporations tc
            ON tc.corporation_id = e.victim_corporation_id
           AND tc.is_active = 1
@@ -10390,9 +10510,12 @@ function db_killmail_overview_page(array $filters = []): array
     $trackedOnly = (bool) ($filters['tracked_only'] ?? false);
     $search = trim((string) ($filters['search'] ?? ''));
     $trackedMatchesSql = db_killmail_tracked_matches_sql();
+    $latestSequencesSql = db_killmail_latest_sequences_sql();
     $trackedJoinType = $trackedOnly ? 'INNER JOIN' : 'LEFT JOIN';
 
-    $fromSql = " FROM killmail_events e
+    $fromSql = " FROM {$latestSequencesSql} latest
+        INNER JOIN killmail_events e
+          ON e.sequence_id = latest.sequence_id
         {$trackedJoinType} {$trackedMatchesSql} tracked
           ON tracked.sequence_id = e.sequence_id
         LEFT JOIN killmail_attackers final_blow_attacker
@@ -10490,7 +10613,7 @@ function db_killmail_overview_page(array $filters = []): array
             CASE WHEN tracked.sequence_id IS NULL THEN 0 ELSE 1 END AS matched_tracked
             {$fromSql}
             {$whereSql}
-         ORDER BY e.sequence_id DESC
+         ORDER BY e.effective_killmail_at DESC, e.sequence_id DESC, e.killmail_id DESC
          LIMIT {$pageSize} OFFSET {$offset}",
         $params
     );

--- a/src/functions.php
+++ b/src/functions.php
@@ -6424,6 +6424,57 @@ function loss_demand_refresh_summary_job_result(string $reason = 'manual'): arra
     ];
 }
 
+function supplycore_rows_unique_by(array $rows, callable $keyResolver): array
+{
+    $unique = [];
+
+    foreach ($rows as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+
+        $key = trim((string) $keyResolver($row));
+        if ($key === '') {
+            continue;
+        }
+
+        if (!array_key_exists($key, $unique)) {
+            $unique[$key] = $row;
+        }
+    }
+
+    return array_values($unique);
+}
+
+function supplycore_sort_rows_by_newest(array &$rows, array $timestampKeys, array $tieBreakerKeys = []): void
+{
+    usort($rows, static function (array $left, array $right) use ($timestampKeys, $tieBreakerKeys): int {
+        foreach ($timestampKeys as $timestampKey) {
+            $leftValue = trim((string) ($left[$timestampKey] ?? ''));
+            $rightValue = trim((string) ($right[$timestampKey] ?? ''));
+            $leftTimestamp = $leftValue !== '' ? (strtotime($leftValue) ?: 0) : 0;
+            $rightTimestamp = $rightValue !== '' ? (strtotime($rightValue) ?: 0) : 0;
+            $compare = $rightTimestamp <=> $leftTimestamp;
+            if ($compare !== 0) {
+                return $compare;
+            }
+        }
+
+        foreach ($tieBreakerKeys as $tieBreakerKey) {
+            $leftValue = $left[$tieBreakerKey] ?? null;
+            $rightValue = $right[$tieBreakerKey] ?? null;
+            $compare = is_numeric($leftValue) && is_numeric($rightValue)
+                ? ((int) $rightValue <=> (int) $leftValue)
+                : strcmp((string) $rightValue, (string) $leftValue);
+            if ($compare !== 0) {
+                return $compare;
+            }
+        }
+
+        return 0;
+    });
+}
+
 function dashboard_intelligence_data_build(): array
 {
     $marketHubRef = market_hub_setting_reference();
@@ -6437,8 +6488,10 @@ function dashboard_intelligence_data_build(): array
 
     $opportunities = $rows;
     usort($opportunities, static fn (array $a, array $b): int => (($b['opportunity_score'] ?? 0) <=> ($a['opportunity_score'] ?? 0)) ?: (($b['volume_score'] ?? 0) <=> ($a['volume_score'] ?? 0)));
+    $opportunities = supplycore_rows_unique_by($opportunities, static fn (array $row): string => 'type:' . (int) ($row['type_id'] ?? 0));
     $risks = $rows;
     usort($risks, static fn (array $a, array $b): int => (($b['risk_score'] ?? 0) <=> ($a['risk_score'] ?? 0)) ?: (($b['stock_score'] ?? 0) <=> ($a['stock_score'] ?? 0)));
+    $risks = supplycore_rows_unique_by($risks, static fn (array $row): string => 'type:' . (int) ($row['type_id'] ?? 0));
 
     $allianceSync = $allianceStructureId !== null
         ? sync_status_for_dataset_keys([sync_dataset_key_alliance_structure_orders_current($allianceStructureId)])
@@ -9977,6 +10030,9 @@ function killmail_overview_data(): array
             return [
                 'sequence_id' => (int) ($row['sequence_id'] ?? 0),
                 'killmail_id' => (int) ($row['killmail_id'] ?? 0),
+                'killmail_time_raw' => isset($row['killmail_time']) ? (string) $row['killmail_time'] : '',
+                'uploaded_at_raw' => isset($row['uploaded_at']) ? (string) $row['uploaded_at'] : '',
+                'created_at_raw' => isset($row['created_at']) ? (string) $row['created_at'] : '',
                 'killmail_time_display' => killmail_format_datetime(isset($row['killmail_time']) ? (string) $row['killmail_time'] : null),
                 'uploaded_at_display' => killmail_format_datetime(isset($row['uploaded_at']) ? (string) $row['uploaded_at'] : null),
                 'created_at_display' => killmail_format_datetime(isset($row['created_at']) ? (string) $row['created_at'] : null),
@@ -10004,6 +10060,8 @@ function killmail_overview_data(): array
                 'inspect_url' => '/killmail-intelligence/view.php?sequence_id=' . urlencode((string) ((int) ($row['sequence_id'] ?? 0))),
             ];
         }, (array) ($listing['rows'] ?? []));
+        $rows = supplycore_rows_unique_by($rows, static fn (array $row): string => 'killmail:' . (int) ($row['killmail_id'] ?? 0) . ':' . (int) ($row['sequence_id'] ?? 0));
+        supplycore_sort_rows_by_newest($rows, ['killmail_time_raw', 'uploaded_at_raw', 'created_at_raw'], ['sequence_id', 'killmail_id']);
 
         $emptyMessage = $totalCount === 0
             ? 'No killmails have been stored yet. Enable killmail ingestion, run the sync worker, and this view will populate as local killmails arrive.'
@@ -23120,6 +23178,172 @@ function supplycore_refresh_current_state_cache(string $reason = 'manual'): arra
         'meta' => [
             'outcome_reason' => 'Market comparison, loss-demand, and dashboard summaries were refreshed into materialized current-state layers.',
         ],
+    ];
+}
+
+function supplycore_rebuild_window_bounds(?int $windowDays = null): array
+{
+    $safeWindowDays = market_hub_local_history_window_days_normalize($windowDays);
+    $startObservedAt = market_hub_local_history_window_start_observed_at($safeWindowDays);
+
+    return [
+        'window_days' => $safeWindowDays,
+        'start_observed_at' => $startObservedAt,
+        'start_date' => substr($startObservedAt, 0, 10),
+        'end_date' => gmdate('Y-m-d'),
+    ];
+}
+
+function supplycore_rebuild_partitioned_market_history(array $window): array
+{
+    $startDate = (string) ($window['start_date'] ?? '');
+    $endDate = (string) ($window['end_date'] ?? '');
+
+    db_market_orders_history_partitioned_schema_ensure();
+    db_market_order_snapshots_summary_partitioned_schema_ensure();
+
+    $historyBackfill = db_market_orders_history_backfill_window($startDate, $endDate);
+    $summaryBackfill = db_market_order_snapshots_summary_backfill_window($startDate, $endDate);
+    $historyCutover = db_market_orders_history_cutover_swap('partitioned', 'dual');
+    $summaryCutover = db_market_order_snapshots_summary_cutover_swap('partitioned', 'dual');
+
+    return [
+        'history_backfill_rows' => $historyBackfill,
+        'summary_backfill_rows' => $summaryBackfill,
+        'history_cutover' => $historyCutover,
+        'summary_cutover' => $summaryCutover,
+    ];
+}
+
+function supplycore_rebuild_current_layers(string $reason = 'manual', bool $fullReset = false): array
+{
+    $sourceRows = db_market_rebuild_source_keys();
+    $resetTables = ['market_order_current_projection', 'market_source_snapshot_state'];
+    $resetCount = db_truncate_tables($resetTables);
+    $sourcesProcessed = 0;
+    $projectionRowsWritten = 0;
+
+    foreach ($sourceRows as $source) {
+        $sourceType = trim((string) ($source['source_type'] ?? ''));
+        $sourceId = (int) ($source['source_id'] ?? 0);
+        if ($sourceType === '' || $sourceId <= 0) {
+            continue;
+        }
+
+        $snapshotRows = db_market_orders_current_latest_snapshot_rows($sourceType, $sourceId);
+        if ($snapshotRows === []) {
+            continue;
+        }
+
+        $projectionRowsWritten += db_market_order_current_projection_refresh_snapshots(
+            db_market_order_current_projection_rows_from_orders($snapshotRows)
+        );
+        db_market_source_snapshot_state_upsert([
+            'source_type' => $sourceType,
+            'source_id' => $sourceId,
+            'latest_current_observed_at' => (string) ($snapshotRows[0]['observed_at'] ?? ''),
+            'current_order_count' => count($snapshotRows),
+            'current_distinct_type_count' => market_order_distinct_type_count($snapshotRows),
+            'last_synced_at' => (string) ($snapshotRows[0]['observed_at'] ?? ''),
+        ]);
+        $sourcesProcessed++;
+    }
+
+    return [
+        'reason' => $reason,
+        'reset_tables' => $resetTables,
+        'reset_count' => $resetCount,
+        'sources_processed' => $sourcesProcessed,
+        'projection_rows_written' => $projectionRowsWritten,
+    ];
+}
+
+function supplycore_rebuild_rollup_layers(string $reason = 'manual', ?int $windowDays = null, bool $fullReset = false): array
+{
+    $window = supplycore_rebuild_window_bounds($windowDays);
+    $startObservedAt = (string) ($window['start_observed_at'] ?? '');
+    $startDate = (string) ($window['start_date'] ?? '');
+    $endDate = (string) ($window['end_date'] ?? '');
+    $sourceRows = db_market_rebuild_source_keys();
+    $resetTables = [
+        'market_order_snapshot_rollup_1h',
+        'market_order_snapshot_rollup_1d',
+    ];
+
+    if ($fullReset) {
+        array_push(
+            $resetTables,
+            'market_order_snapshots_summary',
+            db_market_order_snapshots_summary_partitioned_table(),
+            'market_history_daily',
+            'market_hub_local_history_daily'
+        );
+    }
+
+    $resetCount = $fullReset ? db_truncate_tables($resetTables) : 0;
+    $sourcesProcessed = 0;
+    $summaryRowsWritten = 0;
+    $rollupRowsWritten = ['1h' => 0, '1d' => 0];
+    $dailyRowsWritten = 0;
+    $localDailyRowsWritten = 0;
+
+    foreach ($sourceRows as $source) {
+        $sourceType = trim((string) ($source['source_type'] ?? ''));
+        $sourceId = (int) ($source['source_id'] ?? 0);
+        if ($sourceType === '' || $sourceId <= 0) {
+            continue;
+        }
+
+        if (!$fullReset) {
+            db_market_order_snapshots_summary_delete_window($sourceType, $sourceId, $startDate, $endDate);
+            db_market_snapshot_rollup_delete_window('1h', $sourceType, $sourceId, $startDate, $endDate);
+            db_market_snapshot_rollup_delete_window('1d', $sourceType, $sourceId, $startDate, $endDate);
+            db_market_history_daily_delete_window($sourceType, $sourceId, $startDate, $endDate);
+            if ($sourceType === 'market_hub') {
+                db_market_hub_local_history_daily_delete_window(market_hub_local_history_source(), $sourceId, $startDate, $endDate);
+            }
+        }
+
+        $summaryRows = db_market_orders_snapshot_metrics_window_raw($sourceType, $sourceId, $startObservedAt);
+        if ($summaryRows !== []) {
+            $summaryRowsWritten += db_market_order_snapshots_summary_bulk_upsert($summaryRows);
+            $rollupRowsWritten['1h'] += db_market_snapshot_rollup_bulk_upsert('1h', db_market_snapshot_rollup_rows_from_summary('1h', $summaryRows));
+            $rollupRowsWritten['1d'] += db_market_snapshot_rollup_bulk_upsert('1d', db_market_snapshot_rollup_rows_from_summary('1d', $summaryRows));
+        }
+
+        $snapshotMetrics = db_market_orders_snapshot_metrics_window($sourceType, $sourceId, $startObservedAt);
+        if ($snapshotMetrics === []) {
+            continue;
+        }
+
+        $rebuiltDaily = market_history_daily_rebuild_from_snapshot_metrics($snapshotMetrics, $sourceType);
+        $dailyRowsWritten += db_market_history_daily_bulk_upsert((array) ($rebuiltDaily['rows'] ?? []));
+
+        if ($sourceType === 'market_hub') {
+            $rebuiltLocalDaily = market_hub_local_history_daily_rebuild_from_snapshot_metrics($snapshotMetrics);
+            $localDailyRowsWritten += db_market_hub_local_history_daily_bulk_upsert((array) ($rebuiltLocalDaily['rows'] ?? []));
+        }
+
+        $sourcesProcessed++;
+    }
+
+    $currentState = supplycore_refresh_current_state_cache($reason . ':current-state');
+    $doctrine = doctrine_refresh_intelligence($reason . ':doctrine');
+    $activity = activity_priority_refresh_summary($reason . ':activity-priority');
+
+    return [
+        'reason' => $reason,
+        'window' => $window,
+        'reset_tables' => $resetTables,
+        'reset_count' => $resetCount,
+        'sources_processed' => $sourcesProcessed,
+        'summary_rows_written' => $summaryRowsWritten,
+        'rollup_rows_written' => $rollupRowsWritten,
+        'daily_rows_written' => $dailyRowsWritten,
+        'local_daily_rows_written' => $localDailyRowsWritten,
+        'current_state_rows_written' => (int) ($currentState['rows_written'] ?? 0),
+        'doctrine_snapshot_groups' => count((array) ($doctrine['groups'] ?? [])),
+        'activity_rows' => count((array) ($activity['rows'] ?? [])),
     ];
 }
 

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -6,18 +6,10 @@ $pageHeaderSummary = trim((string) ($pageHeaderSummary ?? brand_tagline()));
 $pageHeaderBadge = trim((string) ($pageHeaderBadge ?? 'Operations aligned'));
 $pageHeaderBadgeTone = trim((string) ($pageHeaderBadgeTone ?? 'border-cyan/20 bg-cyan/10 text-cyan-100'));
 $liveRefreshSummary = supplycore_live_refresh_summary($liveRefreshConfig ?? null);
-$pageHeaderMeta = is_array($pageHeaderMeta ?? null) ? $pageHeaderMeta : [
-    [
-        'label' => 'Data freshness',
-        'value' => $liveRefreshSummary['last_refresh_relative'],
-        'caption' => 'Last visible update ' . $liveRefreshSummary['last_refresh_at'] . '.',
-    ],
-    [
-        'label' => 'Live updates',
-        'value' => $liveRefreshSummary['mode_label'],
-        'caption' => $liveRefreshSummary['health_message'],
-    ],
-];
+$pageFreshness = is_array($pageFreshness ?? null) ? $pageFreshness : [];
+$pageFreshnessLine = $pageFreshness !== []
+    ? trim((string) (($pageFreshness['label'] ?? 'Freshness') . ' · ' . ($pageFreshness['computed_relative'] ?? 'Unknown') . ' · ' . ($pageFreshness['computed_at'] ?? 'Unavailable')))
+    : trim((string) ('Live refresh · ' . ($liveRefreshSummary['last_refresh_relative'] ?? 'Unknown')));
 ?>
 <!doctype html>
 <html lang="en">
@@ -37,7 +29,7 @@ $pageHeaderMeta = is_array($pageHeaderMeta ?? null) ? $pageHeaderMeta : [
     <?php include __DIR__ . '/sidebar.php'; ?>
     <main class="relative flex-1 px-5 py-6 sm:px-6 lg:px-8 xl:px-10 xl:py-8">
         <header class="page-header mb-8">
-            <div class="relative z-10 grid gap-5 xl:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.95fr)] xl:items-start">
+            <div class="relative z-10 grid gap-4 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-start">
                 <div class="max-w-3xl">
                     <p class="eyebrow text-cyan/80"><?= htmlspecialchars(brand_console_label(), ENT_QUOTES) ?></p>
                     <div class="mt-3 flex flex-wrap items-center gap-3">
@@ -47,41 +39,41 @@ $pageHeaderMeta = is_array($pageHeaderMeta ?? null) ? $pageHeaderMeta : [
                             <?= htmlspecialchars($pageHeaderBadge, ENT_QUOTES) ?>
                         </span>
                     </div>
-                    <p class="mt-3 max-w-2xl text-sm leading-6 text-slate-300/88"><?= htmlspecialchars($pageHeaderSummary, ENT_QUOTES) ?></p>
+                    <?php if ($pageHeaderSummary !== ''): ?>
+                        <p class="mt-3 max-w-2xl text-sm leading-6 text-slate-300/88"><?= htmlspecialchars($pageHeaderSummary, ENT_QUOTES) ?></p>
+                    <?php endif; ?>
+                    <?php if ($pageFreshness === [] && $pageFreshnessLine !== ''): ?>
+                        <p class="mt-3 text-sm text-slate-300" data-ui-freshness-target="page-freshness"><?= htmlspecialchars($pageFreshnessLine, ENT_QUOTES) ?></p>
+                    <?php endif; ?>
                 </div>
-                <div class="grid gap-3 xl:grid-cols-2">
-                    <?php foreach ($pageHeaderMeta as $metaCard): ?>
-                        <div class="surface-tertiary relative z-10 px-4 py-3 text-sm text-slate-300">
-                            <span class="eyebrow"><?= htmlspecialchars((string) ($metaCard['label'] ?? 'Operational context'), ENT_QUOTES) ?></span>
-                            <p class="mt-3 font-medium text-slate-100"><?= htmlspecialchars((string) ($metaCard['value'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
-                            <?php if (trim((string) ($metaCard['caption'] ?? '')) !== ''): ?>
-                                <p class="mt-2 text-xs leading-5 text-slate-500"><?= htmlspecialchars((string) ($metaCard['caption'] ?? ''), ENT_QUOTES) ?></p>
-                            <?php endif; ?>
-                        </div>
-                    <?php endforeach; ?>
+                <div class="flex flex-wrap items-start justify-end gap-2">
+                    <?php if ($pageFreshness !== []): ?>
+                        <span class="badge <?= htmlspecialchars((string) ($pageFreshness['tone'] ?? 'border-amber-400/20 bg-amber-500/10 text-amber-100'), ENT_QUOTES) ?>">
+                            <?= htmlspecialchars((string) ($pageFreshness['label'] ?? 'Unknown'), ENT_QUOTES) ?>
+                        </span>
+                    <?php endif; ?>
+                    <span class="badge <?= htmlspecialchars((string) ($liveRefreshSummary['health_tone'] ?? 'border-slate-400/20 bg-slate-500/10 text-slate-100'), ENT_QUOTES) ?>">
+                        <?= htmlspecialchars((string) ($liveRefreshSummary['mode_label'] ?? 'Live updates unavailable'), ENT_QUOTES) ?>
+                    </span>
                     <?php if (supplycore_live_refresh_should_include($liveRefreshConfig ?? null)): ?>
-                        <section class="live-refresh-panel relative z-10 xl:col-span-2 text-left text-xs text-slate-300" data-ui-refresh-diagnostics>
-                            <div class="flex flex-wrap items-start justify-between gap-3">
-                                <div>
-                                    <p class="eyebrow text-cyan-100/80">Live updates</p>
-                                    <p class="mt-2 text-xs leading-5 text-slate-500">Keep refresh health visible without turning the page into a console.</p>
+                        <details class="live-refresh-panel relative z-10 text-left text-xs text-slate-300" data-ui-refresh-diagnostics <?= !empty($liveRefreshSummary['show_advanced']) ? 'open' : '' ?>>
+                            <summary class="cursor-pointer list-none rounded-full border border-white/10 bg-black/20 px-3 py-2 text-sm font-medium text-slate-100">Diagnostics</summary>
+                            <div class="mt-3 rounded-2xl border border-white/8 bg-black/20 p-3">
+                                <div class="grid gap-3 sm:grid-cols-3">
+                                    <p><span class="text-slate-500">Live updates</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-mode><?= htmlspecialchars((string) $liveRefreshSummary['mode_label'], ENT_QUOTES) ?></span></p>
+                                    <p><span class="text-slate-500">Last refresh</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-last-refresh><?= htmlspecialchars((string) $liveRefreshSummary['last_refresh_relative'], ENT_QUOTES) ?></span></p>
+                                    <p><span class="text-slate-500">Refresh health</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-health><?= htmlspecialchars((string) $liveRefreshSummary['health_message'], ENT_QUOTES) ?></span></p>
                                 </div>
-                                <span class="badge <?= htmlspecialchars((string) $liveRefreshSummary['health_tone'], ENT_QUOTES) ?>" data-live-refresh-health-badge><?= htmlspecialchars((string) $liveRefreshSummary['health_label'], ENT_QUOTES) ?></span>
+                                <details class="mt-4 rounded-2xl border border-white/8 bg-black/20 p-3" data-live-refresh-advanced <?= !empty($liveRefreshSummary['show_advanced']) ? 'open' : '' ?>>
+                                    <summary class="cursor-pointer list-none text-sm font-medium text-slate-100">Advanced transport</summary>
+                                    <div class="mt-3 grid gap-3 sm:grid-cols-2">
+                                        <p><span class="text-slate-500">Active transport</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-transport>Starting…</span></p>
+                                        <p><span class="text-slate-500">Last update event</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-last-event>No published refresh event yet</span></p>
+                                        <p class="sm:col-span-2"><span class="text-slate-500">Version markers</span><br><span class="mt-1 inline-block break-all text-sm text-slate-100" data-live-refresh-versions>Loading…</span></p>
+                                    </div>
+                                </details>
                             </div>
-                            <div class="mt-4 grid gap-3 sm:grid-cols-3">
-                                <p><span class="text-slate-500">Live updates</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-mode><?= htmlspecialchars((string) $liveRefreshSummary['mode_label'], ENT_QUOTES) ?></span></p>
-                                <p><span class="text-slate-500">Last refresh</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-last-refresh><?= htmlspecialchars((string) $liveRefreshSummary['last_refresh_relative'], ENT_QUOTES) ?></span></p>
-                                <p><span class="text-slate-500">Refresh health</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-health><?= htmlspecialchars((string) $liveRefreshSummary['health_message'], ENT_QUOTES) ?></span></p>
-                            </div>
-                            <details class="mt-4 rounded-2xl border border-white/8 bg-black/20 p-3" data-live-refresh-advanced <?= !empty($liveRefreshSummary['show_advanced']) ? 'open' : '' ?>>
-                                <summary class="cursor-pointer list-none text-sm font-medium text-slate-100">Advanced diagnostics</summary>
-                                <div class="mt-3 grid gap-3 sm:grid-cols-2">
-                                    <p><span class="text-slate-500">Active transport</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-transport>Starting…</span></p>
-                                    <p><span class="text-slate-500">Last update event</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-last-event>No published refresh event yet</span></p>
-                                    <p class="sm:col-span-2"><span class="text-slate-500">Version markers</span><br><span class="mt-1 inline-block text-sm text-slate-100 break-all" data-live-refresh-versions>Loading…</span></p>
-                                </div>
-                            </details>
-                        </section>
+                        </details>
                     <?php endif; ?>
                 </div>
             </div>
@@ -89,13 +81,12 @@ $pageHeaderMeta = is_array($pageHeaderMeta ?? null) ? $pageHeaderMeta : [
         <?php if ($notice): ?>
             <div class="mb-6 rounded-2xl border border-emerald-500/30 bg-emerald-500/12 px-4 py-3 text-sm text-emerald-100 shadow-[0_0_24px_rgba(34,197,94,0.08)]"><?= htmlspecialchars($notice, ENT_QUOTES) ?></div>
         <?php endif; ?>
-        <?php if (is_array($pageFreshness ?? null) && $pageFreshness !== []): ?>
+        <?php if ($pageFreshness !== []): ?>
             <!-- ui-section:page-freshness:start -->
-            <div class="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-sm shadow-[0_0_24px_rgba(15,23,42,0.14)] <?= htmlspecialchars((string) ($pageFreshness['tone'] ?? 'border-amber-400/20 bg-amber-500/10 text-amber-100'), ENT_QUOTES) ?>" data-ui-section="page-freshness">
+            <div class="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-2xl border px-4 py-2 text-sm shadow-[0_0_24px_rgba(15,23,42,0.14)] <?= htmlspecialchars((string) ($pageFreshness['tone'] ?? 'border-amber-400/20 bg-amber-500/10 text-amber-100'), ENT_QUOTES) ?>" data-ui-section="page-freshness">
                 <div>
                     <p class="font-medium"><?= htmlspecialchars((string) ($pageFreshness['message'] ?? 'Summary freshness unavailable.'), ENT_QUOTES) ?></p>
-                    <p class="mt-1 text-xs opacity-80">Last computed <?= htmlspecialchars((string) ($pageFreshness['computed_relative'] ?? 'Never'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($pageFreshness['computed_at'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
-                    <p class="mt-2 text-[11px] uppercase tracking-[0.14em] text-current/70" data-ui-freshness-target="page-freshness">Refreshed from latest sync</p>
+                    <p class="mt-1 text-xs opacity-80" data-ui-freshness-target="page-freshness">Last computed <?= htmlspecialchars((string) ($pageFreshness['computed_relative'] ?? 'Never'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($pageFreshness['computed_at'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
                 </div>
                 <span class="rounded-full border border-current/20 px-3 py-1 text-[11px] uppercase tracking-[0.14em]"><?= htmlspecialchars((string) ($pageFreshness['label'] ?? 'Unknown'), ENT_QUOTES) ?></span>
             </div>


### PR DESCRIPTION
### Motivation
- Eliminate duplicate rows observed in recent killmail and materialized market views by normalizing the natural current-vs-history model and enforcing read/write semantics at the query/schema layer.
- Make time-ordered lists deterministic (newest-first) with stable tie-breakers so UI lists behave consistently across runs.
- Reduce repeated header/status noise while keeping detailed diagnostics available behind collapsible controls.
- Provide a safe, documented rebuild/reset path to reconstruct derived/current layers and rollups from authoritative history without touching raw append-only sources.

### Description
- Ensure killmail natural-key dedupe by adding a `killmail_id+killmail_hash` index and checking both `sequence_id` and the natural killmail key in `db_killmail_event_exists`, and change overview queries to join only the latest stored sequence per natural key via `db_killmail_latest_sequences_sql()`. (see `src/db.php`).
- Enforce deterministic newest-first ordering in killmail queries using `effective_killmail_at DESC` plus stable tie-breakers (`sequence_id`, `killmail_id`) and add PHP-level defensive dedupe+sort helpers `supplycore_rows_unique_by()` and `supplycore_sort_rows_by_newest()` to canonicalize presentation rows. (see `src/db.php`, `src/functions.php`).
- Prevent duplicate market rows in ranked/dashboard queues by de-duplicating market outcome lists by `type_id` prior to slicing for top queues. (see `src/functions.php`).
- Simplify the shared page header and killmail overview top sections to show only title, a compact freshness/status line, and a single collapsible diagnostics panel for advanced details. (see `src/views/partials/header.php` and `public/killmail-intelligence/index.php`).
- Add a safe rebuild/reset toolset including DB helpers for partition-aware backfill/delete and truncation, `supplycore_rebuild_*` helpers that separate rebuilding current/latest layers from rollups, and a CLI `bin/rebuild_data_model.php` implementing `rebuild-current-only`, `rebuild-rollups-only`, `rebuild-all-derived`, and `full-reset` modes; document usage and safety notes in `README.md`.

### Testing
- Ran PHP lint checks with `php -l` on `src/db.php`, `src/functions.php`, `src/views/partials/header.php`, `public/killmail-intelligence/index.php`, and `bin/rebuild_data_model.php` and they succeeded. 
- Ran repository style/consistency check `git diff --check` with no issues reported. 
- Executed the new rebuild CLI (`php bin/rebuild_data_model.php --mode=rebuild-current-only --window-days=1` and `--mode=rebuild-rollups-only`) and `php bin/partition_health.php` to validate control paths; these returned a runtime error in this environment because the local MySQL connection was unavailable (`SQLSTATE[HY000] [2002] Connection refused`), so the runtime rebuild steps could not complete here. 
- All code changes were committed and are ready for integration testing against a real MySQL instance where the rebuild commands and partition/cutover operations should be exercised end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0fe7f876c832fb07e1a042e276359)