### PR TITLE
Expose repo-local orchestrator CLI via top-level package shim

### DIFF
--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+_package_dir = Path(__file__).resolve().parent
+_repo_root = _package_dir.parent
+_python_orchestrator_dir = _repo_root / "python" / "orchestrator"
+
+if _python_orchestrator_dir.is_dir():
+    __path__.append(str(_python_orchestrator_dir))

--- a/orchestrator/__main__.py
+++ b/orchestrator/__main__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .main import main
+
+raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Ensure that `python -m orchestrator` runs the in-tree `python/orchestrator` implementation so documented CLI commands and flags (for example `worker-pool --execution-modes` and `compute-suspicion-scores`) are available and parseable when invoked from the repository root.

### Description
- Add `orchestrator/__init__.py` which appends the repo's `python/orchestrator` directory to the package path so the local implementation is imported at runtime.
- Add `orchestrator/__main__.py` which invokes the existing orchestrator CLI entrypoint `main()` so `python -m orchestrator` executes the repo-local CLI surface.

### Testing
- Ran `python -m orchestrator worker-pool --app-root /workspace/SupplyCore --queues compute --workload-classes compute --execution-modes python --once` and confirmed the CLI parsed and entered the worker-pool path, then exited with a MySQL connection error (DB unavailable in the test environment). 
- Ran `python bin/python_job_runner.py --schedule-id 1 --app-root /workspace/SupplyCore` and confirmed the entrypoint executed and reached the DB access path, then exited with a MySQL connection error (DB unavailable in the test environment). 
- Ran `python -m orchestrator compute-suspicion-scores --app-root /workspace/SupplyCore --dry-run` and confirmed the command is now registered and executed the Python dispatcher, returning the expected JSON failure shape due to DB unavailability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c41a7093a8832fb71d17eda52d1fcc)