### PR TITLE
Add missing human_duration_seconds helper to prevent fatal error

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -10557,6 +10557,17 @@ function human_duration_ago(int $seconds): string
     return (int) floor($seconds / 86400) . 'd';
 }
 
+function human_duration_seconds(float $seconds): string
+{
+    $seconds = max(0.0, $seconds);
+
+    if ($seconds < 60.0) {
+        return (string) max(0, (int) floor($seconds)) . 's';
+    }
+
+    return human_duration_ago((int) floor($seconds));
+}
+
 function reference_hub_comparison_data(): array
 {
     return supplycore_cache_aside('market_compare', ['reference-comparison'], supplycore_cache_ttl('market_summary'), static function (): array {


### PR DESCRIPTION
### Motivation
- `supplycore_rebuild_status_read()` attempted to call a missing `human_duration_seconds()` helper which caused a fatal `Call to undefined function` error on the `/settings` page. 

### Description
- Add `human_duration_seconds(float $seconds): string` to `src/functions.php` to provide the missing helper. 
- Clamp negative input to zero, format sub-minute values as seconds with an `s` suffix, and delegate minute/hour/day formatting to the existing `human_duration_ago()` to keep output consistent. 

### Testing
- Run `php -l src/functions.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1d5fbe2e8832f85c20e8665065dad)