### PR TITLE
Normalize orchestrator runtime config: alias influx/influxdb and add Redis support

### DIFF
--- a/python/orchestrator/config.py
+++ b/python/orchestrator/config.py
@@ -165,6 +165,16 @@ def load_php_runtime_config(app_root: Path) -> OrchestratorConfig:
 
     live_raw = _load_live_php_runtime_config(app_root)
 
+    if isinstance(raw.get("influxdb"), dict) and not isinstance(raw.get("influx"), dict):
+        raw["influx"] = dict(raw["influxdb"])
+    if isinstance(raw.get("influx"), dict) and not isinstance(raw.get("influxdb"), dict):
+        raw["influxdb"] = dict(raw["influx"])
+
+    if isinstance(live_raw.get("influxdb"), dict) and not isinstance(live_raw.get("influx"), dict):
+        live_raw["influx"] = dict(live_raw["influxdb"])
+    if isinstance(live_raw.get("influx"), dict) and not isinstance(live_raw.get("influxdb"), dict):
+        live_raw["influxdb"] = dict(live_raw["influx"])
+
     defaults = {
         "app": {"name": "SupplyCore", "env": os.getenv("APP_ENV", "development"), "timezone": os.getenv("APP_TIMEZONE", "UTC")},
         "db": {
@@ -193,6 +203,23 @@ def load_php_runtime_config(app_root: Path) -> OrchestratorConfig:
             "token": os.getenv("INFLUXDB_TOKEN", ""),
             "timeout_seconds": _env_int("INFLUXDB_TIMEOUT_SECONDS", 15, 3),
         },
+        "influxdb": {
+            "enabled": os.getenv("INFLUXDB_ENABLED", "0") == "1",
+            "read_enabled": os.getenv("INFLUXDB_READ_ENABLED", "0") == "1",
+            "url": os.getenv("INFLUXDB_URL", "http://127.0.0.1:8086").rstrip("/"),
+            "org": os.getenv("INFLUXDB_ORG", ""),
+            "bucket": os.getenv("INFLUXDB_BUCKET", "supplycore_rollups"),
+            "token": os.getenv("INFLUXDB_TOKEN", ""),
+            "timeout_seconds": _env_int("INFLUXDB_TIMEOUT_SECONDS", 15, 3),
+        },
+        "redis": {
+            "enabled": os.getenv("REDIS_ENABLED", "0") == "1",
+            "host": os.getenv("REDIS_HOST", "127.0.0.1"),
+            "port": _env_int("REDIS_PORT", 6379, 1),
+            "database": _env_int("REDIS_DB", 0, 0),
+            "password": os.getenv("REDIS_PASSWORD", ""),
+            "prefix": os.getenv("REDIS_PREFIX", "supplycore"),
+        },
         "battle_intelligence": {"log_file": str(app_root / "storage/logs/battle-intelligence.log")},
         "paths": {"app_root": str(app_root), "log_file": str(app_root / "storage/logs/orchestrator.log"), "php_binary": "php", "scheduler_daemon": str(app_root / "bin/scheduler_daemon.php"), "scheduler_watchdog": str(app_root / "bin/scheduler_watchdog.php"), "scheduler_health": str(app_root / "bin/scheduler_health.php")},
         "orchestrator": {"state_dir": str(app_root / "storage/run"), "heartbeat_file": str(app_root / "storage/run/orchestrator-heartbeat.json"), "lock_file": str(app_root / "storage/run/orchestrator.lock"), "health_check_interval_seconds": 15, "worker_grace_seconds": 45, "worker_start_backoff_seconds": 5, "max_consecutive_health_failures": 3},
@@ -214,7 +241,7 @@ def load_php_runtime_config(app_root: Path) -> OrchestratorConfig:
     }
 
     merged = defaults | raw | live_raw
-    for key in ("app", "db", "neo4j", "influx", "battle_intelligence", "paths", "orchestrator", "scheduler", "workers"):
+    for key in ("app", "db", "neo4j", "influx", "influxdb", "redis", "battle_intelligence", "paths", "orchestrator", "scheduler", "workers"):
         merged[key] = {
             **defaults.get(key, {}),
             **(raw.get(key, {}) if isinstance(raw.get(key), dict) else {}),

--- a/python/orchestrator/job_context.py
+++ b/python/orchestrator/job_context.py
@@ -23,4 +23,7 @@ def neo4j_runtime(raw_config: dict[str, Any]) -> dict[str, Any]:
 
 
 def influx_runtime(raw_config: dict[str, Any]) -> dict[str, Any]:
-    return runtime_section(raw_config, "influx")
+    influx = runtime_section(raw_config, "influx")
+    if influx == {}:
+        return runtime_section(raw_config, "influxdb")
+    return influx

--- a/src/functions.php
+++ b/src/functions.php
@@ -3754,6 +3754,14 @@ function orchestrator_runtime_config_export(): array
             'export_overlap_seconds' => max(0, (int) config('influxdb.export_overlap_seconds', 21600)),
             'export_log_file' => supplycore_worker_log_path('influx-rollup-export.log', (string) config('influxdb.export_log_file', 'storage/logs/influx-rollup-export.log')),
         ],
+        'redis' => [
+            'enabled' => (bool) config('redis.enabled', false),
+            'host' => (string) config('redis.host', '127.0.0.1'),
+            'port' => max(1, (int) config('redis.port', 6379)),
+            'database' => max(0, (int) config('redis.database', 0)),
+            'password' => (string) config('redis.password', ''),
+            'prefix' => (string) config('redis.prefix', 'supplycore'),
+        ],
         'battle_intelligence' => [
             'log_file' => supplycore_worker_log_path('battle-intelligence.log', (string) config('battle_intelligence.log_file', 'storage/logs/battle-intelligence.log')),
         ],


### PR DESCRIPTION
### Motivation

- Python orchestrator jobs were not seeing runtime settings persisted through the PHP UI because PHP exports an `influxdb` section while Python code expected `influx`, and Redis settings were not included in the exported runtime payload.
- Ensure parity across all launcher paths (scheduler-dispatched, worker pool, manual CLI) so toggling integrations in Settings actually enables them for Python jobs.

### Description

- Treat `influx` and legacy `influxdb` as aliases when loading PHP-exported runtime config in `python/orchestrator/config.py`, merging both representations into the Python `raw` payload.
- Add default `influxdb` and `redis` entries to the Python `defaults` and include them in the merge so `redis` keys are present in `OrchestratorConfig.raw`.
- Add a fallback in `python/orchestrator/job_context.py` so `influx_runtime()` returns `influxdb` if `influx` is absent.
- Extend PHP `orchestrator_runtime_config_export()` in `src/functions.php` to include a `redis` section (enabled/host/port/database/password/prefix) so the PHP export and the Python loader share the same effective runtime data.

### Testing

- Ran `php -l src/functions.php` to validate PHP syntax and it returned no syntax errors.
- Compiled Python modules with `PYTHONPATH=python python -m py_compile python/orchestrator/config.py python/orchestrator/job_context.py` and the compilation succeeded.
- Verified `load_php_runtime_config(Path('/workspace/SupplyCore'))` from Python produced merged keys for `influx`, `influxdb`, and `redis` and showed correct `enabled` values via an interactive Python check, which succeeded.
- Verified `php bin/orchestrator_config.php > /tmp/orch.json` then inspected the JSON payload and confirmed the exported runtime includes `redis` and `influxdb` keys, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42373de1c832fac43f7080f075b4d)