### PR TITLE
Add InfluxDB rollup inspection and sampling commands

### DIFF
--- a/docs/INFLUXDB_ROLLUP_OFFLOAD.md
+++ b/docs/INFLUXDB_ROLLUP_OFFLOAD.md
@@ -254,8 +254,23 @@ systemctl status supplycore-influx-rollup-export.timer
 systemctl list-timers supplycore-influx-rollup-export.timer
 python bin/python_orchestrator.py influx-rollup-export --dry-run --verbose
 python bin/python_orchestrator.py influx-rollup-export --dataset market_item_price_1d --verbose
+python bin/python_orchestrator.py influx-rollup-inspect --verbose
+python bin/python_orchestrator.py influx-rollup-inspect --dataset market_item_price_1d --verbose
+python bin/python_orchestrator.py influx-rollup-sample --dataset market_item_price_1d --limit 5
+python bin/python_orchestrator.py influx-rollup-sample --dataset market_item_price_1d --limit 5 --group-by window --group-by source_type
 mysql -e "SELECT dataset_key, status, last_success_at, last_cursor, last_row_count FROM sync_state WHERE dataset_key LIKE 'influx.rollup_export.%' ORDER BY dataset_key;" supplycore
 mysql -e "SELECT dataset_key, run_status, started_at, finished_at, source_rows, written_rows FROM sync_runs WHERE dataset_key LIKE 'influx.rollup_export.%' ORDER BY id DESC LIMIT 20;" supplycore
+
+The inspection command reports:
+
+- Influx health and bucket name
+- measurement names detected in the bucket
+- logical point count per measurement
+- oldest/newest timestamps per measurement
+- sample tags and fields from the latest point
+- a simple diagnosis for common Data Explorer misses such as wrong time range or not explicitly selecting the measurement
+
+The sample command returns the latest N pivoted points for a measurement and can optionally emit grouped point counts by one or more tag keys.
 ```
 
 ## 8. Phased rollout plan

--- a/python/orchestrator/influx.py
+++ b/python/orchestrator/influx.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
+import csv
+import io
 import json
 from typing import Any
 import urllib.error
@@ -104,6 +106,10 @@ class InfluxWriteError(RuntimeError):
     pass
 
 
+class InfluxQueryError(RuntimeError):
+    pass
+
+
 class InfluxWriter:
     def __init__(self, config: InfluxConfig):
         self._config = config
@@ -134,3 +140,116 @@ class InfluxWriter:
             raise InfluxWriteError(f"InfluxDB write failed with HTTP {error.code}: {details}") from error
         except urllib.error.URLError as error:
             raise InfluxWriteError(f"InfluxDB write failed: {error.reason}") from error
+
+
+def _parse_csv_value(raw: str, datatype: str) -> Any:
+    value = raw.strip()
+    if value == "":
+        return None
+
+    normalized = datatype.strip()
+    if normalized.startswith("dateTime:"):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+    if normalized in {"long", "unsignedLong"}:
+        try:
+            return int(value)
+        except ValueError:
+            return value
+    if normalized in {"double", "decimal"}:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+    if normalized == "boolean":
+        return value.lower() == "true"
+    return value
+
+
+def parse_flux_csv(payload: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    annotations: dict[str, list[str]] = {}
+    header: list[str] | None = None
+
+    for row in csv.reader(io.StringIO(payload)):
+        if row == []:
+            header = None
+            annotations = {}
+            continue
+
+        first = row[0] if row else ""
+        if first.startswith("#"):
+            annotations[first] = row
+            continue
+
+        if header is None:
+            header = row
+            continue
+
+        datatypes = annotations.get("#datatype", [])
+        defaults = annotations.get("#default", [])
+        record: dict[str, Any] = {}
+        for index, column in enumerate(header):
+            if column == "":
+                continue
+            raw_value = row[index] if index < len(row) else ""
+            if raw_value == "" and index < len(defaults):
+                raw_value = defaults[index]
+            datatype = datatypes[index] if index < len(datatypes) else "string"
+            record[column] = _parse_csv_value(raw_value, datatype)
+        records.append(record)
+
+    return records
+
+
+class InfluxClient:
+    def __init__(self, config: InfluxConfig):
+        self._config = config
+
+    @property
+    def query_endpoint(self) -> str:
+        return f"{self._config.url}/api/v2/query?org={urllib.parse.quote(self._config.org)}"
+
+    @property
+    def health_endpoint(self) -> str:
+        return f"{self._config.url}/health"
+
+    def health(self) -> dict[str, Any]:
+        request = urllib.request.Request(
+            self.health_endpoint,
+            method="GET",
+            headers={"Accept": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self._config.timeout_seconds) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            details = error.read().decode("utf-8", errors="replace").strip()
+            raise InfluxQueryError(f"InfluxDB health check failed with HTTP {error.code}: {details}") from error
+        except urllib.error.URLError as error:
+            raise InfluxQueryError(f"InfluxDB health check failed: {error.reason}") from error
+
+    def query_flux(self, flux: str) -> list[dict[str, Any]]:
+        payload = json.dumps({"query": flux, "type": "flux"}).encode("utf-8")
+        request = urllib.request.Request(
+            self.query_endpoint,
+            data=payload,
+            method="POST",
+            headers={
+                "Authorization": f"Token {self._config.token}",
+                "Content-Type": "application/json; charset=utf-8",
+                "Accept": "application/csv",
+            },
+        )
+
+        try:
+            with urllib.request.urlopen(request, timeout=self._config.timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+                return parse_flux_csv(body)
+        except urllib.error.HTTPError as error:
+            details = error.read().decode("utf-8", errors="replace").strip()
+            raise InfluxQueryError(f"InfluxDB query failed with HTTP {error.code}: {details}") from error
+        except urllib.error.URLError as error:
+            raise InfluxQueryError(f"InfluxDB query failed: {error.reason}") from error

--- a/python/orchestrator/influx_inspect.py
+++ b/python/orchestrator/influx_inspect.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .config import load_php_runtime_config
+from .influx import InfluxClient, InfluxConfig, InfluxQueryError
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Inspect SupplyCore InfluxDB rollup exports")
+    parser.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
+    parser.add_argument("--dataset", action="append", default=[], help="Limit inspection to one or more dataset keys or measurement names.")
+    parser.add_argument("--limit", type=int, default=5, help="Sample point limit for the sample command.")
+    parser.add_argument("--group-by", action="append", default=[], help="Optional tag key(s) to group the sample summary by.")
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, datetime):
+        moment = value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        return moment.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    if value is None or value == "":
+        return "—"
+    return str(value)
+
+
+def _format_kv(data: dict[str, Any], keys: list[str]) -> str:
+    pairs = [f"{key}={_format_value(data.get(key))}" for key in keys if data.get(key) not in (None, "")]
+    return ", ".join(pairs) if pairs else "—"
+
+
+def _quote(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _schema_measurements_query(bucket: str) -> str:
+    return f'import "influxdata/influxdb/schema"\nschema.measurements(bucket: "{_quote(bucket)}")'
+
+
+def _schema_tag_keys_query(bucket: str, measurement: str) -> str:
+    return (
+        'import "influxdata/influxdb/schema"\n'
+        f'schema.tagKeys(bucket: "{_quote(bucket)}", predicate: (r) => r._measurement == "{_quote(measurement)}")'
+    )
+
+
+def _schema_field_keys_query(bucket: str, measurement: str) -> str:
+    return (
+        'import "influxdata/influxdb/schema"\n'
+        f'schema.fieldKeys(bucket: "{_quote(bucket)}", predicate: (r) => r._measurement == "{_quote(measurement)}")'
+    )
+
+
+def _pivot_query(bucket: str, measurement: str, tag_keys: list[str], *, sort_desc: bool = False, limit: int | None = None, count_only: bool = False, group_by: list[str] | None = None) -> str:
+    row_key = ", ".join(f'"{_quote(column)}"' for column in (["_time", *tag_keys]))
+    lines = [
+        f'from(bucket: "{_quote(bucket)}")',
+        "  |> range(start: 0)",
+        f'  |> filter(fn: (r) => r._measurement == "{_quote(measurement)}")',
+        f"  |> pivot(rowKey: [{row_key}], columnKey: [\"_field\"], valueColumn: \"_value\")",
+    ]
+    if group_by:
+        group_columns = ", ".join(f'"{_quote(column)}"' for column in group_by)
+        lines.append(f"  |> group(columns: [{group_columns}])")
+    else:
+        lines.append("  |> group()")
+    if count_only:
+        lines.append('  |> count(column: "_time")')
+    else:
+        lines.append(f'  |> sort(columns: ["_time"], desc: {"true" if sort_desc else "false"})')
+        if limit is not None:
+            lines.append(f"  |> limit(n: {max(1, limit)})")
+    return "\n".join(lines)
+
+
+def _normalize_dataset_filters(filters: list[str], available_measurements: list[str]) -> list[str]:
+    if filters == []:
+        return available_measurements
+
+    aliases = {
+        "market_item_price_1h": "market_item_price",
+        "market_item_price_1d": "market_item_price",
+        "market_item_stock_1h": "market_item_stock",
+        "market_item_stock_1d": "market_item_stock",
+        "killmail_item_loss_1h": "killmail_item_loss",
+        "killmail_item_loss_1d": "killmail_item_loss",
+        "killmail_hull_loss_1d": "killmail_hull_loss",
+        "killmail_doctrine_activity_1d": "killmail_doctrine_activity",
+        "doctrine_fit_activity_1d": "doctrine_fit_activity",
+        "doctrine_group_activity_1d": "doctrine_group_activity",
+        "doctrine_fit_stock_pressure_1d": "doctrine_fit_stock_pressure",
+    }
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in filters:
+        value = str(raw).strip()
+        if value == "":
+            continue
+        measurement = aliases.get(value, value)
+        if measurement not in available_measurements:
+            available = ", ".join(available_measurements)
+            raise ValueError(f'Unknown dataset or measurement "{value}". Available measurements: {available}')
+        if measurement in seen:
+            continue
+        seen.add(measurement)
+        normalized.append(measurement)
+    return normalized
+
+
+def _extract_schema_values(rows: list[dict[str, Any]]) -> list[str]:
+    values: list[str] = []
+    for row in rows:
+        value = str(row.get("_value") or "").strip()
+        if value == "" or value.startswith("_"):
+            continue
+        if value not in values:
+            values.append(value)
+    return values
+
+
+def _diagnose_ui(summary: dict[str, Any]) -> list[str]:
+    notes: list[str] = []
+    if summary["point_count"] <= 0:
+        return ["No points were returned for this measurement, so the issue may be an actual write/query gap."]
+
+    notes.append("Data is present in InfluxDB, so the Data Explorer issue is not an export-write failure.")
+    if summary["tag_keys"] == []:
+        notes.append("The measurement is effectively tag-light, so explore it by measurement + field selection instead of tag filters.")
+    else:
+        notes.append(f"Tag keys are present ({', '.join(summary['tag_keys'])}), so the schema is not tag-less.")
+
+    newest = summary.get("newest")
+    oldest = summary.get("oldest")
+    if isinstance(newest, datetime) and isinstance(oldest, datetime):
+        age_days = max(0.0, (datetime.now(timezone.utc) - newest.astimezone(timezone.utc)).total_seconds() / 86400.0)
+        if age_days > 7:
+            notes.append(f"Newest data is {_format_value(newest)}, so a narrow Explorer time range could hide it.")
+        notes.append(f"Select measurement \"{summary['measurement']}\" and set the time range to include {_format_value(oldest)} through {_format_value(newest)}.")
+    else:
+        notes.append(f"Select measurement \"{summary['measurement']}\" explicitly in Data Explorer before concluding the bucket is empty.")
+    return notes
+
+
+def _measurement_summary(client: InfluxClient, bucket: str, measurement: str) -> dict[str, Any]:
+    tag_keys = [key for key in _extract_schema_values(client.query_flux(_schema_tag_keys_query(bucket, measurement))) if key not in {"_measurement"}]
+    field_keys = _extract_schema_values(client.query_flux(_schema_field_keys_query(bucket, measurement)))
+
+    count_rows = client.query_flux(_pivot_query(bucket, measurement, tag_keys, count_only=True))
+    point_count = sum(int(row.get("_value") or 0) for row in count_rows)
+
+    newest_rows = client.query_flux(_pivot_query(bucket, measurement, tag_keys, sort_desc=True, limit=1))
+    oldest_rows = client.query_flux(_pivot_query(bucket, measurement, tag_keys, sort_desc=False, limit=1))
+    sample_rows = client.query_flux(_pivot_query(bucket, measurement, tag_keys, sort_desc=True, limit=1))
+
+    newest = newest_rows[0].get("_time") if newest_rows else None
+    oldest = oldest_rows[0].get("_time") if oldest_rows else None
+    sample_row = sample_rows[0] if sample_rows else {}
+
+    return {
+        "measurement": measurement,
+        "point_count": point_count,
+        "oldest": oldest,
+        "newest": newest,
+        "tag_keys": tag_keys,
+        "field_keys": field_keys,
+        "sample_tags": {key: sample_row.get(key) for key in tag_keys if key in sample_row},
+        "sample_fields": {key: sample_row.get(key) for key in field_keys if key in sample_row},
+    }
+
+
+def _print_inspect(client: InfluxClient, config: InfluxConfig, measurements: list[str]) -> int:
+    health = client.health()
+    print(f"InfluxDB health: {_format_value(health.get('status') or health.get('message') or 'unknown')}")
+    print(f"Bucket: {config.bucket}")
+
+    summaries: list[dict[str, Any]] = []
+    for measurement in measurements:
+        summaries.append(_measurement_summary(client, config.bucket, measurement))
+
+    print("Measurements:")
+    for summary in summaries:
+        print(f"- {summary['measurement']}")
+        print(f"  points: {summary['point_count']}")
+        print(f"  oldest: {_format_value(summary['oldest'])}")
+        print(f"  newest: {_format_value(summary['newest'])}")
+        print(f"  sample tags: {_format_kv(summary['sample_tags'], list(summary['sample_tags'].keys()))}")
+        print(f"  sample fields: {_format_kv(summary['sample_fields'], list(summary['sample_fields'].keys()))}")
+        for note in _diagnose_ui(summary):
+            print(f"  diagnosis: {note}")
+    return 0
+
+
+def _print_samples(client: InfluxClient, config: InfluxConfig, measurements: list[str], *, limit: int, group_by: list[str]) -> int:
+    health = client.health()
+    print(f"InfluxDB health: {_format_value(health.get('status') or health.get('message') or 'unknown')}")
+    print(f"Bucket: {config.bucket}")
+
+    for measurement in measurements:
+        tag_keys = [key for key in _extract_schema_values(client.query_flux(_schema_tag_keys_query(config.bucket, measurement))) if key not in {"_measurement"}]
+        field_keys = _extract_schema_values(client.query_flux(_schema_field_keys_query(config.bucket, measurement)))
+
+        print(f"Measurement: {measurement}")
+        rows = client.query_flux(_pivot_query(config.bucket, measurement, tag_keys, sort_desc=True, limit=limit))
+        if rows == []:
+            print("  No points returned.")
+            continue
+
+        print(f"  Latest {limit} points:")
+        for row in rows:
+            print(f"  - _time={_format_value(row.get('_time'))}")
+            print(f"    tags: {_format_kv(row, tag_keys)}")
+            print(f"    fields: {_format_kv(row, field_keys)}")
+
+        if group_by:
+            group_rows = client.query_flux(_pivot_query(config.bucket, measurement, tag_keys, count_only=True, group_by=group_by))
+            print(f"  Group summary by {', '.join(group_by)}:")
+            for row in group_rows:
+                summary_bits = [f"{column}={_format_value(row.get(column))}" for column in group_by]
+                summary_bits.append(f"points={_format_value(row.get('_value'))}")
+                print(f"  - {', '.join(summary_bits)}")
+
+    return 0
+
+
+def _load_client(app_root: Path) -> tuple[InfluxClient, InfluxConfig]:
+    runtime = load_php_runtime_config(app_root)
+    influx_config = InfluxConfig.from_runtime(dict(runtime.raw.get("influxdb", {})))
+    if not influx_config.enabled:
+        raise ValueError("InfluxDB integration is disabled in runtime config.")
+    validation_errors = influx_config.validate()
+    if validation_errors:
+        raise ValueError("; ".join(validation_errors))
+    return InfluxClient(influx_config), influx_config
+
+
+def inspect_main(argv: list[str] | None = None) -> int:
+    try:
+        args = _parse_args(argv)
+        client, config = _load_client(Path(args.app_root).resolve())
+        available_measurements = _extract_schema_values(client.query_flux(_schema_measurements_query(config.bucket)))
+        measurements = _normalize_dataset_filters(list(args.dataset), available_measurements)
+        return _print_inspect(client, config, measurements)
+    except (InfluxQueryError, ValueError) as error:
+        print(f"ERROR: {error}")
+        return 1
+
+
+def sample_main(argv: list[str] | None = None) -> int:
+    try:
+        args = _parse_args(argv)
+        client, config = _load_client(Path(args.app_root).resolve())
+        available_measurements = _extract_schema_values(client.query_flux(_schema_measurements_query(config.bucket)))
+        measurements = _normalize_dataset_filters(list(args.dataset), available_measurements)
+        if measurements == []:
+            raise ValueError("No measurements matched the requested filters.")
+        return _print_samples(client, config, measurements, limit=max(1, args.limit), group_by=[str(value).strip() for value in args.group_by if str(value).strip() != ""])
+    except (InfluxQueryError, ValueError) as error:
+        print(f"ERROR: {error}")
+        return 1

--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from .config import load_php_runtime_config
 from .influx_export import main as run_influx_rollup_export
+from .influx_inspect import inspect_main as run_influx_rollup_inspect
+from .influx_inspect import sample_main as run_influx_rollup_sample
 from .logging_utils import configure_logging
 from .rebuild_data_model import main as run_rebuild_data_model
 from .supervisor import run_supervisor
@@ -49,6 +51,18 @@ def parse_args() -> argparse.Namespace:
     influx_export.add_argument("--dry-run", action="store_true", help="Read and encode points without writing to InfluxDB.")
     influx_export.add_argument("--batch-size", type=int, default=0, help="Override Influx write batch size.")
     influx_export.add_argument("--verbose", action="store_true")
+
+    influx_inspect = subparsers.add_parser("influx-rollup-inspect", help="Inspect measurement coverage in the InfluxDB rollup bucket")
+    influx_inspect.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
+    influx_inspect.add_argument("--dataset", action="append", default=[], help="Limit inspection to one or more dataset keys or measurement names.")
+    influx_inspect.add_argument("--verbose", action="store_true")
+
+    influx_sample = subparsers.add_parser("influx-rollup-sample", help="Fetch latest sample points from the InfluxDB rollup bucket")
+    influx_sample.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
+    influx_sample.add_argument("--dataset", action="append", default=[], help="Limit sample output to one or more dataset keys or measurement names.")
+    influx_sample.add_argument("--limit", type=int, default=5, help="Number of latest points to return per measurement.")
+    influx_sample.add_argument("--group-by", action="append", default=[], help="Optional tag keys to group summary output by.")
+    influx_sample.add_argument("--verbose", action="store_true")
     return parser.parse_args()
 
 
@@ -86,6 +100,20 @@ def main() -> int:
             *( ["--full"] if args.full else [] ),
             *( ["--dry-run"] if args.dry_run else [] ),
             *( ["--batch-size", str(args.batch_size)] if args.batch_size > 0 else [] ),
+            *( ["--verbose"] if args.verbose else [] ),
+        ])
+    if command == "influx-rollup-inspect":
+        return run_influx_rollup_inspect([
+            "--app-root", args.app_root,
+            *(sum([["--dataset", dataset] for dataset in args.dataset], [])),
+            *( ["--verbose"] if args.verbose else [] ),
+        ])
+    if command == "influx-rollup-sample":
+        return run_influx_rollup_sample([
+            "--app-root", args.app_root,
+            *(sum([["--dataset", dataset] for dataset in args.dataset], [])),
+            "--limit", str(args.limit),
+            *(sum([["--group-by", group] for group in args.group_by], [])),
             *( ["--verbose"] if args.verbose else [] ),
         ])
 


### PR DESCRIPTION
### Motivation
- Provide a reliable command-line inspection path for the InfluxDB rollup bucket so operators can verify what measurements and points were written without relying on the Data Explorer UI. 
- Surface per-measurement point counts, oldest/newest timestamps, sample tags/fields, and a simple diagnosis to distinguish UI selection/time-range problems from actual write gaps. 
- Offer a lightweight sample-query command to fetch latest N pivoted points and grouped summaries for quick operational validation.

### Description
- Add Flux CSV parsing and an `InfluxClient` with `/health` and query support in `python/orchestrator/influx.py` so the orchestrator can run Flux queries and interpret CSV responses. 
- Add a new inspection module `python/orchestrator/influx_inspect.py` implementing `influx-rollup-inspect` (lists measurements, counts, timestamp ranges, sample tags/fields, and simple diagnosis) and `influx-rollup-sample` (returns latest N pivoted points and optional grouped summaries). 
- Wire the new commands into the orchestrator CLI in `python/orchestrator/main.py` and document usage/workflow in `docs/INFLUXDB_ROLLUP_OFFLOAD.md`; measurement aliases for dataset keys (e.g. `market_item_price_1d` -> `market_item_price`) are supported. 
- This change is CLI-focused only and does not add the optional PHP diagnostics UI/card in this pass.

### Testing
- Compiled Python modules with `python3 -m py_compile python/orchestrator/*.py` which succeeded. 
- Verified CLI argument help for the new commands with `python3 bin/python_orchestrator.py influx-rollup-inspect --help` and `python3 bin/python_orchestrator.py influx-rollup-sample --help`, which succeeded. 
- Exercised both commands against a local mock InfluxDB HTTP server (started inside the test) using environment overrides to validate parsing and output formatting, and observed expected inspect and sample output. 
- Attempted to run `influx-rollup-inspect` against the local runtime config but the environment had Influx disabled/unreachable so live-bucket verification could not be completed from this container (the CLI gracefully reports that condition).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c38353dc832f894688c70c181f6c)