### PR TITLE
Load Python worker DB settings from .env by default

### DIFF
--- a/python/orchestrator/config.py
+++ b/python/orchestrator/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -82,8 +83,45 @@ def _env_int(key: str, default: int, minimum: int | None = None) -> int:
     return value
 
 
+def _load_dotenv_defaults(app_root: Path) -> None:
+    env_path = app_root / ".env"
+    if not env_path.is_file():
+        return
+
+    try:
+        lines = env_path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].strip()
+        if "=" not in line:
+            continue
+
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            continue
+
+        value = raw_value.strip()
+        if not value:
+            os.environ.setdefault(key, "")
+            continue
+
+        try:
+            parsed = shlex.split(value, comments=True, posix=True)
+        except ValueError:
+            parsed = [value]
+        os.environ.setdefault(key, parsed[0] if parsed else "")
+
+
 def load_php_runtime_config(app_root: Path) -> OrchestratorConfig:
     app_root = app_root.resolve()
+    _load_dotenv_defaults(app_root)
     runtime_file = Path(os.getenv("SUPPLYCORE_ORCHESTRATOR_CONFIG_JSON", app_root / "storage/run/orchestrator-runtime.json"))
     raw: dict[str, Any] = {}
     if runtime_file.is_file():
@@ -98,7 +136,7 @@ def load_php_runtime_config(app_root: Path) -> OrchestratorConfig:
             "host": os.getenv("DB_HOST", "127.0.0.1"),
             "port": _env_int("DB_PORT", 3306),
             "database": os.getenv("DB_DATABASE", "supplycore"),
-            "username": os.getenv("DB_USERNAME", "root"),
+            "username": os.getenv("DB_USERNAME", "supplycore"),
             "password": os.getenv("DB_PASSWORD", ""),
             "charset": os.getenv("DB_CHARSET", "utf8mb4"),
             "socket": os.getenv("DB_SOCKET", ""),

--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -32,7 +32,7 @@ class SupplyCoreDb:
         return pymysql.connect(
             host=str(self._config.get("host", "127.0.0.1")),
             port=int(self._config.get("port", 3306)),
-            user=str(self._config.get("username", "root")),
+            user=str(self._config.get("username", "supplycore")),
             password=str(self._config.get("password", "")),
             database=str(self._config.get("database", "supplycore")),
             charset=str(self._config.get("charset", "utf8mb4")),


### PR DESCRIPTION
### Motivation
- Python worker processes were falling back to the wrong DB defaults (e.g. `root`) when systemd did not export `DB_*` variables, causing MariaDB auth failures. 
- Workers need a reliable place to bootstrap DB credentials from the app checkout so service units that do not export a full env block still connect correctly. 
- Keep environment precedence safe so explicit service-provided variables still win over any file-sourced defaults.

### Description
- Added `_load_dotenv_defaults()` to `python/orchestrator/config.py` to read `<app_root>/.env` and set missing environment keys via `os.environ.setdefault(...)` before constructing the runtime config. 
- Invoked the new loader at the start of `load_php_runtime_config()` so `.env` values are available to subsequent `os.getenv()` calls. 
- Aligned Python-side DB fallbacks to the repository defaults by changing the default DB username from `root` to `supplycore` in both `python/orchestrator/config.py` and `python/orchestrator/db.py`.

### Testing
- Ran the full Python test collection with `pytest -q python/tests`, which failed to collect tests in this environment due to `PYTHONPATH` not being set (module import errors during discovery). 
- Ran `PYTHONPATH=python pytest -q python/tests/test_killmail_r2z2_stream.py` and the targeted tests passed (`3 passed`). 
- Verified the new code path reads `.env` without overriding explicit service env vars and that the `supplycore` default username is used when no env is provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c406c0e920832faa719eddde9e7911)