### PR TITLE
Add Automation Control settings UI and runtime job management APIs

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -65,6 +65,36 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $saved = save_settings(ai_briefing_settings_from_request($_POST));
             break;
 
+        case 'automation-control':
+            $automationAction = trim((string) ($_POST['automation_action'] ?? 'save-flags'));
+            if ($automationAction === 'enable-all-jobs') {
+                $result = automation_runtime_set_all_jobs_enabled(true);
+                $saved = (bool) ($result['ok'] ?? false);
+                $saveMessage = (string) ($result['message'] ?? 'Requested all jobs to be enabled.');
+                break;
+            }
+            if ($automationAction === 'disable-all-jobs') {
+                $result = automation_runtime_set_all_jobs_enabled(false);
+                $saved = (bool) ($result['ok'] ?? false);
+                $saveMessage = (string) ($result['message'] ?? 'Requested all jobs to be disabled.');
+                break;
+            }
+            if ($automationAction === 'enable-selected-jobs') {
+                $result = automation_runtime_set_jobs_enabled((array) ($_POST['managed_job_keys'] ?? []), true);
+                $saved = (bool) ($result['ok'] ?? false);
+                $saveMessage = (string) ($result['message'] ?? 'Requested selected jobs to be enabled.');
+                break;
+            }
+            if ($automationAction === 'disable-selected-jobs') {
+                $result = automation_runtime_set_jobs_enabled((array) ($_POST['managed_job_keys'] ?? []), false);
+                $saved = (bool) ($result['ok'] ?? false);
+                $saveMessage = (string) ($result['message'] ?? 'Requested selected jobs to be disabled.');
+                break;
+            }
+            $saved = save_settings(automation_runtime_settings_from_request($_POST));
+            $saveMessage = $saved ? 'Automation control settings saved.' : null;
+            break;
+
         case 'esi-login':
             $saved = save_settings([
                 'esi_client_id' => trim($_POST['esi_client_id'] ?? ''),
@@ -276,6 +306,8 @@ $settingsPipelineHealth = array_values((array) ($syncDashboard['pipeline_health'
 $settingsSystemStatus = (array) ($syncDashboard['system_status'] ?? []);
 $rebuildStatus = supplycore_rebuild_status_read();
 $runtimeDatasetCards = array_values((array) ($syncDashboard['runtime_dataset_cards'] ?? []));
+$automationJobs = automation_runtime_jobs_overview();
+$automationEnabledCount = count(array_filter($automationJobs, static fn (array $job): bool => !empty($job['enabled'])));
 if ($dbStatus['ok']) {
     $latestEsiToken = db_latest_esi_oauth_token();
     if ($latestEsiToken !== null) {
@@ -451,6 +483,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 ['href' => '/settings?section=killmail-intelligence', 'title' => 'Doctrine + killmail inputs', 'copy' => 'Tracked alliances, corporations, and demand signals that feed readiness and replenishment views.'],
                 ['href' => '/settings?section=ai-briefings', 'title' => 'AI briefings', 'copy' => 'Choose whether background AI summaries run and which provider they use.'],
                 ['href' => '/settings?section=data-sync', 'title' => 'Sync behavior', 'copy' => 'Control update cadence, freshness expectations, and manual run controls.'],
+                ['href' => '/settings?section=automation-control', 'title' => 'Automation control', 'copy' => 'Centralized toggles for ESI, zKill ingestion, pipelines, and recurring job enablement.'],
             ];
             ?>
             <div class="mt-6 space-y-6">
@@ -1580,6 +1613,98 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
                 <p class="text-sm text-muted">Ingestion consumes R2Z2 as an ordered stream and keeps killmails only when a tracked alliance or corporation appears on the victim side. That keeps the board focused on tracked losses while leaving attacker details available only inside each stored loss.</p>
                 <button class="btn-primary">Save Killmail Intelligence Settings</button>
+            </form>
+        <?php elseif ($section === 'automation-control'): ?>
+            <form class="mt-6 space-y-5" method="post">
+                <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
+                <input type="hidden" name="section" value="automation-control">
+
+                <section class="space-y-3 rounded-2xl border border-border bg-black/20 p-4">
+                    <div>
+                        <p class="text-sm font-semibold text-slate-100">Integration runtime toggles</p>
+                        <p class="mt-1 text-xs text-muted">Centralized runtime switches that were previously spread across multiple settings pages.</p>
+                    </div>
+                    <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
+                        <input type="hidden" name="esi_enabled" value="0">
+                        <input type="checkbox" name="esi_enabled" value="1" <?= ($settingValues['esi_enabled'] ?? '0') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                        <span class="text-sm">Enable ESI OAuth import runtime</span>
+                    </label>
+                    <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
+                        <input type="hidden" name="killmail_ingestion_enabled" value="0">
+                        <input type="checkbox" name="killmail_ingestion_enabled" value="1" <?= ($settingValues['killmail_ingestion_enabled'] ?? '0') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                        <span class="text-sm">Enable zKill stream ingestion runtime</span>
+                    </label>
+                    <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
+                        <input type="hidden" name="incremental_updates_enabled" value="0">
+                        <input type="checkbox" name="incremental_updates_enabled" value="1" <?= ($dataSyncSettingValues['incremental_updates_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                        <span class="text-sm">Enable incremental update execution</span>
+                    </label>
+                    <div class="grid gap-3 md:grid-cols-2">
+                        <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
+                            <input type="hidden" name="alliance_current_pipeline_enabled" value="0">
+                            <input type="checkbox" name="alliance_current_pipeline_enabled" value="1" <?= ($dataSyncSettingValues['alliance_current_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                            <span class="text-sm">Alliance current pipeline</span>
+                        </label>
+                        <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
+                            <input type="hidden" name="alliance_history_pipeline_enabled" value="0">
+                            <input type="checkbox" name="alliance_history_pipeline_enabled" value="1" <?= ($dataSyncSettingValues['alliance_history_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                            <span class="text-sm">Alliance history pipeline</span>
+                        </label>
+                        <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
+                            <input type="hidden" name="hub_history_pipeline_enabled" value="0">
+                            <input type="checkbox" name="hub_history_pipeline_enabled" value="1" <?= ($dataSyncSettingValues['hub_history_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                            <span class="text-sm">Hub history pipeline</span>
+                        </label>
+                        <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
+                            <input type="hidden" name="market_hub_local_history_pipeline_enabled" value="0">
+                            <input type="checkbox" name="market_hub_local_history_pipeline_enabled" value="1" <?= ($dataSyncSettingValues['market_hub_local_history_pipeline_enabled'] ?? '1') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
+                            <span class="text-sm">Hub local history pipeline</span>
+                        </label>
+                    </div>
+                    <button class="btn-primary" name="automation_action" value="save-flags">Save Runtime Toggles</button>
+                </section>
+
+                <section class="space-y-3 rounded-2xl border border-border bg-black/20 p-4">
+                    <div class="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                            <p class="text-sm font-semibold text-slate-100">Recurring job run controls</p>
+                            <p class="mt-1 text-xs text-muted">Enable or disable all recurring schedule rows from one place.</p>
+                        </div>
+                        <span class="inline-flex items-center rounded-full border border-border px-3 py-1 text-xs uppercase tracking-[0.14em] text-slate-100"><?= $automationEnabledCount ?> / <?= count($automationJobs) ?> enabled</span>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                        <button type="submit" name="automation_action" value="enable-all-jobs" class="rounded-lg border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-100 hover:bg-emerald-500/20">Enable all recurring jobs</button>
+                        <button type="submit" name="automation_action" value="disable-all-jobs" class="rounded-lg border border-rose-400/40 bg-rose-500/10 px-4 py-2 text-sm font-medium text-rose-100 hover:bg-rose-500/20">Disable all recurring jobs</button>
+                    </div>
+                    <div class="grid gap-3 md:grid-cols-2">
+                        <?php foreach ($automationJobs as $job): ?>
+                            <label class="rounded-lg border border-border bg-black/30 p-3">
+                                <span class="flex items-start justify-between gap-2">
+                                    <span>
+                                        <span class="text-sm text-slate-100"><?= htmlspecialchars((string) ($job['label'] ?? $job['job_key']), ENT_QUOTES) ?></span>
+                                        <span class="mt-1 block text-xs text-muted font-mono"><?= htmlspecialchars((string) ($job['job_key'] ?? ''), ENT_QUOTES) ?></span>
+                                    </span>
+                                    <span class="text-xs <?= !empty($job['enabled']) ? 'text-emerald-200' : 'text-amber-200' ?>"><?= !empty($job['enabled']) ? 'enabled' : 'disabled' ?></span>
+                                </span>
+                                <span class="mt-2 block text-xs text-muted">Every <?= (int) ($job['interval_minutes'] ?? 0) ?> min · next <?= htmlspecialchars((string) (($job['next_due_at'] ?? '') !== '' ? $job['next_due_at'] : 'not scheduled'), ENT_QUOTES) ?></span>
+                                <?php if (trim((string) ($job['review_reason'] ?? '')) !== ''): ?>
+                                    <span class="mt-1 block text-xs text-amber-200"><?= htmlspecialchars((string) ($job['review_reason'] ?? ''), ENT_QUOTES) ?></span>
+                                <?php endif; ?>
+                                <span class="mt-2 flex items-center gap-2 text-xs text-muted">
+                                    <input type="checkbox" name="managed_job_keys[]" value="<?= htmlspecialchars((string) ($job['job_key'] ?? ''), ENT_QUOTES) ?>" class="size-4 rounded border-border bg-black">
+                                    Select
+                                </span>
+                            </label>
+                        <?php endforeach; ?>
+                        <?php if ($automationJobs === []): ?>
+                            <div class="rounded-lg border border-dashed border-border bg-black/20 p-3 text-xs text-muted md:col-span-2">No manageable recurring jobs were discovered.</div>
+                        <?php endif; ?>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                        <button type="submit" name="automation_action" value="enable-selected-jobs" class="rounded-lg border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-100 hover:bg-emerald-500/20">Enable selected jobs</button>
+                        <button type="submit" name="automation_action" value="disable-selected-jobs" class="rounded-lg border border-rose-400/40 bg-rose-500/10 px-4 py-2 text-sm font-medium text-rose-100 hover:bg-rose-500/20">Disable selected jobs</button>
+                    </div>
+                </section>
             </form>
         <?php elseif ($section === 'esi-login'): ?>
             <form class="mt-6 space-y-4" method="post">

--- a/src/functions.php
+++ b/src/functions.php
@@ -277,6 +277,7 @@ function setting_sections(): array
         'trading-stations' => ['title' => 'Trading Stations', 'description' => 'Configure your reference market hub and operational trading destination.'],
         'item-scope' => ['title' => 'Item Scope', 'description' => 'Control which item classes are operationally relevant across market, doctrine, and loss-demand analytics.'],
         'ai-briefings' => ['title' => 'AI Briefings', 'description' => 'Configure either a local Ollama endpoint or a Runpod serverless endpoint for doctrine briefing summaries.'],
+        'automation-control' => ['title' => 'Automation Control', 'description' => 'Centralized controls for runtime integrations and recurring job schedules.'],
         'esi-login' => ['title' => 'ESI Login', 'description' => 'Configure EVE SSO credentials and callback behavior.'],
         'data-sync' => ['title' => 'Data Sync', 'description' => 'Control database import and incremental update policies.'],
         'deal-alerts' => ['title' => 'Deal Alerts', 'description' => 'Tune mispriced-listing detection thresholds, popup behavior, and anomaly cadence.'],
@@ -6656,6 +6657,161 @@ function save_data_sync_settings(array $request): array
     ];
 }
 
+function automation_runtime_settings_from_request(array $request): array
+{
+    return [
+        'esi_enabled' => isset($request['esi_enabled']) ? '1' : '0',
+        'killmail_ingestion_enabled' => isset($request['killmail_ingestion_enabled']) ? '1' : '0',
+        'incremental_updates_enabled' => sanitize_pipeline_enabled($request['incremental_updates_enabled'] ?? null),
+        'alliance_current_pipeline_enabled' => sanitize_pipeline_enabled($request['alliance_current_pipeline_enabled'] ?? null),
+        'alliance_history_pipeline_enabled' => sanitize_pipeline_enabled($request['alliance_history_pipeline_enabled'] ?? null),
+        'hub_history_pipeline_enabled' => sanitize_pipeline_enabled($request['hub_history_pipeline_enabled'] ?? null),
+        'market_hub_local_history_pipeline_enabled' => sanitize_pipeline_enabled($request['market_hub_local_history_pipeline_enabled'] ?? null),
+    ];
+}
+
+function automation_runtime_manageable_job_keys(): array
+{
+    $definitions = data_sync_schedule_job_definitions();
+    $registry = supplycore_authoritative_job_registry();
+    $jobKeys = [];
+
+    foreach ($definitions as $jobKey => $definition) {
+        $entry = (array) ($registry[$jobKey] ?? []);
+        if ($entry === []) {
+            continue;
+        }
+
+        if ((string) ($entry['category'] ?? '') === 'external_integrated') {
+            continue;
+        }
+
+        if (!empty($entry['parent_job_key'])) {
+            continue;
+        }
+
+        if (($entry['schedulable'] ?? false) !== true) {
+            continue;
+        }
+
+        if (($entry['settings_visible'] ?? false) !== true) {
+            continue;
+        }
+
+        $jobKeys[] = $jobKey;
+    }
+
+    sort($jobKeys);
+
+    return $jobKeys;
+}
+
+function automation_runtime_jobs_overview(): array
+{
+    scheduler_registry_bootstrap();
+    $definitions = data_sync_schedule_job_definitions();
+    $registry = supplycore_authoritative_job_registry();
+    $rowsByJobKey = [];
+
+    try {
+        foreach (db_sync_schedule_fetch_all() as $row) {
+            $rowsByJobKey[(string) ($row['job_key'] ?? '')] = $row;
+        }
+    } catch (Throwable) {
+        $rowsByJobKey = [];
+    }
+
+    $jobs = [];
+    foreach (automation_runtime_manageable_job_keys() as $jobKey) {
+        $definition = (array) ($definitions[$jobKey] ?? []);
+        $entry = (array) ($registry[$jobKey] ?? []);
+        $row = (array) ($rowsByJobKey[$jobKey] ?? []);
+        $enabled = (int) ($row['enabled'] ?? (!empty($entry['enabled_by_default']) ? 1 : 0));
+        $jobs[] = [
+            'job_key' => $jobKey,
+            'label' => (string) ($definition['label'] ?? $entry['label'] ?? $jobKey),
+            'enabled' => $enabled === 1,
+            'interval_minutes' => (int) ($row['interval_minutes'] ?? ($definition['default_interval_minutes'] ?? 30)),
+            'next_due_at' => (string) ($row['next_due_at'] ?? $row['next_run_at'] ?? ''),
+            'review_reason' => (string) ($entry['review_reason'] ?? ''),
+            'worker_safe' => !empty($entry['worker_safe']),
+            'category' => (string) ($entry['category'] ?? 'real_schedulable'),
+        ];
+    }
+
+    usort($jobs, static fn (array $a, array $b): int => strcmp((string) ($a['label'] ?? ''), (string) ($b['label'] ?? '')));
+
+    return $jobs;
+}
+
+function automation_runtime_set_jobs_enabled(array $jobKeys, bool $enabled): array
+{
+    scheduler_registry_bootstrap();
+    $definitions = data_sync_schedule_job_definitions();
+    $allowedJobKeys = array_flip(automation_runtime_manageable_job_keys());
+    $requestedJobKeys = array_values(array_unique(array_filter(array_map(
+        static fn (mixed $value): string => trim((string) $value),
+        $jobKeys
+    ), static fn (string $value): bool => $value !== '' && isset($allowedJobKeys[$value]))));
+
+    if ($requestedJobKeys === []) {
+        return ['ok' => false, 'message' => 'No valid jobs were selected.'];
+    }
+
+    $rowsByJobKey = [];
+    try {
+        foreach (db_sync_schedule_fetch_all() as $row) {
+            $rowsByJobKey[(string) ($row['job_key'] ?? '')] = $row;
+        }
+    } catch (Throwable) {
+        $rowsByJobKey = [];
+    }
+
+    $changed = 0;
+    foreach ($requestedJobKeys as $jobKey) {
+        $definition = (array) ($definitions[$jobKey] ?? []);
+        if ($definition === []) {
+            continue;
+        }
+        $row = (array) ($rowsByJobKey[$jobKey] ?? []);
+        $intervalMinutes = max(1, (int) ($row['interval_minutes'] ?? ($definition['default_interval_minutes'] ?? 30)));
+        $offsetMinutes = max(0, (int) ($row['offset_minutes'] ?? ($definition['default_offset_minutes'] ?? 0)));
+        $ok = db_sync_schedule_upsert(
+            $jobKey,
+            $enabled ? 1 : 0,
+            $intervalMinutes * 60,
+            $offsetMinutes * 60,
+            [
+                'interval_minutes' => $intervalMinutes,
+                'offset_minutes' => $offsetMinutes,
+                'priority' => (string) ($row['priority'] ?? ($definition['priority'] ?? 'normal')),
+                'timeout_seconds' => (int) ($row['timeout_seconds'] ?? ($definition['timeout_seconds'] ?? 300)),
+                'concurrency_policy' => (string) ($row['concurrency_policy'] ?? ($definition['concurrency_policy'] ?? 'single')),
+                'execution_mode' => (string) ($row['execution_mode'] ?? ($definition['execution_mode'] ?? 'python')),
+                'explicitly_configured' => true,
+            ]
+        );
+        if ($ok) {
+            $changed++;
+        }
+    }
+
+    if ($changed === 0) {
+        return ['ok' => false, 'message' => 'No schedules were updated.'];
+    }
+
+    return [
+        'ok' => true,
+        'message' => ($enabled ? 'Enabled ' : 'Disabled ') . $changed . ' job schedule' . ($changed === 1 ? '' : 's') . '.',
+        'changed' => $changed,
+    ];
+}
+
+function automation_runtime_set_all_jobs_enabled(bool $enabled): array
+{
+    return automation_runtime_set_jobs_enabled(automation_runtime_manageable_job_keys(), $enabled);
+}
+
 function sanitize_redis_host(?string $value): string
 {
     $host = trim((string) $value);
@@ -8388,6 +8544,25 @@ function supplycore_freshness_bucket(?int $ageSeconds, int $freshSeconds, int $d
     return 'stale';
 }
 
+function supplycore_runtime_flag_is_recently_active(?string $startedAt, int $activityWindowSeconds): bool
+{
+    if ($startedAt === null) {
+        return false;
+    }
+
+    $normalized = trim($startedAt);
+    if ($normalized === '') {
+        return false;
+    }
+
+    $startedUnix = strtotime($normalized);
+    if ($startedUnix === false) {
+        return false;
+    }
+
+    return (time() - $startedUnix) <= max(60, $activityWindowSeconds);
+}
+
 function supplycore_dataset_runtime_status_from_sync(array $spec): array
 {
     $datasetKeys = array_values(array_filter(array_map(
@@ -8419,17 +8594,26 @@ function supplycore_dataset_runtime_status_from_sync(array $spec): array
 
     $lastSuccessTimestamp = $lastSuccessAt !== null ? (strtotime($lastSuccessAt) ?: null) : null;
     $ageSeconds = $lastSuccessTimestamp !== null ? max(0, time() - $lastSuccessTimestamp) : null;
+    $freshSeconds = max(60, (int) ($spec['fresh_seconds'] ?? 900));
+    $delayedSeconds = max($freshSeconds, (int) ($spec['delayed_seconds'] ?? ($freshSeconds * 3)));
     $runningNow = false;
+    $runningWindowSeconds = max(
+        120,
+        (int) ($spec['running_window_seconds'] ?? min($delayedSeconds, max($freshSeconds, 15 * 60)))
+    );
 
     foreach ($states as $state) {
-        if ((string) ($state['status'] ?? '') === 'running') {
+        if ((string) ($state['status'] ?? '') === 'running'
+            && supplycore_runtime_flag_is_recently_active(
+                isset($state['updated_at']) ? (string) $state['updated_at'] : null,
+                $runningWindowSeconds
+            )
+        ) {
             $runningNow = true;
             break;
         }
     }
 
-    $freshSeconds = max(60, (int) ($spec['fresh_seconds'] ?? 900));
-    $delayedSeconds = max($freshSeconds, (int) ($spec['delayed_seconds'] ?? ($freshSeconds * 3)));
     $freshnessState = supplycore_freshness_bucket($ageSeconds, $freshSeconds, $delayedSeconds, $runningNow);
     $latestFailureMessage = supplycore_latest_run_failure_message($runs);
     $latestRunStatus = is_array($latestRun) ? (string) ($latestRun['run_status'] ?? '') : '';
@@ -8466,7 +8650,18 @@ function supplycore_dataset_runtime_status_from_snapshot(array $spec): array
     $meta = $snapshotKey !== '' ? supplycore_snapshot_freshness($snapshotKey) : [];
     $computedAt = trim((string) ($meta['computed_at'] ?? ''));
     $computedAt = $computedAt !== '' ? $computedAt : null;
-    $runningNow = (string) ($meta['status'] ?? '') === 'updating';
+    $runningWindowSeconds = max(
+        120,
+        (int) ($spec['running_window_seconds'] ?? min(
+            (int) ($meta['stale_after_seconds'] ?? 0),
+            max((int) ($meta['refresh_interval_seconds'] ?? 900), 15 * 60)
+        ))
+    );
+    $runningNow = (string) ($meta['status'] ?? '') === 'updating'
+        && supplycore_runtime_flag_is_recently_active(
+            isset($meta['refresh_started_at']) ? (string) $meta['refresh_started_at'] : null,
+            $runningWindowSeconds
+        );
     $freshSeconds = max(60, (int) ($meta['refresh_interval_seconds'] ?? ($spec['fresh_seconds'] ?? 900)));
     $delayedSeconds = max($freshSeconds, (int) ($meta['stale_after_seconds'] ?? ($spec['delayed_seconds'] ?? ($freshSeconds * 3))));
     $ageSeconds = isset($meta['age_seconds']) ? (int) $meta['age_seconds'] : null;


### PR DESCRIPTION
### Motivation
- Provide a centralized UI to control runtime integration flags and recurring job schedules that were previously scattered across pages.
- Allow operators to enable/disable recurring jobs in bulk or by selection from the web UI and persist related runtime flags.
- Improve freshness/running detection by considering recent "started" timestamps when deciding if a dataset or snapshot is actively updating.

### Description
- Introduces an `automation-control` settings section and UI in `public/settings/index.php` with runtime toggles and recurring job controls, including enable/disable-all and enable/disable-selected actions and a jobs overview list. 
- Adds request handling for the new section in `public/settings/index.php` to save flags via `automation_runtime_settings_from_request` and to call `automation_runtime_set_all_jobs_enabled` / `automation_runtime_set_jobs_enabled` for bulk or selected job updates. 
- Implements helper functions in `src/functions.php`: `automation_runtime_settings_from_request`, `automation_runtime_manageable_job_keys`, `automation_runtime_jobs_overview`, `automation_runtime_set_jobs_enabled`, `automation_runtime_set_all_jobs_enabled`, and `supplycore_runtime_flag_is_recently_active`; and integrates these into dataset/snapshot freshness logic to better detect "running now" state. 
- Registers the new section in `setting_sections()` and adds the settings card to the general settings listing.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4795b608c832fa87fec542987fc6a)