### PR TITLE
Add request/DB telemetry and consolidate Buy-All item-scope metadata to reduce per-item lookups

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -78,6 +78,97 @@ function db_connection_status(): array
     }
 }
 
+function &db_performance_metrics_ref(): array
+{
+    static $metrics = [
+        'query_count' => 0,
+        'query_time_ms' => 0.0,
+        'queries' => [],
+        'calls' => [],
+    ];
+
+    return $metrics;
+}
+
+function db_performance_track_query(string $sql, array $params, float $durationMs): void
+{
+    $metrics = &db_performance_metrics_ref();
+    $metrics['query_count']++;
+    $metrics['query_time_ms'] += max(0.0, $durationMs);
+
+    $fingerprint = md5(trim($sql));
+    if (!isset($metrics['queries'][$fingerprint])) {
+        $metrics['queries'][$fingerprint] = [
+            'fingerprint' => $fingerprint,
+            'sql_preview' => mb_substr(preg_replace('/\s+/', ' ', trim($sql)) ?? '', 0, 160),
+            'count' => 0,
+            'total_ms' => 0.0,
+            'param_count_total' => 0,
+        ];
+    }
+
+    $metrics['queries'][$fingerprint]['count']++;
+    $metrics['queries'][$fingerprint]['total_ms'] += max(0.0, $durationMs);
+    $metrics['queries'][$fingerprint]['param_count_total'] += count($params);
+}
+
+function db_performance_track_call(string $name, float $durationMs, array $context = []): void
+{
+    $metrics = &db_performance_metrics_ref();
+    if (!isset($metrics['calls'][$name])) {
+        $metrics['calls'][$name] = [
+            'count' => 0,
+            'total_ms' => 0.0,
+            'context' => [],
+        ];
+    }
+
+    $metrics['calls'][$name]['count']++;
+    $metrics['calls'][$name]['total_ms'] += max(0.0, $durationMs);
+
+    if ($context !== []) {
+        foreach ($context as $key => $value) {
+            if (!is_scalar($value)) {
+                continue;
+            }
+            if (!isset($metrics['calls'][$name]['context'][$key])) {
+                $metrics['calls'][$name]['context'][$key] = [];
+            }
+            $contextKey = (string) $value;
+            $metrics['calls'][$name]['context'][$key][$contextKey] = (int) (($metrics['calls'][$name]['context'][$key][$contextKey] ?? 0) + 1);
+        }
+    }
+}
+
+function db_performance_snapshot(): array
+{
+    $metrics = db_performance_metrics_ref();
+    $querySummaries = array_values($metrics['queries']);
+    usort($querySummaries, static fn (array $a, array $b): int => ($b['count'] <=> $a['count']) ?: ((int) round(($b['total_ms'] ?? 0.0) * 1000) <=> (int) round(($a['total_ms'] ?? 0.0) * 1000)));
+    $querySummaries = array_slice($querySummaries, 0, 10);
+
+    $callSummaries = [];
+    foreach ((array) $metrics['calls'] as $name => $callStats) {
+        $context = [];
+        foreach ((array) ($callStats['context'] ?? []) as $key => $counts) {
+            arsort($counts);
+            $context[$key] = array_slice($counts, 0, 6, true);
+        }
+        $callSummaries[$name] = [
+            'count' => (int) ($callStats['count'] ?? 0),
+            'total_ms' => round((float) ($callStats['total_ms'] ?? 0.0), 3),
+            'top_context' => $context,
+        ];
+    }
+
+    return [
+        'query_count' => (int) ($metrics['query_count'] ?? 0),
+        'query_time_ms' => round((float) ($metrics['query_time_ms'] ?? 0.0), 3),
+        'top_queries' => $querySummaries,
+        'calls' => $callSummaries,
+    ];
+}
+
 function &db_query_cache_store_ref(): array
 {
     static $store = [
@@ -159,8 +250,11 @@ function db_select_one_cached(string $sql, array $params = [], int $ttlSeconds =
 
 function db_select(string $sql, array $params = []): array
 {
+    $startedAt = microtime(true);
     $stmt = db()->prepare($sql);
     $stmt->execute($params);
+    $durationMs = (microtime(true) - $startedAt) * 1000.0;
+    db_performance_track_query($sql, $params, $durationMs);
 
     return $stmt->fetchAll();
 }
@@ -223,8 +317,11 @@ function db_select_stream_batches(string $sql, array $params, callable $callback
 
 function db_select_one(string $sql, array $params = []): ?array
 {
+    $startedAt = microtime(true);
     $stmt = db()->prepare($sql);
     $stmt->execute($params);
+    $durationMs = (microtime(true) - $startedAt) * 1000.0;
+    db_performance_track_query($sql, $params, $durationMs);
     $result = $stmt->fetch();
 
     return $result === false ? null : $result;
@@ -233,9 +330,13 @@ function db_select_one(string $sql, array $params = []): ?array
 function db_execute(string $sql, array $params = []): bool
 {
     db_query_cache_clear();
+    $startedAt = microtime(true);
     $stmt = db()->prepare($sql);
+    $result = $stmt->execute($params);
+    $durationMs = (microtime(true) - $startedAt) * 1000.0;
+    db_performance_track_query($sql, $params, $durationMs);
 
-    return $stmt->execute($params);
+    return $result;
 }
 
 function db_app_settings_upsert_many(array $settings): bool
@@ -10961,16 +11062,20 @@ function db_ref_item_types_by_names(array $names): array
 
 function db_ref_item_scope_metadata_by_ids(array $typeIds): array
 {
+    $startedAt = microtime(true);
     item_scope_db_ensure_schema();
 
     $ids = array_values(array_unique(array_filter(array_map(static fn (mixed $id): int => (int) $id, $typeIds), static fn (int $id): bool => $id > 0)));
     if ($ids === []) {
+        db_performance_track_call('db_ref_item_scope_metadata_by_ids', (microtime(true) - $startedAt) * 1000.0, ['ids_count' => 0]);
         return [];
     }
+    $patternIds = $ids;
+    sort($patternIds);
 
     $placeholders = implode(',', array_fill(0, count($ids), '?'));
 
-    return db_select(
+    $rows = db_select(
         "SELECT
             rit.type_id,
             rit.type_name,
@@ -10990,16 +11095,21 @@ function db_ref_item_scope_metadata_by_ids(array $typeIds): array
          LEFT JOIN ref_item_categories ric ON ric.category_id = COALESCE(rit.category_id, rig.category_id)
          LEFT JOIN ref_market_groups rmg ON rmg.market_group_id = rit.market_group_id
          LEFT JOIN ref_meta_groups rmeta ON rmeta.meta_group_id = rit.meta_group_id
-         WHERE rit.type_id IN ($placeholders)",
+        WHERE rit.type_id IN ($placeholders)",
         $ids
     );
+
+    db_performance_track_call('db_ref_item_scope_metadata_by_ids', (microtime(true) - $startedAt) * 1000.0, ['ids_count' => count($ids), 'set' => md5(implode(',', $patternIds))]);
+
+    return $rows;
 }
 
 function db_ref_item_scope_catalog(): array
 {
+    $startedAt = microtime(true);
     item_scope_db_ensure_schema();
 
-    return [
+    $catalog = [
         'categories' => db_select(
             'SELECT
                 ric.category_id,
@@ -11048,6 +11158,10 @@ function db_ref_item_scope_catalog(): array
              ORDER BY rmeta.meta_group_id ASC'
         ),
     ];
+
+    db_performance_track_call('db_ref_item_scope_catalog', (microtime(true) - $startedAt) * 1000.0);
+
+    return $catalog;
 }
 
 function db_ref_item_type_ids_published(): array

--- a/src/functions.php
+++ b/src/functions.php
@@ -7,6 +7,116 @@ require_once __DIR__ . '/cache.php';
 
 date_default_timezone_set(app_timezone());
 
+function &supplycore_request_perf_ref(): array
+{
+    static $metrics = [
+        'started_at' => null,
+        'functions' => [],
+        'repeated_patterns' => [],
+        'type_sets' => [],
+        'initialized' => false,
+    ];
+
+    return $metrics;
+}
+
+function supplycore_request_perf_init(): void
+{
+    $metrics = &supplycore_request_perf_ref();
+    if ($metrics['initialized'] === true) {
+        return;
+    }
+
+    $metrics['initialized'] = true;
+    $metrics['started_at'] = microtime(true);
+
+    register_shutdown_function(static function (): void {
+        $metrics = supplycore_request_perf_ref();
+        $startedAt = (float) ($metrics['started_at'] ?? microtime(true));
+        $durationMs = (microtime(true) - $startedAt) * 1000.0;
+        $uri = (string) ($_SERVER['REQUEST_URI'] ?? '/');
+        $path = (string) (parse_url($uri, PHP_URL_PATH) ?: '/');
+        $db = function_exists('db_performance_snapshot') ? db_performance_snapshot() : [];
+        $functionSummaries = [];
+        foreach ((array) ($metrics['functions'] ?? []) as $name => $entry) {
+            $functionSummaries[$name] = [
+                'count' => (int) ($entry['count'] ?? 0),
+                'total_ms' => round((float) ($entry['total_ms'] ?? 0.0), 3),
+            ];
+        }
+        $uniqueTypeCounts = [];
+        foreach ((array) ($metrics['type_sets'] ?? []) as $name => $set) {
+            $uniqueTypeCounts[$name] = count((array) $set);
+        }
+        $repeatedPatterns = [];
+        foreach ((array) ($metrics['repeated_patterns'] ?? []) as $name => $patterns) {
+            arsort($patterns);
+            $repeatedPatterns[$name] = array_slice($patterns, 0, 12, true);
+        }
+
+        $payload = [
+            'event' => 'supplycore.request.perf',
+            'request_uri' => $uri,
+            'request_path' => $path,
+            'duration_ms' => round($durationMs, 3),
+            'peak_memory_mb' => round(memory_get_peak_usage(true) / 1048576, 3),
+            'db' => $db,
+            'functions' => $functionSummaries,
+            'unique_type_counts' => $uniqueTypeCounts,
+            'repeated_patterns' => $repeatedPatterns,
+        ];
+
+        error_log(json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+    });
+}
+
+function supplycore_perf_begin(string $name): float
+{
+    supplycore_request_perf_init();
+    $metrics = &supplycore_request_perf_ref();
+    if (!isset($metrics['functions'][$name])) {
+        $metrics['functions'][$name] = ['count' => 0, 'total_ms' => 0.0];
+    }
+    $metrics['functions'][$name]['count']++;
+
+    return microtime(true);
+}
+
+function supplycore_perf_end(string $name, float $startedAt): void
+{
+    $metrics = &supplycore_request_perf_ref();
+    if (!isset($metrics['functions'][$name])) {
+        $metrics['functions'][$name] = ['count' => 0, 'total_ms' => 0.0];
+    }
+    $metrics['functions'][$name]['total_ms'] += max(0.0, (microtime(true) - $startedAt) * 1000.0);
+}
+
+function supplycore_perf_track_type_ids(string $name, array $typeIds): void
+{
+    $metrics = &supplycore_request_perf_ref();
+    if (!isset($metrics['type_sets'][$name])) {
+        $metrics['type_sets'][$name] = [];
+    }
+    foreach ($typeIds as $typeId) {
+        $safeTypeId = (int) $typeId;
+        if ($safeTypeId > 0) {
+            $metrics['type_sets'][$name][$safeTypeId] = true;
+        }
+    }
+}
+
+function supplycore_perf_track_repeated_pattern(string $name, string $pattern): void
+{
+    $metrics = &supplycore_request_perf_ref();
+    if (!isset($metrics['repeated_patterns'][$name])) {
+        $metrics['repeated_patterns'][$name] = [];
+    }
+
+    $metrics['repeated_patterns'][$name][$pattern] = (int) (($metrics['repeated_patterns'][$name][$pattern] ?? 0) + 1);
+}
+
+supplycore_request_perf_init();
+
 function app_name(): string
 {
     $configured = trim((string) get_setting('app_name', config('app.name', 'SupplyCore')));
@@ -831,10 +941,18 @@ function item_scope_expand_market_group_ids(?int $marketGroupId, array $parentIn
 
 function item_scope_metadata_by_type_ids(array $typeIds): array
 {
+    $perfStartedAt = supplycore_perf_begin(__FUNCTION__);
     $typeIds = array_values(array_unique(array_filter(array_map('intval', $typeIds), static fn (int $typeId): bool => $typeId > 0)));
     if ($typeIds === []) {
+        supplycore_perf_track_repeated_pattern(__FUNCTION__, 'size:0');
+        supplycore_perf_end(__FUNCTION__, $perfStartedAt);
         return [];
     }
+    supplycore_perf_track_type_ids(__FUNCTION__, $typeIds);
+    supplycore_perf_track_repeated_pattern(__FUNCTION__, 'size:' . count($typeIds));
+    $patternIds = $typeIds;
+    sort($patternIds);
+    supplycore_perf_track_repeated_pattern(__FUNCTION__, 'set:' . md5(implode(',', $patternIds)));
 
     static $cache = [];
     $missing = [];
@@ -893,6 +1011,8 @@ function item_scope_metadata_by_type_ids(array $typeIds): array
             $resolved[$typeId] = $cache[$typeId];
         }
     }
+
+    supplycore_perf_end(__FUNCTION__, $perfStartedAt);
 
     return $resolved;
 }
@@ -1088,28 +1208,45 @@ function item_scope_type_metadata_in_scope(array $metadata, ?array $config = nul
 
 function item_scope_is_type_id_in_scope(int $typeId, ?array $config = null, ?array $metadataByType = null): bool
 {
+    $perfStartedAt = supplycore_perf_begin(__FUNCTION__);
     if ($typeId <= 0) {
+        supplycore_perf_end(__FUNCTION__, $perfStartedAt);
         return false;
     }
+    supplycore_perf_track_type_ids(__FUNCTION__, [$typeId]);
 
+    $hasSharedMetadata = $metadataByType !== null;
     $metadataByType ??= item_scope_metadata_by_type_ids([$typeId]);
+    supplycore_perf_track_repeated_pattern(__FUNCTION__, $hasSharedMetadata ? 'metadata:shared' : 'metadata:fallback_single');
     $metadata = $metadataByType[$typeId] ?? null;
     if (!is_array($metadata)) {
+        supplycore_perf_end(__FUNCTION__, $perfStartedAt);
         return false;
     }
 
-    return item_scope_type_metadata_in_scope($metadata, $config);
+    $result = item_scope_type_metadata_in_scope($metadata, $config);
+    supplycore_perf_end(__FUNCTION__, $perfStartedAt);
+
+    return $result;
 }
 
 function item_scope_type_metadata(int $typeId, ?array $metadataByType = null): array
 {
+    $perfStartedAt = supplycore_perf_begin(__FUNCTION__);
     if ($typeId <= 0) {
+        supplycore_perf_end(__FUNCTION__, $perfStartedAt);
         return [];
     }
+    supplycore_perf_track_type_ids(__FUNCTION__, [$typeId]);
 
+    $hasSharedMetadata = $metadataByType !== null;
     $metadataByType ??= item_scope_metadata_by_type_ids([$typeId]);
+    supplycore_perf_track_repeated_pattern(__FUNCTION__, $hasSharedMetadata ? 'metadata:shared' : 'metadata:fallback_single');
 
-    return is_array($metadataByType[$typeId] ?? null) ? (array) $metadataByType[$typeId] : [];
+    $resolved = is_array($metadataByType[$typeId] ?? null) ? (array) $metadataByType[$typeId] : [];
+    supplycore_perf_end(__FUNCTION__, $perfStartedAt);
+
+    return $resolved;
 }
 
 function item_scope_type_is_consumable(int $typeId, ?array $metadataByType = null): bool
@@ -26467,6 +26604,7 @@ function buy_all_pack_pages(array $items): array
 
 function buy_all_planner_data(array $query = []): array
 {
+    $perfStartedAt = supplycore_perf_begin(__FUNCTION__);
     $request = buy_all_request($query);
     $modeDefinitions = buy_all_mode_definitions();
     $modeConfig = $modeDefinitions[$request['mode']] ?? $modeDefinitions['blended'];
@@ -26503,27 +26641,36 @@ function buy_all_planner_data(array $query = []): array
 
     $fitIds = array_values(array_filter(array_map(static fn (array $fit): int => (int) ($fit['id'] ?? 0), $fits), static fn (int $fitId): bool => $fitId > 0));
     $itemsByFitId = [];
+    $rawItemsByFitId = [];
+    $fitItemTypeIds = [];
     $candidateTypeIds = array_keys($marketByTypeId);
     try {
         foreach (db_doctrine_fit_items_by_fit_ids($fitIds) as $item) {
             $fitId = (int) ($item['doctrine_fit_id'] ?? 0);
             $typeId = (int) ($item['type_id'] ?? 0);
-            if ($fitId <= 0 || $typeId <= 0 || !item_scope_is_type_id_in_scope($typeId)) {
+            if ($fitId <= 0 || $typeId <= 0) {
                 continue;
             }
-            $itemsByFitId[$fitId][] = $item;
-            $candidateTypeIds[] = $typeId;
+            $rawItemsByFitId[$fitId][] = $item;
+            $fitItemTypeIds[] = $typeId;
         }
     } catch (Throwable) {
         $itemsByFitId = [];
+        $rawItemsByFitId = [];
+        $fitItemTypeIds = [];
     }
 
-    $candidateTypeIds = array_values(array_unique(array_merge($candidateTypeIds, array_keys($globalByTypeId), array_keys($topMissingByTypeId))));
-    $typeMetaById = [];
-    foreach (db_ref_item_types_by_ids($candidateTypeIds) as $row) {
-        $typeMetaById[(int) ($row['type_id'] ?? 0)] = $row;
-    }
+    $candidateTypeIds = array_values(array_unique(array_merge($candidateTypeIds, array_keys($globalByTypeId), array_keys($topMissingByTypeId), $fitItemTypeIds)));
     $typeMetadataById = item_scope_metadata_by_type_ids($candidateTypeIds);
+    foreach ($rawItemsByFitId as $fitId => $fitItems) {
+        foreach ($fitItems as $item) {
+            $typeId = (int) ($item['type_id'] ?? 0);
+            if ($typeId <= 0 || !item_scope_is_type_id_in_scope($typeId, null, $typeMetadataById)) {
+                continue;
+            }
+            $itemsByFitId[(int) $fitId][] = $item;
+        }
+    }
     $doctrineDemandByType = buy_all_item_impact_map($fits, $itemsByFitId, $marketByTypeId, $typeMetadataById);
     $candidateTypeIds = array_values(array_unique(array_merge($candidateTypeIds, array_keys($doctrineDemandByType))));
 
@@ -26538,7 +26685,7 @@ function buy_all_planner_data(array $query = []): array
         $global = $globalByTypeId[$typeId] ?? [];
         $missing = $topMissingByTypeId[$typeId] ?? [];
         $demand = $doctrineDemandByType[$typeId] ?? [];
-        $meta = $typeMetaById[$typeId] ?? [];
+        $meta = $typeMetadataById[$typeId] ?? [];
         $itemName = trim((string) (($meta['type_name'] ?? $market['type_name'] ?? $global['type_name'] ?? $missing['item_name'] ?? ('Type #' . $typeId))));
         if ($itemName === '') {
             continue;
@@ -26801,7 +26948,7 @@ function buy_all_planner_data(array $query = []): array
         ];
     }
 
-    return [
+    $result = [
         'request' => $request,
         'mode_options' => $modeDefinitions,
         'sort_options' => buy_all_sort_options(),
@@ -26829,6 +26976,11 @@ function buy_all_planner_data(array $query = []): array
             'page_item_type_limit' => buy_all_page_item_type_limit(),
         ],
     ];
+    supplycore_perf_track_type_ids(__FUNCTION__, $candidateTypeIds);
+    supplycore_perf_track_repeated_pattern(__FUNCTION__, 'candidate_type_count:' . count($candidateTypeIds));
+    supplycore_perf_end(__FUNCTION__, $perfStartedAt);
+
+    return $result;
 }
 
 function buy_all_dashboard_summary(): array


### PR DESCRIPTION
### Motivation
- Reduce homepage TTFB by locating and eliminating application-layer hotspots caused by repeated per-item scope checks and fragmented metadata hydration in the buy-all planner path.
- Produce production-grade, low-intrusion instrumentation to prove the hotspot and capture per-request evidence (URI, duration, DB query counts/time, suspect function counts/timers, unique type-id counts, repeated patterns, peak memory).

### Description
- Added request-scoped performance telemetry in `src/functions.php` that registers a shutdown hook and emits a single structured JSON line via `error_log()` containing request URI/path, total duration, peak memory, DB snapshot, function call summaries, unique type-id counts, and repeated-pattern fingerprints; exposed helpers: `supplycore_perf_begin`, `supplycore_perf_end`, `supplycore_perf_track_type_ids`, and `supplycore_perf_track_repeated_pattern`.
- Added DB-layer instrumentation in `src/db.php` including `db_performance_metrics_ref`, `db_performance_track_query`, `db_performance_track_call`, and `db_performance_snapshot`, and wired timing into `db_select`, `db_select_one`, and `db_execute` to capture query counts/times and top fingerprints.
- Instrumented and tracked item-scope helpers (`item_scope_metadata_by_type_ids`, `item_scope_is_type_id_in_scope`, `item_scope_type_metadata`) to count calls, record timing, record whether they used a shared metadata map or fell back to single-item resolution, and capture metadata-set fingerprints.
- Refactored `buy_all_planner_data()` to eliminate per-item fallback scope lookups by pre-collecting fit item type IDs, calling `item_scope_metadata_by_type_ids()` once for the consolidated candidate set, and reusing that metadata for all downstream scope checks and type metadata needs (removed duplicated per-item metadata resolution and redundant hydration patterns).
- Added explicit DB call timing/context for `db_ref_item_scope_metadata_by_ids` and `db_ref_item_scope_catalog` to measure catalog/metadata hydration frequency and payload shapes.

### Testing
- Syntax checks: ran `php -l src/db.php` and `php -l src/functions.php`, both succeeded with no syntax errors.
- Exercised entry points via CLI includes to trigger telemetry and verify JSON emission: invoking the routes produced structured JSON lines (local environment lacked live DB data so DB query counts were zero):
  - `/` produced a telemetry line with `duration_ms: 6.609`, `functions.item_scope_metadata_by_type_ids.count: 1` and pattern `item_scope_metadata_by_type_ids.size:0`.
  - `/history/alliance-trends` produced `duration_ms: 1.659` and an empty function summary for the suspects.
  - `/buy-all` produced `duration_ms: 3.195` and saw `buy_all_planner_data.count: 1` and `item_scope_metadata_by_type_ids.count: 1`.
- Note: these CLI runs validated instrumentation and logical flow but are not production-realistic because the test environment did not exercise DB-backed data paths; the instrumentation is in place to capture exact production metrics (before/after comparisons) when deployed to a live instance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24e28f99c832f9565a191096ea33a)