### PR TITLE
Allow market-hub local history sync to accept --source-id fallback

### DIFF
--- a/bin/sync_runner.php
+++ b/bin/sync_runner.php
@@ -244,8 +244,12 @@ function sync_runner_dispatch_job(string $jobKey, int $sourceId, string $runMode
 
     if ($jobKey === 'market-hub-local-history') {
         $hubRef = market_hub_setting_reference();
+        if ($hubRef === '' && $sourceId > 0) {
+            $hubRef = (string) $sourceId;
+        }
+
         if ($hubRef === '') {
-            throw new RuntimeException('Hub snapshot history sync skipped: configure a reference market hub in Trading Stations settings.');
+            throw new RuntimeException('Hub snapshot history sync skipped: configure a reference market hub in Trading Stations settings or pass --source-id=<station-id>.');
         }
 
         $datasetKey = sync_dataset_key_market_hub_local_history_daily($hubRef);


### PR DESCRIPTION
### Motivation
- Make the `market-hub-local-history` job runnable from CLI in local/dev environments when the Trading Stations reference hub setting is not configured by accepting a `--source-id` fallback.

### Description
- Update `bin/sync_runner.php` to use `--source-id` as a fallback by assigning `$hubRef = (string) $sourceId` when no configured hub exists and a positive `--source-id` is provided.
- Improve the runtime error message to document the new fallback option (`pass --source-id=<station-id>`).

### Testing
- Ran `php -l bin/sync_runner.php` to verify syntax and it reported no syntax errors (success).
- Ran `php bin/sync_runner.php --job=market-hub-local-history --mode=incremental --source-id=60003760` which advanced past the previous configured-hub blocker and reached the DB connection step, then failed with `Connection refused` due to no local DB (expected in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c333c52edc832fa46ea9d79bc0d5d8)