### PR TITLE
Fix Python compute runtime defects (serialization, routing, schema)

### DIFF
--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import math
 import sys
 from collections import defaultdict
@@ -648,7 +647,7 @@ def run_compute_battle_anomalies(db: SupplyCoreDb, runtime: dict[str, Any] | Non
                             anomaly_class,
                             float(z),
                             float(percentile_rank),
-                            json.dumps(explanation, separators=(",", ":"), ensure_ascii=False),
+                            json_dumps_safe(explanation),
                             computed_at,
                         ),
                     )
@@ -996,8 +995,8 @@ def run_compute_suspicion_scores(db: SupplyCoreDb, runtime: dict[str, Any] | Non
                     "enemy_efficiency_uplift": enemy_eff_uplift,
                     "role_weight": role_weight,
                     "supporting_battle_count": eligible_battle_count,
-                    "top_supporting_battles_json": json.dumps(support_battles, separators=(",", ":"), ensure_ascii=False),
-                    "explanation_json": json.dumps(explanation, separators=(",", ":"), ensure_ascii=False),
+                    "top_supporting_battles_json": json_dumps_safe(support_battles),
+                    "explanation_json": json_dumps_safe(explanation),
                 }
             )
 

--- a/python/orchestrator/jobs/behavioral_intelligence_v2.py
+++ b/python/orchestrator/jobs/behavioral_intelligence_v2.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import json
 import math
 import time
 from datetime import UTC, datetime
 from typing import Any
 
 from ..db import SupplyCoreDb
+from ..json_utils import json_dumps_safe
 
 MIN_SAMPLE_COUNT = 5
 
@@ -296,9 +296,9 @@ def run_compute_suspicion_scores_v2(db: SupplyCoreDb, runtime: dict[str, Any] | 
                 eligible,
                 evidence_count,
                 int(row.get("community_id") or 0),
-                json.dumps(top_supporting_battles, separators=(",", ":"), ensure_ascii=False),
-                json.dumps(top_neighbors.get(cid, []), separators=(",", ":"), ensure_ascii=False),
-                json.dumps(explanation, separators=(",", ":"), ensure_ascii=False),
+                json_dumps_safe(top_supporting_battles),
+                json_dumps_safe(top_neighbors.get(cid, [])),
+                json_dumps_safe(explanation),
                 computed_at,
             )
         )

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-import json
 import time
 from pathlib import Path
 from typing import Any
@@ -531,6 +530,29 @@ def _upsert_table(db: SupplyCoreDb, table_name: str, columns: str, placeholders:
             cursor.executemany(f"INSERT INTO {table_name} ({columns}) VALUES ({placeholders})", rows)
 
 
+def _ensure_doctrine_dependency_depth_schema(db: SupplyCoreDb) -> None:
+    column = db.fetch_one(
+        """
+        SELECT COLUMN_NAME
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'doctrine_dependency_depth'
+          AND COLUMN_NAME = 'unique_item_count'
+        LIMIT 1
+        """
+    )
+    if column:
+        return
+
+    db.execute(
+        """
+        ALTER TABLE doctrine_dependency_depth
+        ADD COLUMN unique_item_count INT UNSIGNED NOT NULL DEFAULT 0
+        AFTER item_count
+        """
+    )
+
+
 def run_compute_graph_topology_metrics(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:
     started = time.perf_counter()
     job_name = "compute_graph_topology_metrics"
@@ -645,7 +667,7 @@ def run_compute_graph_topology_metrics(db: SupplyCoreDb, neo4j_raw: dict[str, An
             density,
             bridge,
             member_count,
-            json.dumps([], separators=(",", ":"), ensure_ascii=False),
+            json_dumps_safe([]),
             computed_at,
         ))
         for member in members:
@@ -748,6 +770,8 @@ def run_compute_graph_insights(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | Non
         LIMIT 50000
         """
     )
+
+    _ensure_doctrine_dependency_depth_schema(db)
 
     _upsert_table(
         db,

--- a/python/orchestrator/processor_registry.py
+++ b/python/orchestrator/processor_registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from .job_context import battle_runtime, influx_runtime, neo4j_runtime
+from .json_utils import make_json_safe
 from .jobs import (
     run_compute_battle_actor_features,
     run_compute_battle_anomalies,
@@ -103,6 +104,7 @@ def audit_enabled_python_jobs(db: Any) -> dict[str, Any]:
 
 
 def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
+    safe_result = make_json_safe(result)
     rows_seen = max(0, int(result.get("rows_processed") or result.get("rows_seen") or 0))
     rows_written = max(0, int(result.get("rows_written") or 0))
     status = str(result.get("status") or "success")
@@ -112,12 +114,13 @@ def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
         "summary": summary,
         "rows_processed": rows_seen,
         "rows_written": rows_written,
-        "warnings": list(result.get("warnings") or []),
-        "meta": dict(result.get("meta") or {}),
+        "warnings": list(safe_result.get("warnings") or []),
+        "meta": dict(safe_result.get("meta") or {}),
     }
 
 
 def _compute_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
+    safe_result = make_json_safe(result)
     status = str(result.get("status") or "success")
     rows_processed = max(0, int(result.get("rows_processed") or 0))
     rows_written = max(0, int(result.get("rows_written") or 0))
@@ -126,10 +129,10 @@ def _compute_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any
         "summary": str(result.get("summary") or f"{job_key} completed with status {status}."),
         "rows_processed": rows_processed,
         "rows_written": rows_written,
-        "warnings": list(result.get("warnings") or []),
+        "warnings": list(safe_result.get("warnings") or []),
         "meta": {
             "job_name": job_key,
             "computed_at": str(result.get("computed_at") or ""),
-            "result": dict(result),
+            "result": dict(safe_result),
         },
     }

--- a/python/tests/test_compute_processor_routing.py
+++ b/python/tests/test_compute_processor_routing.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+import unittest
+from unittest.mock import patch
+
+from orchestrator import processor_registry
+from orchestrator.job_runner import PHP_BRIDGED_JOB_KEYS
+
+
+class ComputeProcessorRoutingTests(unittest.TestCase):
+    def test_battle_jobs_have_python_processor_bindings(self) -> None:
+        self.assertIn("compute_battle_anomalies", processor_registry.PYTHON_COMPUTE_PROCESSOR_JOB_KEYS)
+        self.assertIn("compute_suspicion_scores", processor_registry.PYTHON_COMPUTE_PROCESSOR_JOB_KEYS)
+
+    def test_battle_jobs_are_not_php_bridged(self) -> None:
+        self.assertNotIn("compute_battle_anomalies", PHP_BRIDGED_JOB_KEYS)
+        self.assertNotIn("compute_suspicion_scores", PHP_BRIDGED_JOB_KEYS)
+
+    def test_battle_anomalies_routes_through_python_processor(self) -> None:
+        with (
+            patch.object(processor_registry, "run_compute_battle_anomalies", return_value={"status": "success", "rows_processed": 1, "rows_written": 1, "computed_at": "2026-03-25 00:00:00"}) as anomalies,
+            patch.object(processor_registry, "battle_runtime", return_value={}) as runtime,
+        ):
+            result = processor_registry.run_compute_processor("compute_battle_anomalies", db=object(), raw_config={})
+
+        anomalies.assert_called_once()
+        runtime.assert_called_once()
+        self.assertEqual(result["status"], "success")
+
+    def test_suspicion_scores_routes_through_python_processor(self) -> None:
+        with (
+            patch.object(processor_registry, "run_compute_suspicion_scores", return_value={"status": "success", "rows_processed": 2, "rows_written": 2, "computed_at": "2026-03-25 00:00:00"}) as suspicion,
+            patch.object(processor_registry, "battle_runtime", return_value={}) as runtime,
+        ):
+            result = processor_registry.run_compute_processor("compute_suspicion_scores", db=object(), raw_config={})
+
+        suspicion.assert_called_once()
+        runtime.assert_called_once()
+        self.assertEqual(result["status"], "success")
+
+    def test_compute_result_shape_serializes_datetime_and_decimal_metadata(self) -> None:
+        shaped = processor_registry._compute_result_shape(  # noqa: SLF001
+            {
+                "status": "success",
+                "rows_processed": 1,
+                "rows_written": 1,
+                "computed_at": "2026-03-25 00:00:00",
+                "warnings": [],
+                "sample": {"ts": datetime(2026, 3, 25, tzinfo=UTC), "score": Decimal("0.1250")},
+            },
+            "compute_suspicion_scores_v2",
+        )
+        sample = shaped["meta"]["result"]["sample"]
+        self.assertEqual(sample["ts"], "2026-03-25T00:00:00+00:00")
+        self.assertEqual(sample["score"], "0.1250")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent runtime failures caused by non-JSON-serializable values (e.g., `datetime`, `date`, `Decimal`) being embedded in compute job payloads and metadata.
- Confirm Python worker routing for compute jobs no longer falls back to PHP handlers and guarantee compute jobs are bound to Python processors.
- Address MariaDB schema drift where `doctrine_dependency_depth.unique_item_count` was missing and caused INSERT failures.

### Description
- Replaced ad-hoc `json.dumps(...)` usage with centralized `json_dumps_safe(...)` in compute flows to serialize nested `datetime`/`date`/`Decimal` values safely in `python/orchestrator/jobs/battle_intelligence.py`, `python/orchestrator/jobs/behavioral_intelligence_v2.py`, and topology writes in `python/orchestrator/jobs/graph_pipeline.py`.
- Applied `make_json_safe(...)` before shaping processor results in `python/orchestrator/processor_registry.py` to sanitize `warnings` and `meta.result` and avoid downstream serialization errors.
- Added a runtime schema guard `_ensure_doctrine_dependency_depth_schema` in `python/orchestrator/jobs/graph_pipeline.py` to add the `unique_item_count` column when missing before performing inserts, preventing MariaDB schema-drift failures.
- Normalized graph topology JSON persistence to use `json_dumps_safe(...)` and added a new unit test file `python/tests/test_compute_processor_routing.py` which verifies routing and serialization behavior for key compute jobs.

### Testing
- Ran unit tests with `python -m pytest -q python/tests/test_json_utils.py python/tests/test_compute_processor_routing.py`, and all tests passed (`7 passed`).
- Verified Python modules compile with `python -m py_compile ...` for the modified job and registry files and the compile run completed without errors.
- Ran a binding audit snippet that validated targeted job keys are processor-bound and not PHP-bridged (processor-bound = True, php-bridged = False) for the listed compute jobs.
- Note: full end-to-end worker executions against live MariaDB and Neo4j services were not executed in this environment because they require running external database services.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43d11d9a0832f94eed668ac3a49a5)