### PR TITLE
Fix runtime config save/read mismatch for dotted setting keys

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -337,14 +337,42 @@ function runtime_config_settings_from_request(array $request): array
         }
 
         $type = (string) ($spec['type'] ?? 'string');
-        $input = $request[$path] ?? null;
+        $input = runtime_config_request_value($request, $path);
         if ($type === 'bool') {
-            $input = isset($request[$path]) ? '1' : '0';
+            $input = runtime_config_request_has_key($request, $path) ? '1' : '0';
         }
         $settings[$path] = (string) supplycore_cast_runtime_config_value($input ?? ($spec['default'] ?? ''), $type);
     }
 
     return $settings;
+}
+
+function runtime_config_request_key(string $path): string
+{
+    return str_replace('.', '_', $path);
+}
+
+function runtime_config_request_value(array $request, string $path): mixed
+{
+    if (array_key_exists($path, $request)) {
+        return $request[$path];
+    }
+
+    $normalizedKey = runtime_config_request_key($path);
+    if (array_key_exists($normalizedKey, $request)) {
+        return $request[$normalizedKey];
+    }
+
+    return null;
+}
+
+function runtime_config_request_has_key(array $request, string $path): bool
+{
+    if (array_key_exists($path, $request)) {
+        return true;
+    }
+
+    return array_key_exists(runtime_config_request_key($path), $request);
 }
 
 function migrate_local_config_to_app_settings(string $localConfigPath): array


### PR DESCRIPTION
### Motivation
- PHP normalizes form input names containing dots into underscores, so runtime settings submitted with dotted keys like `redis.enabled` or `neo4j.enabled` were not being recognized and re-rendered as default/disabled after save.

### Description
- Updated `runtime_config_settings_from_request()` to read values via `runtime_config_request_value()` and determine booleans via `runtime_config_request_has_key()`, so both dotted (`redis.enabled`) and normalized (`redis_enabled`) POST keys are accepted.
- Added helper functions `runtime_config_request_key()`, `runtime_config_request_value()`, and `runtime_config_request_has_key()` to `src/functions.php` for consistent request key normalization and lookup.
- Adjusted boolean handling to rely on normalized-key presence so checkbox toggles persist and re-render correctly.

### Testing
- Ran a PHP syntax check: `php -l src/functions.php` (passed).
- Executed a runtime parsing validation: `php -r 'require "src/bootstrap.php"; $out = runtime_config_settings_from_request(["redis_enabled"=>"1","neo4j_enabled"=>"1","neo4j_password"=>"secret","redis_password"=>"secret"]); echo $out["redis.enabled"]."|".$out["neo4j.enabled"]."|".$out["neo4j.password"]."|".$out["redis.password"].PHP_EOL;'` which produced `1|1|secret|secret` (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40403bc40832f92ea5a403be78a84)