### PR TITLE
Prefer orchestrator venv for Python CLI wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ pip install ./python
 
 The Python worker package now installs `PyMySQL` for lightweight MySQL access, including server-side streaming cursors for large scheduler jobs.
 
+CLI wrappers such as `php bin/rebuild_data_model.php` now automatically prefer `/var/www/SupplyCore/.venv-orchestrator/bin/python` when that virtual environment exists, then fall back to `.venv`, `venv`, and finally `python3`. You can still override the interpreter explicitly with `SUPPLYCORE_PYTHON_BINARY`, `ORCHESTRATOR_PYTHON_BINARY`, or `PYTHON_BINARY`.
+
 Validation:
 
 ```bash

--- a/src/functions.php
+++ b/src/functions.php
@@ -11289,11 +11289,38 @@ function scheduler_python_job_runner_script_path(): string
     return dirname(__DIR__) . '/bin/python_job_runner.py';
 }
 
-function scheduler_python_binary(): string
+function scheduler_python_binary_candidates(): array
 {
+    $repoRoot = dirname(__DIR__);
+    $candidates = [];
+
     foreach (['SUPPLYCORE_PYTHON_BINARY', 'ORCHESTRATOR_PYTHON_BINARY', 'PYTHON_BINARY'] as $envKey) {
         $candidate = trim((string) getenv($envKey));
         if ($candidate !== '') {
+            $candidates[] = $candidate;
+        }
+    }
+
+    foreach ([
+        $repoRoot . '/.venv-orchestrator/bin/python',
+        $repoRoot . '/.venv/bin/python',
+        $repoRoot . '/venv/bin/python',
+        'python3',
+    ] as $candidate) {
+        $candidates[] = $candidate;
+    }
+
+    return array_values(array_unique($candidates));
+}
+
+function scheduler_python_binary(): string
+{
+    foreach (scheduler_python_binary_candidates() as $candidate) {
+        if ($candidate === 'python3') {
+            return $candidate;
+        }
+
+        if (is_file($candidate) && is_executable($candidate)) {
             return $candidate;
         }
     }


### PR DESCRIPTION
### Motivation
- Ensure CLI PHP wrappers (e.g. `php bin/rebuild_data_model.php`) run the correct Python interpreter so orchestrator code in the repo's venv is used and errors like `ModuleNotFoundError: No module named 'pymysql'` are avoided when invoked outside an active virtualenv.

### Description
- Add `scheduler_python_binary_candidates()` and update `scheduler_python_binary()` in `src/functions.php` to prefer explicit env overrides, then repository-local virtualenv interpreters (`.venv-orchestrator/bin/python`, `.venv/bin/python`, `venv/bin/python`) before falling back to `python3`, and document the resolution order in `README.md`.

### Testing
- Ran `php -l src/functions.php` and `php -l bin/rebuild_data_model.php` to validate PHP syntax, both succeeded. 
- Ran `php -r "require 'src/bootstrap.php'; echo scheduler_python_binary(), PHP_EOL;"` with a temporary executable placed at `.venv-orchestrator/bin/python` to confirm the venv path is preferred, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11d2ad368832fb5c510fbc617db42)