### PR TITLE
Fix worker pool crash from claim diagnostics parameter mismatch

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -13656,6 +13656,14 @@ function db_worker_job_claim_diagnostics(array $queues = [], array $workloadClas
 
     $filters = db_worker_job_filter_fragments($queues, $workloadClasses, $executionModes);
     $whereFiltered = $filters['conditions'] === [] ? '' : (' AND ' . implode(' AND ', $filters['conditions']));
+    $filteredParams = [];
+    if ($whereFiltered !== '') {
+        // The filtered predicate is used in four SELECT expressions below, so
+        // repeat the bound values in the same order for each expression.
+        for ($i = 0; $i < 4; $i++) {
+            array_push($filteredParams, ...$filters['params']);
+        }
+    }
 
     $counts = db_select_one(
         "SELECT
@@ -13665,7 +13673,7 @@ function db_worker_job_claim_diagnostics(array $queues = [], array $workloadClas
             SUM(CASE WHEN status = 'running' {$whereFiltered} THEN 1 ELSE 0 END) AS running_filtered,
             MIN(CASE WHEN status IN ('queued', 'retry') {$whereFiltered} THEN available_at ELSE NULL END) AS next_available_filtered
          FROM worker_jobs",
-        $filters['params']
+        $filteredParams
     );
 
     $readyAll = max(0, (int) (($counts['ready_all'] ?? 0)));


### PR DESCRIPTION
### Motivation

- Worker processes were crashing with `SQLSTATE[HY093]: Invalid parameter number` when the PHP bridge called `claim-worker-job`, causing `supplycore-sync-worker*` services to repeatedly exit and restart. 
- The root cause was the diagnostics aggregate query in `db_worker_job_claim_diagnostics()` reusing the same filtered predicate four times while only binding one set of filter parameters, producing a parameter-count mismatch. 

### Description

- Updated `src/db.php` in `db_worker_job_claim_diagnostics()` to build a new `$filteredParams` array and duplicate the filter parameter list once per repeated filtered expression so bound parameters match every placeholder. 
- The change only adjusts the parameter binding passed to `db_select_one()` and keeps the existing SQL text and filter construction logic unchanged. 

### Testing

- Ran `php -l src/db.php` to validate syntax and it completed successfully. 
- No other automated test failures were observed during the change; additional integration testing (restarting worker services) is recommended after deployment to confirm the runtime bridge errors are resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3df9ca064832f9f379482aa2ef033)