### PR TITLE
Route graph sync/insights jobs through Python runtime

### DIFF
--- a/python/orchestrator/job_runner.py
+++ b/python/orchestrator/job_runner.py
@@ -11,7 +11,13 @@ from typing import Any, Callable
 from .bridge import PhpBridge
 from .config import load_php_runtime_config
 from .db import SupplyCoreDb
-from .jobs import run_killmail_r2z2_stream, run_market_comparison_summary, run_market_hub_local_history
+from .jobs import (
+    run_compute_graph_insights,
+    run_compute_graph_sync,
+    run_killmail_r2z2_stream,
+    run_market_comparison_summary,
+    run_market_hub_local_history,
+)
 from .worker_runtime import resident_memory_bytes, utc_now_iso
 
 
@@ -21,6 +27,7 @@ class PythonWorkerContext:
     app_root: Path
     raw_config: dict[str, Any]
     php_binary: str
+    db: SupplyCoreDb
     job: dict[str, Any]
 
     @property
@@ -55,7 +62,30 @@ PROCESSORS: dict[str, Callable[[PythonWorkerContext], dict[str, Any]]] = {
     "killmail_r2z2_sync": run_killmail_r2z2_stream,
     "market_comparison_summary_sync": run_market_comparison_summary,
     "market_hub_local_history_sync": run_market_hub_local_history,
+    "compute_graph_sync": lambda context: _graph_result_shape(
+        run_compute_graph_sync(context.db, dict(context.raw_config.get("neo4j") or {})),
+        "compute_graph_sync",
+    ),
+    "compute_graph_insights": lambda context: _graph_result_shape(
+        run_compute_graph_insights(context.db, dict(context.raw_config.get("neo4j") or {})),
+        "compute_graph_insights",
+    ),
 }
+
+
+def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
+    rows_seen = max(0, int(result.get("rows_processed") or result.get("rows_seen") or 0))
+    rows_written = max(0, int(result.get("rows_written") or 0))
+    status = str(result.get("status") or "success")
+    summary = str(result.get("summary") or f"{job_key} finished with status {status}.")
+    return {
+        "status": status,
+        "summary": summary,
+        "rows_seen": rows_seen,
+        "rows_written": rows_written,
+        "warnings": list(result.get("warnings") or []),
+        "meta": dict(result.get("meta") or {}),
+    }
 
 
 def parse_args() -> argparse.Namespace:
@@ -159,6 +189,7 @@ def main() -> int:
         app_root=app_root,
         raw_config=config.raw,
         php_binary=config.php_binary,
+        db=db,
         job=job,
     )
 

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -12,7 +12,14 @@ from typing import Any, Callable
 
 from .bridge import PhpBridge
 from .config import load_php_runtime_config
-from .jobs import run_killmail_r2z2_stream, run_market_comparison_summary, run_market_hub_local_history
+from .db import SupplyCoreDb
+from .jobs import (
+    run_compute_graph_insights,
+    run_compute_graph_sync,
+    run_killmail_r2z2_stream,
+    run_market_comparison_summary,
+    run_market_hub_local_history,
+)
 from .logging_utils import LoggerAdapter, configure_logging
 from .worker_runtime import resident_memory_bytes, utc_now_iso
 
@@ -28,6 +35,7 @@ class WorkerPoolContext:
     batch_size: int
     timeout_seconds: int
     memory_abort_threshold_bytes: int
+    db: SupplyCoreDb
 
     @property
     def schedule_id(self) -> int:
@@ -49,6 +57,14 @@ PROCESSORS: dict[str, Callable[[WorkerPoolContext], dict[str, Any]]] = {
     "killmail_r2z2_sync": run_killmail_r2z2_stream,
     "market_comparison_summary_sync": run_market_comparison_summary,
     "market_hub_local_history_sync": run_market_hub_local_history,
+    "compute_graph_sync": lambda context: _graph_result_shape(
+        run_compute_graph_sync(context.db, dict(context.raw_config.get("neo4j") or {})),
+        "compute_graph_sync",
+    ),
+    "compute_graph_insights": lambda context: _graph_result_shape(
+        run_compute_graph_insights(context.db, dict(context.raw_config.get("neo4j") or {})),
+        "compute_graph_insights",
+    ),
 }
 
 PYTHON_PRIMARY_JOB_KEYS = {
@@ -57,7 +73,24 @@ PYTHON_PRIMARY_JOB_KEYS = {
     "market_comparison_summary_sync",
     "market_hub_local_history_sync",
     "killmail_r2z2_sync",
+    "compute_graph_sync",
+    "compute_graph_insights",
 }
+
+
+def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
+    rows_seen = max(0, int(result.get("rows_processed") or result.get("rows_seen") or 0))
+    rows_written = max(0, int(result.get("rows_written") or 0))
+    status = str(result.get("status") or "success")
+    summary = str(result.get("summary") or f"{job_key} finished with status {status}.")
+    return {
+        "status": status,
+        "summary": summary,
+        "rows_seen": rows_seen,
+        "rows_written": rows_written,
+        "warnings": list(result.get("warnings") or []),
+        "meta": dict(result.get("meta") or {}),
+    }
 
 
 class HeartbeatThread(threading.Thread):
@@ -167,6 +200,7 @@ def main(argv: list[str] | None = None) -> int:
     worker_id = args.worker_id.strip() or f"{socket.gethostname()}-{os.getpid()}"
     state_file = Path(worker_settings.get("pool_state_file", app_root / "storage/run/worker-pool-heartbeat.json"))
     bridge = PhpBridge(php_binary, app_root)
+    db = SupplyCoreDb(dict(raw_config.get("db") or {}))
     lease_seconds = max(30, int(worker_settings.get("claim_ttl_seconds", 300)))
     idle_sleep = max(1, int(worker_settings.get("idle_sleep_seconds", 10)))
     sync_idle_sleep = max(1, int(worker_settings.get("sync_idle_sleep_seconds", idle_sleep)))
@@ -248,6 +282,7 @@ def main(argv: list[str] | None = None) -> int:
             batch_size=1000,
             timeout_seconds=timeout_seconds,
             memory_abort_threshold_bytes=min(abort_threshold, memory_limit_mb * 1024 * 1024),
+            db=db,
         )
 
         stop_event = threading.Event()

--- a/src/functions.php
+++ b/src/functions.php
@@ -3787,6 +3787,8 @@ function worker_job_registry_definitions(): array
         'analytics_bucket_1d_sync' => ['workload_class' => 'compute', 'execution_mode' => 'php', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 3600, 'timeout_seconds' => 240, 'memory_limit_mb' => 384, 'retry_delay_seconds' => 60, 'max_attempts' => 4],
         'rebuild_ai_briefings' => ['workload_class' => 'compute', 'execution_mode' => 'php', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 1200, 'timeout_seconds' => 300, 'memory_limit_mb' => 512, 'retry_delay_seconds' => 90, 'max_attempts' => 4],
         'forecasting_ai_sync' => ['workload_class' => 'compute', 'execution_mode' => 'php', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 3600, 'timeout_seconds' => 300, 'memory_limit_mb' => 512, 'retry_delay_seconds' => 90, 'max_attempts' => 4],
+        'compute_graph_sync' => ['workload_class' => 'compute', 'execution_mode' => 'python', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 900, 'timeout_seconds' => 300, 'memory_limit_mb' => 768, 'retry_delay_seconds' => 60, 'max_attempts' => 4],
+        'compute_graph_insights' => ['workload_class' => 'compute', 'execution_mode' => 'python', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 900, 'timeout_seconds' => 300, 'memory_limit_mb' => 768, 'retry_delay_seconds' => 60, 'max_attempts' => 4],
     ];
 }
 
@@ -3822,6 +3824,8 @@ function scheduler_registry_definitions(): array
         'alliance_historical_sync' => ['label' => 'Alliance Historical', 'default_interval_minutes' => 360, 'default_offset_minutes' => 5, 'priority' => 'normal', 'timeout_seconds' => 3600, 'concurrency_policy' => 'background', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
         'market_hub_historical_sync' => ['label' => 'Market Hub Historical', 'default_interval_minutes' => 360, 'default_offset_minutes' => 0, 'priority' => 'normal', 'timeout_seconds' => 3600, 'concurrency_policy' => 'background', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
         'forecasting_ai_sync' => ['label' => 'Forecasting AI', 'default_interval_minutes' => 60, 'default_offset_minutes' => 0, 'priority' => 'normal', 'timeout_seconds' => 300, 'concurrency_policy' => 'background', 'execution_mode' => 'php', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'lightweight'],
+        'compute_graph_sync' => ['label' => 'Graph Sync', 'default_interval_minutes' => 15, 'default_offset_minutes' => 17, 'priority' => 'normal', 'timeout_seconds' => 300, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
+        'compute_graph_insights' => ['label' => 'Graph Insights', 'default_interval_minutes' => 15, 'default_offset_minutes' => 18, 'priority' => 'normal', 'timeout_seconds' => 300, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
     ];
 }
 
@@ -8343,6 +8347,24 @@ function supplycore_settings_runtime_datasets(): array
             'snapshot_key' => loss_demand_snapshot_key(),
             'job_key' => 'loss_demand_summary_sync',
         ],
+        config('neo4j.enabled', false) ? [
+            'key' => 'graph_sync',
+            'label' => 'Graph sync',
+            'source' => 'sync',
+            'dataset_keys' => [scheduler_job_dataset_key('compute_graph_sync')],
+            'job_key' => 'compute_graph_sync',
+            'fresh_seconds' => 30 * 60,
+            'delayed_seconds' => 90 * 60,
+        ] : null,
+        config('neo4j.enabled', false) ? [
+            'key' => 'graph_insights',
+            'label' => 'Graph insights',
+            'source' => 'sync',
+            'dataset_keys' => [scheduler_job_dataset_key('compute_graph_insights')],
+            'job_key' => 'compute_graph_insights',
+            'fresh_seconds' => 30 * 60,
+            'delayed_seconds' => 90 * 60,
+        ] : null,
         [
             'key' => 'killmail_stream',
             'label' => 'Killmail stream',


### PR DESCRIPTION
### Motivation

- Ensure the graph-related scheduler jobs (`compute_graph_sync`, `compute_graph_insights`) run natively in the Python runtime (not via PHP fallback) so the Neo4j-driven graph compute path executes in Python and is observable in runtime dashboards.
- Surface graph dataset health in the Settings runtime cards when Neo4j is enabled so operators can see graph freshness alongside other datasets.

### Description

- Registered `compute_graph_sync` and `compute_graph_insights` in the Python worker processor maps for both the one-off job runner (`python/orchestrator/job_runner.py`) and the continuous worker pool (`python/orchestrator/worker_pool.py`) so they execute the Python processors directly.
- Added a `db` handle to Python worker contexts and wired `SupplyCoreDb` instances into both runners so graph jobs can call `run_compute_graph_sync` / `run_compute_graph_insights` with DB access.
- Normalized graph job return values into the scheduler result contract via `_graph_result_shape` helpers so scheduler finalization receives `status`, `summary`, `rows_seen`, `rows_written`, `warnings`, and `meta` as expected.
- Updated PHP scheduler/worker registries in `src/functions.php` to mark the graph jobs as `execution_mode => 'python'`, added worker registry entries for the graph jobs, and added conditional runtime dataset cards for `graph_sync` and `graph_insights` when Neo4j is enabled.

### Testing

- Compiled the changed Python modules with `python3 -m py_compile python/orchestrator/job_runner.py python/orchestrator/worker_pool.py` and the compile step succeeded.
- Linted the modified PHP file with `php -l src/functions.php` and it reported no syntax errors.
- Ran a small runtime check script to confirm the graph job keys are present in both Python `PROCESSORS` and `PYTHON_PRIMARY_JOB_KEYS`, and it returned positive for `compute_graph_sync` and `compute_graph_insights`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c337be363c832f9f82bdbd8d3b466c)