### PR TITLE
Resolve market history/summary table names via PHP bridge for rebuild

### DIFF
--- a/bin/python_scheduler_bridge.php
+++ b/bin/python_scheduler_bridge.php
@@ -42,6 +42,10 @@ try {
         python_scheduler_bridge_output(['ok' => true, 'context' => python_bridge_market_hub_local_history_context()]);
     }
 
+    if ($action === 'market-history-tables-context') {
+        python_scheduler_bridge_output(['ok' => true, 'context' => python_bridge_market_history_tables_context()]);
+    }
+
     if ($action === 'rebuild-partitioned-history') {
         $input = python_scheduler_bridge_read_stdin_json();
         $window = is_array($input['window'] ?? null) ? $input['window'] : [];

--- a/python/orchestrator/rebuild_data_model.py
+++ b/python/orchestrator/rebuild_data_model.py
@@ -140,6 +140,9 @@ class RebuildRunner:
         self.config = load_php_runtime_config(self.app_root)
         self.db = SupplyCoreDb(self.config.raw["db"])
         self.bridge = PhpBridge(self.config.php_binary, self.app_root)
+        table_context = self.bridge.call("market-history-tables-context")["context"]
+        self.history_read_table = str(table_context.get("history_read_table") or "market_orders_history").strip()
+        self.summary_read_table = str(table_context.get("summary_read_table") or "market_order_snapshots_summary").strip()
         self.status = RebuildStatus(
             run_id=str(uuid.uuid4()),
             mode=args.mode,
@@ -243,12 +246,10 @@ class RebuildRunner:
         )
 
     def _history_table_name(self) -> str:
-        row = self.db.fetch_one("SELECT market_orders_history_read_table() AS table_name")
-        return str((row or {}).get("table_name") or "market_orders_history")
+        return self.history_read_table
 
     def _summary_table_name(self) -> str:
-        row = self.db.fetch_one("SELECT market_order_snapshots_summary_read_table() AS table_name")
-        return str((row or {}).get("table_name") or "market_order_snapshots_summary")
+        return self.summary_read_table
 
     def _run_partition_step(self) -> None:
         self.status.current_phase = "partitioned_history"

--- a/src/functions.php
+++ b/src/functions.php
@@ -14046,6 +14046,14 @@ function python_bridge_killmail_context(): array
     ];
 }
 
+function python_bridge_market_history_tables_context(): array
+{
+    return [
+        'history_read_table' => db_market_orders_history_read_table(),
+        'summary_read_table' => db_market_order_snapshots_summary_read_table(),
+    ];
+}
+
 function python_bridge_market_hub_local_history_context(): array
 {
     $hubRef = market_hub_setting_reference();


### PR DESCRIPTION
### Motivation
- The Python rebuild runner was directly calling MySQL stored functions (`market_orders_history_read_table`, `market_order_snapshots_summary_read_table`) which may not exist in all deployments, causing rebuild failures.
- Centralize table-name resolution through the existing PHP cutover helpers to keep application logic authoritative and avoid DB-function runtime dependency.

### Description
- Add a PHP bridge helper `python_bridge_market_history_tables_context()` in `src/functions.php` that returns the active `history_read_table` and `summary_read_table` using the existing PHP cutover helpers.
- Expose a new bridge action `market-history-tables-context` in `bin/python_scheduler_bridge.php` to return that table-context to Python callers.
- Update the Python `RebuildRunner` in `python/orchestrator/rebuild_data_model.py` to call the new bridge action at startup and cache `history_read_table` and `summary_read_table`, and use those cached names instead of issuing `SELECT ..._read_table()` queries against MySQL.

### Testing
- `php -l src/functions.php` succeeded with no syntax errors.
- `php -l bin/python_scheduler_bridge.php` succeeded with no syntax errors.
- `python -m py_compile python/orchestrator/rebuild_data_model.py python/orchestrator/bridge.py python/orchestrator/config.py` completed successfully.
- Calling the bridge action via `php bin/python_scheduler_bridge.php --action=market-history-tables-context` and running `php bin/rebuild_data_model.php --mode=rebuild-all-derived --window-days=30` were blocked by the environment's database connection refusal (`Connection refused`) and therefore could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c120cc824c832f96d6a2d1754ea2ef)