### PR TITLE
Add Neo4j runtime config export and graph job JSONL logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ README.md
   - `compute_graph_insights`: every 5–10 minutes.
 - Jobs use MariaDB-backed locks (`compute_job_locks`) and structured run telemetry (`job_runs`) to prevent overlap and keep run metrics observable.
 - PHP should continue reading from MariaDB only; InfluxDB and any optional graph intelligence remain Python-side compute dependencies.
+- Configure Neo4j connectivity in `src/config/local.php` (or env vars) under `neo4j`: `enabled`, `url`, `username`, `password`, `database`, `timeout_seconds`, and optional `log_file` (default `storage/logs/graph-sync.log`).
+- Graph job status is visible in **Settings → Data Sync** via scheduler run history (`compute_graph_sync`, `compute_graph_insights`) and in `job_runs` records.
+- If graph jobs are skipped with `neo4j disabled`, enable the `neo4j.enabled` flag first; jobs intentionally no-op until the connection settings are configured.
 
 ## Configuration Strategy
 

--- a/bin/python_compute_graph_insights.py
+++ b/bin/python_compute_graph_insights.py
@@ -3,7 +3,20 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+
+
+def _append_graph_log(config: dict[str, object], event: str, payload: dict[str, object]) -> None:
+    neo4j = dict(config.get("neo4j", {})) if isinstance(config, dict) else {}
+    target = str(neo4j.get("log_file") or "").strip()
+    if target == "":
+        return
+    path = Path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps({"event": event, "ts": datetime.now(timezone.utc).isoformat(), **payload}, ensure_ascii=False)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
 
 
 def main() -> int:
@@ -39,6 +52,7 @@ def main() -> int:
         print(json.dumps({"status": "ok", **result}, ensure_ascii=False))
         return 0
     except Exception as error:  # noqa: BLE001
+        _append_graph_log(config.raw, "graph.insights.failed", {"status": "failed", "error": str(error)})
         finish_job_run(db, run, status="failed", rows_processed=0, rows_written=0, error_text=str(error), meta={"job_name": "compute_graph_insights"})
         print(json.dumps({"status": "failed", "error": str(error)}, ensure_ascii=False))
         return 1

--- a/bin/python_compute_graph_sync.py
+++ b/bin/python_compute_graph_sync.py
@@ -3,7 +3,20 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+
+
+def _append_graph_log(config: dict[str, object], event: str, payload: dict[str, object]) -> None:
+    neo4j = dict(config.get("neo4j", {})) if isinstance(config, dict) else {}
+    target = str(neo4j.get("log_file") or "").strip()
+    if target == "":
+        return
+    path = Path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps({"event": event, "ts": datetime.now(timezone.utc).isoformat(), **payload}, ensure_ascii=False)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
 
 
 def main() -> int:
@@ -39,6 +52,7 @@ def main() -> int:
         print(json.dumps({"status": "ok", **result}, ensure_ascii=False))
         return 0
     except Exception as error:  # noqa: BLE001
+        _append_graph_log(config.raw, "graph.sync.failed", {"status": "failed", "error": str(error)})
         finish_job_run(db, run, status="failed", rows_processed=0, rows_written=0, error_text=str(error), meta={"job_name": "compute_graph_sync"})
         print(json.dumps({"status": "failed", "error": str(error)}, ensure_ascii=False))
         return 1

--- a/python/orchestrator/jobs/compute_graph_insights.py
+++ b/python/orchestrator/jobs/compute_graph_insights.py
@@ -1,16 +1,32 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import json
+from pathlib import Path
 from typing import Any
 
 from ..db import SupplyCoreDb
 from ..neo4j import Neo4jClient, Neo4jConfig
 
 
+def _write_graph_log(log_file: str, event: str, payload: dict[str, Any]) -> None:
+    target = str(log_file).strip()
+    if target == "":
+        return
+
+    path = Path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps({"event": event, "ts": datetime.now(UTC).isoformat(), **payload}, ensure_ascii=False)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
 def run_compute_graph_insights(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:
     config = Neo4jConfig.from_runtime(neo4j_raw or {})
     if not config.enabled:
-        return {"status": "skipped", "reason": "neo4j disabled", "rows_processed": 0, "rows_written": 0}
+        result = {"status": "skipped", "reason": "neo4j disabled", "rows_processed": 0, "rows_written": 0}
+        _write_graph_log(config.log_file, "graph.job.skipped", {"job": "compute_graph_insights", **result})
+        return result
 
     client = Neo4jClient(config)
     computed_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
@@ -72,9 +88,11 @@ def run_compute_graph_insights(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | Non
                 (type_id, doctrine_count, fit_count, dependency_score, computed_at),
             )
 
-    return {
+    result = {
         "status": "success",
         "rows_processed": len(doctrine_rows) + len(item_rows),
         "rows_written": len(doctrine_rows) + len(item_rows),
         "computed_at": computed_at,
     }
+    _write_graph_log(config.log_file, "graph.insights.completed", result)
+    return result

--- a/python/orchestrator/jobs/compute_graph_sync.py
+++ b/python/orchestrator/jobs/compute_graph_sync.py
@@ -1,10 +1,24 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import json
+from pathlib import Path
 from typing import Any
 
 from ..db import SupplyCoreDb
 from ..neo4j import Neo4jClient, Neo4jConfig
+
+
+def _write_graph_log(log_file: str, event: str, payload: dict[str, Any]) -> None:
+    target = str(log_file).strip()
+    if target == "":
+        return
+
+    path = Path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps({"event": event, "ts": datetime.now(UTC).isoformat(), **payload}, ensure_ascii=False)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
 
 
 def _ensure_constraints(client: Neo4jClient) -> None:
@@ -16,7 +30,9 @@ def _ensure_constraints(client: Neo4jClient) -> None:
 def run_compute_graph_sync(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:
     config = Neo4jConfig.from_runtime(neo4j_raw or {})
     if not config.enabled:
-        return {"status": "skipped", "reason": "neo4j disabled", "rows_processed": 0, "rows_written": 0}
+        result = {"status": "skipped", "reason": "neo4j disabled", "rows_processed": 0, "rows_written": 0}
+        _write_graph_log(config.log_file, "graph.job.skipped", {"job": "compute_graph_sync", **result})
+        return result
 
     client = Neo4jClient(config)
     _ensure_constraints(client)
@@ -46,7 +62,9 @@ def run_compute_graph_sync(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = 
         (last_synced_at,),
     )
     if not rows:
-        return {"status": "success", "rows_processed": 0, "rows_written": 0, "last_synced_at": last_synced_at}
+        result = {"status": "success", "rows_processed": 0, "rows_written": 0, "last_synced_at": last_synced_at}
+        _write_graph_log(config.log_file, "graph.sync.idle", result)
+        return result
 
     client.query(
         """
@@ -73,10 +91,12 @@ def run_compute_graph_sync(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = 
         ("doctrine_fit_item", latest_changed_at),
     )
 
-    return {
+    result = {
         "status": "success",
         "rows_processed": len(rows),
         "rows_written": len(rows),
         "last_synced_at": latest_changed_at,
         "computed_at": datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S"),
     }
+    _write_graph_log(config.log_file, "graph.sync.completed", result)
+    return result

--- a/python/orchestrator/neo4j.py
+++ b/python/orchestrator/neo4j.py
@@ -16,6 +16,7 @@ class Neo4jConfig:
     password: str
     database: str
     timeout_seconds: int
+    log_file: str
 
     @classmethod
     def from_runtime(cls, raw: dict[str, Any]) -> "Neo4jConfig":
@@ -26,6 +27,7 @@ class Neo4jConfig:
             password=str(raw.get("password", "")),
             database=str(raw.get("database", "neo4j")),
             timeout_seconds=max(3, int(raw.get("timeout_seconds", 15))),
+            log_file=str(raw.get("log_file", "")).strip(),
         )
 
 

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -29,6 +29,15 @@ $config = [
         'read_timeout' => (float) (getenv('REDIS_READ_TIMEOUT') ?: 1.5),
         'lock_enabled' => (getenv('REDIS_LOCK_ENABLED') ?: '1') === '1',
     ],
+    'neo4j' => [
+        'enabled' => (getenv('NEO4J_ENABLED') ?: '0') === '1',
+        'url' => rtrim((string) (getenv('NEO4J_URL') ?: 'http://127.0.0.1:7474'), '/'),
+        'username' => (string) (getenv('NEO4J_USERNAME') ?: 'neo4j'),
+        'password' => (string) (getenv('NEO4J_PASSWORD') ?: ''),
+        'database' => (string) (getenv('NEO4J_DATABASE') ?: 'neo4j'),
+        'timeout_seconds' => max(3, (int) (getenv('NEO4J_TIMEOUT_SECONDS') ?: 15)),
+        'log_file' => (string) (getenv('NEO4J_LOG_FILE') ?: 'storage/logs/graph-sync.log'),
+    ],
     'influxdb' => [
         'enabled' => (getenv('INFLUXDB_ENABLED') ?: '0') === '1',
         'read_enabled' => (getenv('INFLUXDB_READ_ENABLED') ?: '0') === '1',

--- a/src/config/local.php.example
+++ b/src/config/local.php.example
@@ -25,6 +25,15 @@ return [
         'prefix' => 'supplycore',
         'lock_enabled' => true,
     ],
+    'neo4j' => [
+        'enabled' => false,
+        'url' => 'http://127.0.0.1:7474',
+        'username' => 'neo4j',
+        'password' => 'change-me',
+        'database' => 'neo4j',
+        'timeout_seconds' => 15,
+        'log_file' => 'storage/logs/graph-sync.log',
+    ],
     'influxdb' => [
         'enabled' => false,
         'read_enabled' => false,

--- a/src/functions.php
+++ b/src/functions.php
@@ -3586,6 +3586,15 @@ function orchestrator_runtime_config_export(): array
             'password' => (string) config('db.password', ''),
             'charset' => (string) config('db.charset', 'utf8mb4'),
         ],
+        'neo4j' => [
+            'enabled' => (bool) config('neo4j.enabled', false),
+            'url' => rtrim((string) config('neo4j.url', 'http://127.0.0.1:7474'), '/'),
+            'username' => (string) config('neo4j.username', 'neo4j'),
+            'password' => (string) config('neo4j.password', ''),
+            'database' => (string) config('neo4j.database', 'neo4j'),
+            'timeout_seconds' => max(3, (int) config('neo4j.timeout_seconds', 15)),
+            'log_file' => supplycore_worker_log_path('graph-sync.log', (string) config('neo4j.log_file', 'storage/logs/graph-sync.log')),
+        ],
         'influxdb' => [
             'enabled' => (bool) config('influxdb.enabled', false),
             'read_enabled' => (bool) config('influxdb.read_enabled', false),


### PR DESCRIPTION
### Motivation
- Python graph jobs were receiving an empty Neo4j payload from the PHP runtime bridge so they defaulted to disabled and reported `neo4j disabled` instead of using app config. 
- Operators need an easy place to configure connectivity and a simple JSONL logfile for diagnosing graph sync/insight runs. 

### Description
- Add a `neo4j` section with env-based defaults to `src/config/app.php` and document the same block in `src/config/local.php.example`, including `enabled`, `url`, `username`, `password`, `database`, `timeout_seconds`, and `log_file` (default `storage/logs/graph-sync.log`). 
- Export the `neo4j` block from PHP via `orchestrator_runtime_config_export()` in `src/functions.php` so Python jobs receive real runtime settings. 
- Extend the Python `Neo4jConfig` (`python/orchestrator/neo4j.py`) to include `log_file` and add JSONL append helpers to `python/orchestrator/jobs/compute_graph_sync.py` and `python/orchestrator/jobs/compute_graph_insights.py` to log `skipped`, `idle`, `completed` events. 
- Add lightweight JSONL failure logging in the wrapper scripts `bin/python_compute_graph_sync.py` and `bin/python_compute_graph_insights.py` so run-level exceptions are recorded. 
- Update `README.md` with where to configure Neo4j and how to check job status (Settings → Data Sync / `job_runs`) and note the `neo4j.disabled` behavior. 

### Testing
- Ran PHP syntax checks with `php -l` against `src/config/app.php`, `src/functions.php`, and `src/config/local.php.example`, and they all succeeded. 
- Verified Python sources and wrapper scripts compile with `python -m py_compile` for `python/orchestrator/neo4j.py`, `python/orchestrator/jobs/compute_graph_sync.py`, `python/orchestrator/jobs/compute_graph_insights.py`, `bin/python_compute_graph_sync.py`, and `bin/python_compute_graph_insights.py`, and compilation succeeded. 
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f32b97d0832f88daa7b27368ecca)