### PR TITLE
Materialize control cohorts and record distinct denominators in counterintel pipeline

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1678,6 +1678,8 @@ CREATE TABLE IF NOT EXISTS character_counterintel_features (
     character_id BIGINT UNSIGNED PRIMARY KEY,
     anomalous_battle_presence_count INT UNSIGNED NOT NULL DEFAULT 0,
     control_battle_presence_count INT UNSIGNED NOT NULL DEFAULT 0,
+    anomalous_battle_denominator INT UNSIGNED NOT NULL DEFAULT 0,
+    control_battle_denominator INT UNSIGNED NOT NULL DEFAULT 0,
     anomalous_presence_rate DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
     control_presence_rate DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
     enemy_same_hull_survival_lift DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
@@ -1690,6 +1692,16 @@ CREATE TABLE IF NOT EXISTS character_counterintel_features (
     computed_at DATETIME NOT NULL,
     KEY idx_character_counterintel_features_repeatability (repeatability_score, computed_at),
     KEY idx_character_counterintel_features_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS battle_side_control_cohort_membership (
+    battle_id CHAR(64) NOT NULL,
+    side_key VARCHAR(80) NOT NULL,
+    character_id BIGINT UNSIGNED NOT NULL,
+    computed_at DATETIME NOT NULL,
+    PRIMARY KEY (battle_id, side_key, character_id),
+    KEY idx_battle_side_control_cohort_character (character_id, computed_at),
+    KEY idx_battle_side_control_cohort_computed (computed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS character_counterintel_scores (

--- a/python/orchestrator/jobs/counterintel_pipeline.py
+++ b/python/orchestrator/jobs/counterintel_pipeline.py
@@ -481,6 +481,7 @@ def run_compute_counterintel_pipeline(
             rows_processed += len(participants)
             by_character: dict[int, list[dict[str, Any]]] = defaultdict(list)
             anomalous_battles = {f"{row['battle_id']}|{row['side_key']}" for row in overperformance_rows if row["anomaly_class"] == "high_enemy_overperformance"}
+            control_battles = {f"{row['battle_id']}|{row['side_key']}" for row in overperformance_rows if row["anomaly_class"] != "high_enemy_overperformance"}
             for row in participants:
                 cid = int(row.get("character_id") or 0)
                 if cid <= 0:
@@ -500,19 +501,27 @@ def run_compute_counterintel_pipeline(
             feature_rows: list[dict[str, Any]] = []
             score_rows: list[dict[str, Any]] = []
             evidence_rows: list[dict[str, Any]] = []
+            control_membership_rows: list[tuple[str, str, int]] = []
+            anomalous_battle_denominator = len(anomalous_battles)
+            control_battle_denominator = len(control_battles)
             for character_id, presences in by_character.items():
-                total = len({str(p.get("battle_id")) for p in presences})
                 anomaly_hits = 0
+                control_hits = 0
                 sustain_lifts: list[float] = []
                 for row in presences:
                     key = f"{row.get('battle_id')}|{row.get('side_key')}"
                     if key in anomalous_battles:
                         anomaly_hits += 1
+                    if key in control_battles:
+                        control_hits += 1
+                        control_membership_rows.append((str(row.get("battle_id") or ""), str(row.get("side_key") or "unknown"), character_id))
                     for over in overperformance_rows:
                         if over["battle_id"] == str(row.get("battle_id")) and over["side_key"] != str(row.get("side_key")):
                             sustain_lifts.append(float(over["sustain_lift_score"]))
-                anomalous_rate = _safe_div(float(anomaly_hits), float(max(1, total)), 0.0)
-                control_rate = max(0.0, 1.0 - anomalous_rate)
+                anomalous_rate = _safe_div(float(anomaly_hits), float(max(1, anomalous_battle_denominator)), 0.0)
+                control_rate = _safe_div(float(control_hits), float(max(1, control_battle_denominator)), 0.0)
+                presence_delta = anomalous_rate - control_rate
+                presence_lift = _safe_div(anomalous_rate, control_rate, 0.0) if control_rate > 0 else (1.0 if anomalous_rate > 0 else 0.0)
                 enemy_sustain_lift = _safe_div(sum(sustain_lifts), float(max(1, len(sustain_lifts))), 0.0)
                 bridge = _safe_div(sum(float(r.get("bridge_score") or 0.0) for r in presences), float(max(1, len(presences))), 0.0)
                 org = org_by_character.get(character_id, {})
@@ -525,7 +534,9 @@ def run_compute_counterintel_pipeline(
                     {
                         "character_id": character_id,
                         "anomalous_battle_presence_count": anomaly_hits,
-                        "control_battle_presence_count": max(0, total - anomaly_hits),
+                        "control_battle_presence_count": control_hits,
+                        "anomalous_battle_denominator": anomalous_battle_denominator,
+                        "control_battle_denominator": control_battle_denominator,
                         "anomalous_presence_rate": anomalous_rate,
                         "control_presence_rate": control_rate,
                         "enemy_same_hull_survival_lift": enemy_sustain_lift,
@@ -537,15 +548,26 @@ def run_compute_counterintel_pipeline(
                         "repeatability_score": repeatability,
                     }
                 )
-                review_score = max(0.0, min(1.0, 0.34 * anomalous_rate + 0.26 * min(1.0, enemy_sustain_lift / 1.5) + 0.2 * min(1.0, bridge / 5.0) + 0.1 * min(1.0, corp_hop_frequency * 10) + 0.1 * repeatability))
+                review_score = max(0.0, min(1.0, 0.24 * anomalous_rate + 0.1 * max(0.0, presence_delta) + 0.26 * min(1.0, enemy_sustain_lift / 1.5) + 0.2 * min(1.0, bridge / 5.0) + 0.1 * min(1.0, corp_hop_frequency * 10) + 0.1 * repeatability))
+                cohort_payload = json_dumps_safe(
+                    {
+                        "anomalous_battle_presence_count": anomaly_hits,
+                        "control_battle_presence_count": control_hits,
+                        "anomalous_battle_denominator": anomalous_battle_denominator,
+                        "control_battle_denominator": control_battle_denominator,
+                        "presence_delta": presence_delta,
+                        "presence_lift": presence_lift,
+                    }
+                )
                 evidence_rows.extend(
                     [
-                        {"character_id": character_id, "evidence_key": "anomalous_battle_presence_count", "evidence_value": float(anomaly_hits), "evidence_text": f"present in {anomaly_hits} anomalous large battles", "evidence_payload_json": None},
-                        {"character_id": character_id, "evidence_key": "anomalous_presence_rate", "evidence_value": anomalous_rate, "evidence_text": f"anomalous presence rate {anomalous_rate:.3f} vs control {control_rate:.3f}", "evidence_payload_json": None},
+                        {"character_id": character_id, "evidence_key": "anomalous_battle_presence_count", "evidence_value": float(anomaly_hits), "evidence_text": f"present in {anomaly_hits}/{anomalous_battle_denominator} anomalous large battle-sides", "evidence_payload_json": cohort_payload},
+                        {"character_id": character_id, "evidence_key": "anomalous_presence_rate", "evidence_value": anomalous_rate, "evidence_text": f"anomalous presence rate {anomalous_rate:.3f} ({anomaly_hits}/{anomalous_battle_denominator}) vs control {control_rate:.3f} ({control_hits}/{control_battle_denominator})", "evidence_payload_json": cohort_payload},
+                        {"character_id": character_id, "evidence_key": "presence_rate_delta", "evidence_value": presence_delta, "evidence_text": f"presence delta {presence_delta:.3f}, lift {presence_lift:.3f}", "evidence_payload_json": cohort_payload},
                         {"character_id": character_id, "evidence_key": "enemy_sustain_lift", "evidence_value": enemy_sustain_lift, "evidence_text": f"enemy sustain lift {enemy_sustain_lift:.3f} when present", "evidence_payload_json": None},
                     ]
                 )
-                score_rows.append({"character_id": character_id, "review_priority_score": review_score, "confidence_score": min(1.0, _safe_div(float(total), 8.0, 0.0)), "evidence_count": 3})
+                score_rows.append({"character_id": character_id, "review_priority_score": review_score, "confidence_score": min(1.0, _safe_div(float(anomaly_hits + control_hits), 8.0, 0.0)), "evidence_count": 4})
 
             sorted_scores = sorted([float(row["review_priority_score"]) for row in score_rows])
             for row in score_rows:
@@ -591,13 +613,16 @@ def run_compute_counterintel_pipeline(
                             """
                             INSERT INTO character_counterintel_features (
                                 character_id, anomalous_battle_presence_count, control_battle_presence_count,
+                                anomalous_battle_denominator, control_battle_denominator,
                                 anomalous_presence_rate, control_presence_rate, enemy_same_hull_survival_lift,
                                 enemy_sustain_lift, co_presence_anomalous_density, graph_bridge_score,
                                 corp_hop_frequency_180d, short_tenure_ratio_180d, repeatability_score, computed_at
-                            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                             ON DUPLICATE KEY UPDATE
                                 anomalous_battle_presence_count = VALUES(anomalous_battle_presence_count),
                                 control_battle_presence_count = VALUES(control_battle_presence_count),
+                                anomalous_battle_denominator = VALUES(anomalous_battle_denominator),
+                                control_battle_denominator = VALUES(control_battle_denominator),
                                 anomalous_presence_rate = VALUES(anomalous_presence_rate),
                                 control_presence_rate = VALUES(control_presence_rate),
                                 enemy_same_hull_survival_lift = VALUES(enemy_same_hull_survival_lift),
@@ -609,8 +634,20 @@ def run_compute_counterintel_pipeline(
                                 repeatability_score = VALUES(repeatability_score),
                                 computed_at = VALUES(computed_at)
                             """,
-                            (row["character_id"], row["anomalous_battle_presence_count"], row["control_battle_presence_count"], row["anomalous_presence_rate"], row["control_presence_rate"], row["enemy_same_hull_survival_lift"], row["enemy_sustain_lift"], row["co_presence_anomalous_density"], row["graph_bridge_score"], row["corp_hop_frequency_180d"], row["short_tenure_ratio_180d"], row["repeatability_score"], computed_at),
+                            (row["character_id"], row["anomalous_battle_presence_count"], row["control_battle_presence_count"], row["anomalous_battle_denominator"], row["control_battle_denominator"], row["anomalous_presence_rate"], row["control_presence_rate"], row["enemy_same_hull_survival_lift"], row["enemy_sustain_lift"], row["co_presence_anomalous_density"], row["graph_bridge_score"], row["corp_hop_frequency_180d"], row["short_tenure_ratio_180d"], row["repeatability_score"], computed_at),
                         )
+                    if control_membership_rows:
+                        for battle_id, side_key, character_id in control_membership_rows:
+                            cursor_db.execute(
+                                """
+                                INSERT INTO battle_side_control_cohort_membership (
+                                    battle_id, side_key, character_id, computed_at
+                                ) VALUES (%s, %s, %s, %s)
+                                ON DUPLICATE KEY UPDATE
+                                    computed_at = VALUES(computed_at)
+                                """,
+                                (battle_id, side_key, character_id, computed_at),
+                            )
                     for row in score_rows:
                         cursor_db.execute(
                             """

--- a/src/db.php
+++ b/src/db.php
@@ -14089,7 +14089,7 @@ function db_battle_intelligence_top_characters(int $limit = 50): array
 
     return db_select(
         'SELECT ccs.character_id, ccs.review_priority_score, ccs.percentile_rank, ccs.confidence_score, ccs.evidence_count, ccs.computed_at,
-                ccf.anomalous_battle_presence_count, ccf.control_battle_presence_count, ccf.anomalous_presence_rate, ccf.control_presence_rate,
+                ccf.anomalous_battle_presence_count, ccf.control_battle_presence_count, ccf.anomalous_battle_denominator, ccf.control_battle_denominator, ccf.anomalous_presence_rate, ccf.control_presence_rate,
                 ccf.enemy_same_hull_survival_lift, ccf.enemy_sustain_lift, ccf.co_presence_anomalous_density, ccf.graph_bridge_score,
                 ccf.corp_hop_frequency_180d, ccf.short_tenure_ratio_180d, ccf.repeatability_score,
                 COALESCE(emc.entity_name, CONCAT("Character #", ccs.character_id)) AS character_name
@@ -14126,7 +14126,7 @@ function db_battle_intelligence_character(int $characterId): ?array
 
     $row = db_select_one(
         'SELECT ccs.character_id, ccs.review_priority_score, ccs.percentile_rank, ccs.confidence_score, ccs.evidence_count, ccs.computed_at,
-                ccf.anomalous_battle_presence_count, ccf.control_battle_presence_count, ccf.anomalous_presence_rate, ccf.control_presence_rate,
+                ccf.anomalous_battle_presence_count, ccf.control_battle_presence_count, ccf.anomalous_battle_denominator, ccf.control_battle_denominator, ccf.anomalous_presence_rate, ccf.control_presence_rate,
                 ccf.enemy_same_hull_survival_lift, ccf.enemy_sustain_lift, ccf.co_presence_anomalous_density, ccf.graph_bridge_score,
                 ccf.corp_hop_frequency_180d, ccf.short_tenure_ratio_180d, ccf.repeatability_score,
                 coh.source AS org_history_source, coh.current_corporation_id, coh.current_alliance_id, coh.corp_hops_180d, coh.short_tenure_hops_180d,


### PR DESCRIPTION
### Motivation
- Improve explainability and robustness by computing per-character presence rates against distinct anomalous and control cohorts (for eligible 100+ participant battles) instead of treating control as a complement. 
- Persist cohort membership for control sides so downstream inspection and explainability can reference exact control members per battle/side. 
- Surface cohort sizes (denominators) alongside counts so evidence payloads and scores show sample context for deltas and lifts.

### Description
- In `python/orchestrator/jobs/counterintel_pipeline.py` materialized `control_battles` (battle-side keys where `anomaly_class != 'high_enemy_overperformance'`), tracked per-character `control_hits`, computed `anomalous_battle_denominator` and `control_battle_denominator`, and derived `presence_delta` and `presence_lift`; evidence payloads now include cohort JSON with counts, denominators, delta, and lift, and `review_priority_score` was adjusted to include delta contribution. 
- Persisted per-character features: added `anomalous_battle_denominator` and `control_battle_denominator` to the `character_counterintel_features` write path and updated the insert/update statement accordingly. 
- Materialized control cohort membership rows and wrote them into a new table `battle_side_control_cohort_membership` for each `(battle_id, side_key, character_id)` when applicable. 
- Added schema changes in `database/schema.sql` to add the two denominator columns on `character_counterintel_features` and create `battle_side_control_cohort_membership` (primary key on `(battle_id, side_key, character_id)`). 
- Updated DB read paths in `src/db.php` (`db_battle_intelligence_top_characters` and `db_battle_intelligence_character`) to expose the new denominator columns.

### Testing
- Compiled the modified Python file with `python -m py_compile python/orchestrator/jobs/counterintel_pipeline.py` and it succeeded. 
- PHP lint check `php -l src/db.php` passed with no syntax errors. 
- SQL schema changes were added to `database/schema.sql`; migrations should be applied in deployment to bring the database up to date.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c48a40120c832f934a0a2045e178af)