### PR TITLE
Normalize numeric fields in market comparison rows to prevent Decimal JSON errors

### DIFF
--- a/python/orchestrator/jobs/market_comparison.py
+++ b/python/orchestrator/jobs/market_comparison.py
@@ -10,7 +10,9 @@ from ..worker_runtime import WorkerStats, payload_checksum, resident_memory_byte
 
 def _evaluate_market_row(row: dict[str, Any], thresholds: dict[str, Any]) -> dict[str, Any]:
     alliance_price = float(row["alliance_best_sell_price"]) if row.get("alliance_best_sell_price") is not None else None
+    alliance_buy_price = float(row["alliance_best_buy_price"]) if row.get("alliance_best_buy_price") is not None else None
     reference_price = float(row["reference_best_sell_price"]) if row.get("reference_best_sell_price") is not None else None
+    reference_buy_price = float(row["reference_best_buy_price"]) if row.get("reference_best_buy_price") is not None else None
     alliance_sell_volume = int(row.get("alliance_total_sell_volume") or 0)
     alliance_sell_orders = int(row.get("alliance_sell_order_count") or 0)
     reference_sell_volume = int(row.get("reference_total_sell_volume") or 0)
@@ -55,6 +57,11 @@ def _evaluate_market_row(row: dict[str, Any], thresholds: dict[str, Any]) -> dic
 
     return {
         **row,
+        "type_id": int(row.get("type_id") or 0),
+        "alliance_best_sell_price": alliance_price,
+        "alliance_best_buy_price": alliance_buy_price,
+        "reference_best_sell_price": reference_price,
+        "reference_best_buy_price": reference_buy_price,
         "alliance_total_sell_volume": alliance_sell_volume,
         "alliance_sell_order_count": alliance_sell_orders,
         "reference_total_sell_volume": reference_sell_volume,

--- a/python/tests/test_market_comparison.py
+++ b/python/tests/test_market_comparison.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import unittest
+from decimal import Decimal
+
+from orchestrator.jobs.market_comparison import _evaluate_market_row
+
+
+class MarketComparisonTests(unittest.TestCase):
+    def test_evaluated_row_is_json_serializable(self) -> None:
+        row = {
+            "type_id": 34,
+            "type_name": "Tritanium",
+            "alliance_best_sell_price": Decimal("5.12"),
+            "alliance_best_buy_price": Decimal("5.02"),
+            "alliance_total_sell_volume": 1200,
+            "alliance_total_buy_volume": 800,
+            "alliance_sell_order_count": 12,
+            "alliance_buy_order_count": 8,
+            "alliance_last_observed_at": "2026-03-25 01:00:00",
+            "reference_best_sell_price": Decimal("4.89"),
+            "reference_best_buy_price": Decimal("4.80"),
+            "reference_total_sell_volume": 2200,
+            "reference_total_buy_volume": 1800,
+            "reference_sell_order_count": 22,
+            "reference_buy_order_count": 16,
+            "reference_last_observed_at": "2026-03-25 01:00:00",
+        }
+        thresholds = {
+            "deviation_percent": 5,
+            "min_alliance_sell_volume": 1000,
+            "min_alliance_sell_orders": 10,
+        }
+
+        evaluated = _evaluate_market_row(row, thresholds)
+        encoded = json.dumps(evaluated)
+
+        self.assertIsInstance(evaluated["alliance_best_sell_price"], float)
+        self.assertIsInstance(evaluated["reference_best_sell_price"], float)
+        self.assertIn('"type_id": 34', encoded)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Python worker runs were failing with "Object of type Decimal is not JSON serializable" when streaming market comparison snapshots through the PHP bridge. 
- Prevent Decimal values from leaking into snapshot payloads by converting DB-derived numeric fields to JSON-native primitives before they are included in the payload.

### Description
- Coerce numeric fields in `_evaluate_market_row()` to JSON-safe types by converting `type_id` to `int` and best-buy/best-sell price fields to `float` so `Decimal` instances are not present in the returned row dictionary (`python/orchestrator/jobs/market_comparison.py`).
- Add a regression unit test `python/tests/test_market_comparison.py` that constructs a row containing `Decimal` values, runs `_evaluate_market_row()`, and asserts that `json.dumps()` succeeds and the numeric fields are native Python types.

### Testing
- Ran the new unit test with module path set: `PYTHONPATH=python python -m unittest python/tests/test_market_comparison.py` which passed.
- Ran the full test suite in the tests folder with `PYTHONPATH=python python -m unittest discover -s python/tests` which passed (all tests OK).
- Note: running the single test without `PYTHONPATH` in this environment fails to import the `orchestrator` package, so tests must be executed with `PYTHONPATH=python` as shown above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c33a75b9c0832f8a19a790c58af301)