### PR TITLE
Use json_dumps_safe for file writes and add serialization test

### DIFF
--- a/python/orchestrator/rebuild_data_model.py
+++ b/python/orchestrator/rebuild_data_model.py
@@ -16,6 +16,7 @@ from zoneinfo import ZoneInfo
 from .bridge import PhpBridge
 from .config import load_php_runtime_config
 from .db import SupplyCoreDb
+from .json_utils import json_dumps_safe
 
 
 def _utc_now() -> datetime:
@@ -86,7 +87,7 @@ class StatusTracker:
         payload = status.to_payload()
         self.path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = self.path.with_suffix(self.path.suffix + ".tmp")
-        tmp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        tmp_path.write_text(json_dumps_safe(payload, indent=2) + "\n", encoding="utf-8")
         os.replace(tmp_path, self.path)
 
         monotonic_now = time.monotonic()

--- a/python/orchestrator/supervisor.py
+++ b/python/orchestrator/supervisor.py
@@ -12,6 +12,7 @@ from typing import Any, TextIO
 
 from .config import load_php_runtime_config
 from .health import HealthResult, run_php_healthcheck
+from .json_utils import json_dumps_safe
 from .logging_utils import LoggerAdapter
 from .php_runner import ManagedPhpProcess
 
@@ -115,7 +116,7 @@ class SupplyCoreSupervisor:
             "last_worker_exit_code": self.state.last_worker_exit_code,
             "last_worker_exit_at": self.state.last_worker_exit_at,
         }
-        self.config.heartbeat_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        self.config.heartbeat_file.write_text(json_dumps_safe(payload, indent=2) + "\n", encoding="utf-8")
 
     def evaluate_health(self) -> HealthResult:
         return run_php_healthcheck(self.config.php_binary, self.config.scheduler_health, self.config.app_root)

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -32,7 +32,7 @@ from .jobs import (
     run_compute_suspicion_scores,
     run_compute_suspicion_scores_v2,
 )
-from .json_utils import make_json_safe
+from .json_utils import json_dumps_safe, make_json_safe
 from .logging_utils import LoggerAdapter, configure_logging
 from .worker_registry import WORKER_JOB_DEFINITIONS
 from .worker_runtime import resident_memory_bytes, utc_now_iso
@@ -140,7 +140,7 @@ def _parse_csv(raw: str) -> list[str]:
 
 def _write_state_file(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    path.write_text(json_dumps_safe(payload, indent=2) + "\n", encoding="utf-8")
 
 
 def _process_job(context: WorkerPoolContext) -> dict[str, Any]:

--- a/python/orchestrator/zkill_worker.py
+++ b/python/orchestrator/zkill_worker.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from .config import load_php_runtime_config
+from .json_utils import json_dumps_safe
 from .jobs import run_killmail_r2z2_stream
 from .logging_utils import configure_logging
 from .worker_runtime import resident_memory_bytes, utc_now_iso
@@ -40,7 +41,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def _write_state_file(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    path.write_text(json_dumps_safe(payload, indent=2) + "\n", encoding="utf-8")
 
 
 def _read_state_file(path: Path) -> dict[str, Any]:

--- a/python/tests/test_json_utils.py
+++ b/python/tests/test_json_utils.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import UTC, datetime
+
+from orchestrator.json_utils import json_dumps_safe
+
+
+class JsonUtilsTests(unittest.TestCase):
+    def test_json_dumps_safe_serializes_datetime_payloads(self) -> None:
+        now = datetime(2026, 3, 25, 16, 28, 12, tzinfo=UTC)
+        payload = {
+            "ts": now,
+            "nested": {
+                "items": [now],
+            },
+        }
+
+        decoded = json.loads(json_dumps_safe(payload))
+
+        self.assertEqual(decoded["ts"], now.isoformat())
+        self.assertEqual(decoded["nested"]["items"][0], now.isoformat())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure files written by the orchestrator use a JSON serializer that safely handles non-serializable types like `datetime` to avoid write-time failures and produce stable, ISO-formatted timestamps.
- Avoid occasional JSON encoding errors when status/heartbeat/state payloads include complex objects.
- Standardize on the existing `json_dumps_safe` helper for all state and heartbeat file outputs.

### Description
- Replaced `json.dumps(...)+"\n"` calls with `json_dumps_safe(...)+"\n"` when writing state/heartbeat files in `rebuild_data_model.py`, `supervisor.py`, `worker_pool.py`, and `zkill_worker.py` and added the necessary imports. 
- Updated `worker_pool.py` imports to include `json_dumps_safe` alongside the existing `make_json_safe`. 
- Added a unit test `python/tests/test_json_utils.py` that verifies `json_dumps_safe` serializes `datetime` objects to ISO-formatted strings.

### Testing
- Ran the new unit test with `python -m unittest python/tests/test_json_utils.py`, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40c933934832fb5427e326ea93480)