### PR TITLE
Centralize JSON serialization and fix Neo4j prune Cypher compatibility

### DIFF
--- a/python/orchestrator/job_runner.py
+++ b/python/orchestrator/job_runner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import time
 from dataclasses import dataclass
@@ -11,6 +10,7 @@ from typing import Any
 from .bridge import PhpBridge
 from .config import load_php_runtime_config
 from .db import SupplyCoreDb
+from .json_utils import json_dumps_safe
 from .jobs import (
     run_killmail_r2z2_stream,
     run_market_comparison_summary,
@@ -102,7 +102,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def emit(event: str, payload: dict[str, Any]) -> None:
-    print(json.dumps({"event": event, "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), **payload}))
+    print(json_dumps_safe({"event": event, "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), **payload}))
 
 
 def _fetch_claimed_job(db: SupplyCoreDb, schedule_id: int) -> dict[str, Any]:

--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -13,10 +13,12 @@ if __package__ in (None, ""):
     if package_root not in sys.path:
         sys.path.insert(0, package_root)
     from orchestrator.db import SupplyCoreDb
+    from orchestrator.json_utils import json_dumps_safe
     from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
     from orchestrator.neo4j import Neo4jClient, Neo4jConfig
 else:
     from ..db import SupplyCoreDb
+    from ..json_utils import json_dumps_safe
     from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
     from ..neo4j import Neo4jClient, Neo4jConfig
 
@@ -94,19 +96,6 @@ def _stddev(values: list[float]) -> float:
     return math.sqrt(max(0.0, variance))
 
 
-def _json_default(value: Any) -> Any:
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if hasattr(value, "isoformat"):
-        try:
-            return value.isoformat()
-        except Exception:
-            return str(value)
-    if isinstance(value, Exception):
-        return {"error_type": value.__class__.__name__, "error": str(value)}
-    return str(value)
-
-
 def _battle_log(runtime: dict[str, Any] | None, event: str, payload: dict[str, Any]) -> None:
     log_path = str(((runtime or {}).get("log_file") or "")).strip()
     if log_path == "":
@@ -115,7 +104,7 @@ def _battle_log(runtime: dict[str, Any] | None, event: str, payload: dict[str, A
     path.parent.mkdir(parents=True, exist_ok=True)
     record = {"event": event, "timestamp": datetime.now(UTC).isoformat(), **payload}
     with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record, ensure_ascii=False, default=_json_default) + "\n")
+        handle.write(json_dumps_safe(record) + "\n")
 
 
 def _neo4j_sync_participation(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from ..db import SupplyCoreDb
+from ..json_utils import json_dumps_safe
 from ..neo4j import Neo4jClient, Neo4jConfig, Neo4jError
 
 GRAPH_SYNC_KEYS = {
@@ -34,7 +35,7 @@ def _write_graph_log(log_file: str, event: str, payload: dict[str, Any]) -> None
         return
     path = Path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
-    line = json.dumps({"event": event, "timestamp": datetime.now(UTC).isoformat(), **payload}, ensure_ascii=False)
+    line = json_dumps_safe({"event": event, "timestamp": datetime.now(UTC).isoformat(), **payload})
     with path.open("a", encoding="utf-8") as handle:
         handle.write(line + "\n")
 
@@ -101,14 +102,14 @@ def _snapshot_graph_health(client: Neo4jClient) -> dict[str, Any]:
     degrees = client.query(
         """
         MATCH (c:Character)
-        WITH c, size((c)--()) AS deg
+        WITH c, COUNT { (c)--() } AS deg
         RETURN avg(toFloat(deg)) AS avg_character_degree, max(toInteger(deg)) AS max_character_degree
         """
     )
     fit_degrees = client.query(
         """
         MATCH (f:Fit)
-        WITH f, size((f)--()) AS deg
+        WITH f, COUNT { (f)--() } AS deg
         RETURN avg(toFloat(deg)) AS avg_fit_degree, max(toInteger(deg)) AS max_fit_degree
         """
     )
@@ -498,8 +499,8 @@ def run_compute_graph_prune(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None =
         """,
         (
             _utc_now_sql(),
-            json.dumps(health.get("labels") or [], separators=(",", ":"), ensure_ascii=False),
-            json.dumps(health.get("relationships") or [], separators=(",", ":"), ensure_ascii=False),
+            json_dumps_safe(health.get("labels") or []),
+            json_dumps_safe(health.get("relationships") or []),
             float((health.get("degree") or {}).get("avg_character_degree") or 0.0),
             int((health.get("degree") or {}).get("max_character_degree") or 0),
             float((health.get("fit_degree") or {}).get("avg_fit_degree") or 0.0),

--- a/python/orchestrator/neo4j.py
+++ b/python/orchestrator/neo4j.py
@@ -7,6 +7,8 @@ from typing import Any
 import urllib.error
 import urllib.request
 
+from .json_utils import json_dumps_safe
+
 
 @dataclass(slots=True)
 class Neo4jConfig:
@@ -56,7 +58,7 @@ class Neo4jClient:
         auth = base64.b64encode(f"{self._config.username}:{self._config.password}".encode("utf-8")).decode("ascii")
         request = urllib.request.Request(
             self._endpoint,
-            data=json.dumps(payload).encode("utf-8"),
+            data=json_dumps_safe(payload).encode("utf-8"),
             method="POST",
             headers={
                 "Authorization": f"Basic {auth}",

--- a/python/orchestrator/worker_runtime.py
+++ b/python/orchestrator/worker_runtime.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import resource
 import time
 from dataclasses import dataclass, field
 from typing import Any
+
+from .json_utils import json_dumps_safe
 
 
 def utc_now_iso() -> str:
@@ -13,7 +14,7 @@ def utc_now_iso() -> str:
 
 
 def payload_checksum(payload: Any) -> str:
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    encoded = json_dumps_safe(payload, sort_keys=True)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 

--- a/python/tests/test_json_utils.py
+++ b/python/tests/test_json_utils.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 import unittest
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal
 
 from orchestrator.json_utils import json_dumps_safe
 
@@ -21,6 +22,23 @@ class JsonUtilsTests(unittest.TestCase):
 
         self.assertEqual(decoded["ts"], now.isoformat())
         self.assertEqual(decoded["nested"]["items"][0], now.isoformat())
+
+    def test_json_dumps_safe_serializes_date_decimal_and_nested_values(self) -> None:
+        payload = {
+            "as_of": date(2026, 3, 25),
+            "price": Decimal("1234.5600"),
+            "nested": [
+                {"when": datetime(2026, 3, 25, 17, 0, 0, tzinfo=UTC)},
+                {"value": Decimal("0.42")},
+            ],
+        }
+
+        decoded = json.loads(json_dumps_safe(payload))
+
+        self.assertEqual(decoded["as_of"], "2026-03-25")
+        self.assertEqual(decoded["price"], "1234.5600")
+        self.assertEqual(decoded["nested"][0]["when"], "2026-03-25T17:00:00+00:00")
+        self.assertEqual(decoded["nested"][1]["value"], "0.42")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Worker runtime parity is confirmed but several compute jobs failed due to JSON serialization of non-JSON-native types and a Neo4j Cypher syntax regression for degree calculations. 
- Provide a robust, centralized serializer for `datetime`/`date`/`Decimal` and nested payloads so job results, logs, and transport payloads never include raw non-serializable objects. 
- Update Neo4j queries to use current syntax so graph prune and health queries run on modern Neo4j deployments. 

### Description
- Centralized serialization: reuse the existing `json_dumps_safe`/`make_json_safe` by switching job emission, logging, HTTP payloads and checksum paths to call `json_dumps_safe` instead of ad-hoc `json.dumps` or custom `default` handlers. 
- Neo4j Cypher fix: replaced legacy `size((n)--())` pattern expressions with modern `COUNT { (n)--() }` in the graph health degree queries. 
- Files/functions changed: `python/orchestrator/neo4j.py` (`Neo4jClient.query` now uses `json_dumps_safe`), `python/orchestrator/jobs/graph_pipeline.py` (`_write_graph_log`, `_snapshot_graph_health`, and `run_compute_graph_prune` snapshot JSON writes), `python/orchestrator/jobs/battle_intelligence.py` (`_battle_log` now uses `json_dumps_safe`), `python/orchestrator/job_runner.py` (`emit` now uses `json_dumps_safe`), and `python/orchestrator/worker_runtime.py` (`payload_checksum` now uses `json_dumps_safe`). 
- Tests: expanded `python/tests/test_json_utils.py` to cover `date`, `datetime`, `Decimal`, and nested containers to validate centralized behavior. 
- The serialization fix is centralized: all changed runtime/logging/transport paths call `json_dumps_safe` (no per-job duplication of serialization logic). 

### Testing
- Unit tests: ran `python -m unittest python/tests/test_json_utils.py` and both tests passed (OK). 
- Static/packaging: ran `python -m compileall python/orchestrator python/tests/test_json_utils.py` and compilation succeeded (OK). 
- Job smoke runs: executed the Python job entrypoints for `compute_battle_actor_features`, `compute_graph_sync`, `compute_graph_sync_battle_intelligence`, and `compute_graph_prune` via the Python runner and each returned exit code 0 (ran without JSON serialization or Neo4j syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4399122a8832f9f186b5d1fa532af)