### PR TITLE
Add Battle Intelligence pipeline (DB schema, Python jobs, PHP UI, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ README.md
 - Configure connectivity in `src/config/local.php` under the new `influxdb` section. Keep it disabled until the InfluxDB service, bucket, token, and backfill plan are ready.
 - Detailed rollout guidance, schema mapping, read-path rules, retention, and rollback notes live in `docs/INFLUXDB_ROLLUP_OFFLOAD.md`.
 
+## Battle Intelligence Operations
+
+- Battle intelligence jobs are Python-only compute stages:
+  - `compute-battle-rollups`
+  - `compute-battle-target-metrics`
+  - `compute-battle-anomalies`
+  - `compute-battle-actor-features`
+  - `compute-suspicion-scores`
+- Dedicated JSONL logs default to `storage/logs/battle-intelligence.log` (override via `SUPPLYCORE_BATTLE_INTELLIGENCE_LOG_FILE` or `battle_intelligence.log_file` in `src/config/local.php`).
+- Manual validation SQL lives in `docs/BATTLE_INTELLIGENCE_VALIDATION.md`.
+- Full operator runbook (manual run order, dry-run usage, failure-mode troubleshooting, and sample outputs) lives in `docs/BATTLE_INTELLIGENCE_RUNBOOK.md`.
+
 ## Precomputed Intelligence Pipeline (MariaDB + InfluxDB + Python)
 
 - PHP request handlers now expect precomputed planner/signal datasets in MariaDB (`buy_all_summary`, `buy_all_items`, `signals`, `doctrine_readiness`) and avoid runtime-heavy planner computation.

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1383,6 +1383,165 @@ CREATE TABLE IF NOT EXISTS killmail_tracked_corporations (
     KEY idx_active (is_active)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS battle_rollups (
+    battle_id CHAR(64) PRIMARY KEY,
+    system_id INT UNSIGNED NOT NULL,
+    started_at DATETIME NOT NULL,
+    ended_at DATETIME NOT NULL,
+    duration_seconds INT UNSIGNED NOT NULL DEFAULT 0,
+    participant_count INT UNSIGNED NOT NULL DEFAULT 0,
+    eligible_for_suspicion TINYINT(1) NOT NULL DEFAULT 0,
+    battle_size_class VARCHAR(30) NOT NULL DEFAULT 'small',
+    computed_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_battle_rollups_system_started (system_id, started_at),
+    KEY idx_battle_rollups_eligible (eligible_for_suspicion, started_at),
+    KEY idx_battle_rollups_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS battle_participants (
+    battle_id CHAR(64) NOT NULL,
+    character_id BIGINT UNSIGNED NOT NULL,
+    corporation_id BIGINT UNSIGNED DEFAULT NULL,
+    alliance_id BIGINT UNSIGNED DEFAULT NULL,
+    side_key VARCHAR(80) NOT NULL,
+    ship_type_id INT UNSIGNED DEFAULT NULL,
+    is_logi TINYINT(1) NOT NULL DEFAULT 0,
+    is_command TINYINT(1) NOT NULL DEFAULT 0,
+    is_capital TINYINT(1) NOT NULL DEFAULT 0,
+    participation_count INT UNSIGNED NOT NULL DEFAULT 0,
+    computed_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (battle_id, character_id),
+    KEY idx_battle_participants_character (character_id, battle_id),
+    KEY idx_battle_participants_side (battle_id, side_key),
+    KEY idx_battle_participants_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS battle_target_metrics (
+    battle_id CHAR(64) NOT NULL,
+    killmail_id BIGINT UNSIGNED NOT NULL,
+    victim_character_id BIGINT UNSIGNED DEFAULT NULL,
+    victim_ship_type_id INT UNSIGNED DEFAULT NULL,
+    side_key VARCHAR(80) NOT NULL,
+    first_damage_ts DATETIME NOT NULL,
+    last_damage_ts DATETIME NOT NULL,
+    time_to_die_seconds DECIMAL(12,4) NOT NULL DEFAULT 0.0000,
+    total_damage_taken DECIMAL(20,4) NOT NULL DEFAULT 0.0000,
+    estimated_incoming_dps DECIMAL(20,6) NOT NULL DEFAULT 0.000000,
+    dps_bucket VARCHAR(20) NOT NULL,
+    expected_time_to_die_seconds DECIMAL(12,4) NOT NULL DEFAULT 0.0000,
+    sustain_factor DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    computed_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (battle_id, killmail_id),
+    KEY idx_battle_target_metrics_ship_bucket (victim_ship_type_id, dps_bucket),
+    KEY idx_battle_target_metrics_side (battle_id, side_key),
+    KEY idx_battle_target_metrics_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS battle_side_metrics (
+    battle_id CHAR(64) NOT NULL,
+    side_key VARCHAR(80) NOT NULL,
+    participant_count INT UNSIGNED NOT NULL DEFAULT 0,
+    logi_count INT UNSIGNED NOT NULL DEFAULT 0,
+    command_count INT UNSIGNED NOT NULL DEFAULT 0,
+    capital_count INT UNSIGNED NOT NULL DEFAULT 0,
+    total_kills INT UNSIGNED NOT NULL DEFAULT 0,
+    kill_rate_per_minute DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    median_sustain_factor DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    average_sustain_factor DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    switch_pressure DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    efficiency_score DECIMAL(14,8) NOT NULL DEFAULT 0.00000000,
+    z_efficiency_score DECIMAL(14,8) NOT NULL DEFAULT 0.00000000,
+    computed_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (battle_id, side_key),
+    KEY idx_battle_side_metrics_efficiency (efficiency_score),
+    KEY idx_battle_side_metrics_z (z_efficiency_score),
+    KEY idx_battle_side_metrics_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS battle_anomalies (
+    battle_id CHAR(64) NOT NULL,
+    side_key VARCHAR(80) NOT NULL,
+    anomaly_class VARCHAR(20) NOT NULL,
+    z_efficiency_score DECIMAL(14,8) NOT NULL DEFAULT 0.00000000,
+    percentile_rank DECIMAL(10,6) NOT NULL DEFAULT 0.000000,
+    explanation_json LONGTEXT NOT NULL,
+    computed_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (battle_id, side_key),
+    KEY idx_battle_anomalies_class (anomaly_class, z_efficiency_score),
+    KEY idx_battle_anomalies_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS battle_actor_features (
+    battle_id CHAR(64) NOT NULL,
+    character_id BIGINT UNSIGNED NOT NULL,
+    side_key VARCHAR(80) NOT NULL,
+    participation_count INT UNSIGNED NOT NULL DEFAULT 0,
+    centrality_score DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    visibility_score DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    is_logi TINYINT(1) NOT NULL DEFAULT 0,
+    is_command TINYINT(1) NOT NULL DEFAULT 0,
+    is_capital TINYINT(1) NOT NULL DEFAULT 0,
+    participated_in_high_sustain TINYINT(1) NOT NULL DEFAULT 0,
+    participated_in_low_sustain TINYINT(1) NOT NULL DEFAULT 0,
+    computed_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (battle_id, character_id),
+    KEY idx_battle_actor_features_character (character_id, battle_id),
+    KEY idx_battle_actor_features_flags (participated_in_high_sustain, participated_in_low_sustain),
+    KEY idx_battle_actor_features_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS character_battle_intelligence (
+    character_id BIGINT UNSIGNED PRIMARY KEY,
+    total_battle_count INT UNSIGNED NOT NULL DEFAULT 0,
+    eligible_battle_count INT UNSIGNED NOT NULL DEFAULT 0,
+    high_sustain_battle_count INT UNSIGNED NOT NULL DEFAULT 0,
+    low_sustain_battle_count INT UNSIGNED NOT NULL DEFAULT 0,
+    high_sustain_frequency DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    low_sustain_frequency DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    cross_side_battle_count INT UNSIGNED NOT NULL DEFAULT 0,
+    cross_side_rate DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    enemy_efficiency_uplift DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    ally_efficiency_uplift DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    role_weight DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    anomalous_battle_density DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    computed_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_character_battle_intelligence_support (eligible_battle_count, high_sustain_frequency),
+    KEY idx_character_battle_intelligence_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS character_suspicion_scores (
+    character_id BIGINT UNSIGNED PRIMARY KEY,
+    suspicion_score DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    percentile_rank DECIMAL(10,6) NOT NULL DEFAULT 0.000000,
+    high_sustain_frequency DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    low_sustain_frequency DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    cross_side_rate DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    enemy_efficiency_uplift DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    role_weight DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
+    supporting_battle_count INT UNSIGNED NOT NULL DEFAULT 0,
+    top_supporting_battles_json LONGTEXT NOT NULL,
+    explanation_json LONGTEXT NOT NULL,
+    computed_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_character_suspicion_scores_rank (suspicion_score, percentile_rank),
+    KEY idx_character_suspicion_scores_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS entity_metadata_cache (
     entity_type ENUM('alliance', 'corporation', 'character', 'type', 'system', 'region') NOT NULL,
     entity_id BIGINT UNSIGNED NOT NULL,
@@ -2363,7 +2522,12 @@ INSERT INTO sync_schedules (
     ('deal_alerts_sync', 1, 5, 300, 60, 1, 'high', 'single', 'python', 90, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
     ('activity_priority_summary_sync', 1, 15, 900, 780, 13, 'normal', 'single', 'php', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 0, NULL, NULL, NULL, NULL),
     ('analytics_bucket_1h_sync', 1, 15, 900, 900, 15, 'normal', 'single', 'php', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 0, NULL, NULL, NULL, NULL),
-    ('analytics_bucket_1d_sync', 1, 60, 3600, 960, 16, 'normal', 'single', 'php', 240, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 0, NULL, NULL, NULL, NULL)
+    ('analytics_bucket_1d_sync', 1, 60, 3600, 960, 16, 'normal', 'single', 'php', 240, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 0, NULL, NULL, NULL, NULL),
+    ('compute_battle_rollups', 1, 10, 600, 1260, 21, 'normal', 'single', 'python', 420, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('compute_battle_target_metrics', 1, 10, 600, 1320, 22, 'normal', 'single', 'python', 420, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('compute_battle_anomalies', 1, 10, 600, 1380, 23, 'normal', 'single', 'python', 420, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('compute_battle_actor_features', 1, 10, 600, 1440, 24, 'normal', 'single', 'python', 420, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('compute_suspicion_scores', 1, 10, 600, 1500, 25, 'normal', 'single', 'python', 420, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL)
 ON DUPLICATE KEY UPDATE
     enabled = VALUES(enabled),
     interval_minutes = VALUES(interval_minutes),

--- a/docs/BATTLE_INTELLIGENCE_RUNBOOK.md
+++ b/docs/BATTLE_INTELLIGENCE_RUNBOOK.md
@@ -1,0 +1,220 @@
+# Battle Intelligence Operator Runbook
+
+This runbook explains how to manually run, validate, and debug the Battle Intelligence pipeline in production.
+
+## 1) Architecture and table flow
+
+Heavy compute is Python-only. PHP pages are read-only from MariaDB materialized outputs.
+
+### Job dependency chain
+
+1. `compute-battle-rollups`
+   - writes: `battle_rollups`, `battle_participants`
+2. `compute-battle-target-metrics`
+   - writes: `battle_target_metrics`
+3. `compute-battle-anomalies`
+   - writes: `battle_side_metrics`, `battle_anomalies`
+4. `compute-battle-actor-features`
+   - writes: `battle_actor_features`
+   - optional Neo4j sync of `(:Character)-[:PARTICIPATED_IN]->(:Battle)`
+5. `compute-suspicion-scores`
+   - writes: `character_battle_intelligence`, `character_suspicion_scores`
+
+Optional graph jobs:
+- `compute-graph-sync`
+- `compute-graph-insights`
+
+## 2) Prerequisites
+
+- Activate virtualenv used by orchestrator.
+- Ensure MariaDB connectivity is valid in `src/config/local.php`.
+- Ensure scheduler/worker service is running (if using scheduled mode).
+- Optional: ensure Neo4j is enabled and reachable for graph enhancement.
+
+## 3) Dedicated logfile
+
+Battle jobs write JSONL to:
+
+- default: `storage/logs/battle-intelligence.log`
+- override with `SUPPLYCORE_BATTLE_INTELLIGENCE_LOG_FILE`
+- or set `battle_intelligence.log_file` in `src/config/local.php`
+
+Tail logs:
+
+```bash
+tail -f storage/logs/battle-intelligence.log
+```
+
+## 4) Manual CLI commands
+
+Run from repo root (with venv active):
+
+```bash
+python bin/python_orchestrator.py compute-battle-rollups
+python bin/python_orchestrator.py compute-battle-target-metrics
+python bin/python_orchestrator.py compute-battle-anomalies
+python bin/python_orchestrator.py compute-battle-actor-features
+python bin/python_orchestrator.py compute-suspicion-scores
+```
+
+Dry-run mode (compute + log counters, no table writes):
+
+```bash
+python bin/python_orchestrator.py compute-battle-rollups --dry-run
+python bin/python_orchestrator.py compute-battle-target-metrics --dry-run
+python bin/python_orchestrator.py compute-battle-anomalies --dry-run
+python bin/python_orchestrator.py compute-battle-actor-features --dry-run
+python bin/python_orchestrator.py compute-suspicion-scores --dry-run
+```
+
+### Optional graph commands
+
+```bash
+python bin/python_orchestrator.py compute-graph-sync
+python bin/python_orchestrator.py compute-graph-insights
+```
+
+## 5) First-run sequence (recommended)
+
+1. Execute all five battle jobs in dependency order.
+2. Run SQL validation in `docs/BATTLE_INTELLIGENCE_VALIDATION.md`.
+3. Confirm leaderboard pages render:
+   - `/battle-intelligence`
+   - `/battle-intelligence/battles.php`
+
+## 6) What healthy output looks like
+
+- `battle_rollups` contains rows from recent killmails.
+- `battle_rollups.eligible_for_suspicion = 1` has non-zero count for active large fights.
+- `battle_anomalies` contains mostly `normal`, some `high_sustain` / `low_sustain`.
+- `character_suspicion_scores` has rows with non-zero `supporting_battle_count`.
+- `job_runs` shows recent `success` statuses with non-zero writes (unless dry-run).
+
+## 7) Example CLI outputs
+
+### Successful
+
+```json
+{"command":"compute-battle-rollups","status":"success","rows_processed":8421,"rows_written":612,"rows_would_write":612,"duration_ms":1843,"result":{"job_name":"compute_battle_rollups","status":"success","battle_count":103,"eligible_battle_count":9,"dry_run":false}}
+```
+
+### Failed
+
+```json
+{"command":"compute-battle-anomalies","status":"failed","rows_processed":0,"rows_written":0,"rows_would_write":0,"duration_ms":102,"result":{"status":"failed","error_text":"(2003, 'Can\'t connect to MySQL server')"}}
+```
+
+## 8) Example log JSON entries
+
+### Successful log entry
+
+```json
+{"event":"battle_intelligence.job.success","timestamp":"2026-03-25T12:00:01.000000+00:00","job_name":"compute_suspicion_scores","status":"success","rows_processed":2750,"rows_written":644,"scored_character_count":322,"minimum_sample_filtered_count":41,"duration_ms":973}
+```
+
+### Failed log entry
+
+```json
+{"event":"battle_intelligence.job.failed","timestamp":"2026-03-25T12:02:10.000000+00:00","job_name":"compute_battle_target_metrics","status":"failed","rows_processed":1331,"rows_written":0,"error_text":"division by zero"}
+```
+
+## 9) Common failure modes and troubleshooting
+
+### A) `battle_rollups` is empty
+Possible causes:
+- no recent killmail ingestion
+- `killmail_events.effective_killmail_at` outside window
+- system IDs missing
+
+Check:
+- `SELECT COUNT(*) FROM killmail_events WHERE effective_killmail_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 45 DAY);`
+- recent `job_runs` for `killmail_r2z2_sync` and `compute_battle_rollups`
+
+Action:
+- rerun killmail ingestion and then `compute-battle-rollups`.
+
+### B) No eligible battles
+Possible causes:
+- active period lacks large fights
+- participant extraction too sparse
+
+Check:
+- distribution of `battle_rollups.participant_count`
+- whether attacker/victim character IDs are present
+
+Action:
+- inspect `battle_participants` counts per `battle_id`; rerun rollups.
+
+### C) No anomalies (`high_sustain`/`low_sustain`)
+Possible causes:
+- too little variance in efficiency scores
+- too small sample of eligible battles
+
+Check:
+- `SELECT MIN(efficiency_score), MAX(efficiency_score), AVG(efficiency_score), STDDEV_POP(efficiency_score) FROM battle_side_metrics;`
+
+Action:
+- validate target metrics and sustain factors first; rerun anomalies.
+
+### D) No suspicious characters
+Possible causes:
+- `eligible_battle_count` below minimum sample threshold
+- upstream actor/anomaly tables empty
+
+Check:
+- counts in `battle_actor_features`, `character_battle_intelligence`
+- `minimum_sample_filtered_count` in logs
+
+Action:
+- rerun full chain and inspect eligible battle volume.
+
+### E) Flat scores
+Possible causes:
+- little variation in anomaly z-scores
+- most characters filtered to low samples
+
+Check:
+- histogram/distribution of `character_suspicion_scores.suspicion_score`
+- variance in `battle_side_metrics.z_efficiency_score`
+
+Action:
+- validate anomaly stage inputs and job logs.
+
+### F) Malformed evidence JSON
+Possible causes:
+- legacy stale rows from old run
+- interrupted writes
+
+Check:
+- `JSON_VALID(explanation_json)` and `JSON_VALID(top_supporting_battles_json)`
+
+Action:
+- rerun `compute-suspicion-scores`.
+
+### G) Scheduler runs but no writes
+Possible causes:
+- dry-run accidentally used in manual tests
+- lock contention or no-op due empty upstream tables
+
+Check:
+- battle log JSON entries (`status`, `rows_would_write`, `reason`)
+- `compute_job_locks` and `job_runs`
+
+Action:
+- run job manually without `--dry-run`; verify upstream tables first.
+
+### H) Neo4j enhancement missing
+Possible causes:
+- Neo4j disabled in config
+- connectivity/auth issue
+
+Check:
+- battle log `neo4j` payload from `compute_battle_actor_features`
+- `neo4j.enabled` and connection settings
+
+Action:
+- enable/fix Neo4j config, rerun `compute-battle-actor-features`.
+
+## 10) Validation SQL
+
+Use: `docs/BATTLE_INTELLIGENCE_VALIDATION.md`.

--- a/docs/BATTLE_INTELLIGENCE_VALIDATION.md
+++ b/docs/BATTLE_INTELLIGENCE_VALIDATION.md
@@ -1,0 +1,95 @@
+# Battle Intelligence Validation SQL
+
+Run these after the battle job chain in order:
+
+1. `compute-battle-rollups`
+2. `compute-battle-target-metrics`
+3. `compute-battle-anomalies`
+4. `compute-battle-actor-features`
+5. `compute-suspicion-scores`
+
+```sql
+-- 1) Clustered battle count
+SELECT COUNT(*) AS battle_count FROM battle_rollups;
+
+-- 2) Eligible battle count (>= 100 distinct participants)
+SELECT COUNT(*) AS eligible_battle_count
+FROM battle_rollups
+WHERE eligible_for_suspicion = 1;
+
+-- 3) Anomaly class counts
+SELECT anomaly_class, COUNT(*) AS side_count
+FROM battle_anomalies
+GROUP BY anomaly_class
+ORDER BY side_count DESC;
+
+-- 4) Top 20 anomalous battle sides
+SELECT ba.battle_id, ba.side_key, ba.anomaly_class, ba.z_efficiency_score, ba.percentile_rank,
+       br.system_id, rs.system_name, br.participant_count, br.started_at, br.ended_at
+FROM battle_anomalies ba
+INNER JOIN battle_rollups br ON br.battle_id = ba.battle_id
+LEFT JOIN ref_systems rs ON rs.system_id = br.system_id
+ORDER BY ba.z_efficiency_score DESC
+LIMIT 20;
+
+-- 5) Top 20 suspicious characters
+SELECT css.character_id,
+       COALESCE(emc.entity_name, CONCAT('Character #', css.character_id)) AS character_name,
+       css.suspicion_score,
+       css.percentile_rank,
+       css.high_sustain_frequency,
+       css.low_sustain_frequency,
+       css.cross_side_rate,
+       css.enemy_efficiency_uplift,
+       css.supporting_battle_count
+FROM character_suspicion_scores css
+LEFT JOIN entity_metadata_cache emc ON emc.entity_type = 'character' AND emc.entity_id = css.character_id
+ORDER BY css.suspicion_score DESC
+LIMIT 20;
+
+-- 6) Character drilldown sample (replace ? with a character_id)
+SELECT css.character_id,
+       css.suspicion_score,
+       css.explanation_json,
+       css.top_supporting_battles_json,
+       cbi.total_battle_count,
+       cbi.eligible_battle_count,
+       cbi.high_sustain_frequency,
+       cbi.low_sustain_frequency,
+       cbi.cross_side_rate,
+       cbi.enemy_efficiency_uplift,
+       cbi.ally_efficiency_uplift
+FROM character_suspicion_scores css
+INNER JOIN character_battle_intelligence cbi ON cbi.character_id = css.character_id
+WHERE css.character_id = ?;
+
+-- 7) Battle drilldown sample (replace ? with a battle_id)
+SELECT br.battle_id, br.system_id, rs.system_name, br.started_at, br.ended_at,
+       br.duration_seconds, br.participant_count, br.eligible_for_suspicion, br.battle_size_class
+FROM battle_rollups br
+LEFT JOIN ref_systems rs ON rs.system_id = br.system_id
+WHERE br.battle_id = ?;
+
+SELECT bsm.battle_id, bsm.side_key, bsm.participant_count, bsm.logi_count, bsm.command_count,
+       bsm.capital_count, bsm.total_kills, bsm.kill_rate_per_minute,
+       bsm.median_sustain_factor, bsm.average_sustain_factor,
+       bsm.efficiency_score, bsm.z_efficiency_score,
+       ba.anomaly_class, ba.explanation_json
+FROM battle_side_metrics bsm
+LEFT JOIN battle_anomalies ba ON ba.battle_id = bsm.battle_id AND ba.side_key = bsm.side_key
+WHERE bsm.battle_id = ?
+ORDER BY bsm.z_efficiency_score DESC;
+
+-- 8) Recent job_runs for battle jobs
+SELECT job_name, status, duration_ms, rows_processed, rows_written, error_text, started_at, finished_at
+FROM job_runs
+WHERE job_name IN (
+    'compute_battle_rollups',
+    'compute_battle_target_metrics',
+    'compute_battle_anomalies',
+    'compute_battle_actor_features',
+    'compute_suspicion_scores'
+)
+ORDER BY started_at DESC
+LIMIT 50;
+```

--- a/public/battle-intelligence/battle.php
+++ b/public/battle-intelligence/battle.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$battleId = trim((string) ($_GET['battle_id'] ?? ''));
+$title = 'Battle Drilldown';
+$data = battle_intelligence_battle_data($battleId);
+$battle = $data['battle'] ?? null;
+$sides = (array) ($data['sides'] ?? []);
+$actors = (array) ($data['actors'] ?? []);
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<section class="surface-primary">
+    <a href="/battle-intelligence/battles.php" class="text-sm text-accent">← Back to anomalies</a>
+    <?php if (!is_array($battle)): ?>
+        <p class="mt-4 text-sm text-muted">Battle not found.</p>
+    <?php else: ?>
+        <h1 class="mt-2 text-2xl font-semibold text-slate-50"><?= htmlspecialchars((string) ($battle['system_name'] ?? 'Unknown system'), ENT_QUOTES) ?></h1>
+        <p class="mt-2 text-sm text-muted">Battle <?= htmlspecialchars((string) ($battle['battle_id'] ?? ''), ENT_QUOTES) ?> · Participants <?= (int) ($battle['participant_count'] ?? 0) ?> · <?= htmlspecialchars((string) ($battle['started_at'] ?? ''), ENT_QUOTES) ?> to <?= htmlspecialchars((string) ($battle['ended_at'] ?? ''), ENT_QUOTES) ?></p>
+
+        <h2 class="mt-6 text-lg font-semibold text-slate-100">Side metrics</h2>
+        <div class="mt-3 table-shell"><table class="table-ui"><thead><tr class="border-b border-border/70 text-xs uppercase text-muted"><th class="px-3 py-2 text-left">Side</th><th class="px-3 py-2 text-left">Class</th><th class="px-3 py-2 text-right">Participants</th><th class="px-3 py-2 text-right">Kill/min</th><th class="px-3 py-2 text-right">Median sustain</th><th class="px-3 py-2 text-right">z-score</th></tr></thead><tbody><?php foreach ($sides as $side): ?><tr class="border-b border-border/40"><td class="px-3 py-2"><?= htmlspecialchars((string) ($side['side_key'] ?? ''), ENT_QUOTES) ?></td><td class="px-3 py-2"><?= htmlspecialchars((string) ($side['anomaly_class'] ?? 'normal'), ENT_QUOTES) ?></td><td class="px-3 py-2 text-right"><?= (int) ($side['participant_count'] ?? 0) ?></td><td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($side['kill_rate_per_minute'] ?? 0), 3), ENT_QUOTES) ?></td><td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($side['median_sustain_factor'] ?? 0), 3), ENT_QUOTES) ?></td><td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($side['z_efficiency_score'] ?? 0), 3), ENT_QUOTES) ?></td></tr><?php endforeach; ?></tbody></table></div>
+
+        <h2 class="mt-6 text-lg font-semibold text-slate-100">Notable actors</h2>
+        <div class="mt-3 table-shell"><table class="table-ui"><thead><tr class="border-b border-border/70 text-xs uppercase text-muted"><th class="px-3 py-2 text-left">Character</th><th class="px-3 py-2 text-left">Side</th><th class="px-3 py-2 text-right">Centrality</th><th class="px-3 py-2 text-right">Visibility</th></tr></thead><tbody><?php foreach ($actors as $actor): ?><tr class="border-b border-border/40"><td class="px-3 py-2"><?= htmlspecialchars((string) ($actor['character_name'] ?? ''), ENT_QUOTES) ?></td><td class="px-3 py-2"><?= htmlspecialchars((string) ($actor['side_key'] ?? ''), ENT_QUOTES) ?></td><td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($actor['centrality_score'] ?? 0), 3), ENT_QUOTES) ?></td><td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($actor['visibility_score'] ?? 0), 3), ENT_QUOTES) ?></td></tr><?php endforeach; ?></tbody></table></div>
+    <?php endif; ?>
+</section>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/battle-intelligence/battles.php
+++ b/public/battle-intelligence/battles.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Battle Anomalies';
+$data = battle_intelligence_anomaly_leaderboard_data();
+$rows = (array) ($data['rows'] ?? []);
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<section class="surface-primary">
+    <h1 class="text-2xl font-semibold text-slate-50">Battle anomaly leaderboard</h1>
+    <p class="mt-2 text-sm text-muted">Sides ranked by z-scored battle efficiency.</p>
+
+    <div class="mt-5 table-shell">
+        <table class="table-ui">
+            <thead><tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted"><th class="px-3 py-2 text-left">Battle</th><th class="px-3 py-2 text-left">Side</th><th class="px-3 py-2 text-left">Class</th><th class="px-3 py-2 text-right">z-score</th><th class="px-3 py-2 text-right">Participants</th><th class="px-3 py-2 text-right">Inspect</th></tr></thead>
+            <tbody>
+            <?php foreach ($rows as $row): ?>
+                <tr class="border-b border-border/50">
+                    <td class="px-3 py-2"><?= htmlspecialchars((string) ($row['system_name'] ?? 'Unknown'), ENT_QUOTES) ?><div class="text-xs text-muted"><?= htmlspecialchars((string) ($row['started_at'] ?? ''), ENT_QUOTES) ?></div></td>
+                    <td class="px-3 py-2"><?= htmlspecialchars((string) ($row['side_key'] ?? 'unknown'), ENT_QUOTES) ?></td>
+                    <td class="px-3 py-2"><?= htmlspecialchars((string) ($row['anomaly_class'] ?? 'normal'), ENT_QUOTES) ?></td>
+                    <td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($row['z_efficiency_score'] ?? 0), 3), ENT_QUOTES) ?></td>
+                    <td class="px-3 py-2 text-right"><?= (int) ($row['participant_count'] ?? 0) ?></td>
+                    <td class="px-3 py-2 text-right"><a class="text-accent" href="/battle-intelligence/battle.php?battle_id=<?= urlencode((string) ($row['battle_id'] ?? '')) ?>">Drilldown</a></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</section>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/battle-intelligence/character.php
+++ b/public/battle-intelligence/character.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$characterId = max(0, (int) ($_GET['character_id'] ?? 0));
+$title = 'Character Intelligence';
+$data = battle_intelligence_character_data($characterId);
+$character = $data['character'] ?? null;
+$battles = (array) ($data['battles'] ?? []);
+$explanation = (array) ($data['explanation'] ?? []);
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<section class="surface-primary">
+    <a href="/battle-intelligence" class="text-sm text-accent">← Back to leaderboard</a>
+    <?php if (!is_array($character)): ?>
+        <p class="mt-4 text-sm text-muted">No character intelligence found.</p>
+    <?php else: ?>
+        <h1 class="mt-2 text-2xl font-semibold text-slate-50"><?= htmlspecialchars((string) ($character['character_name'] ?? 'Unknown'), ENT_QUOTES) ?></h1>
+        <div class="mt-4 grid gap-3 md:grid-cols-3">
+            <div class="surface-tertiary"><p class="text-xs text-muted">Suspicion score</p><p class="mt-1 text-xl text-slate-100"><?= htmlspecialchars(number_format((float) ($character['suspicion_score'] ?? 0), 4), ENT_QUOTES) ?></p></div>
+            <div class="surface-tertiary"><p class="text-xs text-muted">High/Low sustain frequency</p><p class="mt-1 text-xl text-slate-100"><?= htmlspecialchars(number_format((float) ($character['high_sustain_frequency'] ?? 0), 3), ENT_QUOTES) ?> / <?= htmlspecialchars(number_format((float) ($character['low_sustain_frequency'] ?? 0), 3), ENT_QUOTES) ?></p></div>
+            <div class="surface-tertiary"><p class="text-xs text-muted">Cross-side / Enemy uplift</p><p class="mt-1 text-xl text-slate-100"><?= htmlspecialchars(number_format((float) ($character['cross_side_rate'] ?? 0), 3), ENT_QUOTES) ?> / <?= htmlspecialchars(number_format((float) ($character['enemy_efficiency_uplift'] ?? 0), 3), ENT_QUOTES) ?></p></div>
+        </div>
+        <details class="mt-4 surface-tertiary"><summary class="cursor-pointer text-sm text-slate-100">Score explanation payload</summary><pre class="mt-3 overflow-auto text-xs text-slate-300"><?= htmlspecialchars(json_encode($explanation, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?: '{}', ENT_QUOTES) ?></pre></details>
+
+        <h2 class="mt-6 text-lg font-semibold text-slate-100">Supporting battles</h2>
+        <div class="mt-3 table-shell"><table class="table-ui"><thead><tr class="border-b border-border/70 text-xs text-muted uppercase"><th class="px-3 py-2 text-left">Battle</th><th class="px-3 py-2 text-left">Side</th><th class="px-3 py-2 text-right">z-score</th><th class="px-3 py-2 text-right">Inspect</th></tr></thead><tbody><?php foreach ($battles as $battle): ?><tr class="border-b border-border/40"><td class="px-3 py-2"><?= htmlspecialchars((string) ($battle['system_name'] ?? 'Unknown'), ENT_QUOTES) ?><div class="text-xs text-muted"><?= htmlspecialchars((string) ($battle['started_at'] ?? ''), ENT_QUOTES) ?></div></td><td class="px-3 py-2"><?= htmlspecialchars((string) ($battle['side_key'] ?? 'unknown'), ENT_QUOTES) ?></td><td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($battle['z_efficiency_score'] ?? 0), 3), ENT_QUOTES) ?></td><td class="px-3 py-2 text-right"><a class="text-accent" href="/battle-intelligence/battle.php?battle_id=<?= urlencode((string) ($battle['battle_id'] ?? '')) ?>">Battle</a></td></tr><?php endforeach; ?></tbody></table></div>
+    <?php endif; ?>
+</section>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/battle-intelligence/index.php
+++ b/public/battle-intelligence/index.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Battle Suspicion Leaderboard';
+$data = battle_intelligence_leaderboard_data();
+$rows = (array) ($data['rows'] ?? []);
+$computedAt = (string) ($data['computed_at'] ?? '');
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<section class="surface-primary">
+    <div class="flex items-center justify-between gap-4">
+        <div>
+            <p class="text-xs uppercase tracking-[0.16em] text-muted">Battle intelligence</p>
+            <h1 class="mt-1 text-2xl font-semibold text-slate-50">Suspicious character leaderboard</h1>
+            <p class="mt-2 text-sm text-muted">Precomputed by Python jobs from battle clustering, sustain anomalies, and cross-side recurrence.</p>
+        </div>
+        <a href="/battle-intelligence/battles.php" class="btn-secondary">View anomalous battles</a>
+    </div>
+    <p class="mt-4 text-xs text-muted">Computed at <?= htmlspecialchars($computedAt !== '' ? $computedAt : 'unavailable', ENT_QUOTES) ?></p>
+
+    <div class="mt-5 table-shell">
+        <table class="table-ui">
+            <thead>
+            <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                <th class="px-3 py-2 text-left">Character</th>
+                <th class="px-3 py-2 text-right">Score</th>
+                <th class="px-3 py-2 text-right">Percentile</th>
+                <th class="px-3 py-2 text-right">High sustain freq</th>
+                <th class="px-3 py-2 text-right">Cross-side rate</th>
+                <th class="px-3 py-2 text-right">Enemy uplift</th>
+                <th class="px-3 py-2 text-right">Battles</th>
+                <th class="px-3 py-2 text-right">Inspect</th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php if ($rows === []): ?>
+                <tr><td colspan="8" class="px-3 py-6 text-sm text-muted">No scored characters yet. Run compute_battle_* and compute_suspicion_scores jobs.</td></tr>
+            <?php else: ?>
+                <?php foreach ($rows as $row): ?>
+                    <tr class="border-b border-border/50">
+                        <td class="px-3 py-2 text-slate-100"><?= htmlspecialchars((string) ($row['character_name'] ?? 'Unknown'), ENT_QUOTES) ?></td>
+                        <td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($row['suspicion_score'] ?? 0), 4), ENT_QUOTES) ?></td>
+                        <td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($row['percentile_rank'] ?? 0) * 100, 1), ENT_QUOTES) ?>%</td>
+                        <td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($row['high_sustain_frequency'] ?? 0), 3), ENT_QUOTES) ?></td>
+                        <td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($row['cross_side_rate'] ?? 0), 3), ENT_QUOTES) ?></td>
+                        <td class="px-3 py-2 text-right"><?= htmlspecialchars(number_format((float) ($row['enemy_efficiency_uplift'] ?? 0), 3), ENT_QUOTES) ?></td>
+                        <td class="px-3 py-2 text-right"><?= (int) ($row['supporting_battle_count'] ?? 0) ?></td>
+                        <td class="px-3 py-2 text-right"><a class="text-accent" href="/battle-intelligence/character.php?character_id=<?= urlencode((string) ((int) ($row['character_id'] ?? 0))) ?>">Drilldown</a></td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+</section>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/python/orchestrator/jobs/__init__.py
+++ b/python/orchestrator/jobs/__init__.py
@@ -5,3 +5,10 @@ from .compute_buy_all import run_compute_buy_all
 from .compute_signals import run_compute_signals
 from .compute_graph_sync import run_compute_graph_sync
 from .compute_graph_insights import run_compute_graph_insights
+from .battle_intelligence import (
+    run_compute_battle_actor_features,
+    run_compute_battle_anomalies,
+    run_compute_battle_rollups,
+    run_compute_battle_target_metrics,
+    run_compute_suspicion_scores,
+)

--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -1,0 +1,1054 @@
+from __future__ import annotations
+
+import json
+import math
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from ..db import SupplyCoreDb
+from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+from ..neo4j import Neo4jClient, Neo4jConfig
+
+WINDOW_SECONDS = 15 * 60
+MIN_ELIGIBLE_PARTICIPANTS = 100
+MIN_SAMPLE_COUNT = 5
+EPSILON = 1e-6
+
+
+def _now_sql() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _safe_div(numerator: float, denominator: float, default: float = 0.0) -> float:
+    if denominator <= 0:
+        return default
+    return numerator / denominator
+
+
+def _dps_bucket(dps: float) -> str:
+    if dps < 100:
+        return "lt_100"
+    if dps < 250:
+        return "100_249"
+    if dps < 500:
+        return "250_499"
+    if dps < 1000:
+        return "500_999"
+    if dps < 2000:
+        return "1000_1999"
+    return "gte_2000"
+
+
+def _battle_size_class(participant_count: int) -> str:
+    if participant_count >= 200:
+        return "mega"
+    if participant_count >= 100:
+        return "large"
+    if participant_count >= 50:
+        return "medium"
+    return "small"
+
+
+def _percentile(sorted_values: list[float], value: float) -> float:
+    if not sorted_values:
+        return 0.0
+    below = 0
+    for candidate in sorted_values:
+        if candidate <= value:
+            below += 1
+        else:
+            break
+    return _safe_div(float(below), float(len(sorted_values)), 0.0)
+
+
+def _stddev(values: list[float]) -> float:
+    if len(values) <= 1:
+        return 0.0
+    mean = sum(values) / len(values)
+    variance = sum((value - mean) ** 2 for value in values) / len(values)
+    return math.sqrt(max(0.0, variance))
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except Exception:
+            return str(value)
+    if isinstance(value, Exception):
+        return {"error_type": value.__class__.__name__, "error": str(value)}
+    return str(value)
+
+
+def _battle_log(runtime: dict[str, Any] | None, event: str, payload: dict[str, Any]) -> None:
+    log_path = str(((runtime or {}).get("log_file") or "")).strip()
+    if log_path == "":
+        return
+    path = Path(log_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {"event": event, "timestamp": datetime.now(UTC).isoformat(), **payload}
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False, default=_json_default) + "\n")
+
+
+def _neo4j_sync_participation(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:
+    config = Neo4jConfig.from_runtime(neo4j_raw or {})
+    if not config.enabled:
+        return {"status": "skipped", "reason": "neo4j disabled", "rows_written": 0}
+
+    rows = db.fetch_all(
+        """
+        SELECT
+            baf.battle_id,
+            br.system_id,
+            br.started_at,
+            br.ended_at,
+            baf.character_id,
+            baf.side_key,
+            baf.centrality_score,
+            baf.visibility_score,
+            COALESCE(bp.alliance_id, 0) AS alliance_id,
+            COALESCE(bp.corporation_id, 0) AS corporation_id
+        FROM battle_actor_features baf
+        INNER JOIN battle_rollups br ON br.battle_id = baf.battle_id
+        INNER JOIN battle_participants bp ON bp.battle_id = baf.battle_id AND bp.character_id = baf.character_id
+        WHERE br.eligible_for_suspicion = 1
+        ORDER BY br.started_at DESC
+        LIMIT 20000
+        """
+    )
+    if not rows:
+        return {"status": "success", "rows_written": 0}
+
+    client = Neo4jClient(config)
+    client.query("CREATE CONSTRAINT battle_id IF NOT EXISTS FOR (b:Battle) REQUIRE b.id IS UNIQUE")
+    client.query("CREATE CONSTRAINT character_id IF NOT EXISTS FOR (c:Character) REQUIRE c.id IS UNIQUE")
+
+    client.query(
+        """
+        UNWIND $rows AS row
+        MERGE (b:Battle {id: row.battle_id})
+          SET b.system_id = row.system_id,
+              b.started_at = row.started_at,
+              b.ended_at = row.ended_at
+        MERGE (c:Character {id: row.character_id})
+        MERGE (c)-[r:PARTICIPATED_IN]->(b)
+          SET r.side_key = row.side_key,
+              r.centrality = row.centrality_score,
+              r.visibility = row.visibility_score,
+              r.alliance_id = row.alliance_id,
+              r.corporation_id = row.corporation_id
+        """,
+        {"rows": rows},
+    )
+    return {"status": "success", "rows_written": len(rows)}
+
+
+def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None = None, *, dry_run: bool = False) -> dict[str, Any]:
+    lock_key = "compute_battle_rollups"
+    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
+    if owner is None:
+        result = {"rows_processed": 0, "rows_written": 0, "status": "skipped", "reason": "lock-not-acquired", "job_name": "compute_battle_rollups"}
+        _battle_log(runtime, "battle_intelligence.job.skipped", result)
+        return result
+
+    job = start_job_run(db, "compute_battle_rollups")
+    started_monotonic = datetime.now(UTC)
+    rows_processed = 0
+    rows_written = 0
+    computed_at = _now_sql()
+    _battle_log(runtime, "battle_intelligence.job.started", {"job_name": "compute_battle_rollups", "dry_run": dry_run, "computed_at": computed_at})
+    try:
+        killmails = db.fetch_all(
+            """
+            SELECT
+                ke.killmail_id,
+                ke.solar_system_id AS system_id,
+                ke.effective_killmail_at AS killmail_time,
+                ke.victim_character_id,
+                ke.victim_corporation_id,
+                ke.victim_alliance_id,
+                ke.victim_ship_type_id,
+                ka.character_id AS attacker_character_id,
+                ka.corporation_id AS attacker_corporation_id,
+                ka.alliance_id AS attacker_alliance_id,
+                ka.ship_type_id AS attacker_ship_type_id
+            FROM killmail_events ke
+            LEFT JOIN killmail_attackers ka ON ka.sequence_id = ke.sequence_id
+            WHERE ke.effective_killmail_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 45 DAY)
+              AND ke.solar_system_id IS NOT NULL
+            ORDER BY ke.solar_system_id ASC, ke.effective_killmail_at ASC, ke.killmail_id ASC
+            """
+        )
+        rows_processed = len(killmails)
+
+        battles: dict[str, dict[str, Any]] = {}
+        participant_sets: dict[str, set[int]] = defaultdict(set)
+        participant_rows: dict[tuple[str, int], dict[str, Any]] = {}
+
+        for row in killmails:
+            system_id = int(row.get("system_id") or 0)
+            killmail_id = int(row.get("killmail_id") or 0)
+            killmail_time = str(row.get("killmail_time") or "")
+            if system_id <= 0 or killmail_id <= 0 or killmail_time == "":
+                continue
+
+            bucket_unix = int(datetime.strptime(killmail_time, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC).timestamp() // WINDOW_SECONDS * WINDOW_SECONDS)
+            battle_id = f"{system_id}:{bucket_unix}"
+            battle_hash = __import__("hashlib").sha256(battle_id.encode("utf-8")).hexdigest()
+
+            battle = battles.setdefault(
+                battle_hash,
+                {
+                    "battle_id": battle_hash,
+                    "system_id": system_id,
+                    "started_at": killmail_time,
+                    "ended_at": killmail_time,
+                },
+            )
+            if killmail_time < battle["started_at"]:
+                battle["started_at"] = killmail_time
+            if killmail_time > battle["ended_at"]:
+                battle["ended_at"] = killmail_time
+
+            for role in (
+                (
+                    int(row.get("victim_character_id") or 0),
+                    int(row.get("victim_corporation_id") or 0),
+                    int(row.get("victim_alliance_id") or 0),
+                    int(row.get("victim_ship_type_id") or 0),
+                ),
+                (
+                    int(row.get("attacker_character_id") or 0),
+                    int(row.get("attacker_corporation_id") or 0),
+                    int(row.get("attacker_alliance_id") or 0),
+                    int(row.get("attacker_ship_type_id") or 0),
+                ),
+            ):
+                character_id, corporation_id, alliance_id, ship_type_id = role
+                if character_id <= 0:
+                    continue
+                participant_sets[battle_hash].add(character_id)
+                side_key = f"a:{alliance_id}" if alliance_id > 0 else (f"c:{corporation_id}" if corporation_id > 0 else "unknown")
+                key = (battle_hash, character_id)
+                current = participant_rows.setdefault(
+                    key,
+                    {
+                        "battle_id": battle_hash,
+                        "character_id": character_id,
+                        "corporation_id": corporation_id if corporation_id > 0 else None,
+                        "alliance_id": alliance_id if alliance_id > 0 else None,
+                        "side_key": side_key,
+                        "ship_type_id": ship_type_id if ship_type_id > 0 else None,
+                        "participation_count": 0,
+                    },
+                )
+                current["participation_count"] = int(current["participation_count"]) + 1
+
+        if not dry_run:
+            with db.transaction() as (_, cursor):
+                cursor.execute("DELETE FROM battle_participants")
+                cursor.execute("DELETE FROM battle_rollups")
+
+                for battle in battles.values():
+                    participants = len(participant_sets.get(str(battle["battle_id"]), set()))
+                    started = datetime.strptime(str(battle["started_at"]), "%Y-%m-%d %H:%M:%S")
+                    ended = datetime.strptime(str(battle["ended_at"]), "%Y-%m-%d %H:%M:%S")
+                    duration_seconds = max(1, int((ended - started).total_seconds()))
+                    cursor.execute(
+                        """
+                        INSERT INTO battle_rollups (
+                            battle_id, system_id, started_at, ended_at, duration_seconds,
+                            participant_count, eligible_for_suspicion, battle_size_class, computed_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            str(battle["battle_id"]),
+                            int(battle["system_id"]),
+                            str(battle["started_at"]),
+                            str(battle["ended_at"]),
+                            duration_seconds,
+                            participants,
+                            1 if participants >= MIN_ELIGIBLE_PARTICIPANTS else 0,
+                            _battle_size_class(participants),
+                            computed_at,
+                        ),
+                    )
+                    rows_written += 1
+
+                role_rows = db.fetch_all(
+                    """
+                    SELECT
+                        rit.type_id,
+                        LOWER(COALESCE(rig.group_name, '')) AS group_name,
+                        LOWER(COALESCE(ric.category_name, '')) AS category_name
+                    FROM ref_item_types rit
+                    LEFT JOIN ref_item_groups rig ON rig.group_id = rit.group_id
+                    LEFT JOIN ref_item_categories ric ON ric.category_id = rit.category_id
+                    """
+                )
+                role_map: dict[int, tuple[int, int, int]] = {}
+                for role_row in role_rows:
+                    type_id = int(role_row.get("type_id") or 0)
+                    if type_id <= 0:
+                        continue
+                    group_name = str(role_row.get("group_name") or "")
+                    category_name = str(role_row.get("category_name") or "")
+                    is_logi = 1 if "logistics" in group_name else 0
+                    is_command = 1 if "command" in group_name else 0
+                    capital_groups = ["dreadnought", "carrier", "force auxiliary", "supercarrier", "titan", "capital"]
+                    is_capital = 1 if any(token in group_name for token in capital_groups) or "capital" in category_name else 0
+                    role_map[type_id] = (is_logi, is_command, is_capital)
+
+                for participant in participant_rows.values():
+                    ship_type_id = int(participant.get("ship_type_id") or 0)
+                    flags = role_map.get(ship_type_id, (0, 0, 0))
+                    cursor.execute(
+                        """
+                        INSERT INTO battle_participants (
+                            battle_id, character_id, corporation_id, alliance_id, side_key, ship_type_id,
+                            is_logi, is_command, is_capital, participation_count, computed_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            str(participant["battle_id"]),
+                            int(participant["character_id"]),
+                            participant.get("corporation_id"),
+                            participant.get("alliance_id"),
+                            str(participant["side_key"]),
+                            participant.get("ship_type_id"),
+                            int(flags[0]),
+                            int(flags[1]),
+                            int(flags[2]),
+                            int(participant.get("participation_count") or 0),
+                            computed_at,
+                        ),
+                    )
+        rows_written = len(battles) + len(participant_rows)
+
+        finish_job_run(
+            db,
+            job,
+            status="success",
+            rows_processed=rows_processed,
+            rows_written=rows_written,
+            meta={"computed_at": computed_at, "battle_count": len(battles), "participant_rows": len(participant_rows)},
+        )
+        duration_ms = int((datetime.now(UTC) - started_monotonic).total_seconds() * 1000)
+        result = {
+            "rows_processed": rows_processed,
+            "rows_written": 0 if dry_run else rows_written,
+            "rows_would_write": rows_written if dry_run else rows_written,
+            "battle_count": len(battles),
+            "eligible_battle_count": sum(1 for battle in battles.values() if len(participant_sets.get(str(battle["battle_id"]), set())) >= MIN_ELIGIBLE_PARTICIPANTS),
+            "computed_at": computed_at,
+            "duration_ms": duration_ms,
+            "dry_run": dry_run,
+            "job_name": "compute_battle_rollups",
+            "status": "success",
+        }
+        _battle_log(runtime, "battle_intelligence.job.success", result)
+        return result
+    except Exception as exc:
+        finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
+        _battle_log(
+            runtime,
+            "battle_intelligence.job.failed",
+            {"job_name": "compute_battle_rollups", "status": "failed", "rows_processed": rows_processed, "rows_written": rows_written, "error_text": str(exc), "dry_run": dry_run},
+        )
+        raise
+    finally:
+        release_job_lock(db, lock_key, owner)
+
+
+def run_compute_battle_target_metrics(db: SupplyCoreDb, runtime: dict[str, Any] | None = None, *, dry_run: bool = False) -> dict[str, Any]:
+    lock_key = "compute_battle_target_metrics"
+    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
+    if owner is None:
+        result = {"rows_processed": 0, "rows_written": 0, "status": "skipped", "reason": "lock-not-acquired", "job_name": "compute_battle_target_metrics"}
+        _battle_log(runtime, "battle_intelligence.job.skipped", result)
+        return result
+
+    job = start_job_run(db, "compute_battle_target_metrics")
+    started_monotonic = datetime.now(UTC)
+    rows_processed = 0
+    rows_written = 0
+    computed_at = _now_sql()
+    unscored_targets = 0
+    _battle_log(runtime, "battle_intelligence.job.started", {"job_name": "compute_battle_target_metrics", "dry_run": dry_run, "computed_at": computed_at})
+    try:
+        rows = db.fetch_all(
+            """
+            SELECT
+                br.battle_id,
+                br.started_at,
+                ke.killmail_id,
+                ke.effective_killmail_at AS killmail_time,
+                ke.victim_character_id,
+                ke.victim_ship_type_id,
+                ke.victim_alliance_id,
+                ke.victim_corporation_id,
+                JSON_UNQUOTE(JSON_EXTRACT(kep.raw_killmail_json, '$.victim.damage_taken')) AS victim_damage_taken
+            FROM battle_rollups br
+            INNER JOIN killmail_events ke
+                ON ke.solar_system_id = br.system_id
+               AND ke.effective_killmail_at BETWEEN br.started_at AND br.ended_at
+            LEFT JOIN killmail_event_payloads kep ON kep.sequence_id = ke.sequence_id
+            WHERE br.eligible_for_suspicion = 1
+            ORDER BY br.started_at DESC, ke.killmail_id ASC
+            """
+        )
+        rows_processed = len(rows)
+
+        prepared: list[dict[str, Any]] = []
+        baseline: dict[tuple[int, str], list[float]] = defaultdict(list)
+        for row in rows:
+            damage = float(row.get("victim_damage_taken") or 0.0)
+            started_at = datetime.strptime(str(row.get("started_at")), "%Y-%m-%d %H:%M:%S")
+            killmail_time = datetime.strptime(str(row.get("killmail_time")), "%Y-%m-%d %H:%M:%S")
+            ttd = max(1.0, (killmail_time - started_at).total_seconds())
+            dps = _safe_div(damage, ttd, 0.0)
+            ship_type_id = int(row.get("victim_ship_type_id") or 0)
+            bucket = _dps_bucket(dps)
+            if ship_type_id <= 0 or damage <= 0:
+                unscored_targets += 1
+                continue
+            baseline[(ship_type_id, bucket)].append(ttd)
+            prepared.append(
+                {
+                    "battle_id": str(row.get("battle_id")),
+                    "killmail_id": int(row.get("killmail_id") or 0),
+                    "victim_character_id": int(row.get("victim_character_id") or 0) or None,
+                    "victim_ship_type_id": ship_type_id,
+                    "side_key": f"a:{int(row.get('victim_alliance_id') or 0)}"
+                    if int(row.get("victim_alliance_id") or 0) > 0
+                    else (f"c:{int(row.get('victim_corporation_id') or 0)}" if int(row.get("victim_corporation_id") or 0) > 0 else "unknown"),
+                    "first_damage_ts": started_at.strftime("%Y-%m-%d %H:%M:%S"),
+                    "last_damage_ts": killmail_time.strftime("%Y-%m-%d %H:%M:%S"),
+                    "time_to_die_seconds": ttd,
+                    "total_damage_taken": damage,
+                    "estimated_incoming_dps": dps,
+                    "dps_bucket": bucket,
+                }
+            )
+
+        expected_ttd: dict[tuple[int, str], float] = {}
+        for key, values in baseline.items():
+            values_sorted = sorted(values)
+            expected_ttd[key] = values_sorted[len(values_sorted) // 2]
+
+        if not dry_run:
+            with db.transaction() as (_, cursor):
+                cursor.execute("DELETE FROM battle_target_metrics")
+                for target in prepared:
+                    baseline_ttd = max(1.0, expected_ttd.get((int(target["victim_ship_type_id"]), str(target["dps_bucket"])), float(target["time_to_die_seconds"])))
+                    sustain_factor = max(0.05, min(8.0, _safe_div(float(target["time_to_die_seconds"]), baseline_ttd, 1.0)))
+                    cursor.execute(
+                        """
+                        INSERT INTO battle_target_metrics (
+                            battle_id, killmail_id, victim_character_id, victim_ship_type_id, side_key,
+                            first_damage_ts, last_damage_ts, time_to_die_seconds, total_damage_taken,
+                            estimated_incoming_dps, dps_bucket, expected_time_to_die_seconds, sustain_factor, computed_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            str(target["battle_id"]),
+                            int(target["killmail_id"]),
+                            target["victim_character_id"],
+                            int(target["victim_ship_type_id"]),
+                            str(target["side_key"]),
+                            str(target["first_damage_ts"]),
+                            str(target["last_damage_ts"]),
+                            float(target["time_to_die_seconds"]),
+                            float(target["total_damage_taken"]),
+                            float(target["estimated_incoming_dps"]),
+                            str(target["dps_bucket"]),
+                            float(baseline_ttd),
+                            float(sustain_factor),
+                            computed_at,
+                        ),
+                    )
+        rows_written = len(prepared)
+
+        finish_job_run(
+            db,
+            job,
+            status="success",
+            rows_processed=rows_processed,
+            rows_written=rows_written,
+            meta={"computed_at": computed_at, "unscored_targets": unscored_targets},
+        )
+        duration_ms = int((datetime.now(UTC) - started_monotonic).total_seconds() * 1000)
+        result = {
+            "rows_processed": rows_processed,
+            "rows_written": 0 if dry_run else rows_written,
+            "rows_would_write": rows_written if dry_run else rows_written,
+            "computed_at": computed_at,
+            "unscored_targets": unscored_targets,
+            "duration_ms": duration_ms,
+            "dry_run": dry_run,
+            "job_name": "compute_battle_target_metrics",
+            "status": "success",
+        }
+        _battle_log(runtime, "battle_intelligence.job.success", result)
+        return result
+    except Exception as exc:
+        finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
+        _battle_log(runtime, "battle_intelligence.job.failed", {"job_name": "compute_battle_target_metrics", "status": "failed", "error_text": str(exc), "rows_processed": rows_processed, "rows_written": rows_written, "dry_run": dry_run})
+        raise
+    finally:
+        release_job_lock(db, lock_key, owner)
+
+
+def run_compute_battle_anomalies(db: SupplyCoreDb, runtime: dict[str, Any] | None = None, *, dry_run: bool = False) -> dict[str, Any]:
+    lock_key = "compute_battle_anomalies"
+    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
+    if owner is None:
+        result = {"rows_processed": 0, "rows_written": 0, "status": "skipped", "reason": "lock-not-acquired", "job_name": "compute_battle_anomalies"}
+        _battle_log(runtime, "battle_intelligence.job.skipped", result)
+        return result
+
+    job = start_job_run(db, "compute_battle_anomalies")
+    started_monotonic = datetime.now(UTC)
+    rows_processed = 0
+    rows_written = 0
+    computed_at = _now_sql()
+    _battle_log(runtime, "battle_intelligence.job.started", {"job_name": "compute_battle_anomalies", "dry_run": dry_run, "computed_at": computed_at})
+    try:
+        side_rows = db.fetch_all(
+            """
+            SELECT
+                bp.battle_id,
+                bp.side_key,
+                br.duration_seconds,
+                SUM(bp.participation_count) AS participant_count,
+                SUM(CASE WHEN bp.is_logi = 1 THEN 1 ELSE 0 END) AS logi_count,
+                SUM(CASE WHEN bp.is_command = 1 THEN 1 ELSE 0 END) AS command_count,
+                SUM(CASE WHEN bp.is_capital = 1 THEN 1 ELSE 0 END) AS capital_count,
+                COUNT(DISTINCT btm.killmail_id) AS total_kills,
+                AVG(btm.sustain_factor) AS avg_sustain_factor,
+                AVG(btm.sustain_factor) AS med_sustain_factor,
+                STDDEV_POP(btm.sustain_factor) AS switch_pressure,
+                br.battle_size_class
+            FROM battle_participants bp
+            INNER JOIN battle_rollups br ON br.battle_id = bp.battle_id
+            LEFT JOIN battle_target_metrics btm ON btm.battle_id = bp.battle_id AND btm.side_key = bp.side_key
+            WHERE br.eligible_for_suspicion = 1
+            GROUP BY bp.battle_id, bp.side_key, br.duration_seconds, br.battle_size_class
+            """
+        )
+        rows_processed = len(side_rows)
+
+        per_size: dict[str, list[float]] = defaultdict(list)
+        shaped: list[dict[str, Any]] = []
+        for row in side_rows:
+            duration_minutes = max(1.0, float(row.get("duration_seconds") or 0) / 60.0)
+            kill_rate = _safe_div(float(row.get("total_kills") or 0), duration_minutes, 0.0)
+            median_sustain = float(row.get("med_sustain_factor") or 0.0)
+            average_sustain = float(row.get("avg_sustain_factor") or 0.0)
+            efficiency = _safe_div(median_sustain, math.log(1.0 + kill_rate + EPSILON), 0.0)
+            shape = {
+                "battle_id": str(row.get("battle_id")),
+                "side_key": str(row.get("side_key")),
+                "participant_count": int(row.get("participant_count") or 0),
+                "logi_count": int(row.get("logi_count") or 0),
+                "command_count": int(row.get("command_count") or 0),
+                "capital_count": int(row.get("capital_count") or 0),
+                "total_kills": int(row.get("total_kills") or 0),
+                "kill_rate_per_minute": kill_rate,
+                "median_sustain_factor": median_sustain,
+                "average_sustain_factor": average_sustain,
+                "switch_pressure": float(row.get("switch_pressure") or 0.0),
+                "efficiency_score": efficiency,
+                "battle_size_class": str(row.get("battle_size_class") or "small"),
+            }
+            per_size[shape["battle_size_class"]].append(efficiency)
+            shaped.append(shape)
+
+        stats: dict[str, tuple[float, float]] = {}
+        for size_class, values in per_size.items():
+            mean = sum(values) / max(1, len(values))
+            stddev = _stddev(values)
+            stats[size_class] = (mean, stddev)
+
+        if not dry_run:
+            with db.transaction() as (_, cursor):
+                cursor.execute("DELETE FROM battle_anomalies")
+                cursor.execute("DELETE FROM battle_side_metrics")
+
+                efficiency_sorted = sorted((float(item["efficiency_score"]) for item in shaped))
+                for item in shaped:
+                    mean, stddev = stats.get(str(item["battle_size_class"]), (0.0, 0.0))
+                    z = _safe_div(float(item["efficiency_score"]) - mean, stddev, 0.0) if stddev > 0 else 0.0
+                    percentile_rank = _percentile(efficiency_sorted, float(item["efficiency_score"]))
+                    anomaly_class = "normal"
+                    if z > 2.0:
+                        anomaly_class = "high_sustain"
+                    elif z < -1.0:
+                        anomaly_class = "low_sustain"
+
+                    cursor.execute(
+                        """
+                        INSERT INTO battle_side_metrics (
+                            battle_id, side_key, participant_count, logi_count, command_count, capital_count,
+                            total_kills, kill_rate_per_minute, median_sustain_factor, average_sustain_factor,
+                            switch_pressure, efficiency_score, z_efficiency_score, computed_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            str(item["battle_id"]),
+                            str(item["side_key"]),
+                            int(item["participant_count"]),
+                            int(item["logi_count"]),
+                            int(item["command_count"]),
+                            int(item["capital_count"]),
+                            int(item["total_kills"]),
+                            float(item["kill_rate_per_minute"]),
+                            float(item["median_sustain_factor"]),
+                            float(item["average_sustain_factor"]),
+                            float(item["switch_pressure"]),
+                            float(item["efficiency_score"]),
+                            float(z),
+                            computed_at,
+                        ),
+                    )
+                    explanation = {
+                        "efficiency_formula": "median_sustain_factor / log(1 + kill_rate_per_minute + epsilon)",
+                        "median_sustain_factor": item["median_sustain_factor"],
+                        "kill_rate_per_minute": item["kill_rate_per_minute"],
+                        "efficiency_score": item["efficiency_score"],
+                        "z_efficiency_score": z,
+                        "peer_group": item["battle_size_class"],
+                    }
+                    cursor.execute(
+                        """
+                        INSERT INTO battle_anomalies (
+                            battle_id, side_key, anomaly_class, z_efficiency_score, percentile_rank, explanation_json, computed_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            str(item["battle_id"]),
+                            str(item["side_key"]),
+                            anomaly_class,
+                            float(z),
+                            float(percentile_rank),
+                            json.dumps(explanation, separators=(",", ":"), ensure_ascii=False),
+                            computed_at,
+                        ),
+                    )
+        rows_written = len(shaped) * 2
+
+        finish_job_run(
+            db,
+            job,
+            status="success",
+            rows_processed=rows_processed,
+            rows_written=rows_written,
+            meta={"computed_at": computed_at, "anomaly_rows": len(shaped)},
+        )
+        high_count = 0
+        for item in shaped:
+            mean, stddev = stats.get(str(item["battle_size_class"]), (0.0, 0.0))
+            if stddev <= 0:
+                continue
+            z_value = _safe_div(float(item["efficiency_score"]) - mean, stddev, 0.0)
+            if z_value > 2.0:
+                high_count += 1
+        duration_ms = int((datetime.now(UTC) - started_monotonic).total_seconds() * 1000)
+        result = {
+            "rows_processed": rows_processed,
+            "rows_written": 0 if dry_run else rows_written,
+            "rows_would_write": rows_written if dry_run else rows_written,
+            "anomaly_count": len(shaped),
+            "high_sustain_count": high_count,
+            "computed_at": computed_at,
+            "duration_ms": duration_ms,
+            "dry_run": dry_run,
+            "job_name": "compute_battle_anomalies",
+            "status": "success",
+        }
+        _battle_log(runtime, "battle_intelligence.job.success", result)
+        return result
+    except Exception as exc:
+        finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
+        _battle_log(runtime, "battle_intelligence.job.failed", {"job_name": "compute_battle_anomalies", "status": "failed", "error_text": str(exc), "rows_processed": rows_processed, "rows_written": rows_written, "dry_run": dry_run})
+        raise
+    finally:
+        release_job_lock(db, lock_key, owner)
+
+
+def run_compute_battle_actor_features(
+    db: SupplyCoreDb,
+    neo4j_raw: dict[str, Any] | None = None,
+    runtime: dict[str, Any] | None = None,
+    *,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    lock_key = "compute_battle_actor_features"
+    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
+    if owner is None:
+        result = {"rows_processed": 0, "rows_written": 0, "status": "skipped", "reason": "lock-not-acquired", "job_name": "compute_battle_actor_features"}
+        _battle_log(runtime, "battle_intelligence.job.skipped", result)
+        return result
+
+    job = start_job_run(db, "compute_battle_actor_features")
+    started_monotonic = datetime.now(UTC)
+    rows_processed = 0
+    rows_written = 0
+    computed_at = _now_sql()
+    _battle_log(runtime, "battle_intelligence.job.started", {"job_name": "compute_battle_actor_features", "dry_run": dry_run, "computed_at": computed_at})
+    try:
+        rows = db.fetch_all(
+            """
+            SELECT
+                bp.battle_id,
+                bp.character_id,
+                bp.side_key,
+                bp.participation_count,
+                bp.is_logi,
+                bp.is_command,
+                bp.is_capital,
+                COALESCE(ba.anomaly_class, 'normal') AS anomaly_class
+            FROM battle_participants bp
+            INNER JOIN battle_rollups br ON br.battle_id = bp.battle_id
+            LEFT JOIN battle_anomalies ba ON ba.battle_id = bp.battle_id AND ba.side_key = bp.side_key
+            WHERE br.eligible_for_suspicion = 1
+            """
+        )
+        rows_processed = len(rows)
+
+        max_participation: dict[str, int] = defaultdict(int)
+        for row in rows:
+            battle_id = str(row.get("battle_id") or "")
+            max_participation[battle_id] = max(max_participation[battle_id], int(row.get("participation_count") or 0))
+
+        if not dry_run:
+            with db.transaction() as (_, cursor):
+                cursor.execute("DELETE FROM battle_actor_features")
+                for row in rows:
+                    battle_id = str(row.get("battle_id") or "")
+                    participation_count = int(row.get("participation_count") or 0)
+                    centrality = _safe_div(float(participation_count), float(max_participation.get(battle_id) or 1), 0.0)
+                    role_weight = 0.2 * int(row.get("is_logi") or 0) + 0.2 * int(row.get("is_command") or 0) + 0.3 * int(row.get("is_capital") or 0)
+                    visibility = min(1.0, centrality + role_weight)
+                    anomaly_class = str(row.get("anomaly_class") or "normal")
+                    cursor.execute(
+                        """
+                        INSERT INTO battle_actor_features (
+                            battle_id, character_id, side_key, participation_count, centrality_score, visibility_score,
+                            is_logi, is_command, is_capital, participated_in_high_sustain, participated_in_low_sustain, computed_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            battle_id,
+                            int(row.get("character_id") or 0),
+                            str(row.get("side_key") or "unknown"),
+                            participation_count,
+                            float(centrality),
+                            float(visibility),
+                            int(row.get("is_logi") or 0),
+                            int(row.get("is_command") or 0),
+                            int(row.get("is_capital") or 0),
+                            1 if anomaly_class == "high_sustain" else 0,
+                            1 if anomaly_class == "low_sustain" else 0,
+                            computed_at,
+                        ),
+                    )
+        rows_written = len(rows)
+
+        neo_result = {"status": "skipped", "reason": "dry-run"} if dry_run else _neo4j_sync_participation(db, neo4j_raw)
+        finish_job_run(
+            db,
+            job,
+            status="success",
+            rows_processed=rows_processed,
+            rows_written=rows_written,
+            meta={"computed_at": computed_at, "neo4j": neo_result},
+        )
+        duration_ms = int((datetime.now(UTC) - started_monotonic).total_seconds() * 1000)
+        result = {
+            "rows_processed": rows_processed,
+            "rows_written": 0 if dry_run else rows_written,
+            "rows_would_write": rows_written if dry_run else rows_written,
+            "computed_at": computed_at,
+            "neo4j": neo_result,
+            "duration_ms": duration_ms,
+            "dry_run": dry_run,
+            "job_name": "compute_battle_actor_features",
+            "status": "success",
+        }
+        _battle_log(runtime, "battle_intelligence.job.success", result)
+        return result
+    except Exception as exc:
+        finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
+        _battle_log(runtime, "battle_intelligence.job.failed", {"job_name": "compute_battle_actor_features", "status": "failed", "error_text": str(exc), "rows_processed": rows_processed, "rows_written": rows_written, "dry_run": dry_run})
+        raise
+    finally:
+        release_job_lock(db, lock_key, owner)
+
+
+def run_compute_suspicion_scores(db: SupplyCoreDb, runtime: dict[str, Any] | None = None, *, dry_run: bool = False) -> dict[str, Any]:
+    lock_key = "compute_suspicion_scores"
+    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
+    if owner is None:
+        result = {"rows_processed": 0, "rows_written": 0, "status": "skipped", "reason": "lock-not-acquired", "job_name": "compute_suspicion_scores"}
+        _battle_log(runtime, "battle_intelligence.job.skipped", result)
+        return result
+
+    job = start_job_run(db, "compute_suspicion_scores")
+    started_monotonic = datetime.now(UTC)
+    rows_processed = 0
+    rows_written = 0
+    computed_at = _now_sql()
+    _battle_log(runtime, "battle_intelligence.job.started", {"job_name": "compute_suspicion_scores", "dry_run": dry_run, "computed_at": computed_at})
+    try:
+        actor_rows = db.fetch_all(
+            """
+            SELECT
+                baf.character_id,
+                baf.battle_id,
+                baf.side_key,
+                baf.is_logi,
+                baf.is_command,
+                baf.is_capital,
+                baf.participated_in_high_sustain,
+                baf.participated_in_low_sustain,
+                bsm.z_efficiency_score,
+                bsm.efficiency_score,
+                br.eligible_for_suspicion
+            FROM battle_actor_features baf
+            INNER JOIN battle_rollups br ON br.battle_id = baf.battle_id
+            LEFT JOIN battle_side_metrics bsm ON bsm.battle_id = baf.battle_id AND bsm.side_key = baf.side_key
+            WHERE baf.character_id > 0
+            """
+        )
+        rows_processed = len(actor_rows)
+
+        by_character: dict[int, list[dict[str, Any]]] = defaultdict(list)
+        battle_side_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in actor_rows:
+            character_id = int(row.get("character_id") or 0)
+            if character_id <= 0:
+                continue
+            by_character[character_id].append(row)
+            battle_side_index[str(row.get("battle_id"))].append(row)
+
+        intelligence_rows: list[dict[str, Any]] = []
+        score_rows: list[dict[str, Any]] = []
+
+        for character_id, rows in by_character.items():
+            total_battle_count = len({str(row.get("battle_id")) for row in rows})
+            eligible_rows = [row for row in rows if int(row.get("eligible_for_suspicion") or 0) == 1]
+            eligible_battle_ids = {str(row.get("battle_id")) for row in eligible_rows}
+            eligible_battle_count = len(eligible_battle_ids)
+            high_sustain_battle_count = len({str(row.get("battle_id")) for row in eligible_rows if int(row.get("participated_in_high_sustain") or 0) == 1})
+            low_sustain_battle_count = len({str(row.get("battle_id")) for row in eligible_rows if int(row.get("participated_in_low_sustain") or 0) == 1})
+            high_sustain_frequency = _safe_div(float(high_sustain_battle_count), float(max(eligible_battle_count, 1)), 0.0)
+            low_sustain_frequency = _safe_div(float(low_sustain_battle_count), float(max(eligible_battle_count, 1)), 0.0)
+            side_count = len({str(row.get("side_key")) for row in eligible_rows})
+            cross_side_battle_count = max(0, side_count - 1)
+            cross_side_rate = _safe_div(float(cross_side_battle_count), float(max(eligible_battle_count, 1)), 0.0)
+            role_weight = min(
+                1.0,
+                _safe_div(
+                    float(
+                        sum(int(row.get("is_logi") or 0) * 2 + int(row.get("is_command") or 0) * 2 + int(row.get("is_capital") or 0) * 3 for row in eligible_rows)
+                    ),
+                    float(max(len(eligible_rows) * 3, 1)),
+                    0.0,
+                ),
+            )
+            anomalous_battle_density = _safe_div(
+                float(high_sustain_battle_count + low_sustain_battle_count),
+                float(max(eligible_battle_count, 1)),
+                0.0,
+            )
+
+            present_enemy_z: list[float] = []
+            for row in eligible_rows:
+                battle_id = str(row.get("battle_id"))
+                side_key = str(row.get("side_key"))
+                for other in battle_side_index.get(battle_id, []):
+                    if str(other.get("side_key")) == side_key:
+                        continue
+                    present_enemy_z.append(float(other.get("z_efficiency_score") or 0.0))
+            absent_enemy_z: list[float] = []
+            for other_character_id, other_rows in by_character.items():
+                if other_character_id == character_id:
+                    continue
+                for other in other_rows:
+                    if str(other.get("battle_id")) in eligible_battle_ids:
+                        continue
+                    if int(other.get("eligible_for_suspicion") or 0) == 1:
+                        absent_enemy_z.append(float(other.get("z_efficiency_score") or 0.0))
+            present_avg = _safe_div(sum(present_enemy_z), float(len(present_enemy_z)), 0.0)
+            absent_avg = _safe_div(sum(absent_enemy_z), float(len(absent_enemy_z)), 0.0)
+            enemy_eff_uplift = present_avg - absent_avg
+            ally_eff_uplift = _safe_div(sum(float(row.get("z_efficiency_score") or 0.0) for row in eligible_rows), float(max(len(eligible_rows), 1)), 0.0)
+
+            intelligence_rows.append(
+                {
+                    "character_id": character_id,
+                    "total_battle_count": total_battle_count,
+                    "eligible_battle_count": eligible_battle_count,
+                    "high_sustain_battle_count": high_sustain_battle_count,
+                    "low_sustain_battle_count": low_sustain_battle_count,
+                    "high_sustain_frequency": high_sustain_frequency,
+                    "low_sustain_frequency": low_sustain_frequency,
+                    "cross_side_battle_count": cross_side_battle_count,
+                    "cross_side_rate": cross_side_rate,
+                    "enemy_efficiency_uplift": enemy_eff_uplift,
+                    "ally_efficiency_uplift": ally_eff_uplift,
+                    "role_weight": role_weight,
+                    "anomalous_battle_density": anomalous_battle_density,
+                }
+            )
+
+            if eligible_battle_count < MIN_SAMPLE_COUNT:
+                suspicion_score = 0.0
+            else:
+                suspicion_score = (
+                    0.25 * high_sustain_frequency
+                    + 0.20 * cross_side_rate
+                    + 0.30 * enemy_eff_uplift
+                    + 0.15 * (high_sustain_frequency - low_sustain_frequency)
+                    + 0.10 * role_weight
+                )
+            suspicion_score = max(0.0, min(1.0, suspicion_score))
+
+            support_battles = sorted(
+                [
+                    {
+                        "battle_id": str(row.get("battle_id")),
+                        "side_key": str(row.get("side_key")),
+                        "z_efficiency_score": float(row.get("z_efficiency_score") or 0.0),
+                        "high_sustain": int(row.get("participated_in_high_sustain") or 0) == 1,
+                    }
+                    for row in eligible_rows
+                ],
+                key=lambda candidate: abs(float(candidate["z_efficiency_score"])),
+                reverse=True,
+            )[:5]
+
+            explanation = {
+                "formula": "0.25*high_sustain_frequency + 0.20*cross_side_rate + 0.30*enemy_efficiency_uplift + 0.15*(high-low) + 0.10*role_weight",
+                "minimum_sample_count": MIN_SAMPLE_COUNT,
+                "eligible_battle_count": eligible_battle_count,
+                "high_sustain_frequency": high_sustain_frequency,
+                "low_sustain_frequency": low_sustain_frequency,
+                "cross_side_rate": cross_side_rate,
+                "enemy_efficiency_uplift": enemy_eff_uplift,
+                "role_weight": role_weight,
+            }
+            score_rows.append(
+                {
+                    "character_id": character_id,
+                    "suspicion_score": suspicion_score,
+                    "high_sustain_frequency": high_sustain_frequency,
+                    "low_sustain_frequency": low_sustain_frequency,
+                    "cross_side_rate": cross_side_rate,
+                    "enemy_efficiency_uplift": enemy_eff_uplift,
+                    "role_weight": role_weight,
+                    "supporting_battle_count": eligible_battle_count,
+                    "top_supporting_battles_json": json.dumps(support_battles, separators=(",", ":"), ensure_ascii=False),
+                    "explanation_json": json.dumps(explanation, separators=(",", ":"), ensure_ascii=False),
+                }
+            )
+
+        scores_sorted = sorted((float(item["suspicion_score"]) for item in score_rows))
+
+        minimum_sample_filtered_count = sum(1 for row in intelligence_rows if int(row["eligible_battle_count"]) < MIN_SAMPLE_COUNT)
+
+        if not dry_run:
+            with db.transaction() as (_, cursor):
+                cursor.execute("DELETE FROM character_battle_intelligence")
+                cursor.execute("DELETE FROM character_suspicion_scores")
+
+                for row in intelligence_rows:
+                    cursor.execute(
+                    """
+                    INSERT INTO character_battle_intelligence (
+                        character_id, total_battle_count, eligible_battle_count, high_sustain_battle_count,
+                        low_sustain_battle_count, high_sustain_frequency, low_sustain_frequency,
+                        cross_side_battle_count, cross_side_rate, enemy_efficiency_uplift, ally_efficiency_uplift,
+                        role_weight, anomalous_battle_density, computed_at
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        int(row["character_id"]),
+                        int(row["total_battle_count"]),
+                        int(row["eligible_battle_count"]),
+                        int(row["high_sustain_battle_count"]),
+                        int(row["low_sustain_battle_count"]),
+                        float(row["high_sustain_frequency"]),
+                        float(row["low_sustain_frequency"]),
+                        int(row["cross_side_battle_count"]),
+                        float(row["cross_side_rate"]),
+                        float(row["enemy_efficiency_uplift"]),
+                        float(row["ally_efficiency_uplift"]),
+                        float(row["role_weight"]),
+                        float(row["anomalous_battle_density"]),
+                        computed_at,
+                    ),
+                )
+
+                for row in score_rows:
+                    percentile_rank = _percentile(scores_sorted, float(row["suspicion_score"]))
+                    cursor.execute(
+                    """
+                    INSERT INTO character_suspicion_scores (
+                        character_id, suspicion_score, percentile_rank, high_sustain_frequency,
+                        low_sustain_frequency, cross_side_rate, enemy_efficiency_uplift, role_weight,
+                        supporting_battle_count, top_supporting_battles_json, explanation_json, computed_at
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        int(row["character_id"]),
+                        float(row["suspicion_score"]),
+                        float(percentile_rank),
+                        float(row["high_sustain_frequency"]),
+                        float(row["low_sustain_frequency"]),
+                        float(row["cross_side_rate"]),
+                        float(row["enemy_efficiency_uplift"]),
+                        float(row["role_weight"]),
+                        int(row["supporting_battle_count"]),
+                        str(row["top_supporting_battles_json"]),
+                        str(row["explanation_json"]),
+                        computed_at,
+                    ),
+                )
+        rows_written = len(intelligence_rows) + len(score_rows)
+
+        finish_job_run(
+            db,
+            job,
+            status="success",
+            rows_processed=rows_processed,
+            rows_written=rows_written,
+            meta={"computed_at": computed_at, "scored_characters": len(score_rows)},
+        )
+        duration_ms = int((datetime.now(UTC) - started_monotonic).total_seconds() * 1000)
+        result = {
+            "rows_processed": rows_processed,
+            "rows_written": 0 if dry_run else rows_written,
+            "rows_would_write": rows_written if dry_run else rows_written,
+            "computed_at": computed_at,
+            "scored_character_count": len(score_rows),
+            "minimum_sample_filtered_count": minimum_sample_filtered_count,
+            "duration_ms": duration_ms,
+            "dry_run": dry_run,
+            "job_name": "compute_suspicion_scores",
+            "status": "success",
+        }
+        _battle_log(runtime, "battle_intelligence.job.success", result)
+        return result
+    except Exception as exc:
+        finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
+        _battle_log(runtime, "battle_intelligence.job.failed", {"job_name": "compute_suspicion_scores", "status": "failed", "error_text": str(exc), "rows_processed": rows_processed, "rows_written": rows_written, "dry_run": dry_run})
+        raise
+    finally:
+        release_job_lock(db, lock_key, owner)

--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import json
+import time
 from pathlib import Path
+from typing import Any
 
 from .config import load_php_runtime_config
 from .influx_export import main as run_influx_rollup_export
@@ -11,6 +14,13 @@ from .jobs.compute_buy_all import run_compute_buy_all
 from .jobs.compute_graph_insights import run_compute_graph_insights
 from .jobs.compute_graph_sync import run_compute_graph_sync
 from .jobs.compute_signals import run_compute_signals
+from .jobs.battle_intelligence import (
+    run_compute_battle_actor_features,
+    run_compute_battle_anomalies,
+    run_compute_battle_rollups,
+    run_compute_battle_target_metrics,
+    run_compute_suspicion_scores,
+)
 from .logging_utils import configure_logging
 from .rebuild_data_model import main as run_rebuild_data_model
 from .supervisor import run_supervisor
@@ -78,7 +88,30 @@ def parse_args() -> argparse.Namespace:
     compute_graph_sync.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
     compute_graph_insights = subparsers.add_parser("compute-graph-insights", help="Compute graph-derived metrics and persist into MariaDB")
     compute_graph_insights.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
+    for command, help_text in [
+        ("compute-battle-rollups", "Cluster killmails into deterministic battle rollups and participants"),
+        ("compute-battle-target-metrics", "Build target-level sustain proxy metrics"),
+        ("compute-battle-anomalies", "Compute side-level efficiency and anomaly scores"),
+        ("compute-battle-actor-features", "Build actor-level battle feature rows and optional graph sync"),
+        ("compute-suspicion-scores", "Compute character battle intelligence and suspicion scores"),
+    ]:
+        parser_job = subparsers.add_parser(command, help=help_text)
+        parser_job.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
+        parser_job.add_argument("--dry-run", action="store_true", help="Compute and log counters without writing MariaDB tables.")
     return parser.parse_args()
+
+
+def _print_cli_result(command: str, started_at: float, result: dict[str, Any]) -> None:
+    payload = {
+        "command": command,
+        "status": str(result.get("status") or "success"),
+        "rows_processed": int(result.get("rows_processed") or 0),
+        "rows_written": int(result.get("rows_written") or 0),
+        "rows_would_write": int(result.get("rows_would_write") or result.get("rows_written") or 0),
+        "duration_ms": max(0, int((time.monotonic() - started_at) * 1000)),
+        "result": result,
+    }
+    print(json.dumps(payload, ensure_ascii=False, default=str))
 
 
 def main() -> int:
@@ -164,6 +197,45 @@ def main() -> int:
         result = run_compute_graph_insights(db, config.raw.get("neo4j", {}))
         print(result)
         return 0
+    if command in {
+        "compute-battle-rollups",
+        "compute-battle-target-metrics",
+        "compute-battle-anomalies",
+        "compute-battle-actor-features",
+        "compute-suspicion-scores",
+    }:
+        app_root = Path(args.app_root).resolve()
+        config = load_php_runtime_config(app_root)
+        from .db import SupplyCoreDb
+
+        db = SupplyCoreDb(config.raw.get("db", {}))
+        battle_runtime = dict(config.raw.get("battle_intelligence") or {})
+        started_at = time.monotonic()
+        try:
+            if command == "compute-battle-rollups":
+                result = run_compute_battle_rollups(db, battle_runtime, dry_run=bool(args.dry_run))
+            elif command == "compute-battle-target-metrics":
+                result = run_compute_battle_target_metrics(db, battle_runtime, dry_run=bool(args.dry_run))
+            elif command == "compute-battle-anomalies":
+                result = run_compute_battle_anomalies(db, battle_runtime, dry_run=bool(args.dry_run))
+            elif command == "compute-battle-actor-features":
+                result = run_compute_battle_actor_features(
+                    db,
+                    dict(config.raw.get("neo4j", {})),
+                    battle_runtime,
+                    dry_run=bool(args.dry_run),
+                )
+            else:
+                result = run_compute_suspicion_scores(db, battle_runtime, dry_run=bool(args.dry_run))
+            _print_cli_result(command, started_at, result)
+            return 0 if str(result.get("status") or "success") != "failed" else 1
+        except Exception as exc:
+            _print_cli_result(
+                command,
+                started_at,
+                {"status": "failed", "error_text": str(exc), "rows_processed": 0, "rows_written": 0},
+            )
+            return 1
 
     app_root = Path(args.app_root).resolve()
     config = load_php_runtime_config(app_root)

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -14,9 +14,14 @@ from .bridge import PhpBridge
 from .config import load_php_runtime_config
 from .db import SupplyCoreDb
 from .jobs import (
+    run_compute_battle_actor_features,
+    run_compute_battle_anomalies,
+    run_compute_battle_rollups,
+    run_compute_battle_target_metrics,
     run_compute_buy_all,
     run_compute_graph_insights,
     run_compute_graph_sync,
+    run_compute_suspicion_scores,
     run_compute_signals,
     run_killmail_r2z2_stream,
     run_market_comparison_summary,
@@ -77,6 +82,30 @@ PROCESSORS: dict[str, Callable[[WorkerPoolContext], dict[str, Any]]] = {
         run_compute_signals(context.db, dict(context.raw_config.get("influx") or {})),
         "compute_signals",
     ),
+    "compute_battle_rollups": lambda context: _compute_result_shape(
+        run_compute_battle_rollups(context.db, dict(context.raw_config.get("battle_intelligence") or {})),
+        "compute_battle_rollups",
+    ),
+    "compute_battle_target_metrics": lambda context: _compute_result_shape(
+        run_compute_battle_target_metrics(context.db, dict(context.raw_config.get("battle_intelligence") or {})),
+        "compute_battle_target_metrics",
+    ),
+    "compute_battle_anomalies": lambda context: _compute_result_shape(
+        run_compute_battle_anomalies(context.db, dict(context.raw_config.get("battle_intelligence") or {})),
+        "compute_battle_anomalies",
+    ),
+    "compute_battle_actor_features": lambda context: _compute_result_shape(
+        run_compute_battle_actor_features(
+            context.db,
+            dict(context.raw_config.get("neo4j") or {}),
+            dict(context.raw_config.get("battle_intelligence") or {}),
+        ),
+        "compute_battle_actor_features",
+    ),
+    "compute_suspicion_scores": lambda context: _compute_result_shape(
+        run_compute_suspicion_scores(context.db, dict(context.raw_config.get("battle_intelligence") or {})),
+        "compute_suspicion_scores",
+    ),
 }
 
 PYTHON_PRIMARY_JOB_KEYS = {
@@ -89,6 +118,11 @@ PYTHON_PRIMARY_JOB_KEYS = {
     "compute_graph_insights",
     "compute_buy_all",
     "compute_signals",
+    "compute_battle_rollups",
+    "compute_battle_target_metrics",
+    "compute_battle_anomalies",
+    "compute_battle_actor_features",
+    "compute_suspicion_scores",
 }
 
 
@@ -108,11 +142,12 @@ def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
 
 
 def _compute_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
+    status = str(result.get("status") or "success")
     rows_processed = max(0, int(result.get("rows_processed") or 0))
     rows_written = max(0, int(result.get("rows_written") or 0))
     return {
-        "status": "success",
-        "summary": f"{job_key} completed successfully.",
+        "status": status,
+        "summary": str(result.get("summary") or f"{job_key} completed with status {status}."),
         "rows_processed": rows_processed,
         "rows_written": rows_written,
         "meta": {

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -50,6 +50,9 @@ $config = [
         'export_overlap_seconds' => max(0, (int) (getenv('INFLUXDB_EXPORT_OVERLAP_SECONDS') ?: 21600)),
         'export_log_file' => (string) (getenv('INFLUXDB_EXPORT_LOG_FILE') ?: 'storage/logs/influx-rollup-export.log'),
     ],
+    'battle_intelligence' => [
+        'log_file' => (string) (getenv('SUPPLYCORE_BATTLE_INTELLIGENCE_LOG_FILE') ?: 'storage/logs/battle-intelligence.log'),
+    ],
     'scheduler' => [
         'default_timeout_seconds' => max(30, (int) (getenv('SCHEDULER_DEFAULT_TIMEOUT_SECONDS') ?: 300)),
         'supervisor_mode' => getenv('SCHEDULER_SUPERVISOR_MODE') ?: 'php',

--- a/src/config/local.php.example
+++ b/src/config/local.php.example
@@ -46,6 +46,9 @@ return [
         'export_overlap_seconds' => 21600,
         'export_log_file' => 'storage/logs/influx-rollup-export.log',
     ],
+    'battle_intelligence' => [
+        'log_file' => 'storage/logs/battle-intelligence.log',
+    ],
     'scheduler' => [
         'default_timeout_seconds' => 300,
     ],

--- a/src/db.php
+++ b/src/db.php
@@ -13824,3 +13824,138 @@ function db_signals_recent(int $limit = 200): array
          LIMIT ' . $safeLimit
     );
 }
+
+function db_battle_intelligence_top_characters(int $limit = 50): array
+{
+    $safeLimit = max(1, min(200, $limit));
+
+    return db_select(
+        'SELECT css.character_id, css.suspicion_score, css.percentile_rank, css.high_sustain_frequency, css.low_sustain_frequency,
+                css.cross_side_rate, css.enemy_efficiency_uplift, css.role_weight, css.supporting_battle_count, css.computed_at,
+                COALESCE(emc.entity_name, CONCAT("Character #", css.character_id)) AS character_name
+         FROM character_suspicion_scores css
+         LEFT JOIN entity_metadata_cache emc ON emc.entity_type = "character" AND emc.entity_id = css.character_id
+         ORDER BY css.suspicion_score DESC, css.supporting_battle_count DESC
+         LIMIT ' . $safeLimit
+    );
+}
+
+function db_battle_intelligence_top_battles(int $limit = 50): array
+{
+    $safeLimit = max(1, min(200, $limit));
+
+    return db_select(
+        'SELECT ba.battle_id, ba.side_key, ba.anomaly_class, ba.z_efficiency_score, ba.percentile_rank, ba.computed_at,
+                br.system_id, br.started_at, br.ended_at, br.participant_count,
+                COALESCE(rs.system_name, CONCAT("System #", br.system_id)) AS system_name
+         FROM battle_anomalies ba
+         INNER JOIN battle_rollups br ON br.battle_id = ba.battle_id
+         LEFT JOIN ref_systems rs ON rs.system_id = br.system_id
+         ORDER BY ba.z_efficiency_score DESC, br.participant_count DESC
+         LIMIT ' . $safeLimit
+    );
+}
+
+function db_battle_intelligence_character(int $characterId): ?array
+{
+    if ($characterId <= 0) {
+        return null;
+    }
+
+    $row = db_select_one(
+        'SELECT css.*, cbi.total_battle_count, cbi.eligible_battle_count, cbi.high_sustain_battle_count, cbi.low_sustain_battle_count,
+                cbi.cross_side_battle_count, cbi.ally_efficiency_uplift, cbi.anomalous_battle_density,
+                COALESCE(emc.entity_name, CONCAT("Character #", css.character_id)) AS character_name
+         FROM character_suspicion_scores css
+         LEFT JOIN character_battle_intelligence cbi ON cbi.character_id = css.character_id
+         LEFT JOIN entity_metadata_cache emc ON emc.entity_type = "character" AND emc.entity_id = css.character_id
+         WHERE css.character_id = ?
+         LIMIT 1',
+        [$characterId]
+    );
+
+    return $row ?: null;
+}
+
+function db_battle_intelligence_character_battles(int $characterId, int $limit = 20): array
+{
+    if ($characterId <= 0) {
+        return [];
+    }
+
+    $safeLimit = max(1, min(100, $limit));
+
+    return db_select(
+        'SELECT baf.battle_id, baf.side_key, baf.centrality_score, baf.visibility_score,
+                baf.participated_in_high_sustain, baf.participated_in_low_sustain,
+                bsm.z_efficiency_score, bsm.efficiency_score,
+                br.system_id, br.started_at, br.ended_at, br.participant_count,
+                COALESCE(rs.system_name, CONCAT("System #", br.system_id)) AS system_name
+         FROM battle_actor_features baf
+         INNER JOIN battle_rollups br ON br.battle_id = baf.battle_id
+         LEFT JOIN battle_side_metrics bsm ON bsm.battle_id = baf.battle_id AND bsm.side_key = baf.side_key
+         LEFT JOIN ref_systems rs ON rs.system_id = br.system_id
+         WHERE baf.character_id = ?
+         ORDER BY ABS(COALESCE(bsm.z_efficiency_score, 0)) DESC, br.started_at DESC
+         LIMIT ' . $safeLimit,
+        [$characterId]
+    );
+}
+
+function db_battle_intelligence_battle(string $battleId): ?array
+{
+    $safeBattleId = trim($battleId);
+    if ($safeBattleId === '') {
+        return null;
+    }
+
+    $row = db_select_one(
+        'SELECT br.*, COALESCE(rs.system_name, CONCAT("System #", br.system_id)) AS system_name
+         FROM battle_rollups br
+         LEFT JOIN ref_systems rs ON rs.system_id = br.system_id
+         WHERE br.battle_id = ?
+         LIMIT 1',
+        [$safeBattleId]
+    );
+
+    return $row ?: null;
+}
+
+function db_battle_intelligence_battle_sides(string $battleId): array
+{
+    $safeBattleId = trim($battleId);
+    if ($safeBattleId === '') {
+        return [];
+    }
+
+    return db_select(
+        'SELECT bsm.*, ba.anomaly_class, ba.percentile_rank, ba.explanation_json
+         FROM battle_side_metrics bsm
+         LEFT JOIN battle_anomalies ba ON ba.battle_id = bsm.battle_id AND ba.side_key = bsm.side_key
+         WHERE bsm.battle_id = ?
+         ORDER BY bsm.z_efficiency_score DESC',
+        [$safeBattleId]
+    );
+}
+
+function db_battle_intelligence_battle_notable_actors(string $battleId, int $limit = 30): array
+{
+    $safeBattleId = trim($battleId);
+    if ($safeBattleId === '') {
+        return [];
+    }
+
+    $safeLimit = max(1, min(200, $limit));
+
+    return db_select(
+        'SELECT baf.character_id, baf.side_key, baf.centrality_score, baf.visibility_score, baf.participation_count,
+                baf.participated_in_high_sustain, baf.participated_in_low_sustain,
+                COALESCE(emc.entity_name, CONCAT("Character #", baf.character_id)) AS character_name
+         FROM battle_actor_features baf
+         LEFT JOIN entity_metadata_cache emc ON emc.entity_type = "character" AND emc.entity_id = baf.character_id
+         WHERE baf.battle_id = ?
+         ORDER BY baf.visibility_score DESC, baf.centrality_score DESC
+         LIMIT ' . $safeLimit,
+        [$safeBattleId]
+    );
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -234,6 +234,15 @@ function nav_items(): array
             ],
         ],
         [
+            'label' => 'Battle Intelligence',
+            'path' => '/battle-intelligence',
+            'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16"/><path stroke-linecap="round" stroke-linejoin="round" d="M4 12h16"/><path stroke-linecap="round" stroke-linejoin="round" d="M4 18h16"/><path stroke-linecap="round" stroke-linejoin="round" d="m9 9 3 3 3-3"/></svg>',
+            'children' => [
+                ['label' => 'Suspicion Leaderboard', 'path' => '/battle-intelligence'],
+                ['label' => 'Battle Anomalies', 'path' => '/battle-intelligence/battles.php'],
+            ],
+        ],
+        [
             'label' => 'Activity Priority',
             'path' => '/activity-priority',
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16"/><path stroke-linecap="round" stroke-linejoin="round" d="M6 12h12"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 17h6"/><path stroke-linecap="round" stroke-linejoin="round" d="m15 5 4 4-4 4"/></svg>',
@@ -3618,6 +3627,9 @@ function orchestrator_runtime_config_export(): array
             'export_overlap_seconds' => max(0, (int) config('influxdb.export_overlap_seconds', 21600)),
             'export_log_file' => supplycore_worker_log_path('influx-rollup-export.log', (string) config('influxdb.export_log_file', 'storage/logs/influx-rollup-export.log')),
         ],
+        'battle_intelligence' => [
+            'log_file' => supplycore_worker_log_path('battle-intelligence.log', (string) config('battle_intelligence.log_file', 'storage/logs/battle-intelligence.log')),
+        ],
         'paths' => [
             'app_root' => $appRoot,
             'bootstrap' => __DIR__ . '/bootstrap.php',
@@ -3795,6 +3807,11 @@ function worker_job_registry_definitions(): array
         'compute_graph_insights' => ['workload_class' => 'compute', 'execution_mode' => 'python', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 900, 'timeout_seconds' => 300, 'memory_limit_mb' => 768, 'retry_delay_seconds' => 60, 'max_attempts' => 4],
         'compute_buy_all' => ['workload_class' => 'compute', 'execution_mode' => 'python', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 900, 'timeout_seconds' => 420, 'memory_limit_mb' => 1024, 'retry_delay_seconds' => 60, 'max_attempts' => 4],
         'compute_signals' => ['workload_class' => 'compute', 'execution_mode' => 'python', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 900, 'timeout_seconds' => 300, 'memory_limit_mb' => 768, 'retry_delay_seconds' => 60, 'max_attempts' => 4],
+        'compute_battle_rollups' => ['workload_class' => 'compute', 'execution_mode' => 'python', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 600, 'timeout_seconds' => 420, 'memory_limit_mb' => 1024, 'retry_delay_seconds' => 90, 'max_attempts' => 4],
+        'compute_battle_target_metrics' => ['workload_class' => 'compute', 'execution_mode' => 'python', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 600, 'timeout_seconds' => 420, 'memory_limit_mb' => 1024, 'retry_delay_seconds' => 90, 'max_attempts' => 4],
+        'compute_battle_anomalies' => ['workload_class' => 'compute', 'execution_mode' => 'python', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 600, 'timeout_seconds' => 420, 'memory_limit_mb' => 1024, 'retry_delay_seconds' => 90, 'max_attempts' => 4],
+        'compute_battle_actor_features' => ['workload_class' => 'compute', 'execution_mode' => 'python', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 600, 'timeout_seconds' => 420, 'memory_limit_mb' => 1024, 'retry_delay_seconds' => 90, 'max_attempts' => 4],
+        'compute_suspicion_scores' => ['workload_class' => 'compute', 'execution_mode' => 'python', 'queue_name' => 'compute', 'priority' => 'normal', 'interval_seconds' => 600, 'timeout_seconds' => 420, 'memory_limit_mb' => 1024, 'retry_delay_seconds' => 90, 'max_attempts' => 4],
     ];
 }
 
@@ -3834,6 +3851,11 @@ function scheduler_registry_definitions(): array
         'compute_graph_insights' => ['label' => 'Graph Insights', 'default_interval_minutes' => 15, 'default_offset_minutes' => 18, 'priority' => 'normal', 'timeout_seconds' => 300, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
         'compute_buy_all' => ['label' => 'Compute Buy All', 'default_interval_minutes' => 15, 'default_offset_minutes' => 19, 'priority' => 'normal', 'timeout_seconds' => 420, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
         'compute_signals' => ['label' => 'Compute Signals', 'default_interval_minutes' => 15, 'default_offset_minutes' => 20, 'priority' => 'normal', 'timeout_seconds' => 300, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'lightweight'],
+        'compute_battle_rollups' => ['label' => 'Compute Battle Rollups', 'default_interval_minutes' => 10, 'default_offset_minutes' => 21, 'priority' => 'normal', 'timeout_seconds' => 420, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
+        'compute_battle_target_metrics' => ['label' => 'Compute Battle Target Metrics', 'default_interval_minutes' => 10, 'default_offset_minutes' => 22, 'priority' => 'normal', 'timeout_seconds' => 420, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
+        'compute_battle_anomalies' => ['label' => 'Compute Battle Anomalies', 'default_interval_minutes' => 10, 'default_offset_minutes' => 23, 'priority' => 'normal', 'timeout_seconds' => 420, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
+        'compute_battle_actor_features' => ['label' => 'Compute Battle Actor Features', 'default_interval_minutes' => 10, 'default_offset_minutes' => 24, 'priority' => 'normal', 'timeout_seconds' => 420, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
+        'compute_suspicion_scores' => ['label' => 'Compute Suspicion Scores', 'default_interval_minutes' => 10, 'default_offset_minutes' => 25, 'priority' => 'normal', 'timeout_seconds' => 420, 'concurrency_policy' => 'single', 'execution_mode' => 'python', 'tuning_mode' => 'automatic', 'explicitly_configured' => true, 'workload_class' => 'heavy'],
     ];
 }
 
@@ -27893,5 +27915,71 @@ function activity_priority_summary_build(string $reason = 'manual'): array
         'fit_count' => count($fitRows),
         'group_count' => count($groupRows),
         'item_count' => count($itemRows),
+    ];
+}
+
+function battle_intelligence_leaderboard_data(): array
+{
+    $rows = db_battle_intelligence_top_characters(100);
+
+    return [
+        'rows' => $rows,
+        'computed_at' => $rows !== [] ? (string) ($rows[0]['computed_at'] ?? '') : null,
+    ];
+}
+
+function battle_intelligence_anomaly_leaderboard_data(): array
+{
+    $rows = db_battle_intelligence_top_battles(100);
+
+    return [
+        'rows' => $rows,
+        'computed_at' => $rows !== [] ? (string) ($rows[0]['computed_at'] ?? '') : null,
+    ];
+}
+
+function battle_intelligence_character_data(int $characterId): array
+{
+    $character = db_battle_intelligence_character($characterId);
+    $battles = db_battle_intelligence_character_battles($characterId, 30);
+    $supportingBattles = [];
+    $explanation = [];
+
+    if (is_array($character)) {
+        $supportingBattles = json_decode((string) ($character['top_supporting_battles_json'] ?? '[]'), true);
+        if (!is_array($supportingBattles)) {
+            $supportingBattles = [];
+        }
+
+        $explanation = json_decode((string) ($character['explanation_json'] ?? '{}'), true);
+        if (!is_array($explanation)) {
+            $explanation = [];
+        }
+    }
+
+    return [
+        'character' => $character,
+        'battles' => $battles,
+        'supporting_battles' => $supportingBattles,
+        'explanation' => $explanation,
+    ];
+}
+
+function battle_intelligence_battle_data(string $battleId): array
+{
+    $battle = db_battle_intelligence_battle($battleId);
+    $sides = db_battle_intelligence_battle_sides($battleId);
+    $actors = db_battle_intelligence_battle_notable_actors($battleId, 40);
+
+    foreach ($sides as &$side) {
+        $decoded = json_decode((string) ($side['explanation_json'] ?? '{}'), true);
+        $side['explanation'] = is_array($decoded) ? $decoded : [];
+    }
+    unset($side);
+
+    return [
+        'battle' => $battle,
+        'sides' => $sides,
+        'actors' => $actors,
     ];
 }


### PR DESCRIPTION
### Motivation

- Introduce a precomputed Battle Intelligence subsystem to cluster killmails into battles, compute per-target metrics, detect side-level anomalies, derive actor features, and score suspicious characters for operator visibility and investigation.

### Description

- Add MariaDB schema for Battle Intelligence including tables `battle_rollups`, `battle_participants`, `battle_target_metrics`, `battle_side_metrics`, `battle_anomalies`, `battle_actor_features`, `character_battle_intelligence`, and `character_suspicion_scores`, and register scheduler entries for the new Python jobs.
- Implement a full Python job chain in `python/orchestrator/jobs/battle_intelligence.py` with jobs `run_compute_battle_rollups`, `run_compute_battle_target_metrics`, `run_compute_battle_anomalies`, `run_compute_battle_actor_features`, and `run_compute_suspicion_scores`, plus orchestrator CLI and worker-pool wiring and runtime logging support (`battle_intelligence.log_file`).
- Expose read-only operator pages and plumbing in PHP: new public pages under `public/battle-intelligence/*`, DB access helpers in `src/db.php`, view/controller helpers in `src/functions.php`, nav menu entries, and config integration (`battle_intelligence` settings in `src/config/*`).
- Add operator documentation and validation artifacts: `docs/BATTLE_INTELLIGENCE_RUNBOOK.md`, `docs/BATTLE_INTELLIGENCE_VALIDATION.md`, and README notes describing the subsystem and recommended run order.

### Testing

- Performed CLI dry-run smoke checks of the new Python jobs using the orchestrator, e.g. `python bin/python_orchestrator.py compute-battle-rollups --dry-run` and equivalent commands for each job, which completed and emitted expected JSON summary payloads.
- Ran PHP syntax checks (`php -l`) against the new PHP pages to validate there are no syntax errors in the added files, which passed.
- No new unit tests were added as part of this change; integration testing is expected by running the job chain and the SQL validation queries in `docs/BATTLE_INTELLIGENCE_VALIDATION.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a194b47c832f86081cc3c167495e)