### PR TITLE
Ensure battle_intelligence.py prefers repo-local orchestrator package

### DIFF
--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -9,7 +9,9 @@ from pathlib import Path
 from typing import Any
 
 if __package__ in (None, ""):
-    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    package_root = str(Path(__file__).resolve().parents[2])
+    if package_root not in sys.path:
+        sys.path.insert(0, package_root)
     from orchestrator.db import SupplyCoreDb
     from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
     from orchestrator.neo4j import Neo4jClient, Neo4jConfig


### PR DESCRIPTION
### Motivation
- Prevent `ModuleNotFoundError` and ambiguous imports when running the job script directly by ensuring the repository's `python/orchestrator` package is resolved before any globally installed `orchestrator` package.

### Description
- Replace the unguarded `sys.path.append(...)` bootstrap in `python/orchestrator/jobs/battle_intelligence.py` with a guarded `sys.path.insert(0, ...)` that checks `sys.path` first so the local package root is prepended and not duplicated.

### Testing
- Ran `python python/orchestrator/jobs/battle_intelligence.py` and the process exited successfully (code 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3be6ccf10832fb8c7421df0a92edc)