### PR TITLE
Ensure selected jobs always run via PHP bridge and set default execution_mode to PHP

### DIFF
--- a/python/orchestrator/job_runner.py
+++ b/python/orchestrator/job_runner.py
@@ -146,6 +146,28 @@ PROCESSORS: dict[str, Callable[[PythonWorkerContext], dict[str, Any]]] = {
     ),
 }
 
+# Jobs that intentionally execute via the PHP bridge while still running under the
+# Python scheduler/runtime process.
+PHP_BRIDGED_JOB_KEYS: set[str] = {
+    "market_hub_current_sync",
+    "deal_alerts_sync",
+    "alliance_current_sync",
+    "current_state_refresh_sync",
+    "doctrine_intelligence_sync",
+    "market_comparison_summary_sync",
+    "loss_demand_summary_sync",
+    "dashboard_summary_sync",
+    "rebuild_ai_briefings",
+    "activity_priority_summary_sync",
+    "market_hub_local_history_sync",
+    "analytics_bucket_1h_sync",
+    "analytics_bucket_1d_sync",
+    "alliance_historical_sync",
+    "market_hub_historical_sync",
+    "forecasting_ai_sync",
+    "killmail_r2z2_sync",
+}
+
 
 def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
     rows_seen = max(0, int(result.get("rows_processed") or result.get("rows_seen") or 0))
@@ -258,9 +280,12 @@ def process_job(context: PythonWorkerContext) -> dict[str, Any]:
     )
 
     if processor is None:
-        if not bool(context.scheduler_config.get("python_php_fallback_enabled", True)):
+        if context.job_key in PHP_BRIDGED_JOB_KEYS:
+            result = _run_php_fallback(context, bridge)
+        elif not bool(context.scheduler_config.get("python_php_fallback_enabled", True)):
             raise RuntimeError(f"No Python processor is registered for job {context.job_key} and PHP fallback is disabled.")
-        result = _run_php_fallback(context, bridge)
+        else:
+            result = _run_php_fallback(context, bridge)
     else:
         result = processor(context)
 

--- a/src/db.php
+++ b/src/db.php
@@ -8512,7 +8512,7 @@ function db_sync_schedule_ensure_job(string $jobKey, int $enabled, int $interval
             max_early_start_seconds = COALESCE(sync_schedules.max_early_start_seconds, VALUES(max_early_start_seconds)),
             latency_sensitive = GREATEST(sync_schedules.latency_sensitive, VALUES(latency_sensitive)),
             user_facing = GREATEST(sync_schedules.user_facing, VALUES(user_facing)),
-            execution_mode = COALESCE(NULLIF(sync_schedules.execution_mode, \'\'), VALUES(execution_mode)),
+            execution_mode = VALUES(execution_mode),
             tuning_mode = COALESCE(sync_schedules.tuning_mode, VALUES(tuning_mode)),
             next_run_at = CASE
                 WHEN sync_schedules.enabled = 1 AND sync_schedules.next_run_at IS NULL THEN VALUES(next_run_at)

--- a/src/functions.php
+++ b/src/functions.php
@@ -12806,6 +12806,7 @@ function scheduler_registry_bootstrap(): void
                 'backfill_priority' => (string) ($definition['backfill_priority'] ?? ($definition['priority'] ?? 'normal')),
                 'min_backfill_gap_seconds' => (int) ($definition['min_backfill_gap_seconds'] ?? 900),
                 'max_early_start_seconds' => (int) ($definition['max_early_start_seconds'] ?? 0),
+                'execution_mode' => (string) ($definition['execution_mode'] ?? 'php'),
                 'tuning_mode' => (string) ($definition['tuning_mode'] ?? 'automatic'),
                 'discovered_from_code' => true,
                 'explicitly_configured' => (bool) ($definition['explicitly_configured'] ?? false),


### PR DESCRIPTION
### Motivation

- Ensure selected legacy or PHP-first jobs are executed through the PHP bridge even when Python fallback is globally disabled by the scheduler configuration. 
- Make code-discovered job definitions default to `execution_mode = 'php'` and ensure the DB upsert uses the provided execution mode from code when bootstrapping schedules.

### Description

- Added `PHP_BRIDGED_JOB_KEYS` set in `python/orchestrator/job_runner.py` that lists job keys which must always run via the PHP bridge. 
- Updated `process_job` in `python/orchestrator/job_runner.py` to run `_run_php_fallback` unconditionally for jobs in `PHP_BRIDGED_JOB_KEYS`, and to only raise when a processor is missing and PHP fallback is disabled for other jobs. 
- Changed the SQL upsert behavior in `src/db.php` to always use `VALUES(execution_mode)` when updating `sync_schedules.execution_mode` so the supplied execution mode from code overwrites existing DB values. 
- Set the default `execution_mode` to `'php'` when bootstrapping scheduler definitions in `src/functions.php` so discovered jobs without an explicit execution mode are marked to run via PHP by default.

### Testing

- Ran the scheduler-related unit tests and integration checks against the job runner and scheduler bootstrap paths, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4106a9be0832fa174c7bb9f21fd4b)