### PR TITLE
Refactor config architecture to env DB bootstrap + DB-backed runtime settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=supplycore
+DB_USERNAME=supplycore
+DB_PASSWORD=StrongPasswordHere
+DB_SOCKET=
+APP_ENV=development

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ src/
   cache.php                 # Redis client + low-level cache/lock primitives
   db.php                    # Config + PDO + query helpers + transactions
   functions.php             # Navigation, settings services, shared helpers
-  config/app.php            # Base app/db config with optional local PHP override
-  config/local.php.example  # Copy to local.php for server-specific secrets/settings
+  config/app.php            # Bootstrap defaults + env-backed DB config
+  config/runtime_settings.php # Runtime settings registry/schema (drives UI + persistence)
+  config/local.php.example  # Legacy example only (not part of runtime override chain)
   views/partials/           # Header / sidebar / footer layout partials
 database/
   schema.sql                # Tables + starter data
@@ -63,42 +64,49 @@ README.md
 
 > Upgrading an existing installation? Apply schema changes before the next sync run so local snapshot history can keep rebuilding cleanly from your stored ESI order snapshots.
 
-2. **Configure the app in PHP (no `.env` file required or expected)**
+2. **Configure bootstrap DB settings in `.env`**
    ```bash
-   cp src/config/local.php.example src/config/local.php
+   cp .env.example .env
    ```
 
-   Then edit `src/config/local.php` and set the values for your server:
+   Then edit `.env` and set database credentials:
    ```bash
-   nano src/config/local.php
+   nano .env
    ```
 
    Minimal example:
-   ```php
-   <?php
-   return [
-       'app' => [
-           'env' => 'development',
-           'base_url' => 'http://localhost:8080',
-           'timezone' => 'UTC',
-       ],
-       'db' => [
-           'host' => '127.0.0.1',
-           'port' => 3306,
-           'database' => 'supplycore',
-           'username' => 'root',
-           'password' => 'secret',
-           'socket' => '', // Optional: set this when MySQL only listens on a local unix socket.
-       ],
-   ];
+   ```dotenv
+   DB_HOST=127.0.0.1
+   DB_PORT=3306
+   DB_DATABASE=supplycore
+   DB_USERNAME=supplycore
+   DB_PASSWORD=StrongPasswordHere
+   DB_SOCKET=
+   APP_ENV=development
    ```
 
    Notes:
-   - `src/config/app.php` loads the repository defaults first.
-   - If `src/config/local.php` exists, it is merged on top of those defaults.
-   - Set `db.socket` (or `DB_SOCKET`) when Apache/PHP should connect through a local MySQL unix socket instead of TCP. SupplyCore now tries configured/default socket paths before falling back to `host` + `port`.
-   - Environment variables still work, but they are optional. For most installs, editing `src/config/local.php` is simpler and matches this repository’s recommended workflow.
-   - Keep `src/config/local.php` out of version control.
+   - DB bootstrap settings are env-only and read-only in Settings UI.
+   - Runtime/application settings are stored in `app_settings` and managed from **Settings → Runtime Config**.
+   - `src/config/app.php` is defaults/bootstrap only.
+   - `src/config/local.php` is no longer used as a runtime override layer.
+
+### Runtime configuration model
+
+- **`.env`**: only bootstrap/infrastructure values required before DB reads (DB connection + optional `APP_ENV`).
+- **Database (`app_settings`)**: authoritative runtime config (app, redis, neo4j, influxdb, scheduler, workers, battle intelligence, orchestrator, rebuild, etc.).
+- **`src/config/app.php`**: defaults/fallbacks + schema bootstrap values.
+- **Settings UI**: authoritative runtime editor; saves to DB only (no config file writes).
+
+### Migrating old `local.php` values
+
+If you previously stored runtime values in `src/config/local.php`, import them once:
+
+```bash
+php bin/migrate_local_config.php
+```
+
+After import, runtime settings are read from `app_settings`; `local.php` is not merged at runtime.
 
 3. **Run with PHP built-in server (dev only)**
    ```bash

--- a/bin/migrate_local_config.php
+++ b/bin/migrate_local_config.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+$path = $argv[1] ?? (__DIR__ . '/../src/config/local.php');
+$result = migrate_local_config_to_app_settings($path);
+
+if (($result['ok'] ?? false) !== true) {
+    fwrite(STDERR, (string) ($result['message'] ?? 'Migration failed') . PHP_EOL);
+    exit(1);
+}
+
+fwrite(STDOUT, sprintf("%s Imported=%d\n", (string) ($result['message'] ?? 'Migration complete'), (int) ($result['imported'] ?? 0)));

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -20,6 +20,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $saveMessage = null;
 
     switch ($submittedSection) {
+        case 'runtime-config':
+            $saved = save_settings(runtime_config_settings_from_request($_POST));
+            if ($saved) {
+                supplycore_runtime_config_refresh();
+            }
+            break;
+
         case 'general':
             $saved = save_settings([
                 'app_name' => sanitize_app_name((string) ($_POST['app_name'] ?? app_name())),
@@ -245,6 +252,8 @@ $settingValues = get_settings([
 
 $dataSyncSettingValues = data_sync_pipeline_settings_view($settingValues);
 $dealAlertSettingValues = deal_alert_settings_view($settingValues);
+$runtimeConfigSections = runtime_config_sections_for_ui();
+$bootstrapDbConfig = (array) (supplycore_base_config()['db'] ?? []);
 
 $dbStatus = db_connection_status();
 $latestEsiToken = null;
@@ -388,7 +397,52 @@ include __DIR__ . '/../../src/views/partials/header.php';
             </div>
         <?php endif; ?>
 
-        <?php if ($section === 'general'): ?>
+        <?php if ($section === 'runtime-config'): ?>
+            <div class="mt-6 space-y-6">
+                <section class="rounded-2xl border border-border bg-black/20 p-4">
+                    <p class="text-sm font-semibold text-slate-100">Database connection (env-only)</p>
+                    <p class="mt-1 text-sm text-muted">These values are loaded from <code>.env</code>/<code>getenv()</code> and are never saved from this UI.</p>
+                    <div class="mt-4 grid gap-3 md:grid-cols-2">
+                        <p class="text-sm text-slate-200">Host: <span class="font-mono text-slate-100"><?= htmlspecialchars((string) ($bootstrapDbConfig['host'] ?? ''), ENT_QUOTES) ?></span></p>
+                        <p class="text-sm text-slate-200">Port: <span class="font-mono text-slate-100"><?= htmlspecialchars((string) ($bootstrapDbConfig['port'] ?? ''), ENT_QUOTES) ?></span></p>
+                        <p class="text-sm text-slate-200">Database: <span class="font-mono text-slate-100"><?= htmlspecialchars((string) ($bootstrapDbConfig['database'] ?? ''), ENT_QUOTES) ?></span></p>
+                        <p class="text-sm text-slate-200">Username: <span class="font-mono text-slate-100"><?= htmlspecialchars((string) ($bootstrapDbConfig['username'] ?? ''), ENT_QUOTES) ?></span></p>
+                        <p class="text-sm text-slate-200">Socket: <span class="font-mono text-slate-100"><?= htmlspecialchars((string) ($bootstrapDbConfig['socket'] ?? ''), ENT_QUOTES) ?></span></p>
+                        <p class="text-sm text-slate-200">Password configured: <span class="font-mono text-slate-100"><?= ((string) ($bootstrapDbConfig['password'] ?? '')) !== '' ? 'yes' : 'no' ?></span></p>
+                    </div>
+                </section>
+
+                <form method="post" class="space-y-6">
+                    <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
+                    <input type="hidden" name="section" value="runtime-config">
+                    <?php foreach ($runtimeConfigSections as $registrySectionKey => $registrySection): ?>
+                        <?php if ($registrySectionKey === 'db') {
+                            continue;
+                        } ?>
+                        <section class="rounded-2xl border border-border bg-black/20 p-4">
+                            <p class="text-sm font-semibold text-slate-100"><?= htmlspecialchars((string) ($registrySection['title'] ?? $registrySectionKey), ENT_QUOTES) ?></p>
+                            <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($registrySection['description'] ?? ''), ENT_QUOTES) ?></p>
+                            <div class="mt-4 grid gap-4 md:grid-cols-2">
+                                <?php foreach ((array) ($registrySection['fields'] ?? []) as $path => $field): ?>
+                                    <?php if (($field['editable'] ?? false) !== true) {
+                                        continue;
+                                    } ?>
+                                    <label class="block space-y-2">
+                                        <span class="text-sm text-muted"><?= htmlspecialchars($path, ENT_QUOTES) ?> (<?= htmlspecialchars((string) ($field['type'] ?? 'string'), ENT_QUOTES) ?>)</span>
+                                        <?php if (($field['type'] ?? 'string') === 'bool'): ?>
+                                            <input type="checkbox" name="<?= htmlspecialchars($path, ENT_QUOTES) ?>" value="1" <?= !empty($field['value']) ? 'checked' : '' ?>>
+                                        <?php else: ?>
+                                            <input name="<?= htmlspecialchars($path, ENT_QUOTES) ?>" value="<?= htmlspecialchars((string) ($field['value'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" />
+                                        <?php endif; ?>
+                                    </label>
+                                <?php endforeach; ?>
+                            </div>
+                        </section>
+                    <?php endforeach; ?>
+                    <button class="btn-primary">Save runtime settings</button>
+                </form>
+            </div>
+        <?php elseif ($section === 'general'): ?>
             <?php
             $businessConfigCards = [
                 ['href' => '/settings?section=trading-stations', 'title' => 'Trading stations', 'copy' => 'Reference hub and alliance destination used by market, doctrine, and buy-all workflows.'],

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -2,132 +2,93 @@
 
 declare(strict_types=1);
 
-$config = [
+return [
     'app' => [
         'name' => 'SupplyCore',
         'env' => getenv('APP_ENV') ?: 'development',
-        'base_url' => getenv('APP_BASE_URL') ?: 'http://localhost:8080',
-        'timezone' => getenv('APP_TIMEZONE') ?: 'UTC',
+        'base_url' => 'http://localhost:8080',
+        'timezone' => 'UTC',
     ],
     'db' => [
         'host' => getenv('DB_HOST') ?: '127.0.0.1',
         'port' => (int) (getenv('DB_PORT') ?: 3306),
         'database' => getenv('DB_DATABASE') ?: 'supplycore',
-        'username' => getenv('DB_USERNAME') ?: 'root',
-        'password' => getenv('DB_PASSWORD') ?: '',
+        'username' => getenv('DB_USERNAME') ?: 'supplycore',
+        'password' => getenv('DB_PASSWORD') ?: 'StrongPasswordHere',
         'charset' => 'utf8mb4',
         'socket' => trim((string) (getenv('DB_SOCKET') ?: '')),
     ],
     'redis' => [
-        'enabled' => (getenv('REDIS_ENABLED') ?: '0') === '1',
-        'host' => getenv('REDIS_HOST') ?: '127.0.0.1',
-        'port' => (int) (getenv('REDIS_PORT') ?: 6379),
-        'database' => (int) (getenv('REDIS_DATABASE') ?: 0),
-        'password' => getenv('REDIS_PASSWORD') ?: '',
-        'prefix' => getenv('REDIS_PREFIX') ?: 'supplycore',
-        'connect_timeout' => (float) (getenv('REDIS_CONNECT_TIMEOUT') ?: 1.5),
-        'read_timeout' => (float) (getenv('REDIS_READ_TIMEOUT') ?: 1.5),
-        'lock_enabled' => (getenv('REDIS_LOCK_ENABLED') ?: '1') === '1',
+        'enabled' => false,
+        'host' => '127.0.0.1',
+        'port' => 6379,
+        'database' => 0,
+        'password' => '',
+        'prefix' => 'supplycore',
+        'connect_timeout' => 1.5,
+        'read_timeout' => 1.5,
+        'lock_enabled' => true,
     ],
     'neo4j' => [
-        'enabled' => (getenv('NEO4J_ENABLED') ?: '0') === '1',
-        'url' => rtrim((string) (getenv('NEO4J_URL') ?: 'http://127.0.0.1:7474'), '/'),
-        'username' => (string) (getenv('NEO4J_USERNAME') ?: 'neo4j'),
-        'password' => (string) (getenv('NEO4J_PASSWORD') ?: ''),
-        'database' => (string) (getenv('NEO4J_DATABASE') ?: 'neo4j'),
-        'timeout_seconds' => max(3, (int) (getenv('NEO4J_TIMEOUT_SECONDS') ?: 15)),
-        'log_file' => (string) (getenv('NEO4J_LOG_FILE') ?: 'storage/logs/graph-sync.log'),
+        'enabled' => false,
+        'url' => 'http://127.0.0.1:7474',
+        'username' => 'neo4j',
+        'password' => '',
+        'database' => 'neo4j',
+        'timeout_seconds' => 15,
+        'log_file' => 'storage/logs/graph-sync.log',
     ],
     'influxdb' => [
-        'enabled' => (getenv('INFLUXDB_ENABLED') ?: '0') === '1',
-        'read_enabled' => (getenv('INFLUXDB_READ_ENABLED') ?: '0') === '1',
-        'url' => rtrim((string) (getenv('INFLUXDB_URL') ?: 'http://127.0.0.1:8086'), '/'),
-        'org' => (string) (getenv('INFLUXDB_ORG') ?: ''),
-        'bucket' => (string) (getenv('INFLUXDB_BUCKET') ?: 'supplycore_rollups'),
-        'token' => (string) (getenv('INFLUXDB_TOKEN') ?: ''),
-        'timeout_seconds' => max(3, (int) (getenv('INFLUXDB_TIMEOUT_SECONDS') ?: 15)),
-        'export_batch_size' => max(100, (int) (getenv('INFLUXDB_EXPORT_BATCH_SIZE') ?: 1000)),
-        'export_overlap_seconds' => max(0, (int) (getenv('INFLUXDB_EXPORT_OVERLAP_SECONDS') ?: 21600)),
-        'export_log_file' => (string) (getenv('INFLUXDB_EXPORT_LOG_FILE') ?: 'storage/logs/influx-rollup-export.log'),
+        'enabled' => false,
+        'read_enabled' => false,
+        'url' => 'http://127.0.0.1:8086',
+        'org' => '',
+        'bucket' => 'supplycore_rollups',
+        'token' => '',
+        'timeout_seconds' => 15,
+        'export_batch_size' => 1000,
+        'export_overlap_seconds' => 21600,
+        'export_log_file' => 'storage/logs/influx-rollup-export.log',
     ],
     'battle_intelligence' => [
-        'log_file' => (string) (getenv('SUPPLYCORE_BATTLE_INTELLIGENCE_LOG_FILE') ?: 'storage/logs/battle-intelligence.log'),
+        'log_file' => 'storage/logs/battle-intelligence.log',
     ],
     'scheduler' => [
-        'default_timeout_seconds' => max(30, (int) (getenv('SCHEDULER_DEFAULT_TIMEOUT_SECONDS') ?: 300)),
-        'supervisor_mode' => getenv('SCHEDULER_SUPERVISOR_MODE') ?: 'php',
-        'systemd_service' => getenv('SCHEDULER_SYSTEMD_SERVICE') ?: 'supplycore-scheduler.service',
-        'python_service_name' => getenv('SCHEDULER_PYTHON_SERVICE_NAME') ?: 'supplycore-orchestrator.service',
-        'python_heavy_jobs_enabled' => (getenv('SCHEDULER_PYTHON_HEAVY_JOBS_ENABLED') ?: '1') !== '0',
-        'python_php_fallback_enabled' => (getenv('SCHEDULER_PYTHON_PHP_FALLBACK_ENABLED') ?: '1') !== '0',
+        'default_timeout_seconds' => 300,
+        'supervisor_mode' => 'php',
+        'systemd_service' => 'supplycore-scheduler.service',
+        'python_service_name' => 'supplycore-orchestrator.service',
+        'python_heavy_jobs_enabled' => true,
+        'python_php_fallback_enabled' => true,
     ],
     'orchestrator' => [
-        'heartbeat_file' => getenv('ORCHESTRATOR_HEARTBEAT_FILE') ?: 'storage/run/orchestrator-heartbeat.json',
-        'lock_file' => getenv('ORCHESTRATOR_LOCK_FILE') ?: 'storage/run/orchestrator.lock',
-        'state_dir' => getenv('ORCHESTRATOR_STATE_DIR') ?: 'storage/run',
-        'health_check_interval_seconds' => max(5, (int) (getenv('ORCHESTRATOR_HEALTH_CHECK_INTERVAL_SECONDS') ?: 15)),
-        'worker_grace_seconds' => max(15, (int) (getenv('ORCHESTRATOR_WORKER_GRACE_SECONDS') ?: 45)),
-        'worker_start_backoff_seconds' => max(1, (int) (getenv('ORCHESTRATOR_WORKER_START_BACKOFF_SECONDS') ?: 5)),
-        'max_consecutive_health_failures' => max(1, (int) (getenv('ORCHESTRATOR_MAX_CONSECUTIVE_HEALTH_FAILURES') ?: 3)),
+        'heartbeat_file' => 'storage/run/orchestrator-heartbeat.json',
+        'lock_file' => 'storage/run/orchestrator.lock',
+        'state_dir' => 'storage/run',
+        'health_check_interval_seconds' => 15,
+        'worker_grace_seconds' => 45,
+        'worker_start_backoff_seconds' => 5,
+        'max_consecutive_health_failures' => 3,
     ],
     'rebuild' => [
-        'status_file' => getenv('SUPPLYCORE_REBUILD_STATUS_FILE') ?: 'storage/run/rebuild-data-model-status.json',
-        'lock_file' => getenv('SUPPLYCORE_REBUILD_LOCK_FILE') ?: 'storage/run/rebuild-data-model.lock',
-        'progress_interval_seconds' => max(1, (int) (getenv('SUPPLYCORE_REBUILD_PROGRESS_INTERVAL_SECONDS') ?: 2)),
+        'status_file' => 'storage/run/rebuild-data-model-status.json',
+        'lock_file' => 'storage/run/rebuild-data-model.lock',
+        'progress_interval_seconds' => 2,
     ],
     'workers' => [
-        'queue_name' => getenv('SUPPLYCORE_WORKER_QUEUE') ?: 'default',
-        'claim_ttl_seconds' => max(30, (int) (getenv('SUPPLYCORE_WORKER_CLAIM_TTL_SECONDS') ?: 300)),
-        'idle_sleep_seconds' => max(0, (int) (getenv('SUPPLYCORE_WORKER_IDLE_SLEEP_SECONDS') ?: 10)),
-        'compute_idle_sleep_seconds' => max(0, (int) (getenv('SUPPLYCORE_COMPUTE_IDLE_SLEEP_SECONDS') ?: 15)),
-        'sync_idle_sleep_seconds' => max(0, (int) (getenv('SUPPLYCORE_SYNC_IDLE_SLEEP_SECONDS') ?: 8)),
-        'memory_pause_threshold_bytes' => max(134217728, (int) (getenv('SUPPLYCORE_WORKER_MEMORY_PAUSE_THRESHOLD_BYTES') ?: 402653184)),
-        'memory_abort_threshold_bytes' => max(268435456, (int) (getenv('SUPPLYCORE_WORKER_MEMORY_ABORT_THRESHOLD_BYTES') ?: 536870912)),
-        'retry_backoff_seconds' => max(5, (int) (getenv('SUPPLYCORE_WORKER_RETRY_BACKOFF_SECONDS') ?: 30)),
-        'zkill_stuck_cursor_threshold' => max(2, (int) (getenv('SUPPLYCORE_ZKILL_STUCK_CURSOR_THRESHOLD') ?: 3)),
-        'zkill_log_file' => getenv('SUPPLYCORE_ZKILL_LOG_FILE') ?: 'storage/logs/zkill.log',
-        'worker_log_file' => getenv('SUPPLYCORE_WORKER_LOG_FILE') ?: 'storage/logs/worker.log',
-        'compute_log_file' => getenv('SUPPLYCORE_COMPUTE_LOG_FILE') ?: 'storage/logs/compute.log',
-        'pool_state_file' => getenv('SUPPLYCORE_WORKER_POOL_STATE_FILE') ?: 'storage/run/worker-pool-heartbeat.json',
-        'zkill_state_file' => getenv('SUPPLYCORE_ZKILL_STATE_FILE') ?: 'storage/run/zkill-heartbeat.json',
+        'queue_name' => 'default',
+        'claim_ttl_seconds' => 300,
+        'idle_sleep_seconds' => 10,
+        'compute_idle_sleep_seconds' => 15,
+        'sync_idle_sleep_seconds' => 8,
+        'memory_pause_threshold_bytes' => 402653184,
+        'memory_abort_threshold_bytes' => 536870912,
+        'retry_backoff_seconds' => 30,
+        'zkill_stuck_cursor_threshold' => 3,
+        'zkill_log_file' => 'storage/logs/zkill.log',
+        'worker_log_file' => 'storage/logs/worker.log',
+        'compute_log_file' => 'storage/logs/compute.log',
+        'pool_state_file' => 'storage/run/worker-pool-heartbeat.json',
+        'zkill_state_file' => 'storage/run/zkill-heartbeat.json',
     ],
 ];
-
-/**
- * @return array<string, mixed>|null
- */
-function supplycore_load_local_config(string $localConfigPath): ?array
-{
-    if (!is_file($localConfigPath)) {
-        return null;
-    }
-
-    try {
-        $localConfig = (static function (string $path): mixed {
-            return require $path;
-        })($localConfigPath);
-    } catch (ParseError $exception) {
-        throw new RuntimeException(
-            sprintf('Invalid PHP syntax in %s: %s', $localConfigPath, $exception->getMessage()),
-            previous: $exception,
-        );
-    }
-
-    if ($localConfig === null) {
-        return null;
-    }
-
-    if (!is_array($localConfig)) {
-        throw new RuntimeException(sprintf('Local config file at %s must return an array.', $localConfigPath));
-    }
-
-    return $localConfig;
-}
-
-$localConfigPath = __DIR__ . '/local.php';
-$localConfig = supplycore_load_local_config($localConfigPath);
-if (is_array($localConfig)) {
-    $config = array_replace_recursive($config, $localConfig);
-}
-
-return $config;

--- a/src/config/local.php.example
+++ b/src/config/local.php.example
@@ -3,53 +3,12 @@
 declare(strict_types=1);
 
 return [
-    'app' => [
-        'env' => 'production',
-        'base_url' => 'https://supplycore.example.com',
-        'timezone' => 'UTC',
-    ],
-    'db' => [
-        'host' => '127.0.0.1',
-        'port' => 3306,
-        'database' => 'supplycore',
-        'username' => 'supplycore',
-        'password' => 'change-me',
-        'socket' => '', // Optional: set when MySQL is exposed via a local unix socket instead of TCP.
-    ],
-    'redis' => [
-        'enabled' => false,
-        'host' => '127.0.0.1',
-        'port' => 6379,
-        'database' => 0,
-        'password' => '',
-        'prefix' => 'supplycore',
-        'lock_enabled' => true,
-    ],
-    'neo4j' => [
-        'enabled' => false,
-        'url' => 'http://127.0.0.1:7474',
-        'username' => 'neo4j',
-        'password' => 'change-me',
-        'database' => 'neo4j',
-        'timeout_seconds' => 15,
-        'log_file' => 'storage/logs/graph-sync.log',
-    ],
-    'influxdb' => [
-        'enabled' => false,
-        'read_enabled' => false,
-        'url' => 'http://127.0.0.1:8086',
-        'org' => 'supplycore',
-        'bucket' => 'supplycore_rollups',
-        'token' => 'change-me',
-        'timeout_seconds' => 15,
-        'export_batch_size' => 1000,
-        'export_overlap_seconds' => 21600,
-        'export_log_file' => 'storage/logs/influx-rollup-export.log',
-    ],
-    'battle_intelligence' => [
-        'log_file' => 'storage/logs/battle-intelligence.log',
-    ],
-    'scheduler' => [
-        'default_timeout_seconds' => 300,
+    // Legacy migration-only file.
+    // Runtime config is no longer loaded from local.php.
+    // Use .env for DB bootstrap and Settings UI (app_settings table) for runtime values.
+    'runtime_config' => [
+        'app.base_url' => 'https://supplycore.example.com',
+        'redis.enabled' => false,
+        'neo4j.enabled' => false,
     ],
 ];

--- a/src/config/runtime_settings.php
+++ b/src/config/runtime_settings.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'db' => [
+        'title' => 'Database (env/bootstrap)',
+        'description' => 'Read-only infrastructure settings loaded from environment variables.',
+        'fields' => [
+            'db.host' => ['type' => 'string', 'default' => '127.0.0.1', 'editable' => false, 'sensitive' => false, 'env_only' => true, 'database_backed' => false],
+            'db.port' => ['type' => 'int', 'default' => 3306, 'editable' => false, 'sensitive' => false, 'env_only' => true, 'database_backed' => false],
+            'db.database' => ['type' => 'string', 'default' => 'supplycore', 'editable' => false, 'sensitive' => false, 'env_only' => true, 'database_backed' => false],
+            'db.username' => ['type' => 'string', 'default' => 'supplycore', 'editable' => false, 'sensitive' => false, 'env_only' => true, 'database_backed' => false],
+            'db.password' => ['type' => 'string', 'default' => '', 'editable' => false, 'sensitive' => true, 'env_only' => true, 'database_backed' => false],
+            'db.socket' => ['type' => 'string', 'default' => '', 'editable' => false, 'sensitive' => false, 'env_only' => true, 'database_backed' => false],
+        ],
+    ],
+    'app' => [
+        'title' => 'App',
+        'description' => 'Core runtime behavior.',
+        'fields' => [
+            'app.base_url' => ['type' => 'string', 'default' => 'http://localhost:8080', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'app.timezone' => ['type' => 'string', 'default' => 'UTC', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+        ],
+    ],
+    'redis' => [
+        'title' => 'Redis',
+        'description' => 'Cache and lock settings.',
+        'fields' => [
+            'redis.enabled' => ['type' => 'bool', 'default' => false, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'redis.host' => ['type' => 'string', 'default' => '127.0.0.1', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'redis.port' => ['type' => 'int', 'default' => 6379, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'redis.database' => ['type' => 'int', 'default' => 0, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'redis.password' => ['type' => 'string', 'default' => '', 'editable' => true, 'sensitive' => true, 'env_only' => false, 'database_backed' => true],
+            'redis.prefix' => ['type' => 'string', 'default' => 'supplycore', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+        ],
+    ],
+    'neo4j' => [
+        'title' => 'Neo4j',
+        'description' => 'Graph intelligence runtime connectivity.',
+        'fields' => [
+            'neo4j.enabled' => ['type' => 'bool', 'default' => false, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'neo4j.url' => ['type' => 'string', 'default' => 'http://127.0.0.1:7474', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'neo4j.username' => ['type' => 'string', 'default' => 'neo4j', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'neo4j.password' => ['type' => 'string', 'default' => '', 'editable' => true, 'sensitive' => true, 'env_only' => false, 'database_backed' => true],
+            'neo4j.database' => ['type' => 'string', 'default' => 'neo4j', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'neo4j.timeout_seconds' => ['type' => 'int', 'default' => 15, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+        ],
+    ],
+    'influxdb' => [
+        'title' => 'InfluxDB',
+        'description' => 'Rollup export and query integration settings.',
+        'fields' => [
+            'influxdb.enabled' => ['type' => 'bool', 'default' => false, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'influxdb.read_enabled' => ['type' => 'bool', 'default' => false, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'influxdb.url' => ['type' => 'string', 'default' => 'http://127.0.0.1:8086', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'influxdb.org' => ['type' => 'string', 'default' => '', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'influxdb.bucket' => ['type' => 'string', 'default' => 'supplycore_rollups', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'influxdb.token' => ['type' => 'string', 'default' => '', 'editable' => true, 'sensitive' => true, 'env_only' => false, 'database_backed' => true],
+        ],
+    ],
+    'scheduler' => [
+        'title' => 'Scheduler',
+        'description' => 'Job runtime supervisor behavior.',
+        'fields' => [
+            'scheduler.default_timeout_seconds' => ['type' => 'int', 'default' => 300, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'scheduler.supervisor_mode' => ['type' => 'string', 'default' => 'php', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'scheduler.python_heavy_jobs_enabled' => ['type' => 'bool', 'default' => true, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'scheduler.python_php_fallback_enabled' => ['type' => 'bool', 'default' => true, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+        ],
+    ],
+    'workers' => [
+        'title' => 'Workers',
+        'description' => 'Queue worker pacing and memory limits.',
+        'fields' => [
+            'workers.idle_sleep_seconds' => ['type' => 'int', 'default' => 10, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'workers.compute_idle_sleep_seconds' => ['type' => 'int', 'default' => 15, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'workers.sync_idle_sleep_seconds' => ['type' => 'int', 'default' => 8, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'workers.retry_backoff_seconds' => ['type' => 'int', 'default' => 30, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'workers.memory_pause_threshold_bytes' => ['type' => 'int', 'default' => 402653184, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'workers.memory_abort_threshold_bytes' => ['type' => 'int', 'default' => 536870912, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+        ],
+    ],
+    'battle_intelligence' => [
+        'title' => 'Battle intelligence',
+        'description' => 'Battle intelligence module runtime settings.',
+        'fields' => [
+            'battle_intelligence.log_file' => ['type' => 'string', 'default' => 'storage/logs/battle-intelligence.log', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+        ],
+    ],
+    'orchestrator' => [
+        'title' => 'Orchestrator',
+        'description' => 'Python orchestrator runtime files and controls.',
+        'fields' => [
+            'orchestrator.health_check_interval_seconds' => ['type' => 'int', 'default' => 15, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'orchestrator.worker_grace_seconds' => ['type' => 'int', 'default' => 45, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'orchestrator.worker_start_backoff_seconds' => ['type' => 'int', 'default' => 5, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+        ],
+    ],
+    'rebuild' => [
+        'title' => 'Rebuild',
+        'description' => 'Data-model rebuild runtime controls.',
+        'fields' => [
+            'rebuild.progress_interval_seconds' => ['type' => 'int', 'default' => 2, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+        ],
+    ],
+];

--- a/src/db.php
+++ b/src/db.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 function config(string $key = null, mixed $default = null): mixed
 {
-    static $config;
-
-    if ($config === null) {
-        $config = require __DIR__ . '/config/app.php';
-    }
+    $config = supplycore_runtime_config();
 
     if ($key === null) {
         return $config;
@@ -25,6 +21,126 @@ function config(string $key = null, mixed $default = null): mixed
     }
 
     return $value;
+}
+
+function supplycore_base_config(): array
+{
+    static $config = null;
+    if ($config !== null) {
+        return $config;
+    }
+
+    $loaded = require __DIR__ . '/config/app.php';
+    $config = is_array($loaded) ? $loaded : [];
+
+    return $config;
+}
+
+function supplycore_runtime_settings_registry(): array
+{
+    static $registry = null;
+    if ($registry !== null) {
+        return $registry;
+    }
+
+    $loaded = require __DIR__ . '/config/runtime_settings.php';
+    $registry = is_array($loaded) ? $loaded : [];
+
+    return $registry;
+}
+
+function supplycore_cast_runtime_config_value(mixed $value, string $type): mixed
+{
+    return match ($type) {
+        'bool' => in_array(strtolower(trim((string) $value)), ['1', 'true', 'yes', 'on'], true),
+        'int' => (int) $value,
+        'float' => (float) $value,
+        default => (string) $value,
+    };
+}
+
+function &supplycore_runtime_config_cache_ref(): array
+{
+    static $cache = [
+        'db_overrides_loaded' => false,
+        'db_overrides' => [],
+        'runtime_loaded' => false,
+        'runtime' => [],
+    ];
+
+    return $cache;
+}
+
+function supplycore_runtime_config_cache_clear(): void
+{
+    $cache = &supplycore_runtime_config_cache_ref();
+    $cache['db_overrides_loaded'] = false;
+    $cache['db_overrides'] = [];
+    $cache['runtime_loaded'] = false;
+    $cache['runtime'] = [];
+}
+
+function supplycore_runtime_db_overrides(): array
+{
+    $cache = &supplycore_runtime_config_cache_ref();
+    if ($cache['db_overrides_loaded'] === true) {
+        return (array) $cache['db_overrides'];
+    }
+
+    $overrides = [];
+    $registry = supplycore_runtime_settings_registry();
+
+    try {
+        $rows = db_app_settings_all();
+    } catch (Throwable) {
+        return $overrides;
+    }
+
+    foreach ($registry as $section => $sectionSpec) {
+        $fields = (array) ($sectionSpec['fields'] ?? []);
+        foreach ($fields as $path => $fieldSpec) {
+            if (($fieldSpec['database_backed'] ?? false) !== true) {
+                continue;
+            }
+
+            if (!array_key_exists($path, $rows)) {
+                continue;
+            }
+
+            $leafKey = (string) preg_replace('/^[^.]+\./', '', (string) $path);
+            $overrides[$section][$leafKey] = supplycore_cast_runtime_config_value(
+                $rows[$path],
+                (string) ($fieldSpec['type'] ?? 'string')
+            );
+        }
+    }
+
+    $cache['db_overrides_loaded'] = true;
+    $cache['db_overrides'] = $overrides;
+
+    return (array) $cache['db_overrides'];
+}
+
+function supplycore_runtime_config(bool $refresh = false): array
+{
+    if ($refresh) {
+        supplycore_runtime_config_cache_clear();
+    }
+    $cache = &supplycore_runtime_config_cache_ref();
+    if ($cache['runtime_loaded'] === true) {
+        return (array) $cache['runtime'];
+    }
+
+    $base = supplycore_base_config();
+    $cache['runtime'] = array_replace_recursive($base, supplycore_runtime_db_overrides());
+    $cache['runtime_loaded'] = true;
+
+    return (array) $cache['runtime'];
+}
+
+function supplycore_runtime_config_refresh(): void
+{
+    supplycore_runtime_config(true);
 }
 
 function db(): PDO
@@ -219,6 +335,7 @@ function db_app_settings_cache_clear(): void
     $cache = &db_app_settings_cache_ref();
     $cache['loaded'] = false;
     $cache['values'] = [];
+    supplycore_runtime_config_cache_clear();
 }
 
 function db_app_settings_all(): array
@@ -249,6 +366,24 @@ function db_app_setting_get(string $settingKey, mixed $default = null): mixed
     $settings = db_app_settings_all();
 
     return $settings[$settingKey] ?? $default;
+}
+
+function db_app_settings_by_prefix(string $prefix): array
+{
+    $settings = db_app_settings_all();
+    $filtered = [];
+    foreach ($settings as $key => $value) {
+        if (str_starts_with((string) $key, $prefix)) {
+            $filtered[$key] = $value;
+        }
+    }
+
+    return $filtered;
+}
+
+function db_app_setting_set(string $settingKey, string $value): bool
+{
+    return db_app_settings_upsert_many([$settingKey => $value]);
 }
 
 function db_runtime_schema_checks_enabled(): bool

--- a/src/functions.php
+++ b/src/functions.php
@@ -272,6 +272,7 @@ function nav_items(): array
 function setting_sections(): array
 {
     return [
+        'runtime-config' => ['title' => 'Runtime Config', 'description' => 'Authoritative runtime configuration stored in app_settings and merged over app.php defaults.'],
         'general' => ['title' => 'General Settings', 'description' => 'Core application behavior and preferences.'],
         'trading-stations' => ['title' => 'Trading Stations', 'description' => 'Configure your reference market hub and operational trading destination.'],
         'item-scope' => ['title' => 'Item Scope', 'description' => 'Control which item classes are operationally relevant across market, doctrine, and loss-demand analytics.'],
@@ -281,6 +282,104 @@ function setting_sections(): array
         'deal-alerts' => ['title' => 'Deal Alerts', 'description' => 'Tune mispriced-listing detection thresholds, popup behavior, and anomaly cadence.'],
         'killmail-intelligence' => ['title' => 'Killmail Intelligence', 'description' => 'Manage zKillboard stream ingestion, tracked entities, and demand prediction foundation.'],
     ];
+}
+
+function runtime_config_registry(): array
+{
+    return supplycore_runtime_settings_registry();
+}
+
+function runtime_config_flat_fields(): array
+{
+    $flat = [];
+    foreach (runtime_config_registry() as $sectionKey => $sectionSpec) {
+        foreach ((array) ($sectionSpec['fields'] ?? []) as $path => $fieldSpec) {
+            $flat[$path] = ['section' => $sectionKey] + (array) $fieldSpec;
+        }
+    }
+
+    return $flat;
+}
+
+function runtime_config_sections_for_ui(): array
+{
+    $effective = supplycore_runtime_config();
+    $flat = runtime_config_flat_fields();
+    $sections = [];
+
+    foreach (runtime_config_registry() as $sectionKey => $sectionSpec) {
+        $fields = [];
+        foreach ((array) ($sectionSpec['fields'] ?? []) as $path => $fieldSpec) {
+            $segments = explode('.', $path, 2);
+            $groupKey = (string) ($segments[0] ?? '');
+            $leafKey = (string) ($segments[1] ?? '');
+            $value = $effective[$groupKey][$leafKey] ?? ($fieldSpec['default'] ?? '');
+            $fields[$path] = (array) $fieldSpec + ['value' => $value];
+        }
+        $sections[$sectionKey] = [
+            'title' => (string) ($sectionSpec['title'] ?? ucfirst(str_replace('_', ' ', $sectionKey))),
+            'description' => (string) ($sectionSpec['description'] ?? ''),
+            'fields' => $fields,
+        ];
+    }
+
+    return $sections;
+}
+
+function runtime_config_settings_from_request(array $request): array
+{
+    $flat = runtime_config_flat_fields();
+    $settings = [];
+
+    foreach ($flat as $path => $spec) {
+        if (($spec['database_backed'] ?? false) !== true || ($spec['editable'] ?? false) !== true) {
+            continue;
+        }
+
+        $type = (string) ($spec['type'] ?? 'string');
+        $input = $request[$path] ?? null;
+        if ($type === 'bool') {
+            $input = isset($request[$path]) ? '1' : '0';
+        }
+        $settings[$path] = (string) supplycore_cast_runtime_config_value($input ?? ($spec['default'] ?? ''), $type);
+    }
+
+    return $settings;
+}
+
+function migrate_local_config_to_app_settings(string $localConfigPath): array
+{
+    if (!is_file($localConfigPath)) {
+        return ['ok' => false, 'message' => 'local.php not found', 'imported' => 0];
+    }
+
+    $loaded = (static function (string $path): mixed {
+        return require $path;
+    })($localConfigPath);
+    if (!is_array($loaded)) {
+        return ['ok' => false, 'message' => 'local.php must return an array', 'imported' => 0];
+    }
+
+    $registry = runtime_config_flat_fields();
+    $toPersist = [];
+    foreach ($registry as $path => $spec) {
+        if (($spec['database_backed'] ?? false) !== true) {
+            continue;
+        }
+
+        [$section, $key] = explode('.', $path, 2);
+        if (!isset($loaded[$section]) || !is_array($loaded[$section]) || !array_key_exists($key, $loaded[$section])) {
+            continue;
+        }
+        $toPersist[$path] = (string) supplycore_cast_runtime_config_value($loaded[$section][$key], (string) ($spec['type'] ?? 'string'));
+    }
+
+    if ($toPersist !== []) {
+        save_settings($toPersist);
+        supplycore_runtime_config_refresh();
+    }
+
+    return ['ok' => true, 'message' => 'Imported local.php runtime values into app_settings.', 'imported' => count($toPersist)];
 }
 
 function active_section(): string


### PR DESCRIPTION
### Motivation

- Separate bootstrap/infrastructure secrets (DB credentials) from operator-editable runtime settings and remove `local.php` as an active runtime override. 
- Make the Settings UI the authoritative editor for runtime config stored in the database and keep `app.php` as defaults/bootstrap only. 
- Provide a typed, centralized registry/schema so the app reads a single effective config source instead of ad-hoc lookups and file overrides.

### Description

- Converted `src/config/app.php` to a bootstrap/defaults-only file and ensured the `db` section is env-driven in the requested shape (`DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD`, `DB_SOCKET`).
- Added a runtime settings registry schema at `src/config/runtime_settings.php` describing sections, field keys, types, defaults, `editable`/`sensitive`/`env_only`/`database_backed` metadata.
- Implemented a centralized effective config loader in `src/db.php` (`supplycore_runtime_config()` / `config()`): it starts from `app.php` defaults and overlays typed database-backed settings from `app_settings`, with caching and a `supplycore_runtime_config_refresh()` helper; removed the previous `local.php` merge logic.
- Added runtime helpers and UI integration in `src/functions.php`: `runtime_config_registry()`, `runtime_config_sections_for_ui()`, `runtime_config_settings_from_request()` for typed normalization, and `migrate_local_config_to_app_settings()` to import legacy `local.php` values into the DB (non-destructive, one-time migration path).
- Updated Settings UI (`public/settings/index.php`) with a new **Runtime Config** section that shows DB connection values as read-only (password shown only as configured yes/no) and persists editable runtime fields into `app_settings`; saving refreshes the runtime config cache rather than writing files.
- Added DB helper functions `db_app_settings_by_prefix()` and `db_app_setting_set()` and ensured `db_app_settings_cache_clear()` clears the runtime config cache so changes take effect immediately.
- Added a migration CLI `bin/migrate_local_config.php`, a `.env.example` containing only bootstrap DB vars, and updated `README.md` to document the new model (env for DB/bootstrap, DB for runtime, `app.php` defaults, `local.php` phased out).

### Testing

- Ran PHP lint (`php -l`) on modified files: `src/config/app.php`, `src/config/runtime_settings.php`, `src/db.php`, `src/functions.php`, `public/settings/index.php`, `bin/migrate_local_config.php`, and `src/config/local.php.example`; all reported no syntax errors (success).
- No automated unit/integration tests were present for the settings flow in this change; manual runtime validation and web UI behavior should be exercised in staging (migration script provided to import legacy `local.php` values).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3fcdd6344832fae274ad0df1350c5)