### PR TITLE
Trigger background summary recompute after sync success

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -1624,6 +1624,36 @@ function supplycore_cache_invalidate_for_dataset(string $datasetKey): void
     }
 }
 
+function supplycore_dataset_triggers_summary_refresh(string $datasetKey): bool
+{
+    $normalized = trim($datasetKey);
+    if ($normalized === '') {
+        return false;
+    }
+
+    return str_starts_with($normalized, 'alliance.structure.')
+        || str_starts_with($normalized, 'market.hub.')
+        || str_starts_with($normalized, 'killmail.r2z2')
+        || str_starts_with($normalized, 'static_data.');
+}
+
+function supplycore_schedule_summary_refresh_for_dataset(string $datasetKey, string $reason = 'sync-success'): void
+{
+    if (!supplycore_dataset_triggers_summary_refresh($datasetKey)) {
+        return;
+    }
+
+    $safeReason = trim($reason);
+    if ($safeReason === '') {
+        $safeReason = 'sync-success';
+    }
+
+    $datasetToken = preg_replace('/[^a-z0-9_.:-]+/i', '-', strtolower(trim($datasetKey))) ?: 'dataset';
+    $refreshReason = mb_substr($safeReason . ':' . $datasetToken, 0, 160);
+
+    doctrine_schedule_intelligence_refresh($refreshReason);
+}
+
 function station_options(): array
 {
     try {
@@ -11215,6 +11245,7 @@ function mark_sync_success(string $datasetKey, string $syncMode, ?string $cursor
 
     if ($ok) {
         supplycore_cache_invalidate_for_dataset($datasetKey);
+        supplycore_schedule_summary_refresh_for_dataset($datasetKey);
     }
 
     return $ok;


### PR DESCRIPTION
### Motivation

- Make user-facing pages feel snappier by precomputing materialized summaries and storing them in Redis instead of waiting for a user request to trigger expensive recomputation after data syncs.
- Ensure relevant dataset sync completions automatically schedule background recomputation so the web UI presents fresh Redis-backed snapshots immediately after syncs.

### Description

- Added `supplycore_dataset_triggers_summary_refresh(string $datasetKey): bool` to centralize which dataset keys should trigger summary refreshes (matches `alliance.structure.*`, `market.hub.*`, `killmail.r2z2`, and `static_data.*`).
- Added `supplycore_schedule_summary_refresh_for_dataset(string $datasetKey, string $reason = 'sync-success'): void` to create a safe refresh reason token and call the existing intelligence refresh scheduler (`doctrine_schedule_intelligence_refresh(...)`).
- Wired the new scheduling hook into `mark_sync_success()` so that after cache invalidation a background summary recompute is scheduled for relevant datasets (file changed: `src/functions.php`).

### Testing

- Ran PHP syntax check `php -l src/functions.php`, which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1f1701f44832fb52dae9927bee3ba)