### PR TITLE
Fix compute job dispatch in Python scheduler workers

### DIFF
--- a/python/orchestrator/job_runner.py
+++ b/python/orchestrator/job_runner.py
@@ -12,6 +12,8 @@ from .bridge import PhpBridge
 from .config import load_php_runtime_config
 from .db import SupplyCoreDb
 from .jobs import (
+    run_compute_buy_all,
+    run_compute_signals,
     run_compute_graph_insights,
     run_compute_graph_sync,
     run_killmail_r2z2_stream,
@@ -52,7 +54,7 @@ class PythonWorkerContext:
 
     @property
     def job_key(self) -> str:
-        return str(self.job.get("job_key", ""))
+        return str(self.job.get("job_key", "")).strip()
 
     def emit(self, event: str, payload: dict[str, Any]) -> None:
         emit(event, payload)
@@ -70,6 +72,14 @@ PROCESSORS: dict[str, Callable[[PythonWorkerContext], dict[str, Any]]] = {
         run_compute_graph_insights(context.db, dict(context.raw_config.get("neo4j") or {})),
         "compute_graph_insights",
     ),
+    "compute_buy_all": lambda context: _compute_result_shape(
+        run_compute_buy_all(context.db),
+        "compute_buy_all",
+    ),
+    "compute_signals": lambda context: _compute_result_shape(
+        run_compute_signals(context.db, dict(context.raw_config.get("influx") or {})),
+        "compute_signals",
+    ),
 }
 
 
@@ -85,6 +95,22 @@ def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
         "rows_written": rows_written,
         "warnings": list(result.get("warnings") or []),
         "meta": dict(result.get("meta") or {}),
+    }
+
+
+def _compute_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
+    rows_processed = max(0, int(result.get("rows_processed") or 0))
+    rows_written = max(0, int(result.get("rows_written") or 0))
+    return {
+        "status": "success",
+        "summary": f"{job_key} completed successfully.",
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "meta": {
+            "job_name": job_key,
+            "computed_at": str(result.get("computed_at") or ""),
+            "result": dict(result),
+        },
     }
 
 

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -47,7 +47,7 @@ class WorkerPoolContext:
 
     @property
     def job_key(self) -> str:
-        return str(self.job.get("job_key") or "")
+        return str(self.job.get("job_key") or "").strip()
 
     @property
     def db_config(self) -> dict[str, Any]:


### PR DESCRIPTION
### Motivation
- Prevent compute scheduler jobs from falling back to the PHP bridge and failing with "No scheduler handler is registered" by ensuring Python workers dispatch them natively.
- Normalize `job_key` access to avoid accidental fallback when queued `job_key` values contain leading/trailing whitespace.

### Description
- Added imports for `run_compute_buy_all` and `run_compute_signals` and registered them in the Python `PROCESSORS` map in `python/orchestrator/job_runner.py` so those jobs are handled by Python processors instead of the PHP bridge.
- Introduced `_compute_result_shape` in `python/orchestrator/job_runner.py` to produce a consistent compute job result shape matching worker-pool semantics.
- Trimmed `job_key` via `.strip()` in both `python/orchestrator/job_runner.py` and `python/orchestrator/worker_pool.py` to normalize matching and avoid false negatives when looking up processors.

### Testing
- Ran Python bytecode compilation with `python3 -m py_compile python/orchestrator/job_runner.py python/orchestrator/worker_pool.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c39be083b8832fa9f6e2773030494b)