### PR TITLE
Make battle_intelligence.py runnable as a script by fixing imports

### DIFF
--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -2,14 +2,21 @@ from __future__ import annotations
 
 import json
 import math
+import sys
 from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from ..db import SupplyCoreDb
-from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
-from ..neo4j import Neo4jClient, Neo4jConfig
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from orchestrator.db import SupplyCoreDb
+    from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from orchestrator.neo4j import Neo4jClient, Neo4jConfig
+else:
+    from ..db import SupplyCoreDb
+    from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from ..neo4j import Neo4jClient, Neo4jConfig
 
 WINDOW_SECONDS = 15 * 60
 MIN_ELIGIBLE_PARTICIPANTS = 100


### PR DESCRIPTION
### Motivation
- Running `python/orchestrator/jobs/battle_intelligence.py` directly failed due to relative imports when `__package__` was unset, making local debugging and direct execution awkward.

### Description
- Added an import-mode guard that checks `__package__` and when empty appends the repository `python/` directory to `sys.path` and uses absolute `orchestrator.*` imports.
- Preserved the original relative imports for normal package/module execution paths so packaged usage remains unchanged.
- Added an `import sys` and adjusted `python/orchestrator/jobs/battle_intelligence.py` to use the new guard.

### Testing
- Ran `python python/orchestrator/jobs/battle_intelligence.py` and the script exited successfully with no import error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3bc97d4bc832f9ad5967268420b19)