### PR TITLE
Fix market-hub local-history freshness fallback and remove live-refresh diagnostics panel

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -5077,6 +5077,30 @@ function db_market_hub_local_history_daily_by_trade_date(string $source, int $so
     return array_map('db_market_hub_local_history_daily_normalize_result_row', $rows);
 }
 
+function db_market_hub_local_history_daily_latest_captured_at(string $source, int $sourceId): ?string
+{
+    $safeSource = trim($source);
+    $safeSourceId = max(0, $sourceId);
+    if ($safeSource === '' || $safeSourceId <= 0) {
+        return null;
+    }
+
+    $row = db_fetch_one(
+        'SELECT MAX(captured_at) AS latest_captured_at
+           FROM market_hub_local_history_daily
+          WHERE source = :source
+            AND source_id = :source_id',
+        [
+            'source' => $safeSource,
+            'source_id' => $safeSourceId,
+        ]
+    );
+
+    $latestCapturedAt = is_array($row) ? trim((string) ($row['latest_captured_at'] ?? '')) : '';
+
+    return $latestCapturedAt !== '' ? $latestCapturedAt : null;
+}
+
 function db_market_hub_local_history_daily_recent_window(string $source, int $sourceId, int $days = 8, int $typeLimit = 120): array
 {
     $safeSource = trim($source);

--- a/src/functions.php
+++ b/src/functions.php
@@ -7939,6 +7939,23 @@ function supplycore_dataset_runtime_status_from_sync(array $spec): array
     $latestRun = is_array($runs[0] ?? null) ? $runs[0] : null;
     $lastSuccessAt = isset($status['last_success_at']) ? (string) $status['last_success_at'] : null;
     $lastSuccessAt = is_string($lastSuccessAt) && trim($lastSuccessAt) !== '' ? $lastSuccessAt : null;
+    $fallbackCapturedAt = null;
+    if (((string) ($spec['key'] ?? '')) === 'market_hub_local_history') {
+        $fallbackSource = trim((string) ($spec['history_source'] ?? ''));
+        $fallbackSourceId = max(0, (int) ($spec['history_source_id'] ?? 0));
+        if ($fallbackSource !== '' && $fallbackSourceId > 0) {
+            $fallbackCapturedAt = db_market_hub_local_history_daily_latest_captured_at($fallbackSource, $fallbackSourceId);
+        }
+    }
+
+    if ($fallbackCapturedAt !== null) {
+        $lastSuccessUnix = $lastSuccessAt !== null ? (strtotime($lastSuccessAt) ?: null) : null;
+        $fallbackUnix = strtotime($fallbackCapturedAt) ?: null;
+        if ($fallbackUnix !== null && ($lastSuccessUnix === null || $fallbackUnix > $lastSuccessUnix)) {
+            $lastSuccessAt = $fallbackCapturedAt;
+        }
+    }
+
     $lastSuccessTimestamp = $lastSuccessAt !== null ? (strtotime($lastSuccessAt) ?: null) : null;
     $ageSeconds = $lastSuccessTimestamp !== null ? max(0, time() - $lastSuccessTimestamp) : null;
     $runningNow = false;
@@ -8154,6 +8171,8 @@ function supplycore_settings_runtime_datasets(): array
             'label' => 'Market hub local history',
             'source' => 'sync',
             'dataset_keys' => [sync_dataset_key_market_hub_local_history_daily($marketHubRef)],
+            'history_source' => market_hub_local_history_source(),
+            'history_source_id' => sync_source_id_from_hub_ref($marketHubRef),
             'fresh_seconds' => 6 * 3600,
             'delayed_seconds' => 24 * 3600,
         ] : null,

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -55,26 +55,6 @@ $pageFreshnessLine = $pageFreshness !== []
                     <span class="badge <?= htmlspecialchars((string) ($liveRefreshSummary['health_tone'] ?? 'border-slate-400/20 bg-slate-500/10 text-slate-100'), ENT_QUOTES) ?>">
                         <?= htmlspecialchars((string) ($liveRefreshSummary['mode_label'] ?? 'Live updates unavailable'), ENT_QUOTES) ?>
                     </span>
-                    <?php if (supplycore_live_refresh_should_include($liveRefreshConfig ?? null)): ?>
-                        <details class="live-refresh-panel relative z-10 text-left text-xs text-slate-300" data-ui-refresh-diagnostics <?= !empty($liveRefreshSummary['show_advanced']) ? 'open' : '' ?>>
-                            <summary class="cursor-pointer list-none rounded-full border border-white/10 bg-black/20 px-3 py-2 text-sm font-medium text-slate-100">Diagnostics</summary>
-                            <div class="mt-3 rounded-2xl border border-white/8 bg-black/20 p-3">
-                                <div class="grid gap-3 sm:grid-cols-3">
-                                    <p><span class="text-slate-500">Live updates</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-mode><?= htmlspecialchars((string) $liveRefreshSummary['mode_label'], ENT_QUOTES) ?></span></p>
-                                    <p><span class="text-slate-500">Last refresh</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-last-refresh><?= htmlspecialchars((string) $liveRefreshSummary['last_refresh_relative'], ENT_QUOTES) ?></span></p>
-                                    <p><span class="text-slate-500">Refresh health</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-health><?= htmlspecialchars((string) $liveRefreshSummary['health_message'], ENT_QUOTES) ?></span></p>
-                                </div>
-                                <details class="mt-4 rounded-2xl border border-white/8 bg-black/20 p-3" data-live-refresh-advanced <?= !empty($liveRefreshSummary['show_advanced']) ? 'open' : '' ?>>
-                                    <summary class="cursor-pointer list-none text-sm font-medium text-slate-100">Advanced transport</summary>
-                                    <div class="mt-3 grid gap-3 sm:grid-cols-2">
-                                        <p><span class="text-slate-500">Active transport</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-transport>Starting…</span></p>
-                                        <p><span class="text-slate-500">Last update event</span><br><span class="mt-1 inline-block text-sm text-slate-100" data-live-refresh-last-event>No published refresh event yet</span></p>
-                                        <p class="sm:col-span-2"><span class="text-slate-500">Version markers</span><br><span class="mt-1 inline-block break-all text-sm text-slate-100" data-live-refresh-versions>Loading…</span></p>
-                                    </div>
-                                </details>
-                            </div>
-                        </details>
-                    <?php endif; ?>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
### Motivation

- The `Market hub local history` freshness card could report stale when persisted local-history rows were actually newer than the sync-state metadata, causing misleading UI state.
- The live-refresh diagnostics panel in the shared header exposed noisy/misleading transport details and duplicated checks (including stale php crontab signals) that are not useful on the Command Dashboard.

### Description

- Added a DB helper `db_market_hub_local_history_daily_latest_captured_at()` in `src/db.php` to fetch the latest persisted `captured_at` for a given `source`/`source_id`.
- Updated `supplycore_dataset_runtime_status_from_sync()` in `src/functions.php` to use the latest local-history `captured_at` as a fallback for the `market_hub_local_history` dataset when that timestamp is newer than the sync-state `last_success_at`.
- Wired runtime dataset spec for `market_hub_local_history` with `history_source` and `history_source_id` in `supplycore_settings_runtime_datasets()` so the fallback can deterministically resolve the DB source.
- Removed the expanded live-refresh `Diagnostics` details panel from `src/views/partials/header.php`, leaving the compact live-updates badge only.

### Testing

- Ran PHP syntax checks with `php -l src/functions.php`, `php -l src/db.php`, and `php -l src/views/partials/header.php`, and all returned `No syntax errors detected`.
- No automated unit tests were added or changed; changes are limited to DB helper, runtime status logic, and header UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1e3c70904832f8f86c7f63f2cd763)