### PR TITLE
Centralize Python compute dispatch and add worker binding audits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Preserve a modular, production-oriented PHP architecture for EveMarket. Favor ma
    - Normalize runtime dependencies (config, DB access, logger/log sinks, timestamps/metadata) through reusable Python context helpers instead of launcher-specific assumptions.
    - New or changed Python jobs are not complete until parity is validated across worker, scheduler-dispatched, and manual CLI execution paths.
    - Never “fix” Python job execution failures by routing the job through PHP when the target architecture is Python-only.
+   - Runtime safety audit is mandatory: enabled `execution_mode='python'` compute jobs must have a worker-pool processor binding and must not depend on scheduler-only PHP handlers.
 
 ## Preferred Workflow for Changes
 

--- a/docs/python_enabled_jobs_audit.md
+++ b/docs/python_enabled_jobs_audit.md
@@ -1,0 +1,48 @@
+# Enabled Python Job Audit Matrix
+
+This matrix records the worker binding status for the currently-enabled Python compute jobs.
+
+| job_key | enabled | worker processor function | underlying implementation function(s) | worker_safe | cli_safe | scheduler_safe | runtime_guard_present | duplicate_entrypoints | fix_applied |
+|---|---:|---|---|---|---|---|---|---|---|
+| compute_graph_insights | 1 | `run_compute_processor()` dispatch | `run_compute_graph_insights()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_graph_sync | 1 | `run_compute_processor()` dispatch | `run_compute_graph_sync()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_battle_actor_features | 1 | `run_compute_processor()` dispatch | `run_compute_battle_actor_features()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_battle_anomalies | 1 | `run_compute_processor()` dispatch | `run_compute_battle_anomalies()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_battle_rollups | 1 | `run_compute_processor()` dispatch | `run_compute_battle_rollups()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_battle_target_metrics | 1 | `run_compute_processor()` dispatch | `run_compute_battle_target_metrics()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_suspicion_scores | 1 | `run_compute_processor()` dispatch | `run_compute_suspicion_scores()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_graph_sync_doctrine_dependency | 1 | `run_compute_processor()` dispatch | `run_compute_graph_sync_doctrine_dependency()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_graph_sync_battle_intelligence | 1 | `run_compute_processor()` dispatch | `run_compute_graph_sync_battle_intelligence()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_graph_derived_relationships | 1 | `run_compute_processor()` dispatch | `run_compute_graph_derived_relationships()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_graph_prune | 1 | `run_compute_processor()` dispatch | `run_compute_graph_prune()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_graph_topology_metrics | 1 | `run_compute_processor()` dispatch | `run_compute_graph_topology_metrics()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_behavioral_baselines | 1 | `run_compute_processor()` dispatch | `run_compute_behavioral_baselines()` | yes | yes | yes | no | no (registry consolidated) | yes |
+| compute_suspicion_scores_v2 | 1 | `run_compute_processor()` dispatch | `run_compute_suspicion_scores_v2()` | yes | yes | yes | no | no (registry consolidated) | yes |
+
+## Worker Path Trace (failing jobs)
+
+### `compute_battle_rollups`
+1. Claimed from DB by `SupplyCoreDb.claim_next_worker_job(...)`.
+2. Worker executes `_process_job(...)` in `worker_pool.py`.
+3. `_process_job(...)` calls `run_compute_processor('compute_battle_rollups', ...)`.
+4. Registry dispatch calls `run_compute_battle_rollups(db, battle_runtime(raw_config))`.
+5. Result is completed with `execution_language='python'` and `subprocess_invoked=false`.
+
+### `compute_battle_target_metrics`
+1. Claimed from DB by `SupplyCoreDb.claim_next_worker_job(...)`.
+2. Worker executes `_process_job(...)` in `worker_pool.py`.
+3. `_process_job(...)` calls `run_compute_processor('compute_battle_target_metrics', ...)`.
+4. Registry dispatch calls `run_compute_battle_target_metrics(db, battle_runtime(raw_config))`.
+5. Result is completed with `execution_language='python'` and `subprocess_invoked=false`.
+
+## Root Cause Fixed
+
+Scheduler runtime mode resolver now preserves registry-declared Python jobs on Python runtime and no longer downgrades them to PHP mode via a global heavy-job toggle.
+
+## `sync_schedules` helper/internal row assessment
+
+- Real recurring jobs: keys present in `scheduler_registry_definitions()` and intended to run on cadence.
+- Internal/helper pseudo-jobs: keys matched by `scheduler_internal_mechanic_job_keys()` and `scheduler_is_internal_mechanic_job()` prefix/needle checks.
+- Legacy noise candidates: rows that are disabled (`enabled=0`) and classify as internal/helper pseudo-jobs.
+
+Current handling keeps those rows discoverable for diagnostics/operator visibility, but the runtime audit only validates enabled Python rows and only enforces compute worker bindings.

--- a/python/orchestrator/job_runner.py
+++ b/python/orchestrator/job_runner.py
@@ -6,33 +6,17 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from .bridge import PhpBridge
 from .config import load_php_runtime_config
 from .db import SupplyCoreDb
-from .job_context import battle_runtime, influx_runtime, neo4j_runtime
 from .jobs import (
-    run_compute_battle_actor_features,
-    run_compute_battle_anomalies,
-    run_compute_battle_rollups,
-    run_compute_battle_target_metrics,
-    run_compute_buy_all,
-    run_compute_signals,
-    run_compute_graph_insights,
-    run_compute_graph_sync,
-    run_compute_graph_sync_battle_intelligence,
-    run_compute_graph_sync_doctrine_dependency,
-    run_compute_graph_derived_relationships,
-    run_compute_graph_prune,
-    run_compute_graph_topology_metrics,
-    run_compute_behavioral_baselines,
-    run_compute_suspicion_scores_v2,
-    run_compute_suspicion_scores,
     run_killmail_r2z2_stream,
     run_market_comparison_summary,
     run_market_hub_local_history,
 )
+from .processor_registry import PYTHON_COMPUTE_PROCESSOR_JOB_KEYS, audit_enabled_python_jobs, run_compute_processor
 from .worker_runtime import resident_memory_bytes, utc_now_iso
 
 
@@ -73,29 +57,10 @@ class PythonWorkerContext:
         emit(event, payload)
 
 
-PROCESSORS: dict[str, Callable[[PythonWorkerContext], dict[str, Any]]] = {
+PROCESSORS = {
     "killmail_r2z2_sync": run_killmail_r2z2_stream,
     "market_comparison_summary_sync": run_market_comparison_summary,
     "market_hub_local_history_sync": run_market_hub_local_history,
-    "compute_graph_sync": lambda context: _graph_result_shape(run_compute_graph_sync(context.db, neo4j_runtime(context.raw_config)), "compute_graph_sync"),
-    "compute_graph_sync_doctrine_dependency": lambda context: _graph_result_shape(run_compute_graph_sync_doctrine_dependency(context.db, neo4j_runtime(context.raw_config)), "compute_graph_sync_doctrine_dependency"),
-    "compute_graph_sync_battle_intelligence": lambda context: _graph_result_shape(run_compute_graph_sync_battle_intelligence(context.db, neo4j_runtime(context.raw_config)), "compute_graph_sync_battle_intelligence"),
-    "compute_graph_derived_relationships": lambda context: _graph_result_shape(run_compute_graph_derived_relationships(context.db, neo4j_runtime(context.raw_config)), "compute_graph_derived_relationships"),
-    "compute_graph_insights": lambda context: _graph_result_shape(run_compute_graph_insights(context.db, neo4j_runtime(context.raw_config)), "compute_graph_insights"),
-    "compute_graph_prune": lambda context: _graph_result_shape(run_compute_graph_prune(context.db, neo4j_runtime(context.raw_config)), "compute_graph_prune"),
-    "compute_graph_topology_metrics": lambda context: _graph_result_shape(run_compute_graph_topology_metrics(context.db, neo4j_runtime(context.raw_config)), "compute_graph_topology_metrics"),
-    "compute_behavioral_baselines": lambda context: _compute_result_shape(run_compute_behavioral_baselines(context.db, battle_runtime(context.raw_config)), "compute_behavioral_baselines"),
-    "compute_suspicion_scores_v2": lambda context: _compute_result_shape(run_compute_suspicion_scores_v2(context.db, battle_runtime(context.raw_config)), "compute_suspicion_scores_v2"),
-    "compute_buy_all": lambda context: _compute_result_shape(
-        run_compute_buy_all(context.db),
-        "compute_buy_all",
-    ),
-    "compute_signals": lambda context: _compute_result_shape(run_compute_signals(context.db, influx_runtime(context.raw_config)), "compute_signals"),
-    "compute_battle_rollups": lambda context: _compute_result_shape(run_compute_battle_rollups(context.db, battle_runtime(context.raw_config)), "compute_battle_rollups"),
-    "compute_battle_target_metrics": lambda context: _compute_result_shape(run_compute_battle_target_metrics(context.db, battle_runtime(context.raw_config)), "compute_battle_target_metrics"),
-    "compute_battle_anomalies": lambda context: _compute_result_shape(run_compute_battle_anomalies(context.db, battle_runtime(context.raw_config)), "compute_battle_anomalies"),
-    "compute_battle_actor_features": lambda context: _compute_result_shape(run_compute_battle_actor_features(context.db, neo4j_runtime(context.raw_config), battle_runtime(context.raw_config)), "compute_battle_actor_features"),
-    "compute_suspicion_scores": lambda context: _compute_result_shape(run_compute_suspicion_scores(context.db, battle_runtime(context.raw_config)), "compute_suspicion_scores"),
 }
 
 # Jobs that intentionally execute via the PHP bridge while still running under the
@@ -123,39 +88,6 @@ PHP_BRIDGED_JOB_KEYS: set[str] = {
 INVALID_BRIDGED_JOB_KEYS = sorted(job_key for job_key in PHP_BRIDGED_JOB_KEYS if job_key.startswith("compute_"))
 if INVALID_BRIDGED_JOB_KEYS:
     raise RuntimeError(f"Compute jobs must be Python-native and cannot use PHP bridge fallback: {', '.join(INVALID_BRIDGED_JOB_KEYS)}")
-
-
-def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
-    rows_seen = max(0, int(result.get("rows_processed") or result.get("rows_seen") or 0))
-    rows_written = max(0, int(result.get("rows_written") or 0))
-    status = str(result.get("status") or "success")
-    summary = str(result.get("summary") or f"{job_key} finished with status {status}.")
-    return {
-        "status": status,
-        "summary": summary,
-        "rows_seen": rows_seen,
-        "rows_written": rows_written,
-        "warnings": list(result.get("warnings") or []),
-        "meta": dict(result.get("meta") or {}),
-    }
-
-
-def _compute_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
-    status = str(result.get("status") or "success")
-    rows_processed = max(0, int(result.get("rows_processed") or 0))
-    rows_written = max(0, int(result.get("rows_written") or 0))
-    return {
-        "status": status,
-        "summary": str(result.get("summary") or f"{job_key} completed with status {status}."),
-        "rows_processed": rows_processed,
-        "rows_written": rows_written,
-        "warnings": list(result.get("warnings") or []),
-        "meta": {
-            "job_name": job_key,
-            "computed_at": str(result.get("computed_at") or ""),
-            "result": dict(result),
-        },
-    }
 
 
 def parse_args() -> argparse.Namespace:
@@ -245,7 +177,10 @@ def process_job(context: PythonWorkerContext) -> dict[str, Any]:
         else:
             result = _run_php_fallback(context, bridge)
     else:
-        result = processor(context)
+        if context.job_key in PYTHON_COMPUTE_PROCESSOR_JOB_KEYS:
+            result = run_compute_processor(context.job_key, context.db, context.raw_config)
+        else:
+            result = processor(context)
 
     result.setdefault("duration_ms", int((time.time() - start) * 1000))
     result.setdefault("started_at", utc_now_iso())
@@ -258,6 +193,9 @@ def main() -> int:
     app_root = Path(args.app_root).resolve()
     config = load_php_runtime_config(app_root)
     db = SupplyCoreDb(config.raw.get("db", {}))
+    audit = audit_enabled_python_jobs(db)
+    if audit["issues"]:
+        raise RuntimeError("Enabled Python job binding audit failed: " + "; ".join(audit["issues"]))
     job = _fetch_claimed_job(db, max(0, args.schedule_id))
     context = PythonWorkerContext(
         schedule_id=max(0, args.schedule_id),

--- a/python/orchestrator/processor_registry.py
+++ b/python/orchestrator/processor_registry.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .job_context import battle_runtime, influx_runtime, neo4j_runtime
+from .jobs import (
+    run_compute_battle_actor_features,
+    run_compute_battle_anomalies,
+    run_compute_battle_rollups,
+    run_compute_battle_target_metrics,
+    run_compute_behavioral_baselines,
+    run_compute_buy_all,
+    run_compute_graph_derived_relationships,
+    run_compute_graph_insights,
+    run_compute_graph_prune,
+    run_compute_graph_sync,
+    run_compute_graph_sync_battle_intelligence,
+    run_compute_graph_sync_doctrine_dependency,
+    run_compute_graph_topology_metrics,
+    run_compute_signals,
+    run_compute_suspicion_scores,
+    run_compute_suspicion_scores_v2,
+)
+
+PYTHON_COMPUTE_PROCESSOR_JOB_KEYS: set[str] = {
+    "compute_graph_sync",
+    "compute_graph_sync_doctrine_dependency",
+    "compute_graph_sync_battle_intelligence",
+    "compute_graph_derived_relationships",
+    "compute_graph_insights",
+    "compute_graph_prune",
+    "compute_graph_topology_metrics",
+    "compute_behavioral_baselines",
+    "compute_suspicion_scores_v2",
+    "compute_buy_all",
+    "compute_signals",
+    "compute_battle_rollups",
+    "compute_battle_target_metrics",
+    "compute_battle_anomalies",
+    "compute_battle_actor_features",
+    "compute_suspicion_scores",
+}
+
+
+def run_compute_processor(job_key: str, db: Any, raw_config: dict[str, Any]) -> dict[str, Any]:
+    if job_key == "compute_graph_sync":
+        return _graph_result_shape(run_compute_graph_sync(db, neo4j_runtime(raw_config)), job_key)
+    if job_key == "compute_graph_sync_doctrine_dependency":
+        return _graph_result_shape(run_compute_graph_sync_doctrine_dependency(db, neo4j_runtime(raw_config)), job_key)
+    if job_key == "compute_graph_sync_battle_intelligence":
+        return _graph_result_shape(run_compute_graph_sync_battle_intelligence(db, neo4j_runtime(raw_config)), job_key)
+    if job_key == "compute_graph_derived_relationships":
+        return _graph_result_shape(run_compute_graph_derived_relationships(db, neo4j_runtime(raw_config)), job_key)
+    if job_key == "compute_graph_insights":
+        return _graph_result_shape(run_compute_graph_insights(db, neo4j_runtime(raw_config)), job_key)
+    if job_key == "compute_graph_prune":
+        return _graph_result_shape(run_compute_graph_prune(db, neo4j_runtime(raw_config)), job_key)
+    if job_key == "compute_graph_topology_metrics":
+        return _graph_result_shape(run_compute_graph_topology_metrics(db, neo4j_runtime(raw_config)), job_key)
+    if job_key == "compute_behavioral_baselines":
+        return _compute_result_shape(run_compute_behavioral_baselines(db, battle_runtime(raw_config)), job_key)
+    if job_key == "compute_suspicion_scores_v2":
+        return _compute_result_shape(run_compute_suspicion_scores_v2(db, battle_runtime(raw_config)), job_key)
+    if job_key == "compute_buy_all":
+        return _compute_result_shape(run_compute_buy_all(db), job_key)
+    if job_key == "compute_signals":
+        return _compute_result_shape(run_compute_signals(db, influx_runtime(raw_config)), job_key)
+    if job_key == "compute_battle_rollups":
+        return _compute_result_shape(run_compute_battle_rollups(db, battle_runtime(raw_config)), job_key)
+    if job_key == "compute_battle_target_metrics":
+        return _compute_result_shape(run_compute_battle_target_metrics(db, battle_runtime(raw_config)), job_key)
+    if job_key == "compute_battle_anomalies":
+        return _compute_result_shape(run_compute_battle_anomalies(db, battle_runtime(raw_config)), job_key)
+    if job_key == "compute_battle_actor_features":
+        return _compute_result_shape(run_compute_battle_actor_features(db, neo4j_runtime(raw_config), battle_runtime(raw_config)), job_key)
+    if job_key == "compute_suspicion_scores":
+        return _compute_result_shape(run_compute_suspicion_scores(db, battle_runtime(raw_config)), job_key)
+    raise KeyError(f"No Python processor is registered for compute job {job_key}.")
+
+
+def audit_enabled_python_jobs(db: Any) -> dict[str, Any]:
+    rows = db.fetch_all(
+        "SELECT job_key, enabled, execution_mode FROM sync_schedules WHERE enabled = 1 AND execution_mode = 'python' ORDER BY job_key ASC"
+    )
+    matrix: list[dict[str, Any]] = []
+    issues: list[str] = []
+    for row in rows:
+        job_key = str(row.get("job_key") or "").strip()
+        is_compute = job_key.startswith("compute_")
+        has_processor = job_key in PYTHON_COMPUTE_PROCESSOR_JOB_KEYS
+        if is_compute and not has_processor:
+            issues.append(f"Enabled Python compute job {job_key} is missing a Python worker processor binding.")
+        matrix.append(
+            {
+                "job_key": job_key,
+                "enabled": True,
+                "execution_mode": "python",
+                "is_compute_job": is_compute,
+                "worker_processor_bound": has_processor,
+            }
+        )
+    return {"jobs": matrix, "issues": issues}
+
+
+def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
+    rows_seen = max(0, int(result.get("rows_processed") or result.get("rows_seen") or 0))
+    rows_written = max(0, int(result.get("rows_written") or 0))
+    status = str(result.get("status") or "success")
+    summary = str(result.get("summary") or f"{job_key} finished with status {status}.")
+    return {
+        "status": status,
+        "summary": summary,
+        "rows_processed": rows_seen,
+        "rows_written": rows_written,
+        "warnings": list(result.get("warnings") or []),
+        "meta": dict(result.get("meta") or {}),
+    }
+
+
+def _compute_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
+    status = str(result.get("status") or "success")
+    rows_processed = max(0, int(result.get("rows_processed") or 0))
+    rows_written = max(0, int(result.get("rows_written") or 0))
+    return {
+        "status": status,
+        "summary": str(result.get("summary") or f"{job_key} completed with status {status}."),
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": list(result.get("warnings") or []),
+        "meta": {
+            "job_name": job_key,
+            "computed_at": str(result.get("computed_at") or ""),
+            "result": dict(result),
+        },
+    }

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -8,33 +8,15 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import pymysql
 
 from .config import load_php_runtime_config
 from .db import SupplyCoreDb
-from .job_context import battle_runtime, influx_runtime, neo4j_runtime
-from .jobs import (
-    run_compute_battle_actor_features,
-    run_compute_battle_anomalies,
-    run_compute_battle_rollups,
-    run_compute_battle_target_metrics,
-    run_compute_behavioral_baselines,
-    run_compute_buy_all,
-    run_compute_graph_derived_relationships,
-    run_compute_graph_insights,
-    run_compute_graph_prune,
-    run_compute_graph_sync,
-    run_compute_graph_sync_battle_intelligence,
-    run_compute_graph_sync_doctrine_dependency,
-    run_compute_graph_topology_metrics,
-    run_compute_signals,
-    run_compute_suspicion_scores,
-    run_compute_suspicion_scores_v2,
-)
 from .json_utils import json_dumps_safe, make_json_safe
 from .logging_utils import LoggerAdapter, configure_logging
+from .processor_registry import audit_enabled_python_jobs, run_compute_processor
 from .worker_registry import WORKER_JOB_DEFINITIONS
 from .worker_runtime import resident_memory_bytes, utc_now_iso
 
@@ -60,49 +42,6 @@ class WorkerPoolContext:
 
     def emit(self, event: str, payload: dict[str, Any]) -> None:
         self.logger.info(event, payload={"event": event, **payload})
-
-
-PROCESSORS: dict[str, Callable[[WorkerPoolContext], dict[str, Any]]] = {
-    "compute_graph_sync": lambda context: _graph_result_shape(run_compute_graph_sync(context.db, neo4j_runtime(context.raw_config)), "compute_graph_sync"),
-    "compute_graph_sync_doctrine_dependency": lambda context: _graph_result_shape(run_compute_graph_sync_doctrine_dependency(context.db, neo4j_runtime(context.raw_config)), "compute_graph_sync_doctrine_dependency"),
-    "compute_graph_sync_battle_intelligence": lambda context: _graph_result_shape(run_compute_graph_sync_battle_intelligence(context.db, neo4j_runtime(context.raw_config)), "compute_graph_sync_battle_intelligence"),
-    "compute_graph_derived_relationships": lambda context: _graph_result_shape(run_compute_graph_derived_relationships(context.db, neo4j_runtime(context.raw_config)), "compute_graph_derived_relationships"),
-    "compute_graph_insights": lambda context: _graph_result_shape(run_compute_graph_insights(context.db, neo4j_runtime(context.raw_config)), "compute_graph_insights"),
-    "compute_graph_prune": lambda context: _graph_result_shape(run_compute_graph_prune(context.db, neo4j_runtime(context.raw_config)), "compute_graph_prune"),
-    "compute_graph_topology_metrics": lambda context: _graph_result_shape(run_compute_graph_topology_metrics(context.db, neo4j_runtime(context.raw_config)), "compute_graph_topology_metrics"),
-    "compute_behavioral_baselines": lambda context: _compute_result_shape(run_compute_behavioral_baselines(context.db, battle_runtime(context.raw_config)), "compute_behavioral_baselines"),
-    "compute_suspicion_scores_v2": lambda context: _compute_result_shape(run_compute_suspicion_scores_v2(context.db, battle_runtime(context.raw_config)), "compute_suspicion_scores_v2"),
-    "compute_buy_all": lambda context: _compute_result_shape(run_compute_buy_all(context.db), "compute_buy_all"),
-    "compute_signals": lambda context: _compute_result_shape(run_compute_signals(context.db, influx_runtime(context.raw_config)), "compute_signals"),
-    "compute_battle_rollups": lambda context: _compute_result_shape(run_compute_battle_rollups(context.db, battle_runtime(context.raw_config)), "compute_battle_rollups"),
-    "compute_battle_target_metrics": lambda context: _compute_result_shape(run_compute_battle_target_metrics(context.db, battle_runtime(context.raw_config)), "compute_battle_target_metrics"),
-    "compute_battle_anomalies": lambda context: _compute_result_shape(run_compute_battle_anomalies(context.db, battle_runtime(context.raw_config)), "compute_battle_anomalies"),
-    "compute_battle_actor_features": lambda context: _compute_result_shape(run_compute_battle_actor_features(context.db, neo4j_runtime(context.raw_config), battle_runtime(context.raw_config)), "compute_battle_actor_features"),
-    "compute_suspicion_scores": lambda context: _compute_result_shape(run_compute_suspicion_scores(context.db, battle_runtime(context.raw_config)), "compute_suspicion_scores"),
-}
-
-
-def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
-    return {
-        "status": str(result.get("status") or "success"),
-        "summary": str(result.get("summary") or f"{job_key} finished."),
-        "rows_processed": max(0, int(result.get("rows_processed") or result.get("rows_seen") or 0)),
-        "rows_written": max(0, int(result.get("rows_written") or 0)),
-        "warnings": list(result.get("warnings") or []),
-        "meta": dict(result.get("meta") or {}),
-    }
-
-
-def _compute_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
-    status = str(result.get("status") or "success")
-    return {
-        "status": status,
-        "summary": str(result.get("summary") or f"{job_key} completed with status {status}."),
-        "rows_processed": max(0, int(result.get("rows_processed") or 0)),
-        "rows_written": max(0, int(result.get("rows_written") or 0)),
-        "warnings": list(result.get("warnings") or []),
-        "meta": {"job_name": job_key, "result": dict(result)},
-    }
 
 
 class HeartbeatThread(threading.Thread):
@@ -145,11 +84,8 @@ def _write_state_file(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _process_job(context: WorkerPoolContext) -> dict[str, Any]:
-    processor = PROCESSORS.get(context.job_key)
-    if processor is None:
-        raise RuntimeError(f"No Python processor registered for job {context.job_key}; job is disabled until ported.")
     started = time.monotonic()
-    result = processor(context)
+    result = run_compute_processor(context.job_key, context.db, context.raw_config)
     result.setdefault("duration_ms", int((time.monotonic() - started) * 1000))
     result.setdefault("started_at", utc_now_iso())
     result.setdefault("finished_at", utc_now_iso())
@@ -172,6 +108,11 @@ def main(argv: list[str] | None = None) -> int:
     worker_id = args.worker_id.strip() or f"{socket.gethostname()}-{os.getpid()}"
     state_file = Path(worker_settings.get("pool_state_file", app_root / "storage/run/worker-pool-heartbeat.json"))
     db = SupplyCoreDb(dict(raw_config.get("db") or {}))
+    audit = audit_enabled_python_jobs(db)
+    if audit["issues"]:
+        for issue in audit["issues"]:
+            logger.error("python worker binding audit failure", payload={"event": "worker_pool.binding_audit.failed", "issue": issue})
+        return 1
 
     lease_seconds = max(30, int(worker_settings.get("claim_ttl_seconds", 300)))
     idle_sleep = max(0, int(worker_settings.get("idle_sleep_seconds", 10)))

--- a/src/functions.php
+++ b/src/functions.php
@@ -4436,11 +4436,35 @@ function scheduler_job_execution_mode(array $job, ?array $definition = null): st
         ? 'python'
         : ($jobMode !== '' ? $jobMode : 'php');
 
-    if ($configured === 'python' && !scheduler_python_heavy_jobs_enabled()) {
-        return 'php';
+    return $configured === 'python' ? 'python' : 'php';
+}
+
+function scheduler_enabled_python_worker_binding_audit(): array
+{
+    $rows = db_sync_schedule_fetch_all();
+    $workerDefinitions = worker_job_registry_definitions();
+    $issues = [];
+
+    foreach ($rows as $row) {
+        if ((int) ($row['enabled'] ?? 1) !== 1) {
+            continue;
+        }
+
+        $jobKey = trim((string) ($row['job_key'] ?? ''));
+        $executionMode = strtolower(trim((string) ($row['execution_mode'] ?? 'php')));
+        if ($jobKey === '' || $executionMode !== 'python') {
+            continue;
+        }
+
+        if (str_starts_with($jobKey, 'compute_') && !isset($workerDefinitions[$jobKey])) {
+            $issues[] = 'Enabled Python compute job "' . $jobKey . '" is missing a worker-pool processor binding.';
+        }
     }
 
-    return $configured === 'python' ? 'python' : 'php';
+    return [
+        'issues' => $issues,
+        'issue_count' => count($issues),
+    ];
 }
 
 function scheduler_job_workload_profile(string $jobKey): array
@@ -13882,6 +13906,19 @@ function scheduler_run_optimizer(): ?array
 
 function cron_tick_run(?callable $logger = null): array
 {
+    try {
+        $bindingAudit = scheduler_enabled_python_worker_binding_audit();
+        foreach ((array) ($bindingAudit['issues'] ?? []) as $issue) {
+            if ($logger !== null) {
+                $logger('job.binding_audit.failed', ['issue' => (string) $issue]);
+            }
+        }
+    } catch (Throwable $exception) {
+        if ($logger !== null) {
+            $logger('job.binding_audit.error', ['error' => scheduler_normalize_error_message($exception->getMessage())]);
+        }
+    }
+
     $profiling = scheduler_profiling_tick($logger);
     if ($profiling !== null) {
         return [


### PR DESCRIPTION
### Motivation
- Worker runs for enabled Python compute jobs were hitting scheduler-only PHP handlers and throwing "must run in the Python scheduler runtime" because dispatcher logic had drifted between launchers. 
- The goal was to ensure one authoritative Python-native implementation per compute job so the worker path always selects a worker-safe processor. 
- An anti-regression mechanism was required so enabled Python jobs cannot silently be left without worker bindings again.

### Description
- Added a single authoritative Python compute dispatcher in `python/orchestrator/processor_registry.py` that centralizes compute job keys (`PYTHON_COMPUTE_PROCESSOR_JOB_KEYS`) and the `run_compute_processor()` dispatch logic used by all Python launchers. 
- Wired both `python/orchestrator/worker_pool.py` and `python/orchestrator/job_runner.py` to call `run_compute_processor()` instead of maintaining duplicate per-launcher processor maps, and added startup audits (`audit_enabled_python_jobs`) so the Python worker or scheduler runner fails early if enabled `execution_mode='python'` compute jobs lack a processor binding. 
- Restored registry-declared Python runtime behavior by removing the downgraded-path in `scheduler_job_execution_mode()` so jobs declared in `scheduler_registry_definitions()` with `execution_mode='python'` remain Python-runtime dispatch candidates. 
- Added a scheduler-side binding-audit hook in `cron_tick_run()` and documented the anti-regression requirement in `AGENTS.md` and the enabled-job audit matrix and traces in `docs/python_enabled_jobs_audit.md`.

### Testing
- Ran Python static checks with `python3 -m py_compile python/orchestrator/processor_registry.py python/orchestrator/worker_pool.py python/orchestrator/job_runner.py`, which succeeded. 
- Ran PHP syntax check with `php -l src/functions.php`, which succeeded. 
- Attempted a live DB-backed worker/scheduler validation but it could not be performed in this environment due to MySQL connectivity failure (`Can't connect to MySQL server on '127.0.0.1'`), so end-to-end worker-run proof against real `sync_schedules` rows could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42a14ebe4832f8f9292075410b3d3)