### PR TITLE
Route market_hub_local_history jobs through Python worker pool execution

### DIFF
--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from .bridge import PhpBridge
 from .config import load_php_runtime_config
-from .jobs import run_killmail_r2z2_stream, run_market_comparison_summary
+from .jobs import run_killmail_r2z2_stream, run_market_comparison_summary, run_market_hub_local_history
 from .logging_utils import LoggerAdapter, configure_logging
 from .worker_runtime import resident_memory_bytes, utc_now_iso
 
@@ -48,12 +48,14 @@ class WorkerPoolContext:
 PROCESSORS: dict[str, Callable[[WorkerPoolContext], dict[str, Any]]] = {
     "killmail_r2z2_sync": run_killmail_r2z2_stream,
     "market_comparison_summary_sync": run_market_comparison_summary,
+    "market_hub_local_history_sync": run_market_hub_local_history,
 }
 
 PYTHON_PRIMARY_JOB_KEYS = {
     "market_hub_current_sync",
     "dashboard_summary_sync",
     "market_comparison_summary_sync",
+    "market_hub_local_history_sync",
     "killmail_r2z2_sync",
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the existing Python implementation for `market_hub_local_history_sync` is actually executed by the continuous Python worker pool instead of falling back to the PHP handler so local snapshot-history rebuilds run under the intended Python pipeline and resource controls.

### Description
- Registered `run_market_hub_local_history` in `python/orchestrator/worker_pool.py` and added `"market_hub_local_history_sync"` to the worker pool `PROCESSORS` map and `PYTHON_PRIMARY_JOB_KEYS` so the job is dispatched to the Python processor (file changed: `python/orchestrator/worker_pool.py`).

### Testing
- Compiled the relevant modules with `python -m py_compile python/orchestrator/worker_pool.py python/orchestrator/jobs/market_hub_local_history.py python/orchestrator/jobs/__init__.py` and the check completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1e5adfddc832f8002fbc61a1f5129)