### PR TITLE
Avoid InfluxDB 'unsupported aggregate column type time' by counting `_measurement` in pivoted queries

### DIFF
--- a/python/orchestrator/influx_inspect.py
+++ b/python/orchestrator/influx_inspect.py
@@ -69,7 +69,8 @@ def _pivot_query(bucket: str, measurement: str, tag_keys: list[str], *, sort_des
     else:
         lines.append("  |> group()")
     if count_only:
-        lines.append('  |> count(column: "_time")')
+        # Flux cannot aggregate time-typed columns, so count a stable string column.
+        lines.append('  |> count(column: "_measurement")')
     else:
         lines.append(f'  |> sort(columns: ["_time"], desc: {"true" if sort_desc else "false"})')
         if limit is not None:

--- a/python/tests/test_influx_inspect.py
+++ b/python/tests/test_influx_inspect.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import unittest
+
+from orchestrator.influx_inspect import _pivot_query
+
+
+class InfluxInspectTests(unittest.TestCase):
+    def test_count_query_does_not_aggregate_time_column(self) -> None:
+        query = _pivot_query(
+            bucket="supplycore_rollups",
+            measurement="market_item_price",
+            tag_keys=["type_id", "source_id"],
+            count_only=True,
+        )
+
+        self.assertIn('count(column: "_measurement")', query)
+        self.assertNotIn('count(column: "_time")', query)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Running `influx-rollup-inspect` could fail with InfluxDB HTTP 400 `unsupported aggregate column type time` when the code attempted `count` over a pivoted `_time` column.
- The change ensures InfluxDB inspection tools do not break the operational inspection workflow by using a non-time column for counts.

### Description
- Updated the Flux query builder in `python/orchestrator/influx_inspect.py` to use `|> count(column: "_measurement")` when `count_only=True` instead of counting `_time`.
- Added a regression unit test `python/tests/test_influx_inspect.py` asserting the generated query contains `count(column: "_measurement")` and does not contain `count(column: "_time")`.

### Testing
- Ran `PYTHONPATH=python python -m unittest python.tests.test_influx_inspect` and it passed (`OK`).
- Ran `PYTHONPATH=python python -m unittest python.tests.test_rebuild_data_model` and existing tests passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1d68eb668832f86cc15dd190b90f5)