### PR TITLE
Register compute_graph_sync_doctrine_dependency in PHP scheduler handlers

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -12040,6 +12040,14 @@ function scheduler_job_definitions(): array
                 throw new RuntimeException('compute_graph_sync must run in the Python scheduler runtime.');
             },
         ],
+        'compute_graph_sync_doctrine_dependency' => [
+            'timeout_seconds' => 420,
+            'lock_ttl_seconds' => 480,
+            'execution' => 'background',
+            'handler' => static function (): array {
+                throw new RuntimeException('compute_graph_sync_doctrine_dependency must run in the Python scheduler runtime.');
+            },
+        ],
         'compute_graph_insights' => [
             'timeout_seconds' => 300,
             'lock_ttl_seconds' => 360,
@@ -12133,6 +12141,7 @@ function scheduler_job_type(string $jobKey): string
         'forecasting_ai_sync' => 'sync.forecasting',
         'killmail_r2z2_sync' => 'sync.killmail',
         'compute_graph_sync' => 'compute.graph_sync',
+        'compute_graph_sync_doctrine_dependency' => 'compute.graph_sync_doctrine_dependency',
         'compute_graph_insights' => 'compute.graph_insights',
         'compute_buy_all' => 'compute.buy_all',
         'compute_signals' => 'compute.signals',


### PR DESCRIPTION
### Motivation
- The Python worker registry contains `compute_graph_sync_doctrine_dependency` but the PHP scheduler lacked a matching handler, causing bridge/fallback lookups to fail with `No scheduler handler is registered for job key: compute_graph_sync_doctrine_dependency`; this change registers the job in PHP so handler resolution and job typing are consistent across runtimes.

### Description
- Added a `compute_graph_sync_doctrine_dependency` entry to `scheduler_job_definitions()` with `timeout_seconds` 420, `lock_ttl_seconds` 480, `execution` set to `background`, and a handler that throws a `RuntimeException` indicating it must run in the Python scheduler runtime, and added a `scheduler_job_type()` mapping to `compute.graph_sync_doctrine_dependency`.

### Testing
- Ran `php -l src/functions.php` which returned `No syntax errors detected`, indicating the PHP file parses successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40efa0f18832fb7162bd7e6fb58fd)