### PR TITLE
Fix worker diagnostics SQL parameter count

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -332,7 +332,7 @@ class SupplyCoreDb:
             clauses.append("workload_class IN (" + ",".join(["%s"] * len(workload_classes)) + ")")
             params.extend(workload_classes)
         where_filtered = " AND " + " AND ".join(clauses)
-        repeated = params * 4
+        repeated = params * 3
         counts = self.fetch_one(
             f"""SELECT
                 SUM(CASE WHEN status IN ('queued','retry') AND available_at <= UTC_TIMESTAMP() THEN 1 ELSE 0 END) AS ready_all,


### PR DESCRIPTION
### Motivation
- The orchestrator was raising `TypeError: not all arguments converted during string formatting` because the diagnostics SQL was given more bound parameters than there were `%s` placeholders in the query.
- The `worker_claim_diagnostics` aggregate contains three filtered `CASE` expressions that consume the filter placeholders, not four, so the parameter fan-out was incorrect.

### Description
- Adjusted `worker_claim_diagnostics` in `python/orchestrator/db.py` to change `repeated = params * 4` to `repeated = params * 3` so the bound argument count matches the three filtered aggregates.
- Kept the existing `where_filtered` construction and `fetch_one` usage and only corrected the multiplier that builds the final parameter tuple.

### Testing
- Ran `python3 -m py_compile python/orchestrator/db.py` and it succeeded.
- Executed a small Python verification script that builds the query and compares placeholder counts to parameter counts for several `queues`/`workload_classes` combinations, and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40a6299f0832f87a2986857901679)