### PR TITLE
Add graph-derived dependency scoring to Buy All and Signals pipelines

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -99,23 +99,34 @@ CREATE TABLE IF NOT EXISTS graph_sync_state (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS doctrine_dependency_depth (
-    doctrine_id INT UNSIGNED PRIMARY KEY,
-    doctrine_name VARCHAR(190) NOT NULL,
+    doctrine_id BIGINT UNSIGNED PRIMARY KEY,
     fit_count INT UNSIGNED NOT NULL DEFAULT 0,
     item_count INT UNSIGNED NOT NULL DEFAULT 0,
-    dependency_depth INT UNSIGNED NOT NULL DEFAULT 0,
+    unique_item_count INT UNSIGNED NOT NULL DEFAULT 0,
+    dependency_depth_score DECIMAL(12,4) NOT NULL DEFAULT 0.0000,
     computed_at DATETIME NOT NULL,
+    KEY idx_doctrine_dependency_depth_score (dependency_depth_score, computed_at),
     KEY idx_doctrine_dependency_depth_computed (computed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS item_dependency_score (
-    type_id INT UNSIGNED PRIMARY KEY,
+    type_id BIGINT UNSIGNED PRIMARY KEY,
     doctrine_count INT UNSIGNED NOT NULL DEFAULT 0,
     fit_count INT UNSIGNED NOT NULL DEFAULT 0,
-    dependency_score DECIMAL(8,2) NOT NULL DEFAULT 0.00,
+    dependency_score DECIMAL(12,4) NOT NULL DEFAULT 0.0000,
     computed_at DATETIME NOT NULL,
     KEY idx_item_dependency_score_value (dependency_score, computed_at),
     KEY idx_item_dependency_score_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS fit_overlap_score (
+    fit_id BIGINT UNSIGNED NOT NULL,
+    other_fit_id BIGINT UNSIGNED NOT NULL,
+    shared_item_count INT UNSIGNED NOT NULL DEFAULT 0,
+    overlap_score DECIMAL(12,4) NOT NULL DEFAULT 0.0000,
+    computed_at DATETIME NOT NULL,
+    PRIMARY KEY (fit_id, other_fit_id),
+    KEY idx_fit_overlap_score_value (overlap_score, computed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS doctrine_readiness (

--- a/public/buy-all/index.php
+++ b/public/buy-all/index.php
@@ -273,6 +273,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 <td class="px-4 py-3 align-top">
                                     <p class="text-sm text-slate-200"><?= htmlspecialchars((string) ($item['reason_text'] ?? ''), ENT_QUOTES) ?></p>
                                     <p class="mt-1 text-xs text-slate-500">Doctrine impact <?= htmlspecialchars((string) ($item['doctrine_fit_impact'] ?? 0), ENT_QUOTES) ?> fits · pricing <?= htmlspecialchars((string) ($item['pricing_completeness'] ?? 'partial'), ENT_QUOTES) ?></p>
+                                    <p class="mt-1 text-xs text-cyan-200/85">Graph dependency <?= htmlspecialchars(number_format((float) ($item['dependency_score'] ?? 0.0), 1), ENT_QUOTES) ?> · used by <?= htmlspecialchars((string) ($item['valid_doctrine_count'] ?? 0), ENT_QUOTES) ?> doctrines / <?= htmlspecialchars((string) ($item['valid_fits_count'] ?? 0), ENT_QUOTES) ?> fits</p>
                                     <?php $affectedFits = array_values((array) ($item['affected_fits'] ?? [])); ?>
                                     <details class="mt-2 rounded-lg border border-white/8 bg-white/[0.03] px-3 py-2">
                                         <summary class="cursor-pointer list-none text-xs font-medium text-slate-100">More detail</summary>

--- a/python/orchestrator/jobs/compute_buy_all.py
+++ b/python/orchestrator/jobs/compute_buy_all.py
@@ -35,7 +35,10 @@ def _load_market_rows(db: SupplyCoreDb, limit: int = 600) -> list[dict[str, Any]
             COALESCE(alliance.total_sell_volume, 0) AS alliance_total_sell_volume,
             COALESCE(rit.volume, 1.0) AS unit_volume,
             CASE WHEN alliance.type_id IS NULL THEN 1 ELSE 0 END AS missing_in_alliance,
-            CASE WHEN COALESCE(alliance.total_sell_volume, 0) < 20 THEN 1 ELSE 0 END AS weak_alliance_stock
+            CASE WHEN COALESCE(alliance.total_sell_volume, 0) < 20 THEN 1 ELSE 0 END AS weak_alliance_stock,
+            COALESCE(ids.doctrine_count, 0) AS doctrine_count,
+            COALESCE(ids.fit_count, 0) AS dependency_fit_count,
+            COALESCE(ids.dependency_score, 0.0) AS dependency_score
         FROM market_order_snapshots_summary ref
         LEFT JOIN market_order_snapshots_summary alliance
             ON alliance.type_id = ref.type_id
@@ -47,6 +50,7 @@ def _load_market_rows(db: SupplyCoreDb, limit: int = 600) -> list[dict[str, Any]
                   AND inner_a.source_id = alliance.source_id
            )
         LEFT JOIN ref_item_types rit ON rit.type_id = ref.type_id
+        LEFT JOIN item_dependency_score ids ON ids.type_id = ref.type_id
         WHERE ref.source_type = 'market_hub'
           AND ref.observed_at = (
                 SELECT MAX(inner_r.observed_at)
@@ -71,10 +75,32 @@ def _ranked_items(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
         sell_price = float(row.get("sell_price") or 0.0)
         quantity = max(1, int((row.get("reference_total_sell_volume") or 0) * 0.06))
         quantity = min(500, quantity)
-        necessity = min(100.0, (float(row.get("risk_score") or 0) * 0.55) + (35.0 if int(row.get("missing_in_alliance") or 0) == 1 else 0.0))
+        dependency_score = float(row.get("dependency_score") or 0.0)
+        doctrine_count = max(0, int(row.get("doctrine_count") or 0))
+        dependency_fit_count = max(0, int(row.get("dependency_fit_count") or 0))
+
+        dependency_necessity_boost = min(30.0, dependency_score * 0.45)
+        doctrine_breadth_boost = min(18.0, float(doctrine_count) * 1.8)
+        bottleneck_bonus = 12.0 if doctrine_count >= 3 and int(row.get("weak_alliance_stock") or 0) == 1 else 0.0
+
+        necessity = min(
+            100.0,
+            (float(row.get("risk_score") or 0) * 0.50)
+            + (35.0 if int(row.get("missing_in_alliance") or 0) == 1 else 0.0)
+            + dependency_necessity_boost
+            + doctrine_breadth_boost
+            + bottleneck_bonus,
+        )
         profit = min(100.0, max(0.0, float(row.get("opportunity_score") or 0)))
-        mode_rank = round((necessity * 0.55) + (profit * 0.45), 2)
+        mode_rank = round((necessity * 0.62) + (profit * 0.38), 2)
+        blended_score = round(min(100.0, mode_rank + min(15.0, dependency_score * 0.18)), 2)
+
         net_profit_per_unit = sell_price - buy_price if buy_price > 0 and sell_price > 0 else 0.0
+        graph_reason = (
+            f"Used by {doctrine_count} doctrine(s), {dependency_fit_count} fit(s), dependency score {dependency_score:.1f}."
+            if dependency_score > 0
+            else "No graph dependency enrichment yet."
+        )
         ranked.append(
             {
                 "type_id": type_id,
@@ -84,19 +110,29 @@ def _ranked_items(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "necessity_score": round(necessity, 2),
                 "profit_score": round(profit, 2),
                 "mode_rank_score": mode_rank,
-                "blended_score": mode_rank,
+                "blended_score": blended_score,
+                "final_priority_score": blended_score,
                 "buy_price": round(buy_price, 2) if buy_price > 0 else None,
                 "sell_price": round(sell_price, 2) if sell_price > 0 else None,
                 "net_profit_total": round(net_profit_per_unit * quantity, 2),
-                "is_doctrine_critical": bool(int(row.get("missing_in_alliance") or 0) == 1 or int(row.get("weak_alliance_stock") or 0) == 1),
+                "is_doctrine_critical": bool(
+                    int(row.get("missing_in_alliance") or 0) == 1
+                    or int(row.get("weak_alliance_stock") or 0) == 1
+                    or doctrine_count >= 3
+                ),
                 "unit_volume": float(row.get("unit_volume") or 1.0),
                 "total_volume": round(float(row.get("unit_volume") or 1.0) * quantity, 2),
                 "missing_in_alliance": bool(int(row.get("missing_in_alliance") or 0) == 1),
                 "weak_alliance_stock": bool(int(row.get("weak_alliance_stock") or 0) == 1),
+                "valid_doctrine_count": doctrine_count,
+                "valid_fits_count": dependency_fit_count,
+                "dependency_score": round(dependency_score, 4),
+                "reason_text": graph_reason,
+                "reason_theme": "Graph dependency priority" if dependency_score > 0 else "Market-only priority",
             }
         )
 
-    ranked.sort(key=lambda item: (float(item.get("mode_rank_score") or 0.0), float(item.get("necessity_score") or 0.0)), reverse=True)
+    ranked.sort(key=lambda item: (float(item.get("blended_score") or 0.0), float(item.get("necessity_score") or 0.0)), reverse=True)
     for idx, item in enumerate(ranked, start=1):
         item["rank_position"] = idx
     return ranked
@@ -130,7 +166,7 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
                 "total_volume": round(sum(float(item.get("total_volume") or 0.0) for item in page_items), 2),
                 "total_net_profit": round(sum(float(item.get("net_profit_total") or 0.0) for item in page_items), 2),
                 "doctrine_critical_count": sum(1 for item in page_items if bool(item.get("is_doctrine_critical"))),
-                "top_reason_theme": "Precomputed intelligence",
+                "top_reason_theme": "Graph dependency priority",
             },
             "items": page_items,
             "pages": [{"number": 1, "items": page_items, "item_count": len(page_items)}],

--- a/python/orchestrator/jobs/compute_graph_insights.py
+++ b/python/orchestrator/jobs/compute_graph_insights.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 import json
+import time
 from pathlib import Path
 from typing import Any
 
@@ -21,77 +22,117 @@ def _write_graph_log(log_file: str, event: str, payload: dict[str, Any]) -> None
         handle.write(line + "\n")
 
 
+def _query_item_dependency_rows(client: Neo4jClient) -> list[dict[str, Any]]:
+    return client.query(
+        """
+        MATCH (d:Doctrine)-[:USES]->(f:Fit)-[:CONTAINS]->(i:Item)
+        WITH i,
+             count(DISTINCT d) AS doctrine_count,
+             count(DISTINCT f) AS fit_count
+        RETURN
+            toInteger(i.type_id) AS type_id,
+            toInteger(doctrine_count) AS doctrine_count,
+            toInteger(fit_count) AS fit_count,
+            toFloat((doctrine_count * 10) + fit_count) AS dependency_score
+        ORDER BY dependency_score DESC, type_id ASC
+        """
+    )
+
+
+def _query_doctrine_dependency_rows(client: Neo4jClient) -> list[dict[str, Any]]:
+    return client.query(
+        """
+        MATCH (d:Doctrine)
+        OPTIONAL MATCH (d)-[:USES]->(f:Fit)
+        OPTIONAL MATCH (f)-[:CONTAINS]->(i:Item)
+        WITH d,
+             count(DISTINCT f) AS fit_count,
+             count(i) AS item_count,
+             count(DISTINCT i) AS unique_item_count
+        RETURN
+            toInteger(d.id) AS doctrine_id,
+            toInteger(fit_count) AS fit_count,
+            toInteger(item_count) AS item_count,
+            toInteger(unique_item_count) AS unique_item_count,
+            toFloat(unique_item_count + (fit_count * 5)) AS dependency_depth_score
+        ORDER BY dependency_depth_score DESC, doctrine_id ASC
+        """
+    )
+
+
 def run_compute_graph_insights(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:
+    started = time.perf_counter()
     config = Neo4jConfig.from_runtime(neo4j_raw or {})
     if not config.enabled:
-        result = {"status": "skipped", "reason": "neo4j disabled", "rows_processed": 0, "rows_written": 0}
+        result = {
+            "status": "skipped",
+            "reason": "neo4j disabled",
+            "rows_processed": 0,
+            "rows_written": 0,
+            "duration_ms": int((time.perf_counter() - started) * 1000),
+            "errors": [],
+        }
         _write_graph_log(config.log_file, "graph.job.skipped", {"job": "compute_graph_insights", **result})
         return result
 
     client = Neo4jClient(config)
     computed_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    errors: list[str] = []
 
-    doctrine_rows = client.query(
-        """
-        MATCH (d:Doctrine)-[:USES]->(f:Fit)
-        OPTIONAL MATCH (f)-[:CONTAINS]->(i:Item)
-        RETURN d.id AS doctrine_id, coalesce(d.name, '') AS doctrine_name, count(DISTINCT f) AS fit_count, count(DISTINCT i) AS item_count
-        """
-    )
+    item_rows = _query_item_dependency_rows(client)
+    doctrine_rows = _query_doctrine_dependency_rows(client)
 
-    item_rows = client.query(
-        """
-        MATCH (d:Doctrine)-[:USES]->(f:Fit)-[:CONTAINS]->(i:Item)
-        RETURN i.type_id AS type_id, count(DISTINCT d) AS doctrine_count, count(DISTINCT f) AS fit_count
-        """
-    )
+    item_payload: list[tuple[int, int, int, float, str]] = []
+    for row in item_rows:
+        type_id = int(row.get("type_id") or 0)
+        if type_id <= 0:
+            continue
+        doctrine_count = max(0, int(row.get("doctrine_count") or 0))
+        fit_count = max(0, int(row.get("fit_count") or 0))
+        dependency_score = float(row.get("dependency_score") or 0.0)
+        item_payload.append((type_id, doctrine_count, fit_count, round(dependency_score, 4), computed_at))
+
+    doctrine_payload: list[tuple[int, int, int, int, float, str]] = []
+    for row in doctrine_rows:
+        doctrine_id = int(row.get("doctrine_id") or 0)
+        if doctrine_id <= 0:
+            continue
+        fit_count = max(0, int(row.get("fit_count") or 0))
+        item_count = max(0, int(row.get("item_count") or 0))
+        unique_item_count = max(0, int(row.get("unique_item_count") or 0))
+        dependency_depth_score = float(row.get("dependency_depth_score") or 0.0)
+        doctrine_payload.append((doctrine_id, fit_count, item_count, unique_item_count, round(dependency_depth_score, 4), computed_at))
 
     with db.transaction() as (_, cursor):
-        for row in doctrine_rows:
-            doctrine_id = int(row.get("doctrine_id") or 0)
-            if doctrine_id <= 0:
-                continue
-            fit_count = max(0, int(row.get("fit_count") or 0))
-            item_count = max(0, int(row.get("item_count") or 0))
-            dependency_depth = 2 if fit_count > 0 and item_count > 0 else (1 if fit_count > 0 else 0)
-            cursor.execute(
-                """
-                INSERT INTO doctrine_dependency_depth (doctrine_id, doctrine_name, fit_count, item_count, dependency_depth, computed_at)
-                VALUES (%s, %s, %s, %s, %s, %s)
-                ON DUPLICATE KEY UPDATE
-                    doctrine_name = VALUES(doctrine_name),
-                    fit_count = VALUES(fit_count),
-                    item_count = VALUES(item_count),
-                    dependency_depth = VALUES(dependency_depth),
-                    computed_at = VALUES(computed_at)
-                """,
-                (doctrine_id, str(row.get("doctrine_name") or "Doctrine"), fit_count, item_count, dependency_depth, computed_at),
-            )
-
-        for row in item_rows:
-            type_id = int(row.get("type_id") or 0)
-            if type_id <= 0:
-                continue
-            doctrine_count = max(0, int(row.get("doctrine_count") or 0))
-            fit_count = max(0, int(row.get("fit_count") or 0))
-            dependency_score = round((doctrine_count * 0.7) + (fit_count * 0.3), 2)
-            cursor.execute(
+        cursor.execute("DELETE FROM item_dependency_score")
+        if item_payload:
+            cursor.executemany(
                 """
                 INSERT INTO item_dependency_score (type_id, doctrine_count, fit_count, dependency_score, computed_at)
                 VALUES (%s, %s, %s, %s, %s)
-                ON DUPLICATE KEY UPDATE
-                    doctrine_count = VALUES(doctrine_count),
-                    fit_count = VALUES(fit_count),
-                    dependency_score = VALUES(dependency_score),
-                    computed_at = VALUES(computed_at)
                 """,
-                (type_id, doctrine_count, fit_count, dependency_score, computed_at),
+                item_payload,
             )
 
+        cursor.execute("DELETE FROM doctrine_dependency_depth")
+        if doctrine_payload:
+            cursor.executemany(
+                """
+                INSERT INTO doctrine_dependency_depth (doctrine_id, fit_count, item_count, unique_item_count, dependency_depth_score, computed_at)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                doctrine_payload,
+            )
+
+    rows_processed = len(item_rows) + len(doctrine_rows)
+    rows_written = len(item_payload) + len(doctrine_payload)
+    duration_ms = int((time.perf_counter() - started) * 1000)
     result = {
         "status": "success",
-        "rows_processed": len(doctrine_rows) + len(item_rows),
-        "rows_written": len(doctrine_rows) + len(item_rows),
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "duration_ms": duration_ms,
+        "errors": errors,
         "computed_at": computed_at,
     }
     _write_graph_log(config.log_file, "graph.insights.completed", result)

--- a/python/orchestrator/jobs/compute_signals.py
+++ b/python/orchestrator/jobs/compute_signals.py
@@ -51,12 +51,16 @@ def run_compute_signals(db: SupplyCoreDb, influx_raw: dict[str, Any] | None = No
             MAX(COALESCE(bai.quantity, 0)) AS planner_qty,
             MAX(COALESCE(mh.best_sell_price, mh.best_buy_price, 0)) AS hub_price,
             MAX(COALESCE(asrc.best_sell_price, asrc.best_buy_price, 0)) AS alliance_price,
-            MAX(COALESCE(asrc.total_sell_volume, 0)) AS alliance_volume
+            MAX(COALESCE(asrc.total_sell_volume, 0)) AS alliance_volume,
+            MAX(COALESCE(ids.dependency_score, 0.0)) AS dependency_score,
+            MAX(COALESCE(ids.doctrine_count, 0)) AS doctrine_count,
+            MAX(COALESCE(ids.fit_count, 0)) AS dependency_fit_count
         FROM buy_all_items bai
         INNER JOIN buy_all_summary bas ON bas.id = bai.summary_id
         LEFT JOIN ref_item_types rit ON rit.type_id = bai.type_id
         LEFT JOIN market_order_snapshots_summary mh ON mh.type_id = bai.type_id AND mh.source_type = 'market_hub'
         LEFT JOIN market_order_snapshots_summary asrc ON asrc.type_id = bai.type_id AND asrc.source_type = 'alliance_structure'
+        LEFT JOIN item_dependency_score ids ON ids.type_id = bai.type_id
         WHERE bas.computed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 24 HOUR)
         GROUP BY bai.type_id
         ORDER BY mode_rank_score DESC
@@ -79,13 +83,41 @@ def run_compute_signals(db: SupplyCoreDb, influx_raw: dict[str, Any] | None = No
             hub_price = float(row.get("hub_price") or 0.0)
             alliance_volume = int(row.get("alliance_volume") or 0)
             necessity = float(row.get("necessity_score") or 0.0)
+            dependency_score = float(row.get("dependency_score") or 0.0)
+            doctrine_count = int(row.get("doctrine_count") or 0)
+            dependency_fit_count = int(row.get("dependency_fit_count") or 0)
 
             signal_type = "market_spike"
             severity = "medium"
             signal_text = f"Planner rank {float(row.get('mode_rank_score') or 0.0):.1f} with alliance volume {alliance_volume}."
 
             hist = float(historical.get(type_id) or 0.0)
-            if hist > 0 and hub_price > 0 and hub_price <= hist * 0.9:
+            price_worsening = bool(hist > 0 and hub_price > (hist * 1.10))
+            low_supply = alliance_volume < 20
+            high_dependency = dependency_score >= 30.0 or doctrine_count >= 3
+
+            if high_dependency and low_supply and price_worsening:
+                signal_type = "high_dependency_low_supply"
+                severity = "critical"
+                signal_text = (
+                    f"Dependency score {dependency_score:.1f} across {doctrine_count} doctrines with low alliance volume {alliance_volume}; "
+                    f"hub price {hub_price:.2f} is above 14d mean {hist:.2f}."
+                )
+            elif high_dependency and low_supply:
+                signal_type = "critical_shared_dependency"
+                severity = "critical"
+                signal_text = (
+                    f"Shared dependency risk: score {dependency_score:.1f}, doctrines {doctrine_count}, fits {dependency_fit_count}, "
+                    f"alliance volume {alliance_volume}."
+                )
+            elif high_dependency and necessity >= 60.0:
+                signal_type = "doctrine_bottleneck"
+                severity = "high"
+                signal_text = (
+                    f"Doctrine bottleneck candidate with dependency score {dependency_score:.1f}, necessity {necessity:.1f}, "
+                    f"used by {doctrine_count} doctrines."
+                )
+            elif hist > 0 and hub_price > 0 and hub_price <= hist * 0.9:
                 signal_type = "undervalued_item"
                 severity = "high"
                 signal_text = f"Hub price {hub_price:.2f} is below 14d mean {hist:.2f}."
@@ -106,6 +138,9 @@ def run_compute_signals(db: SupplyCoreDb, influx_raw: dict[str, Any] | None = No
                 "mode_rank_score": float(row.get("mode_rank_score") or 0.0),
                 "necessity_score": necessity,
                 "profit_score": float(row.get("profit_score") or 0.0),
+                "dependency_score": dependency_score,
+                "doctrine_count": doctrine_count,
+                "dependency_fit_count": dependency_fit_count,
             }
             signal_key = f"{signal_type}:{type_id}"
             cursor.execute(


### PR DESCRIPTION
### Motivation
- Make Neo4j graph intelligence useful for website decisions while keeping PHP read-only against MariaDB by materializing graph-derived metrics into indexed tables. 
- Provide weighted item/doctrine dependency scores to improve buy-ranking and generate higher-fidelity operational signals. 
- Keep web request performance intact by ensuring all runtime reads remain against precomputed, indexed MariaDB tables.

### Description
- Schema updates: `item_dependency_score` and `doctrine_dependency_depth` now use `BIGINT` keys and `DECIMAL(12,4)` scoring/precision, `doctrine_dependency_depth` stores `unique_item_count` and `dependency_depth_score`, and an optional `fit_overlap_score` table was added for future use (see `database/schema.sql`).
- New/rewritten Python job `run_compute_graph_insights()` queries Neo4j for item and doctrine metrics using the requested formulas, computes scores, and atomically refreshes MariaDB tables inside a transaction while logging `rows_processed`, `rows_written`, `duration_ms`, and `errors` (see `python/orchestrator/jobs/compute_graph_insights.py`).
- `compute_buy_all` now joins `item_dependency_score` and factors dependency breadth/bottleneck boosts into necessity/ranking and doctrine-critical classification, and persists graph-enriched payloads for PHP to read (see `python/orchestrator/jobs/compute_buy_all.py`).
- `compute_signals` now joins `item_dependency_score` and emits graph-aware signal types (`critical_shared_dependency`, `doctrine_bottleneck`, `high_dependency_low_supply`) with context persisted in `signal_payload_json` (see `python/orchestrator/jobs/compute_signals.py`).
- PHP UI change: `public/buy-all/index.php` surfaces `dependency_score` and doctrine/fit usage counts in the Buy All view using only precomputed payload fields, with no Neo4j/Influx access added to the web tier.

### Testing
- Ran Python syntax check with `python -m compileall python/orchestrator/jobs/compute_graph_insights.py python/orchestrator/jobs/compute_buy_all.py python/orchestrator/jobs/compute_signals.py` and compilation succeeded.
- Ran PHP linting with `php -l public/buy-all/index.php`, `php -l src/functions.php`, and `php -l src/db.php`, and all reported no syntax errors.
- Changes were committed (`Add graph-derived dependency scoring into buy-all and signals`) and include the modified schema, Python jobs, and PHP view files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c304112d38832fb004897d46c2d5e2)