### PR TITLE
Avoid recursive runtime config during DB bootstrap (fix memory exhaustion)

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -36,6 +36,22 @@ function supplycore_base_config(): array
     return $config;
 }
 
+function supplycore_base_config_value(string $key, mixed $default = null): mixed
+{
+    $segments = explode('.', $key);
+    $value = supplycore_base_config();
+
+    foreach ($segments as $segment) {
+        if (!is_array($value) || !array_key_exists($segment, $value)) {
+            return $default;
+        }
+
+        $value = $value[$segment];
+    }
+
+    return $value;
+}
+
 function supplycore_runtime_settings_registry(): array
 {
     static $registry = null;
@@ -158,17 +174,17 @@ function db(): PDO
 
     $dsn = sprintf(
         'mysql:host=%s;port=%d;dbname=%s;charset=%s',
-        config('db.host'),
-        config('db.port'),
-        config('db.database'),
-        config('db.charset')
+        (string) supplycore_base_config_value('db.host', '127.0.0.1'),
+        (int) supplycore_base_config_value('db.port', 3306),
+        (string) supplycore_base_config_value('db.database', ''),
+        (string) supplycore_base_config_value('db.charset', 'utf8mb4')
     );
 
     try {
         $pdo = new PDO(
             $dsn,
-            config('db.username'),
-            config('db.password'),
+            (string) supplycore_base_config_value('db.username', ''),
+            (string) supplycore_base_config_value('db.password', ''),
             [
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,


### PR DESCRIPTION
### Motivation
- Loading the index caused a PHP fatal: allowed memory size exhausted due to a recursion between runtime config loading and DB bootstrap. 
- The recursion occurred because `db()` used `config('db.*')`, which can trigger runtime DB-backed settings loading that itself calls DB access before the connection is established.

### Description
- Added `supplycore_base_config_value()` to read dotted keys directly from the base `app.php` config without invoking runtime overrides. 
- Updated `db()` to build the DSN and credentials from `supplycore_base_config_value()` with safe defaults and explicit casts instead of calling `config()`. 
- This breaks the bootstrap cycle so runtime DB-backed settings are only applied after a DB connection exists.

### Testing
- Ran a PHP syntax check with `php -l src/db.php` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4013bdbac832f9afe88e360c908da)