### PR TITLE
Wire battle-intelligence compute jobs into Python scheduler runtime

### DIFF
--- a/python/orchestrator/job_runner.py
+++ b/python/orchestrator/job_runner.py
@@ -12,10 +12,15 @@ from .bridge import PhpBridge
 from .config import load_php_runtime_config
 from .db import SupplyCoreDb
 from .jobs import (
+    run_compute_battle_actor_features,
+    run_compute_battle_anomalies,
+    run_compute_battle_rollups,
+    run_compute_battle_target_metrics,
     run_compute_buy_all,
     run_compute_signals,
     run_compute_graph_insights,
     run_compute_graph_sync,
+    run_compute_suspicion_scores,
     run_killmail_r2z2_stream,
     run_market_comparison_summary,
     run_market_hub_local_history,
@@ -80,6 +85,30 @@ PROCESSORS: dict[str, Callable[[PythonWorkerContext], dict[str, Any]]] = {
         run_compute_signals(context.db, dict(context.raw_config.get("influx") or {})),
         "compute_signals",
     ),
+    "compute_battle_rollups": lambda context: _compute_result_shape(
+        run_compute_battle_rollups(context.db, dict(context.raw_config.get("battle_intelligence") or {})),
+        "compute_battle_rollups",
+    ),
+    "compute_battle_target_metrics": lambda context: _compute_result_shape(
+        run_compute_battle_target_metrics(context.db, dict(context.raw_config.get("battle_intelligence") or {})),
+        "compute_battle_target_metrics",
+    ),
+    "compute_battle_anomalies": lambda context: _compute_result_shape(
+        run_compute_battle_anomalies(context.db, dict(context.raw_config.get("battle_intelligence") or {})),
+        "compute_battle_anomalies",
+    ),
+    "compute_battle_actor_features": lambda context: _compute_result_shape(
+        run_compute_battle_actor_features(
+            context.db,
+            dict(context.raw_config.get("neo4j") or {}),
+            dict(context.raw_config.get("battle_intelligence") or {}),
+        ),
+        "compute_battle_actor_features",
+    ),
+    "compute_suspicion_scores": lambda context: _compute_result_shape(
+        run_compute_suspicion_scores(context.db, dict(context.raw_config.get("battle_intelligence") or {})),
+        "compute_suspicion_scores",
+    ),
 }
 
 
@@ -99,13 +128,15 @@ def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
 
 
 def _compute_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
+    status = str(result.get("status") or "success")
     rows_processed = max(0, int(result.get("rows_processed") or 0))
     rows_written = max(0, int(result.get("rows_written") or 0))
     return {
-        "status": "success",
-        "summary": f"{job_key} completed successfully.",
+        "status": status,
+        "summary": str(result.get("summary") or f"{job_key} completed with status {status}."),
         "rows_processed": rows_processed,
         "rows_written": rows_written,
+        "warnings": list(result.get("warnings") or []),
         "meta": {
             "job_name": job_key,
             "computed_at": str(result.get("computed_at") or ""),

--- a/src/functions.php
+++ b/src/functions.php
@@ -11914,6 +11914,78 @@ function scheduler_job_definitions(): array
                 return supplycore_refresh_forecasting_snapshot_job_result('scheduler');
             },
         ],
+        'compute_graph_sync' => [
+            'timeout_seconds' => 300,
+            'lock_ttl_seconds' => 360,
+            'execution' => 'background',
+            'handler' => static function (): array {
+                throw new RuntimeException('compute_graph_sync must run in the Python scheduler runtime.');
+            },
+        ],
+        'compute_graph_insights' => [
+            'timeout_seconds' => 300,
+            'lock_ttl_seconds' => 360,
+            'execution' => 'background',
+            'handler' => static function (): array {
+                throw new RuntimeException('compute_graph_insights must run in the Python scheduler runtime.');
+            },
+        ],
+        'compute_buy_all' => [
+            'timeout_seconds' => 420,
+            'lock_ttl_seconds' => 480,
+            'execution' => 'background',
+            'handler' => static function (): array {
+                throw new RuntimeException('compute_buy_all must run in the Python scheduler runtime.');
+            },
+        ],
+        'compute_signals' => [
+            'timeout_seconds' => 300,
+            'lock_ttl_seconds' => 360,
+            'execution' => 'background',
+            'handler' => static function (): array {
+                throw new RuntimeException('compute_signals must run in the Python scheduler runtime.');
+            },
+        ],
+        'compute_battle_rollups' => [
+            'timeout_seconds' => 420,
+            'lock_ttl_seconds' => 480,
+            'execution' => 'background',
+            'handler' => static function (): array {
+                throw new RuntimeException('compute_battle_rollups must run in the Python scheduler runtime.');
+            },
+        ],
+        'compute_battle_target_metrics' => [
+            'timeout_seconds' => 420,
+            'lock_ttl_seconds' => 480,
+            'execution' => 'background',
+            'handler' => static function (): array {
+                throw new RuntimeException('compute_battle_target_metrics must run in the Python scheduler runtime.');
+            },
+        ],
+        'compute_battle_anomalies' => [
+            'timeout_seconds' => 420,
+            'lock_ttl_seconds' => 480,
+            'execution' => 'background',
+            'handler' => static function (): array {
+                throw new RuntimeException('compute_battle_anomalies must run in the Python scheduler runtime.');
+            },
+        ],
+        'compute_battle_actor_features' => [
+            'timeout_seconds' => 420,
+            'lock_ttl_seconds' => 480,
+            'execution' => 'background',
+            'handler' => static function (): array {
+                throw new RuntimeException('compute_battle_actor_features must run in the Python scheduler runtime.');
+            },
+        ],
+        'compute_suspicion_scores' => [
+            'timeout_seconds' => 420,
+            'lock_ttl_seconds' => 480,
+            'execution' => 'background',
+            'handler' => static function (): array {
+                throw new RuntimeException('compute_suspicion_scores must run in the Python scheduler runtime.');
+            },
+        ],
         'killmail_r2z2_sync' => [
             'timeout_seconds' => 180,
             'lock_ttl_seconds' => 300,
@@ -11942,6 +12014,15 @@ function scheduler_job_type(string $jobKey): string
         'rebuild_ai_briefings' => 'sync.doctrine_ai',
         'forecasting_ai_sync' => 'sync.forecasting',
         'killmail_r2z2_sync' => 'sync.killmail',
+        'compute_graph_sync' => 'compute.graph_sync',
+        'compute_graph_insights' => 'compute.graph_insights',
+        'compute_buy_all' => 'compute.buy_all',
+        'compute_signals' => 'compute.signals',
+        'compute_battle_rollups' => 'compute.battle_rollups',
+        'compute_battle_target_metrics' => 'compute.battle_target_metrics',
+        'compute_battle_anomalies' => 'compute.battle_anomalies',
+        'compute_battle_actor_features' => 'compute.battle_actor_features',
+        'compute_suspicion_scores' => 'compute.suspicion_scores',
         default => 'sync.generic',
     };
 }


### PR DESCRIPTION
### Motivation
- Ensure the full battle-intelligence chain runs under the Python scheduler so heavy compute work uses the Python worker pool rather than legacy PHP/cron paths. 
- Surface accurate job statuses (skipped/failed/warnings) from Python compute jobs into the scheduler/UI so website status panels and planner logic reflect real outcomes. 
- Register all Python compute job keys in the scheduler registry so bootstrap, discovery, and dispatch treat them as background Python workloads.

### Description
- Add direct Python processors for the battle-intelligence jobs in `python/orchestrator/job_runner.py` so `compute_battle_rollups`, `compute_battle_target_metrics`, `compute_battle_anomalies`, `compute_battle_actor_features`, and `compute_suspicion_scores` call `python/orchestrator/jobs/battle_intelligence.py` implementations. 
- Preserve and propagate `status`, `summary`, and `warnings` in `_compute_result_shape` so compute-job results (including `skipped` and `failed`) are not coerced to success. 
- Register all Python compute jobs (graph sync/insights, buy-all/signals, and the battle-intel chain) in `scheduler_job_definitions()` as background jobs with a placeholder handler that throws if invoked from PHP, forcing them to run in the Python scheduler runtime. 
- Classify the new compute job keys in `scheduler_job_type()` so scheduler telemetry and UI cards show appropriate compute job types.

### Testing
- Ran Python compile check with `python -m compileall python/orchestrator/job_runner.py` which completed successfully. 
- Linted PHP with `php -l src/functions.php` which reported no syntax errors. 
- Confirmed the new processors and registry entries are present using targeted `rg` searches for the new `compute_battle_*` and `compute_suspicion_scores` keys in `python/orchestrator/job_runner.py` and `src/functions.php`, which returned matches. 
- Verified there are no missing compute-job registrations by scripting a registry vs worker list check which returned no missing entries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3c125f568832fbb5f1b93313a8486)