### PR TITLE
Fix Decimal consistency in buy-all and signals jobs

### DIFF
--- a/bin/python_compute_buy_all.py
+++ b/bin/python_compute_buy_all.py
@@ -16,6 +16,7 @@ def main() -> int:
     from orchestrator.db import SupplyCoreDb
     from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
     from orchestrator.jobs.compute_buy_all import run_compute_buy_all
+    from orchestrator.jobs.compute_signals import run_compute_signals
 
     config = load_php_runtime_config(repo_root)
     db = SupplyCoreDb(config.raw.get("db", {}))
@@ -27,6 +28,16 @@ def main() -> int:
     run = start_job_run(db, "compute_buy_all")
     try:
         result = run_compute_buy_all(db)
+        print(
+            json.dumps(
+                {
+                    "job": "compute_buy_all",
+                    "rows_processed": int(result.get("rows_processed") or 0),
+                    "rows_written": int(result.get("rows_written") or 0),
+                },
+                ensure_ascii=False,
+            )
+        )
         finish_job_run(
             db,
             run,
@@ -35,7 +46,45 @@ def main() -> int:
             rows_written=int(result.get("rows_written") or 0),
             meta={"job_name": "compute_buy_all"},
         )
-        print(json.dumps({"status": "ok", **result}, ensure_ascii=False))
+        signals_result: dict[str, object] = {"status": "skipped", "reason": "lock_not_acquired"}
+        signal_lock_owner = acquire_job_lock(db, "compute_signals", ttl_seconds=300)
+        if signal_lock_owner is not None:
+            signal_run = start_job_run(db, "compute_signals")
+            try:
+                signals_result = run_compute_signals(db, config.raw.get("influx", {}))
+                print(
+                    json.dumps(
+                        {
+                            "job": "compute_signals",
+                            "rows_processed": int(signals_result.get("rows_processed") or 0),
+                            "rows_written": int(signals_result.get("rows_written") or 0),
+                        },
+                        ensure_ascii=False,
+                    )
+                )
+                finish_job_run(
+                    db,
+                    signal_run,
+                    status="success",
+                    rows_processed=int(signals_result.get("rows_processed") or 0),
+                    rows_written=int(signals_result.get("rows_written") or 0),
+                    meta={"job_name": "compute_signals", "trigger": "compute_buy_all"},
+                )
+            except Exception as signal_error:  # noqa: BLE001
+                finish_job_run(
+                    db,
+                    signal_run,
+                    status="failed",
+                    rows_processed=0,
+                    rows_written=0,
+                    error_text=str(signal_error),
+                    meta={"job_name": "compute_signals", "trigger": "compute_buy_all"},
+                )
+                raise
+            finally:
+                release_job_lock(db, "compute_signals", signal_lock_owner)
+
+        print(json.dumps({"status": "ok", **result, "compute_signals": signals_result}, ensure_ascii=False))
         return 0
     except Exception as error:  # noqa: BLE001
         finish_job_run(db, run, status="failed", rows_processed=0, rows_written=0, error_text=str(error), meta={"job_name": "compute_buy_all"})

--- a/bin/python_compute_signals.py
+++ b/bin/python_compute_signals.py
@@ -27,6 +27,16 @@ def main() -> int:
     run = start_job_run(db, "compute_signals")
     try:
         result = run_compute_signals(db, config.raw.get("influx", {}))
+        print(
+            json.dumps(
+                {
+                    "job": "compute_signals",
+                    "rows_processed": int(result.get("rows_processed") or 0),
+                    "rows_written": int(result.get("rows_written") or 0),
+                },
+                ensure_ascii=False,
+            )
+        )
         finish_job_run(
             db,
             run,

--- a/python/orchestrator/jobs/compute_buy_all.py
+++ b/python/orchestrator/jobs/compute_buy_all.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from hashlib import sha256
 from typing import Any
 
@@ -13,6 +14,23 @@ DEFAULT_REQUESTS: list[dict[str, Any]] = [
     {"mode": "opportunity", "sort": "mode_rank_score", "filters": {}},
     {"mode": "seed_backlog", "sort": "necessity_score", "filters": {}},
 ]
+
+DECIMAL_ZERO = Decimal("0")
+
+
+def to_decimal(value: Any, default: str = "0") -> Decimal:
+    if value is None:
+        return Decimal(default)
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return Decimal(default)
+
+
+def _q2(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
 def _filters_hash(filters: dict[str, Any]) -> str:
@@ -71,68 +89,78 @@ def _ranked_items(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
         type_id = int(row.get("type_id") or 0)
         if type_id <= 0:
             continue
-        buy_price = float(row.get("buy_price") or 0.0)
-        sell_price = float(row.get("sell_price") or 0.0)
-        quantity = max(1, int((row.get("reference_total_sell_volume") or 0) * 0.06))
+        buy_price = to_decimal(row.get("buy_price"))
+        sell_price = to_decimal(row.get("sell_price"))
+        quantity = max(1, int(to_decimal(row.get("reference_total_sell_volume")) * Decimal("0.06")))
         quantity = min(500, quantity)
-        dependency_score = float(row.get("dependency_score") or 0.0)
+        dependency_score = to_decimal(row.get("dependency_score"))
         doctrine_count = max(0, int(row.get("doctrine_count") or 0))
         dependency_fit_count = max(0, int(row.get("dependency_fit_count") or 0))
+        risk_score = to_decimal(row.get("risk_score"))
+        opportunity_score = to_decimal(row.get("opportunity_score"))
+        unit_volume = to_decimal(row.get("unit_volume"), default="1")
 
-        dependency_necessity_boost = min(30.0, dependency_score * 0.45)
-        doctrine_breadth_boost = min(18.0, float(doctrine_count) * 1.8)
-        bottleneck_bonus = 12.0 if doctrine_count >= 3 and int(row.get("weak_alliance_stock") or 0) == 1 else 0.0
+        dependency_necessity_boost = min(Decimal("30"), dependency_score * Decimal("0.45"))
+        doctrine_breadth_boost = min(Decimal("18"), Decimal(doctrine_count) * Decimal("1.8"))
+        bottleneck_bonus = Decimal("12") if doctrine_count >= 3 and int(row.get("weak_alliance_stock") or 0) == 1 else DECIMAL_ZERO
 
         necessity = min(
-            100.0,
-            (float(row.get("risk_score") or 0) * 0.50)
-            + (35.0 if int(row.get("missing_in_alliance") or 0) == 1 else 0.0)
+            Decimal("100"),
+            (risk_score * Decimal("0.50"))
+            + (Decimal("35") if int(row.get("missing_in_alliance") or 0) == 1 else DECIMAL_ZERO)
             + dependency_necessity_boost
             + doctrine_breadth_boost
             + bottleneck_bonus,
         )
-        profit = min(100.0, max(0.0, float(row.get("opportunity_score") or 0)))
-        mode_rank = round((necessity * 0.62) + (profit * 0.38), 2)
-        blended_score = round(min(100.0, mode_rank + min(15.0, dependency_score * 0.18)), 2)
+        profit = min(Decimal("100"), max(DECIMAL_ZERO, opportunity_score))
+        mode_rank = _q2((necessity * Decimal("0.62")) + (profit * Decimal("0.38")))
+        blended_score = _q2(min(Decimal("100"), mode_rank + min(Decimal("15"), dependency_score * Decimal("0.18"))))
 
-        net_profit_per_unit = sell_price - buy_price if buy_price > 0 and sell_price > 0 else 0.0
+        net_profit_per_unit = sell_price - buy_price if buy_price > DECIMAL_ZERO and sell_price > DECIMAL_ZERO else DECIMAL_ZERO
         graph_reason = (
-            f"Used by {doctrine_count} doctrine(s), {dependency_fit_count} fit(s), dependency score {dependency_score:.1f}."
-            if dependency_score > 0
+            f"Used by {doctrine_count} doctrine(s), {dependency_fit_count} fit(s), dependency score {_q2(dependency_score):.1f}."
+            if dependency_score > DECIMAL_ZERO
             else "No graph dependency enrichment yet."
         )
+        total_volume = _q2(unit_volume * Decimal(quantity))
         ranked.append(
             {
                 "type_id": type_id,
                 "item_name": str(row.get("type_name") or f"Type #{type_id}"),
                 "quantity": quantity,
                 "final_planner_quantity": quantity,
-                "necessity_score": round(necessity, 2),
-                "profit_score": round(profit, 2),
+                "necessity_score": _q2(necessity),
+                "profit_score": _q2(profit),
                 "mode_rank_score": mode_rank,
                 "blended_score": blended_score,
                 "final_priority_score": blended_score,
-                "buy_price": round(buy_price, 2) if buy_price > 0 else None,
-                "sell_price": round(sell_price, 2) if sell_price > 0 else None,
-                "net_profit_total": round(net_profit_per_unit * quantity, 2),
+                "buy_price": _q2(buy_price) if buy_price > DECIMAL_ZERO else None,
+                "sell_price": _q2(sell_price) if sell_price > DECIMAL_ZERO else None,
+                "net_profit_total": _q2(net_profit_per_unit * Decimal(quantity)),
                 "is_doctrine_critical": bool(
                     int(row.get("missing_in_alliance") or 0) == 1
                     or int(row.get("weak_alliance_stock") or 0) == 1
                     or doctrine_count >= 3
                 ),
-                "unit_volume": float(row.get("unit_volume") or 1.0),
-                "total_volume": round(float(row.get("unit_volume") or 1.0) * quantity, 2),
+                "unit_volume": unit_volume,
+                "total_volume": total_volume,
                 "missing_in_alliance": bool(int(row.get("missing_in_alliance") or 0) == 1),
                 "weak_alliance_stock": bool(int(row.get("weak_alliance_stock") or 0) == 1),
                 "valid_doctrine_count": doctrine_count,
                 "valid_fits_count": dependency_fit_count,
-                "dependency_score": round(dependency_score, 4),
+                "dependency_score": dependency_score.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP),
                 "reason_text": graph_reason,
-                "reason_theme": "Graph dependency priority" if dependency_score > 0 else "Market-only priority",
+                "reason_theme": "Graph dependency priority" if dependency_score > DECIMAL_ZERO else "Market-only priority",
             }
         )
 
-    ranked.sort(key=lambda item: (float(item.get("blended_score") or 0.0), float(item.get("necessity_score") or 0.0)), reverse=True)
+    ranked.sort(
+        key=lambda item: (
+            to_decimal(item.get("blended_score")),
+            to_decimal(item.get("necessity_score")),
+        ),
+        reverse=True,
+    )
     for idx, item in enumerate(ranked, start=1):
         item["rank_position"] = idx
     return ranked
@@ -163,8 +191,8 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
                 "candidate_count": len(page_items),
                 "total_item_types": len(page_items),
                 "total_units": sum(int(item.get("quantity") or 0) for item in page_items),
-                "total_volume": round(sum(float(item.get("total_volume") or 0.0) for item in page_items), 2),
-                "total_net_profit": round(sum(float(item.get("net_profit_total") or 0.0) for item in page_items), 2),
+                "total_volume": _q2(sum(to_decimal(item.get("total_volume")) for item in page_items)),
+                "total_net_profit": _q2(sum(to_decimal(item.get("net_profit_total")) for item in page_items)),
                 "doctrine_critical_count": sum(1 for item in page_items if bool(item.get("is_doctrine_critical"))),
                 "top_reason_theme": "Graph dependency priority",
             },
@@ -178,13 +206,13 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
                 "buy": "Hub snapshot from market_comparison_snapshot.",
                 "sell": "Alliance snapshot from market_comparison_snapshot.",
             },
-            "hauling": {"cost_per_m3": 320.0, "page_volume_limit": 385000.0, "page_item_type_limit": 42},
+            "hauling": {"cost_per_m3": Decimal("320"), "page_volume_limit": Decimal("385000"), "page_item_type_limit": 42},
             "mode_options": {},
             "sort_options": {},
         }
 
-        summary_json = json.dumps(payload["summary"], separators=(",", ":"), ensure_ascii=False)
-        payload_json = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        summary_json = json.dumps(payload["summary"], separators=(",", ":"), ensure_ascii=False, default=_decimal_json_default)
+        payload_json = json.dumps(payload, separators=(",", ":"), ensure_ascii=False, default=_decimal_json_default)
         with db.transaction() as (_, cursor):
             cursor.execute(
                 """
@@ -228,10 +256,10 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
                         int(item.get("rank_position") or 0),
                         int(item.get("type_id") or 0),
                         int(item.get("quantity") or 0),
-                        float(item.get("mode_rank_score") or 0.0),
-                        float(item.get("necessity_score") or 0.0),
-                        float(item.get("profit_score") or 0.0),
-                        json.dumps(item, separators=(",", ":"), ensure_ascii=False),
+                        to_decimal(item.get("mode_rank_score")),
+                        to_decimal(item.get("necessity_score")),
+                        to_decimal(item.get("profit_score")),
+                        json.dumps(item, separators=(",", ":"), ensure_ascii=False, default=_decimal_json_default),
                         computed_at,
                     ),
                 )
@@ -246,3 +274,9 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
         "rows_processed": rows_processed,
         "rows_written": rows_written,
     }
+
+
+def _decimal_json_default(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return float(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")

--- a/python/orchestrator/jobs/compute_signals.py
+++ b/python/orchestrator/jobs/compute_signals.py
@@ -2,13 +2,28 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from ..db import SupplyCoreDb
 from ..influx import InfluxClient, InfluxConfig, InfluxQueryError
 
 
-def _historical_mean_by_type(influx_raw: dict[str, Any], type_ids: list[int]) -> dict[int, float]:
+DECIMAL_ZERO = Decimal("0")
+
+
+def to_decimal(value: Any, default: str = "0") -> Decimal:
+    if value is None:
+        return Decimal(default)
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return Decimal(default)
+
+
+def _historical_mean_by_type(influx_raw: dict[str, Any], type_ids: list[int]) -> dict[int, Decimal]:
     if not bool(influx_raw.get("enabled", False)) or not type_ids:
         return {}
 
@@ -29,11 +44,11 @@ from(bucket: "{config.bucket}")
     except InfluxQueryError:
         return {}
 
-    out: dict[int, float] = {}
+    out: dict[int, Decimal] = {}
     for row in rows:
         type_id = int(row.get("type_id") or 0)
-        mean_price = float(row.get("_value") or 0.0)
-        if type_id > 0 and mean_price > 0:
+        mean_price = to_decimal(row.get("_value"))
+        if type_id > 0 and mean_price > DECIMAL_ZERO:
             out[type_id] = mean_price
     return out
 
@@ -80,21 +95,22 @@ def run_compute_signals(db: SupplyCoreDb, influx_raw: dict[str, Any] | None = No
             if type_id <= 0:
                 continue
             title = str(row.get("type_name") or f"Type #{type_id}")
-            hub_price = float(row.get("hub_price") or 0.0)
+            hub_price = to_decimal(row.get("hub_price"))
             alliance_volume = int(row.get("alliance_volume") or 0)
-            necessity = float(row.get("necessity_score") or 0.0)
-            dependency_score = float(row.get("dependency_score") or 0.0)
+            necessity = to_decimal(row.get("necessity_score"))
+            dependency_score = to_decimal(row.get("dependency_score"))
             doctrine_count = int(row.get("doctrine_count") or 0)
             dependency_fit_count = int(row.get("dependency_fit_count") or 0)
 
             signal_type = "market_spike"
             severity = "medium"
-            signal_text = f"Planner rank {float(row.get('mode_rank_score') or 0.0):.1f} with alliance volume {alliance_volume}."
+            mode_rank_score = to_decimal(row.get("mode_rank_score"))
+            signal_text = f"Planner rank {mode_rank_score:.1f} with alliance volume {alliance_volume}."
 
-            hist = float(historical.get(type_id) or 0.0)
-            price_worsening = bool(hist > 0 and hub_price > (hist * 1.10))
+            hist = to_decimal(historical.get(type_id))
+            price_worsening = bool(hist > DECIMAL_ZERO and hub_price > (hist * Decimal("1.10")))
             low_supply = alliance_volume < 20
-            high_dependency = dependency_score >= 30.0 or doctrine_count >= 3
+            high_dependency = dependency_score >= Decimal("30") or doctrine_count >= 3
 
             if high_dependency and low_supply and price_worsening:
                 signal_type = "high_dependency_low_supply"
@@ -110,34 +126,34 @@ def run_compute_signals(db: SupplyCoreDb, influx_raw: dict[str, Any] | None = No
                     f"Shared dependency risk: score {dependency_score:.1f}, doctrines {doctrine_count}, fits {dependency_fit_count}, "
                     f"alliance volume {alliance_volume}."
                 )
-            elif high_dependency and necessity >= 60.0:
+            elif high_dependency and necessity >= Decimal("60"):
                 signal_type = "doctrine_bottleneck"
                 severity = "high"
                 signal_text = (
                     f"Doctrine bottleneck candidate with dependency score {dependency_score:.1f}, necessity {necessity:.1f}, "
                     f"used by {doctrine_count} doctrines."
                 )
-            elif hist > 0 and hub_price > 0 and hub_price <= hist * 0.9:
+            elif hist > DECIMAL_ZERO and hub_price > DECIMAL_ZERO and hub_price <= hist * Decimal("0.9"):
                 signal_type = "undervalued_item"
                 severity = "high"
                 signal_text = f"Hub price {hub_price:.2f} is below 14d mean {hist:.2f}."
-            elif alliance_volume < 25 and necessity >= 55.0:
+            elif alliance_volume < 25 and necessity >= Decimal("55"):
                 signal_type = "supply_shortage"
                 severity = "critical"
                 signal_text = f"Alliance volume {alliance_volume} is low for necessity score {necessity:.1f}."
-            elif necessity >= 70.0:
+            elif necessity >= Decimal("70"):
                 signal_type = "doctrine_blocking_item"
                 severity = "high"
                 signal_text = f"Necessity score {necessity:.1f} indicates doctrine blocking risk."
 
             payload = {
                 "hub_price": hub_price,
-                "historical_mean": hist if hist > 0 else None,
+                "historical_mean": hist if hist > DECIMAL_ZERO else None,
                 "alliance_volume": alliance_volume,
                 "planner_qty": int(row.get("planner_qty") or 0),
-                "mode_rank_score": float(row.get("mode_rank_score") or 0.0),
+                "mode_rank_score": mode_rank_score,
                 "necessity_score": necessity,
-                "profit_score": float(row.get("profit_score") or 0.0),
+                "profit_score": to_decimal(row.get("profit_score")),
                 "dependency_score": dependency_score,
                 "doctrine_count": doctrine_count,
                 "dependency_fit_count": dependency_fit_count,
@@ -154,8 +170,14 @@ def run_compute_signals(db: SupplyCoreDb, influx_raw: dict[str, Any] | None = No
                     signal_payload_json = VALUES(signal_payload_json),
                     computed_at = VALUES(computed_at)
                 """,
-                (signal_key, signal_type, severity, type_id, title, signal_text, json.dumps(payload, separators=(",", ":"), ensure_ascii=False), computed_at),
+                (signal_key, signal_type, severity, type_id, title, signal_text, json.dumps(payload, separators=(",", ":"), ensure_ascii=False, default=_decimal_json_default), computed_at),
             )
             created += 1
 
     return {"computed_at": computed_at, "signals_created": created, "rows_processed": len(rows), "rows_written": created}
+
+
+def _decimal_json_default(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return float(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")


### PR DESCRIPTION
### Motivation

- Prevent runtime `Decimal * float` errors by normalizing all numeric inputs and keeping scoring/monetary math in `Decimal` across the buy-all ranking pipeline.
- Normalize nullable DB numeric fields to a safe default so `None` values do not cause arithmetic or comparison errors in scoring.
- Ensure the `compute_buy_all` job materializes precomputed payloads into `buy_all_summary` / `buy_all_items`, then re-run `compute_signals`, and log row counts for observability.

### Description

- Added a centralized `to_decimal(value, default="0")` helper and `DECIMAL_ZERO` constant to normalize DB inputs and literals in `python/orchestrator/jobs/compute_buy_all.py` and `python/orchestrator/jobs/compute_signals.py`.
- Replaced float literals and mixed-type arithmetic with `Decimal("...")` and a small helper `_q2()` for quantized two-decimal rounding, preserving Decimal math end-to-end in ranking and payload aggregation.
- Converted comparisons, min/max, and sorting keys to use `Decimal` so ranking, thresholds and boosts no longer mix floats with `Decimal` values.
- Added a Decimal-aware JSON encoder fallback (`_decimal_json_default`) so `Decimal` values are only converted at serialization boundaries.
- Updated `bin/python_compute_buy_all.py` to invoke `compute_signals` after a successful buy-all run (with lock and job-run tracking) and added explicit `rows_processed` / `rows_written` `json` logging for both `compute_buy_all` and `compute_signals` runners.

### Testing

- Compiled the modified modules with `python3 -m py_compile bin/python_compute_buy_all.py bin/python_compute_signals.py python/orchestrator/jobs/compute_buy_all.py python/orchestrator/jobs/compute_signals.py`, which succeeded.
- Attempted to run `python3 bin/python_compute_buy_all.py` and `python3 bin/python_compute_signals.py` to exercise end-to-end DB writes and the `compute_signals` trigger, but runtime execution failed due to a MariaDB connection refusal at `127.0.0.1`, so database writes to `buy_all_summary` / `buy_all_items` / `signals` could not be validated in this environment.
- The code-paths for Decimal normalization, ranking math, JSON serialization, and runner orchestration were reviewed and unit-compile validated; runtime DB integration remains blocked by local DB connectivity.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c30cf3e40c832faa084434a9fd0260)