### PR TITLE
Enforce Python runtime parity from scheduler registry definitions

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -4423,8 +4423,18 @@ function scheduler_python_php_fallback_enabled(): bool
 
 function scheduler_job_execution_mode(array $job, ?array $definition = null): string
 {
-    $resolvedDefinition = is_array($definition) ? $definition : (scheduler_registry_definitions()[(string) ($job['job_key'] ?? '')] ?? []);
-    $configured = strtolower(trim((string) ($job['execution_mode'] ?? $resolvedDefinition['execution_mode'] ?? 'php')));
+    $jobKey = trim((string) ($job['job_key'] ?? ''));
+    $resolvedDefinition = is_array($definition) ? $definition : (scheduler_registry_definitions()[$jobKey] ?? []);
+    $definitionMode = strtolower(trim((string) ($resolvedDefinition['execution_mode'] ?? '')));
+    $jobMode = strtolower(trim((string) ($job['execution_mode'] ?? '')));
+
+    // Runtime parity guard:
+    // registry-declared Python jobs (especially compute battle-intelligence jobs)
+    // must stay on the Python runtime across scheduler, worker pool, and CLI
+    // launchers even if an old row still carries execution_mode='php'.
+    $configured = $definitionMode === 'python'
+        ? 'python'
+        : ($jobMode !== '' ? $jobMode : 'php');
 
     if ($configured === 'python' && !scheduler_python_heavy_jobs_enabled()) {
         return 'php';


### PR DESCRIPTION
### Motivation

- Worker-pool runs for `compute_battle_rollups` and `compute_battle_target_metrics` were being routed through PHP, triggering the "must run in the Python scheduler runtime" exceptions and proving a runtime-selection parity bug between launchers. 
- The intent is to ensure registry-declared Python compute jobs resolve to the Python runtime across scheduler-dispatched, worker-pool, and CLI paths so there is a single normalized decision point.

### Description

- Changed `scheduler_job_execution_mode(...)` in `src/functions.php` to prioritize the scheduler registry definition's `execution_mode` (i.e. the canonical job declaration) over potentially stale per-row `sync_schedules.execution_mode` values so registry-declared Python jobs always resolve to `python` unless the global heavy-job switch disables Python. 
- Added a short runtime-parity guard and clarifying comments around the selection logic; no compute jobs were added to PHP bridge allowlists and no PHP fallback paths for compute jobs were introduced.
- No changes were made to the Python worker/processors mappings; the Python worker and job-runner continue to use the shared `battle_runtime(...)` and processors already present in `python/orchestrator/worker_pool.py` and `python/orchestrator/job_runner.py`.

### Testing

- Ran `php -l src/functions.php` and it reported no syntax errors (success). 
- Attempted worker-pool validation with `python3 -m orchestrator worker-pool --app-root /workspace/SupplyCore --queues compute --workload-classes compute --execution-modes python --once --verbose`, but the run could not proceed due to MySQL being unavailable in the environment (`Can't connect to MySQL server on '127.0.0.1'`), so end-to-end worker-pool execution could not be completed here (database connectivity failure). 
- Attempted to exercise job queueing (`queue_due_recurring_jobs`) from Python and also encountered the same DB connection refusal, so live confirmation of `execution_language=python` / `subprocess_invoked=false` from this container is blocked by the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42509a364832fa2199fdc7e1d285f)