### PR TITLE
Add ESI market adapter, DB helpers and job processors; wire processors into sync runtime

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -385,6 +385,251 @@ class SupplyCoreDb:
             (next_status, next_status, delay, error[:500], json_dumps_safe(result), job_id, worker_id[:190]),
         )
 
+    def fetch_scalar(self, sql: str, params: Sequence[Any] | None = None, *, default: int = 0) -> int:
+        row = self.fetch_one(sql, params)
+        if not row:
+            return default
+        first = next(iter(row.values()), default)
+        return int(first or 0)
+
+    def upsert_sync_state(
+        self,
+        *,
+        dataset_key: str,
+        status: str,
+        row_count: int,
+        checksum: str | None = None,
+        cursor: str | None = None,
+        error_message: str | None = None,
+    ) -> int:
+        return self.execute(
+            """INSERT INTO sync_state (
+                    dataset_key, sync_mode, status, last_success_at, last_cursor, last_row_count, last_checksum, last_error_message
+                ) VALUES (
+                    %s, 'incremental', %s, CASE WHEN %s='success' THEN UTC_TIMESTAMP() ELSE NULL END, %s, %s, %s, %s
+                )
+                ON DUPLICATE KEY UPDATE
+                    status = VALUES(status),
+                    last_success_at = CASE WHEN VALUES(status)='success' THEN UTC_TIMESTAMP() ELSE sync_state.last_success_at END,
+                    last_cursor = VALUES(last_cursor),
+                    last_row_count = VALUES(last_row_count),
+                    last_checksum = VALUES(last_checksum),
+                    last_error_message = VALUES(last_error_message)""",
+            (dataset_key[:190], status[:20], status[:20], cursor, max(0, row_count), checksum, error_message),
+        )
+
+    def upsert_intelligence_snapshot(
+        self,
+        *,
+        snapshot_key: str,
+        payload_json: str,
+        metadata_json: str,
+        expires_seconds: int = 900,
+    ) -> int:
+        return self.execute(
+            """INSERT INTO intelligence_snapshots (
+                    snapshot_key, snapshot_status, payload_json, metadata_json, computed_at, refresh_started_at, expires_at
+                ) VALUES (
+                    %s, 'ready', %s, %s, UTC_TIMESTAMP(), UTC_TIMESTAMP(), DATE_ADD(UTC_TIMESTAMP(), INTERVAL %s SECOND)
+                )
+                ON DUPLICATE KEY UPDATE
+                    snapshot_status='ready',
+                    payload_json=VALUES(payload_json),
+                    metadata_json=VALUES(metadata_json),
+                    computed_at=VALUES(computed_at),
+                    refresh_started_at=VALUES(refresh_started_at),
+                    expires_at=VALUES(expires_at)""",
+            (snapshot_key[:190], payload_json, metadata_json, max(60, expires_seconds)),
+        )
+
+    def refresh_market_order_current_projection(self, *, source_type: str) -> dict[str, int]:
+        rows_processed = self.fetch_scalar(
+            "SELECT COUNT(*) AS c FROM market_orders_current WHERE source_type = %s",
+            (source_type,),
+        )
+        rows_written = self.execute(
+            """INSERT INTO market_order_current_projection (
+                    source_type, source_id, type_id, observed_at, best_sell_price, best_buy_price,
+                    total_sell_volume, total_buy_volume, sell_order_count, buy_order_count, total_volume
+                )
+                SELECT
+                    source_type,
+                    source_id,
+                    type_id,
+                    MAX(observed_at) AS observed_at,
+                    MIN(CASE WHEN is_buy_order = 0 THEN price END) AS best_sell_price,
+                    MAX(CASE WHEN is_buy_order = 1 THEN price END) AS best_buy_price,
+                    SUM(CASE WHEN is_buy_order = 0 THEN volume_remain ELSE 0 END) AS total_sell_volume,
+                    SUM(CASE WHEN is_buy_order = 1 THEN volume_remain ELSE 0 END) AS total_buy_volume,
+                    SUM(CASE WHEN is_buy_order = 0 THEN 1 ELSE 0 END) AS sell_order_count,
+                    SUM(CASE WHEN is_buy_order = 1 THEN 1 ELSE 0 END) AS buy_order_count,
+                    SUM(volume_remain) AS total_volume
+                FROM market_orders_current
+                WHERE source_type = %s
+                GROUP BY source_type, source_id, type_id
+                ON DUPLICATE KEY UPDATE
+                    observed_at = VALUES(observed_at),
+                    best_sell_price = VALUES(best_sell_price),
+                    best_buy_price = VALUES(best_buy_price),
+                    total_sell_volume = VALUES(total_sell_volume),
+                    total_buy_volume = VALUES(total_buy_volume),
+                    sell_order_count = VALUES(sell_order_count),
+                    buy_order_count = VALUES(buy_order_count),
+                    total_volume = VALUES(total_volume)""",
+            (source_type,),
+        )
+        self.execute(
+            """INSERT INTO market_source_snapshot_state (
+                    source_type, source_id, latest_current_observed_at, current_order_count, current_distinct_type_count, summary_row_count, last_synced_at
+                )
+                SELECT
+                    source_type,
+                    source_id,
+                    MAX(observed_at) AS latest_current_observed_at,
+                    COUNT(*) AS current_order_count,
+                    COUNT(DISTINCT type_id) AS current_distinct_type_count,
+                    0 AS summary_row_count,
+                    UTC_TIMESTAMP() AS last_synced_at
+                FROM market_orders_current
+                WHERE source_type = %s
+                GROUP BY source_type, source_id
+                ON DUPLICATE KEY UPDATE
+                    latest_current_observed_at = VALUES(latest_current_observed_at),
+                    current_order_count = VALUES(current_order_count),
+                    current_distinct_type_count = VALUES(current_distinct_type_count),
+                    last_synced_at = VALUES(last_synced_at)""",
+            (source_type,),
+        )
+        return {"rows_processed": rows_processed, "rows_written": rows_written}
+
+    def materialize_market_history_from_projection(self, *, source_type: str) -> dict[str, int]:
+        rows_processed = self.fetch_scalar(
+            "SELECT COUNT(*) FROM market_order_current_projection WHERE source_type = %s",
+            (source_type,),
+        )
+        rows_written = self.execute(
+            """INSERT INTO market_order_snapshots_summary (
+                    source_type, source_id, type_id, observed_at, best_sell_price, best_buy_price,
+                    total_buy_volume, total_sell_volume, total_volume, buy_order_count, sell_order_count
+                )
+                SELECT
+                    source_type,
+                    source_id,
+                    type_id,
+                    observed_at,
+                    best_sell_price,
+                    best_buy_price,
+                    total_buy_volume,
+                    total_sell_volume,
+                    total_volume,
+                    buy_order_count,
+                    sell_order_count
+                FROM market_order_current_projection
+                WHERE source_type = %s
+                ON DUPLICATE KEY UPDATE
+                    best_sell_price = VALUES(best_sell_price),
+                    best_buy_price = VALUES(best_buy_price),
+                    total_buy_volume = VALUES(total_buy_volume),
+                    total_sell_volume = VALUES(total_sell_volume),
+                    total_volume = VALUES(total_volume),
+                    buy_order_count = VALUES(buy_order_count),
+                    sell_order_count = VALUES(sell_order_count)""",
+            (source_type,),
+        )
+        return {"rows_processed": rows_processed, "rows_written": rows_written}
+
+    def fetch_market_hub_sources(self, *, limit: int = 5) -> list[dict[str, int]]:
+        rows = self.fetch_all(
+            """SELECT DISTINCT rs.station_id AS source_id, rs.region_id
+                FROM ref_npc_stations rs
+                INNER JOIN trading_stations ts ON ts.id = rs.station_id
+                WHERE ts.station_type = 'market'
+                ORDER BY rs.station_id ASC
+                LIMIT %s""",
+            (max(1, limit),),
+        )
+        return [{"source_id": int(row.get("source_id") or 0), "region_id": int(row.get("region_id") or 0)} for row in rows]
+
+    def fetch_alliance_structure_sources(self, *, limit: int = 5) -> list[int]:
+        rows = self.fetch_all(
+            """SELECT structure_id
+                FROM alliance_structure_metadata
+                ORDER BY last_verified_at DESC
+                LIMIT %s""",
+            (max(1, limit),),
+        )
+        return [int(row.get("structure_id") or 0) for row in rows if int(row.get("structure_id") or 0) > 0]
+
+    def fetch_latest_esi_access_token(self) -> str | None:
+        row = self.fetch_one(
+            """SELECT access_token
+                FROM esi_oauth_tokens
+                WHERE expires_at > UTC_TIMESTAMP()
+                ORDER BY expires_at DESC
+                LIMIT 1"""
+        ) or {}
+        token = str(row.get("access_token") or "").strip()
+        return token or None
+
+    def replace_market_orders_for_source(
+        self,
+        *,
+        source_type: str,
+        source_id: int,
+        observed_at: str,
+        orders: list[dict[str, Any]],
+    ) -> dict[str, int]:
+        safe_orders: list[tuple[Any, ...]] = []
+        for row in orders:
+            order_id = int(row.get("order_id") or 0)
+            type_id = int(row.get("type_id") or 0)
+            if order_id <= 0 or type_id <= 0:
+                continue
+            safe_orders.append(
+                (
+                    source_type,
+                    max(0, source_id),
+                    type_id,
+                    order_id,
+                    1 if bool(row.get("is_buy_order")) else 0,
+                    float(row.get("price") or 0.0),
+                    max(0, int(row.get("volume_remain") or 0)),
+                    max(0, int(row.get("volume_total") or 0)),
+                    max(1, int(row.get("min_volume") or 1)),
+                    str(row.get("range") or "region")[:20],
+                    max(1, int(row.get("duration") or 1)),
+                    str(row.get("issued") or observed_at)[:19],
+                    str(row.get("expires") or observed_at)[:19],
+                    observed_at,
+                )
+            )
+
+        with self.transaction() as (_, cursor):
+            cursor.execute(
+                "DELETE FROM market_orders_current WHERE source_type = %s AND source_id = %s",
+                (source_type, max(0, source_id)),
+            )
+            if safe_orders:
+                cursor.executemany(
+                    """INSERT INTO market_orders_current (
+                            source_type, source_id, type_id, order_id, is_buy_order, price, volume_remain, volume_total,
+                            min_volume, `range`, duration, issued, expires, observed_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                    safe_orders,
+                )
+                cursor.executemany(
+                    """INSERT INTO market_orders_history (
+                            source_type, source_id, type_id, order_id, is_buy_order, price, volume_remain, volume_total,
+                            min_volume, `range`, duration, issued, expires, observed_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        ON DUPLICATE KEY UPDATE
+                            price = VALUES(price),
+                            volume_remain = VALUES(volume_remain),
+                            volume_total = VALUES(volume_total)""",
+                    safe_orders,
+                )
+        return {"rows_processed": len(orders), "rows_written": len(safe_orders)}
+
 
 def json_dumps(value: Any) -> str:
     return json_dumps_safe(value)

--- a/python/orchestrator/esi_market_adapter.py
+++ b/python/orchestrator/esi_market_adapter.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from .json_utils import json_loads_safe
+
+ESI_BASE = "https://esi.evetech.net"
+ESI_COMPATIBILITY_DATE = "2025-12-16"
+
+
+@dataclass(slots=True)
+class EsiOrdersResponse:
+    orders: list[dict[str, Any]]
+    pages: int
+    status_code: int
+
+
+class EsiMarketAdapter:
+    def __init__(self, *, timeout_seconds: int = 30) -> None:
+        self._timeout_seconds = max(5, timeout_seconds)
+
+    def fetch_region_orders(self, *, region_id: int, order_type: str = "all", page: int = 1) -> EsiOrdersResponse:
+        query = urlencode({"order_type": order_type, "page": page})
+        url = f"{ESI_BASE}/latest/markets/{region_id}/orders/?{query}"
+        return self._request_json(url)
+
+    def fetch_structure_orders(self, *, structure_id: int, access_token: str, page: int = 1) -> EsiOrdersResponse:
+        query = urlencode({"page": page})
+        url = f"{ESI_BASE}/latest/markets/structures/{structure_id}/?{query}"
+        return self._request_json(url, token=access_token)
+
+    def _request_json(self, url: str, token: str | None = None) -> EsiOrdersResponse:
+        headers = {
+            "Accept": "application/json",
+            "X-Compatibility-Date": ESI_COMPATIBILITY_DATE,
+            "X-Tenant": "tranquility",
+            "Accept-Language": "en",
+            "User-Agent": "SupplyCore-Orchestrator/1.0",
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        request = Request(url, headers=headers, method="GET")
+        try:
+            with urlopen(request, timeout=self._timeout_seconds) as response:
+                payload = response.read().decode("utf-8")
+                rows = json_loads_safe(payload)
+                if not isinstance(rows, list):
+                    rows = []
+                pages = int(response.headers.get("X-Pages", "1") or "1")
+                return EsiOrdersResponse(orders=[row for row in rows if isinstance(row, dict)], pages=max(1, pages), status_code=int(response.status))
+        except HTTPError as exc:
+            if exc.code == 304:
+                return EsiOrdersResponse(orders=[], pages=1, status_code=304)
+            raise RuntimeError(f"ESI request failed ({exc.code}) for {url}") from exc
+
+
+def parse_esi_datetime(value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    return parsed.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S")

--- a/python/orchestrator/jobs/activity_priority_summary_sync.py
+++ b/python/orchestrator/jobs/activity_priority_summary_sync.py
@@ -4,5 +4,55 @@ from ..db import SupplyCoreDb
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    rows_processed = db.fetch_scalar("SELECT COUNT(*) FROM doctrine_fit_activity_1d WHERE bucket_start = CURDATE()")
+    rows_written = db.execute(
+        """INSERT INTO doctrine_activity_snapshots (
+                entity_type, entity_id, entity_name, snapshot_time, rank_position, activity_score, activity_level,
+                hull_losses_24h, hull_losses_3d, hull_losses_7d, module_losses_24h, module_losses_3d, module_losses_7d,
+                fit_equivalent_losses_24h, fit_equivalent_losses_3d, fit_equivalent_losses_7d,
+                readiness_state, resupply_pressure_state, resupply_pressure, readiness_gap_count, explanation_text
+            )
+            SELECT
+                'fit' AS entity_type,
+                fa.fit_id AS entity_id,
+                COALESCE(f.fit_name, CONCAT('fit-', fa.fit_id)) AS entity_name,
+                UTC_TIMESTAMP() AS snapshot_time,
+                ROW_NUMBER() OVER (ORDER BY fa.priority_score DESC, fa.fit_gap DESC, fa.fit_id ASC) AS rank_position,
+                fa.priority_score AS activity_score,
+                CASE WHEN fa.priority_score >= 100 THEN 'critical' WHEN fa.priority_score >= 25 THEN 'elevated' ELSE 'low' END AS activity_level,
+                fa.hull_loss_count,
+                fa.hull_loss_count,
+                fa.hull_loss_count,
+                fa.doctrine_item_loss_count,
+                fa.doctrine_item_loss_count,
+                fa.doctrine_item_loss_count,
+                fa.doctrine_item_loss_count,
+                fa.doctrine_item_loss_count,
+                fa.doctrine_item_loss_count,
+                fa.readiness_state,
+                fa.resupply_pressure,
+                fa.resupply_pressure,
+                fa.fit_gap,
+                CONCAT('fit_gap=', fa.fit_gap, ', complete_fits_available=', fa.complete_fits_available)
+            FROM doctrine_fit_activity_1d fa
+            LEFT JOIN doctrine_fits f ON f.id = fa.fit_id
+            WHERE fa.bucket_start = CURDATE()
+            ON DUPLICATE KEY UPDATE
+                rank_position = VALUES(rank_position), activity_score = VALUES(activity_score), activity_level = VALUES(activity_level),
+                hull_losses_24h = VALUES(hull_losses_24h), module_losses_24h = VALUES(module_losses_24h),
+                fit_equivalent_losses_24h = VALUES(fit_equivalent_losses_24h), readiness_state = VALUES(readiness_state),
+                resupply_pressure_state = VALUES(resupply_pressure_state), resupply_pressure = VALUES(resupply_pressure),
+                readiness_gap_count = VALUES(readiness_gap_count), explanation_text = VALUES(explanation_text)"""
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": [] if rows_processed > 0 else ["No doctrine fit activity rows available for today."],
+        "summary": f"Refreshed doctrine activity snapshots with {rows_written} upserts.",
+        "meta": {"entity_type": "fit"},
+    }
+
+
 def run_activity_priority_summary_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="activity_priority_summary_sync", phase="B", objective="activity summaries")
+    return run_sync_phase_job(db, job_key="activity_priority_summary_sync", phase="B", objective="activity summaries", processor=_processor)

--- a/python/orchestrator/jobs/alliance_current_sync.py
+++ b/python/orchestrator/jobs/alliance_current_sync.py
@@ -1,8 +1,67 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..esi_market_adapter import EsiMarketAdapter, parse_esi_datetime
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    adapter = EsiMarketAdapter(timeout_seconds=30)
+    access_token = db.fetch_latest_esi_access_token()
+    structure_ids = db.fetch_alliance_structure_sources(limit=3)
+    warnings: list[str] = []
+    if not access_token:
+        warnings.append("No active ESI OAuth token found; alliance structure orders were not fetched from ESI.")
+    rows_processed = 0
+    rows_written = 0
+    if access_token:
+        for structure_id in structure_ids:
+            orders: list[dict[str, object]] = []
+            try:
+                first_page = adapter.fetch_structure_orders(structure_id=structure_id, access_token=access_token, page=1)
+                orders.extend(first_page.orders)
+                max_pages = min(4, first_page.pages)
+                for page in range(2, max_pages + 1):
+                    response = adapter.fetch_structure_orders(structure_id=structure_id, access_token=access_token, page=page)
+                    orders.extend(response.orders)
+            except Exception as exc:
+                warnings.append(f"alliance structure {structure_id} fetch failed: {exc}")
+                continue
+            normalized_orders: list[dict[str, object]] = []
+            for order in orders:
+                row = dict(order)
+                row["issued"] = parse_esi_datetime(row.get("issued"))
+                row["expires"] = parse_esi_datetime(row.get("expires"))
+                normalized_orders.append(row)
+            observed_at = parse_esi_datetime(None)
+            ingest_stats = db.replace_market_orders_for_source(
+                source_type="alliance_structure",
+                source_id=structure_id,
+                observed_at=observed_at,
+                orders=normalized_orders,
+            )
+            rows_processed += int(ingest_stats["rows_processed"])
+            rows_written += int(ingest_stats["rows_written"])
+
+    stats = db.refresh_market_order_current_projection(source_type="alliance_structure")
+    rows_processed += int(stats["rows_processed"])
+    rows_written += int(stats["rows_written"])
+    if not structure_ids:
+        warnings.append("No alliance_structure_metadata sources were available for ESI structure sync.")
+    db.upsert_sync_state(
+        dataset_key="alliance.structure.orders.current",
+        status="success",
+        row_count=rows_written,
+        cursor=None,
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": warnings,
+        "summary": f"Ingested/projected alliance structure orders ({rows_written} writes across {len(structure_ids)} structures).",
+        "meta": {"dataset_key": "alliance.structure.orders.current"},
+    }
+
+
 def run_alliance_current_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="alliance_current_sync", phase="A", objective="alliance snapshots")
+    return run_sync_phase_job(db, job_key="alliance_current_sync", phase="A", objective="alliance snapshots", processor=_processor)

--- a/python/orchestrator/jobs/alliance_historical_sync.py
+++ b/python/orchestrator/jobs/alliance_historical_sync.py
@@ -4,5 +4,20 @@ from ..db import SupplyCoreDb
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    stats = db.materialize_market_history_from_projection(source_type="alliance_structure")
+    warnings: list[str] = []
+    if stats["rows_processed"] == 0:
+        warnings.append("No alliance_structure projection rows were available for historical materialization.")
+    db.upsert_sync_state(dataset_key="alliance.structure.orders.history", status="success", row_count=stats["rows_written"])
+    return {
+        "rows_processed": stats["rows_processed"],
+        "rows_written": stats["rows_written"],
+        "warnings": warnings,
+        "summary": f"Materialized {stats['rows_written']} alliance_structure historical snapshot rows.",
+        "meta": {"dataset_key": "alliance.structure.orders.history"},
+    }
+
+
 def run_alliance_historical_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="alliance_historical_sync", phase="A", objective="alliance history")
+    return run_sync_phase_job(db, job_key="alliance_historical_sync", phase="A", objective="alliance history", processor=_processor)

--- a/python/orchestrator/jobs/analytics_bucket_1d_sync.py
+++ b/python/orchestrator/jobs/analytics_bucket_1d_sync.py
@@ -4,5 +4,68 @@ from ..db import SupplyCoreDb
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    rows_processed = db.fetch_scalar(
+        "SELECT COUNT(*) FROM market_orders_history WHERE observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 14 DAY)"
+    )
+    stock_written = db.execute(
+        """INSERT INTO market_item_stock_1d (
+                bucket_start, source_type, source_id, type_id, sample_count, stock_units_sum, listing_count_sum, local_stock_units, listing_count
+            )
+            SELECT
+                DATE(observed_at) AS bucket_start,
+                source_type,
+                source_id,
+                type_id,
+                COUNT(*) AS sample_count,
+                SUM(volume_remain) AS stock_units_sum,
+                COUNT(*) AS listing_count_sum,
+                SUM(volume_remain) AS local_stock_units,
+                COUNT(*) AS listing_count
+            FROM market_orders_history
+            WHERE observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 14 DAY)
+            GROUP BY DATE(observed_at), source_type, source_id, type_id
+            ON DUPLICATE KEY UPDATE
+                sample_count = VALUES(sample_count), stock_units_sum = VALUES(stock_units_sum), listing_count_sum = VALUES(listing_count_sum),
+                local_stock_units = VALUES(local_stock_units), listing_count = VALUES(listing_count)"""
+    )
+    price_written = db.execute(
+        """INSERT INTO market_item_price_1d (
+                bucket_start, source_type, source_id, type_id, sample_count, listing_count_sum, avg_price_sum,
+                weighted_price_numerator, weighted_price_denominator, listing_count, min_price, max_price, avg_price, weighted_price
+            )
+            SELECT
+                DATE(observed_at) AS bucket_start,
+                source_type,
+                source_id,
+                type_id,
+                COUNT(*) AS sample_count,
+                COUNT(*) AS listing_count_sum,
+                SUM(price) AS avg_price_sum,
+                SUM(price * volume_remain) AS weighted_price_numerator,
+                SUM(volume_remain) AS weighted_price_denominator,
+                COUNT(*) AS listing_count,
+                MIN(price) AS min_price,
+                MAX(price) AS max_price,
+                AVG(price) AS avg_price,
+                SUM(price * volume_remain) / NULLIF(SUM(volume_remain), 0) AS weighted_price
+            FROM market_orders_history
+            WHERE observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 14 DAY)
+            GROUP BY DATE(observed_at), source_type, source_id, type_id
+            ON DUPLICATE KEY UPDATE
+                sample_count = VALUES(sample_count), listing_count_sum = VALUES(listing_count_sum), avg_price_sum = VALUES(avg_price_sum),
+                weighted_price_numerator = VALUES(weighted_price_numerator), weighted_price_denominator = VALUES(weighted_price_denominator),
+                listing_count = VALUES(listing_count), min_price = VALUES(min_price), max_price = VALUES(max_price),
+                avg_price = VALUES(avg_price), weighted_price = VALUES(weighted_price)"""
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": stock_written + price_written,
+        "warnings": [] if rows_processed > 0 else ["No history rows available in the last 14d for daily analytics buckets."],
+        "summary": f"Upserted {stock_written} stock and {price_written} price daily bucket rows.",
+        "meta": {"window_days": 14},
+    }
+
+
 def run_analytics_bucket_1d_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="analytics_bucket_1d_sync", phase="B", objective="daily rollups")
+    return run_sync_phase_job(db, job_key="analytics_bucket_1d_sync", phase="B", objective="daily rollups", processor=_processor)

--- a/python/orchestrator/jobs/analytics_bucket_1h_sync.py
+++ b/python/orchestrator/jobs/analytics_bucket_1h_sync.py
@@ -4,5 +4,68 @@ from ..db import SupplyCoreDb
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    rows_processed = db.fetch_scalar(
+        "SELECT COUNT(*) FROM market_orders_history WHERE observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 48 HOUR)"
+    )
+    stock_written = db.execute(
+        """INSERT INTO market_item_stock_1h (
+                bucket_start, source_type, source_id, type_id, sample_count, stock_units_sum, listing_count_sum, local_stock_units, listing_count
+            )
+            SELECT
+                DATE_FORMAT(observed_at, '%Y-%m-%d %H:00:00') AS bucket_start,
+                source_type,
+                source_id,
+                type_id,
+                COUNT(*) AS sample_count,
+                SUM(volume_remain) AS stock_units_sum,
+                COUNT(*) AS listing_count_sum,
+                SUM(volume_remain) AS local_stock_units,
+                COUNT(*) AS listing_count
+            FROM market_orders_history
+            WHERE observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 48 HOUR)
+            GROUP BY DATE_FORMAT(observed_at, '%Y-%m-%d %H:00:00'), source_type, source_id, type_id
+            ON DUPLICATE KEY UPDATE
+                sample_count = VALUES(sample_count), stock_units_sum = VALUES(stock_units_sum), listing_count_sum = VALUES(listing_count_sum),
+                local_stock_units = VALUES(local_stock_units), listing_count = VALUES(listing_count)"""
+    )
+    price_written = db.execute(
+        """INSERT INTO market_item_price_1h (
+                bucket_start, source_type, source_id, type_id, sample_count, listing_count_sum, avg_price_sum,
+                weighted_price_numerator, weighted_price_denominator, listing_count, min_price, max_price, avg_price, weighted_price
+            )
+            SELECT
+                DATE_FORMAT(observed_at, '%Y-%m-%d %H:00:00') AS bucket_start,
+                source_type,
+                source_id,
+                type_id,
+                COUNT(*) AS sample_count,
+                COUNT(*) AS listing_count_sum,
+                SUM(price) AS avg_price_sum,
+                SUM(price * volume_remain) AS weighted_price_numerator,
+                SUM(volume_remain) AS weighted_price_denominator,
+                COUNT(*) AS listing_count,
+                MIN(price) AS min_price,
+                MAX(price) AS max_price,
+                AVG(price) AS avg_price,
+                SUM(price * volume_remain) / NULLIF(SUM(volume_remain), 0) AS weighted_price
+            FROM market_orders_history
+            WHERE observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 48 HOUR)
+            GROUP BY DATE_FORMAT(observed_at, '%Y-%m-%d %H:00:00'), source_type, source_id, type_id
+            ON DUPLICATE KEY UPDATE
+                sample_count = VALUES(sample_count), listing_count_sum = VALUES(listing_count_sum), avg_price_sum = VALUES(avg_price_sum),
+                weighted_price_numerator = VALUES(weighted_price_numerator), weighted_price_denominator = VALUES(weighted_price_denominator),
+                listing_count = VALUES(listing_count), min_price = VALUES(min_price), max_price = VALUES(max_price),
+                avg_price = VALUES(avg_price), weighted_price = VALUES(weighted_price)"""
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": stock_written + price_written,
+        "warnings": [] if rows_processed > 0 else ["No history rows available in the last 48h for hourly analytics buckets."],
+        "summary": f"Upserted {stock_written} stock and {price_written} price hourly bucket rows.",
+        "meta": {"window_hours": 48},
+    }
+
+
 def run_analytics_bucket_1h_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="analytics_bucket_1h_sync", phase="B", objective="hourly rollups")
+    return run_sync_phase_job(db, job_key="analytics_bucket_1h_sync", phase="B", objective="hourly rollups", processor=_processor)

--- a/python/orchestrator/jobs/current_state_refresh_sync.py
+++ b/python/orchestrator/jobs/current_state_refresh_sync.py
@@ -1,8 +1,58 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..json_utils import json_dumps_safe
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    rows_processed = db.fetch_scalar("SELECT COUNT(*) FROM sync_schedules")
+    rows_written = db.execute(
+        """INSERT INTO scheduler_job_current_status (
+                job_key, dataset_key, latest_status, last_started_at, last_finished_at, last_success_at, last_failure_at,
+                last_failure_message, current_pressure_state, last_event_at
+            )
+            SELECT
+                job_key,
+                CONCAT('scheduler.job.', job_key) AS dataset_key,
+                COALESCE(last_status, 'unknown') AS latest_status,
+                last_started_at,
+                last_finished_at,
+                CASE WHEN last_status = 'success' THEN last_finished_at ELSE NULL END,
+                CASE WHEN last_status = 'failed' THEN last_finished_at ELSE NULL END,
+                CASE WHEN last_status = 'failed' THEN LEFT(COALESCE(last_error, ''), 500) ELSE NULL END,
+                CASE
+                    WHEN COALESCE(last_status, 'unknown') = 'failed' THEN 'elevated'
+                    WHEN locked_until IS NOT NULL AND locked_until > UTC_TIMESTAMP() THEN 'busy'
+                    ELSE 'healthy'
+                END AS current_pressure_state,
+                COALESCE(last_finished_at, last_started_at) AS last_event_at
+            FROM sync_schedules
+            ON DUPLICATE KEY UPDATE
+                latest_status = VALUES(latest_status),
+                last_started_at = VALUES(last_started_at),
+                last_finished_at = VALUES(last_finished_at),
+                last_success_at = CASE WHEN VALUES(latest_status) = 'success' THEN VALUES(last_finished_at) ELSE scheduler_job_current_status.last_success_at END,
+                last_failure_at = CASE WHEN VALUES(latest_status) = 'failed' THEN VALUES(last_finished_at) ELSE scheduler_job_current_status.last_failure_at END,
+                last_failure_message = VALUES(last_failure_message),
+                current_pressure_state = VALUES(current_pressure_state),
+                last_event_at = VALUES(last_event_at)"""
+    )
+    payload = {"rows_processed": rows_processed, "rows_written": rows_written}
+    db.upsert_intelligence_snapshot(
+        snapshot_key="scheduler_current_state",
+        payload_json=json_dumps_safe(payload),
+        metadata_json=json_dumps_safe({"source": "sync_schedules"}),
+        expires_seconds=600,
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": [],
+        "summary": f"Refreshed scheduler current-state rows for {rows_written} jobs.",
+        "meta": {"snapshot_key": "scheduler_current_state"},
+    }
+
+
 def run_current_state_refresh_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="current_state_refresh_sync", phase="A", objective="current state refresh")
+    return run_sync_phase_job(db, job_key="current_state_refresh_sync", phase="A", objective="current state refresh", processor=_processor)

--- a/python/orchestrator/jobs/dashboard_summary_sync.py
+++ b/python/orchestrator/jobs/dashboard_summary_sync.py
@@ -1,8 +1,44 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..json_utils import json_dumps_safe
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    queue_stats = db.fetch_one(
+        """SELECT
+                SUM(CASE WHEN status IN ('queued', 'retry') THEN 1 ELSE 0 END) AS queued_jobs,
+                SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) AS running_jobs,
+                SUM(CASE WHEN status = 'dead' THEN 1 ELSE 0 END) AS dead_jobs
+            FROM worker_jobs"""
+    ) or {}
+    alert_count = db.fetch_scalar("SELECT COUNT(*) FROM market_deal_alerts_current WHERE status = 'active'")
+    schedules = db.fetch_scalar("SELECT COUNT(*) FROM sync_schedules WHERE enabled = 1")
+    rows_processed = 3
+    payload = {
+        "kpis": {
+            "queued_jobs": int(queue_stats.get("queued_jobs") or 0),
+            "running_jobs": int(queue_stats.get("running_jobs") or 0),
+            "dead_jobs": int(queue_stats.get("dead_jobs") or 0),
+            "active_deal_alerts": alert_count,
+            "enabled_schedules": schedules,
+        }
+    }
+    rows_written = db.upsert_intelligence_snapshot(
+        snapshot_key="dashboard_summaries",
+        payload_json=json_dumps_safe(payload),
+        metadata_json=json_dumps_safe({"source": "worker_jobs+market_deal_alerts_current+sync_schedules"}),
+        expires_seconds=600,
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": [],
+        "summary": "Refreshed dashboard summary intelligence snapshot.",
+        "meta": {"snapshot_key": "dashboard_summaries"},
+    }
+
+
 def run_dashboard_summary_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="dashboard_summary_sync", phase="B", objective="dashboard summaries")
+    return run_sync_phase_job(db, job_key="dashboard_summary_sync", phase="B", objective="dashboard summaries", processor=_processor)

--- a/python/orchestrator/jobs/deal_alerts_sync.py
+++ b/python/orchestrator/jobs/deal_alerts_sync.py
@@ -4,5 +4,71 @@ from ..db import SupplyCoreDb
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    rows_processed = db.fetch_scalar("SELECT COUNT(*) FROM market_order_current_projection")
+    rows_written = db.execute(
+        """INSERT INTO market_deal_alerts_current (
+                alert_key, item_type_id, source_type, source_id, source_name, percent_band,
+                current_price, normal_price, percent_of_normal, anomaly_score, severity, severity_rank,
+                quantity_available, listing_count, best_order_id, observed_at, detected_at, last_seen_at,
+                freshness_seconds, status, metadata_json
+            )
+            SELECT
+                CONCAT(p.source_type, ':', p.source_id, ':', p.type_id) AS alert_key,
+                p.type_id,
+                p.source_type,
+                p.source_id,
+                CAST(p.source_id AS CHAR(190)) AS source_name,
+                ROUND((p.best_sell_price / NULLIF(d.weighted_price, 0)) * 100, 2) AS percent_band,
+                p.best_sell_price AS current_price,
+                d.weighted_price AS normal_price,
+                p.best_sell_price / NULLIF(d.weighted_price, 0) AS percent_of_normal,
+                ABS(100 - ((p.best_sell_price / NULLIF(d.weighted_price, 0)) * 100)) AS anomaly_score,
+                CASE
+                    WHEN p.best_sell_price / NULLIF(d.weighted_price, 0) <= 0.50 THEN 'critical'
+                    WHEN p.best_sell_price / NULLIF(d.weighted_price, 0) <= 0.70 THEN 'very_strong'
+                    WHEN p.best_sell_price / NULLIF(d.weighted_price, 0) <= 0.85 THEN 'strong'
+                    ELSE 'watch'
+                END AS severity,
+                CASE
+                    WHEN p.best_sell_price / NULLIF(d.weighted_price, 0) <= 0.50 THEN 4
+                    WHEN p.best_sell_price / NULLIF(d.weighted_price, 0) <= 0.70 THEN 3
+                    WHEN p.best_sell_price / NULLIF(d.weighted_price, 0) <= 0.85 THEN 2
+                    ELSE 1
+                END AS severity_rank,
+                p.total_sell_volume,
+                p.sell_order_count,
+                NULL,
+                p.observed_at,
+                UTC_TIMESTAMP(),
+                UTC_TIMESTAMP(),
+                TIMESTAMPDIFF(SECOND, p.observed_at, UTC_TIMESTAMP()),
+                'active',
+                JSON_OBJECT('baseline_model', 'weighted_price_1d', 'bucket_start', d.bucket_start)
+            FROM market_order_current_projection p
+            INNER JOIN market_item_price_1d d
+                ON d.source_type = p.source_type
+                AND d.source_id = p.source_id
+                AND d.type_id = p.type_id
+                AND d.bucket_start = (SELECT MAX(bucket_start) FROM market_item_price_1d)
+            WHERE p.best_sell_price IS NOT NULL
+                AND d.weighted_price IS NOT NULL
+                AND d.weighted_price > 0
+                AND p.best_sell_price / d.weighted_price <= 0.95
+            ON DUPLICATE KEY UPDATE
+                current_price = VALUES(current_price), normal_price = VALUES(normal_price), percent_of_normal = VALUES(percent_of_normal),
+                anomaly_score = VALUES(anomaly_score), severity = VALUES(severity), severity_rank = VALUES(severity_rank),
+                quantity_available = VALUES(quantity_available), listing_count = VALUES(listing_count), observed_at = VALUES(observed_at),
+                last_seen_at = VALUES(last_seen_at), freshness_seconds = VALUES(freshness_seconds), status='active', metadata_json = VALUES(metadata_json)"""
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": [] if rows_written > 0 else ["No alert candidates met the configured anomaly threshold (<=95% of baseline)."],
+        "summary": f"Materialized {rows_written} active deal alerts.",
+        "meta": {"threshold_percent_of_normal_max": 0.95},
+    }
+
+
 def run_deal_alerts_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="deal_alerts_sync", phase="C", objective="deal alerts")
+    return run_sync_phase_job(db, job_key="deal_alerts_sync", phase="C", objective="deal alerts", processor=_processor)

--- a/python/orchestrator/jobs/doctrine_intelligence_sync.py
+++ b/python/orchestrator/jobs/doctrine_intelligence_sync.py
@@ -4,5 +4,65 @@ from ..db import SupplyCoreDb
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    rows_processed = db.fetch_scalar("SELECT COUNT(*) FROM doctrine_fits WHERE is_active = 1")
+    stock_written = db.execute(
+        """INSERT INTO doctrine_item_stock_1d (
+                bucket_start, fit_id, doctrine_group_id, type_id, required_units, local_stock_units, complete_fits_supported, fit_gap
+            )
+            SELECT
+                CURDATE() AS bucket_start,
+                f.id AS fit_id,
+                f.doctrine_group_id,
+                i.type_id,
+                i.required_quantity,
+                COALESCE(SUM(s.local_stock_units), 0) AS local_stock_units,
+                FLOOR(COALESCE(SUM(s.local_stock_units), 0) / NULLIF(i.required_quantity, 0)) AS complete_fits_supported,
+                GREATEST(0, i.required_quantity - COALESCE(SUM(s.local_stock_units), 0)) AS fit_gap
+            FROM doctrine_fits f
+            INNER JOIN doctrine_fit_items i ON i.doctrine_fit_id = f.id
+            LEFT JOIN market_item_stock_1d s ON s.type_id = i.type_id AND s.bucket_start = CURDATE()
+            WHERE f.is_active = 1
+            GROUP BY f.id, f.doctrine_group_id, i.type_id, i.required_quantity
+            ON DUPLICATE KEY UPDATE
+                local_stock_units = VALUES(local_stock_units), complete_fits_supported = VALUES(complete_fits_supported), fit_gap = VALUES(fit_gap)"""
+    )
+    fit_written = db.execute(
+        """INSERT INTO doctrine_fit_activity_1d (
+                bucket_start, fit_id, hull_type_id, doctrine_group_id, hull_loss_count, doctrine_item_loss_count,
+                complete_fits_available, target_fits, fit_gap, readiness_state, resupply_pressure, priority_score
+            )
+            SELECT
+                CURDATE(),
+                f.id,
+                f.hull_type_id,
+                f.doctrine_group_id,
+                0,
+                COALESCE(SUM(il.quantity_lost), 0) AS doctrine_item_loss_count,
+                COALESCE(MIN(dis.complete_fits_supported), 0) AS complete_fits_available,
+                f.target_fleet_size,
+                GREATEST(0, f.target_fleet_size - COALESCE(MIN(dis.complete_fits_supported), 0)) AS fit_gap,
+                CASE WHEN COALESCE(MIN(dis.complete_fits_supported), 0) >= f.target_fleet_size THEN 'ready' ELSE 'degraded' END,
+                CASE WHEN COALESCE(SUM(il.quantity_lost), 0) > 0 THEN 'elevated' ELSE 'stable' END,
+                (COALESCE(SUM(il.quantity_lost), 0) * 1.0) + GREATEST(0, f.target_fleet_size - COALESCE(MIN(dis.complete_fits_supported), 0))
+            FROM doctrine_fits f
+            LEFT JOIN doctrine_item_stock_1d dis ON dis.fit_id = f.id AND dis.bucket_start = CURDATE()
+            LEFT JOIN killmail_item_loss_1d il ON il.type_id = dis.type_id AND il.bucket_start >= DATE_SUB(CURDATE(), INTERVAL 1 DAY)
+            WHERE f.is_active = 1
+            GROUP BY f.id, f.hull_type_id, f.doctrine_group_id, f.target_fleet_size
+            ON DUPLICATE KEY UPDATE
+                doctrine_item_loss_count = VALUES(doctrine_item_loss_count), complete_fits_available = VALUES(complete_fits_available),
+                target_fits = VALUES(target_fits), fit_gap = VALUES(fit_gap), readiness_state = VALUES(readiness_state),
+                resupply_pressure = VALUES(resupply_pressure), priority_score = VALUES(priority_score)"""
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": stock_written + fit_written,
+        "warnings": [] if rows_processed > 0 else ["No active doctrine fits found while building doctrine intelligence."],
+        "summary": f"Updated doctrine intelligence stock/activity rows ({stock_written + fit_written} upserts).",
+        "meta": {"bucket_start": "CURDATE"},
+    }
+
+
 def run_doctrine_intelligence_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="doctrine_intelligence_sync", phase="C", objective="doctrine intelligence")
+    return run_sync_phase_job(db, job_key="doctrine_intelligence_sync", phase="C", objective="doctrine intelligence", processor=_processor)

--- a/python/orchestrator/jobs/forecasting_ai_sync.py
+++ b/python/orchestrator/jobs/forecasting_ai_sync.py
@@ -1,8 +1,38 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..json_utils import json_dumps_safe
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    rows = db.fetch_all(
+        """SELECT
+                d.type_id,
+                AVG(CASE WHEN d.bucket_start >= DATE_SUB(CURDATE(), INTERVAL 3 DAY) THEN d.weighted_price END) AS avg_3d,
+                AVG(d.weighted_price) AS avg_14d
+            FROM market_item_price_1d d
+            WHERE d.bucket_start >= DATE_SUB(CURDATE(), INTERVAL 14 DAY)
+            GROUP BY d.type_id
+            HAVING avg_14d IS NOT NULL
+            ORDER BY ABS((avg_3d - avg_14d) / NULLIF(avg_14d, 0)) DESC
+            LIMIT 300"""
+    )
+    rows_processed = len(rows)
+    rows_written = db.upsert_intelligence_snapshot(
+        snapshot_key="forecasting_ai_summaries",
+        payload_json=json_dumps_safe({"rows": rows}),
+        metadata_json=json_dumps_safe({"source": "market_item_price_1d", "window_days": 14, "row_count": rows_processed}),
+        expires_seconds=1800,
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": [] if rows_processed > 0 else ["No daily price rows available for forecasting snapshot."],
+        "summary": f"Refreshed forecasting snapshot with {rows_processed} candidates.",
+        "meta": {"snapshot_key": "forecasting_ai_summaries"},
+    }
+
+
 def run_forecasting_ai_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="forecasting_ai_sync", phase="C", objective="forecasting outputs")
+    return run_sync_phase_job(db, job_key="forecasting_ai_sync", phase="C", objective="forecasting outputs", processor=_processor)

--- a/python/orchestrator/jobs/loss_demand_summary_sync.py
+++ b/python/orchestrator/jobs/loss_demand_summary_sync.py
@@ -1,8 +1,38 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..json_utils import json_dumps_safe
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    rows = db.fetch_all(
+        """SELECT l.type_id, SUM(l.quantity_lost) AS qty_lost_7d, COALESCE(SUM(s.local_stock_units), 0) AS local_stock
+            FROM killmail_item_loss_1d l
+            LEFT JOIN market_item_stock_1d s
+                ON s.type_id = l.type_id
+                AND s.bucket_start >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+            WHERE l.bucket_start >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+            GROUP BY l.type_id
+            ORDER BY qty_lost_7d DESC
+            LIMIT 250"""
+    )
+    rows_processed = len(rows)
+    payload = {"generated_at": "utc", "rows": rows}
+    rows_written = db.upsert_intelligence_snapshot(
+        snapshot_key="loss_demand_summaries",
+        payload_json=json_dumps_safe(payload),
+        metadata_json=json_dumps_safe({"source": "killmail_item_loss_1d", "window_days": 7, "row_count": rows_processed}),
+        expires_seconds=900,
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": [] if rows_processed > 0 else ["No loss-demand rows found for the trailing 7-day window."],
+        "summary": f"Refreshed loss-demand intelligence snapshot with {rows_processed} rows.",
+        "meta": {"snapshot_key": "loss_demand_summaries"},
+    }
+
+
 def run_loss_demand_summary_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="loss_demand_summary_sync", phase="B", objective="loss-demand summaries")
+    return run_sync_phase_job(db, job_key="loss_demand_summary_sync", phase="B", objective="loss-demand summaries", processor=_processor)

--- a/python/orchestrator/jobs/market_hub_current_sync.py
+++ b/python/orchestrator/jobs/market_hub_current_sync.py
@@ -1,8 +1,68 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..esi_market_adapter import EsiMarketAdapter, parse_esi_datetime
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    adapter = EsiMarketAdapter(timeout_seconds=30)
+    sources = db.fetch_market_hub_sources(limit=4)
+    warnings: list[str] = []
+    rows_processed = 0
+    rows_written = 0
+    for source in sources:
+        source_id = int(source.get("source_id") or 0)
+        region_id = int(source.get("region_id") or 0)
+        if source_id <= 0 or region_id <= 0:
+            continue
+        orders: list[dict[str, object]] = []
+        try:
+            first_page = adapter.fetch_region_orders(region_id=region_id, order_type="all", page=1)
+            orders.extend(first_page.orders)
+            max_pages = min(4, first_page.pages)
+            for page in range(2, max_pages + 1):
+                response = adapter.fetch_region_orders(region_id=region_id, order_type="all", page=page)
+                orders.extend(response.orders)
+        except Exception as exc:
+            warnings.append(f"market_hub source {source_id} region {region_id} fetch failed: {exc}")
+            continue
+
+        normalized_orders: list[dict[str, object]] = []
+        for order in orders:
+            row = dict(order)
+            row["issued"] = parse_esi_datetime(row.get("issued"))
+            row["expires"] = parse_esi_datetime(row.get("expires"))
+            normalized_orders.append(row)
+        observed_at = parse_esi_datetime(None)
+        ingest_stats = db.replace_market_orders_for_source(
+            source_type="market_hub",
+            source_id=source_id,
+            observed_at=observed_at,
+            orders=normalized_orders,
+        )
+        rows_processed += int(ingest_stats["rows_processed"])
+        rows_written += int(ingest_stats["rows_written"])
+
+    stats = db.refresh_market_order_current_projection(source_type="market_hub")
+    rows_processed += int(stats["rows_processed"])
+    rows_written += int(stats["rows_written"])
+    if not sources:
+        warnings.append("No configured NPC market-hub sources were found (trading_stations + ref_npc_stations join returned empty).")
+    db.upsert_sync_state(
+        dataset_key="market_hub.orders.current",
+        status="success",
+        row_count=rows_written,
+        cursor=None,
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": warnings,
+        "summary": f"Ingested/projected market-hub orders ({rows_written} writes across {len(sources)} sources).",
+        "meta": {"dataset_key": "market_hub.orders.current"},
+    }
+
+
 def run_market_hub_current_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="market_hub_current_sync", phase="A", objective="market snapshots")
+    return run_sync_phase_job(db, job_key="market_hub_current_sync", phase="A", objective="market snapshots", processor=_processor)

--- a/python/orchestrator/jobs/market_hub_historical_sync.py
+++ b/python/orchestrator/jobs/market_hub_historical_sync.py
@@ -4,5 +4,20 @@ from ..db import SupplyCoreDb
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    stats = db.materialize_market_history_from_projection(source_type="market_hub")
+    warnings: list[str] = []
+    if stats["rows_processed"] == 0:
+        warnings.append("No market_hub projection rows were available for historical materialization.")
+    db.upsert_sync_state(dataset_key="market_hub.orders.history", status="success", row_count=stats["rows_written"])
+    return {
+        "rows_processed": stats["rows_processed"],
+        "rows_written": stats["rows_written"],
+        "warnings": warnings,
+        "summary": f"Materialized {stats['rows_written']} market_hub historical snapshot rows.",
+        "meta": {"dataset_key": "market_hub.orders.history"},
+    }
+
+
 def run_market_hub_historical_sync(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="market_hub_historical_sync", phase="A", objective="market history")
+    return run_sync_phase_job(db, job_key="market_hub_historical_sync", phase="A", objective="market history", processor=_processor)

--- a/python/orchestrator/jobs/rebuild_ai_briefings.py
+++ b/python/orchestrator/jobs/rebuild_ai_briefings.py
@@ -1,8 +1,54 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..json_utils import json_dumps_safe
 from .sync_runtime import run_sync_phase_job
 
 
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    rows_processed = db.fetch_scalar("SELECT COUNT(*) FROM doctrine_fit_activity_1d WHERE bucket_start = CURDATE()")
+    rows_written = db.execute(
+        """INSERT INTO doctrine_ai_briefings (
+                entity_type, entity_id, fit_id, group_id, generation_status, computed_at, model_name,
+                headline, summary, action_text, priority_level, source_payload_json, response_json, error_message
+            )
+            SELECT
+                'fit' AS entity_type,
+                fa.fit_id AS entity_id,
+                fa.fit_id,
+                fa.doctrine_group_id,
+                'ready' AS generation_status,
+                UTC_TIMESTAMP() AS computed_at,
+                'deterministic-briefing-v1' AS model_name,
+                CONCAT('Doctrine fit ', COALESCE(f.fit_name, fa.fit_id), ' readiness: ', fa.readiness_state) AS headline,
+                CONCAT('Fit gap=', fa.fit_gap, ', complete fits available=', fa.complete_fits_available, ', item-loss-24h=', fa.doctrine_item_loss_count) AS summary,
+                CASE WHEN fa.fit_gap > 0 THEN 'Restock constrained doctrine items and prioritize missing fits.' ELSE 'Maintain current supply posture.' END AS action_text,
+                CASE WHEN fa.fit_gap > 20 THEN 'critical' WHEN fa.fit_gap > 5 THEN 'high' ELSE 'medium' END AS priority_level,
+                JSON_OBJECT('fit_gap', fa.fit_gap, 'complete_fits_available', fa.complete_fits_available, 'loss_24h', fa.doctrine_item_loss_count),
+                JSON_OBJECT('pipeline', 'python.rebuild_ai_briefings', 'kind', 'deterministic'),
+                NULL
+            FROM doctrine_fit_activity_1d fa
+            LEFT JOIN doctrine_fits f ON f.id = fa.fit_id
+            WHERE fa.bucket_start = CURDATE()
+            ON DUPLICATE KEY UPDATE
+                generation_status = VALUES(generation_status), computed_at = VALUES(computed_at), model_name = VALUES(model_name),
+                headline = VALUES(headline), summary = VALUES(summary), action_text = VALUES(action_text), priority_level = VALUES(priority_level),
+                source_payload_json = VALUES(source_payload_json), response_json = VALUES(response_json), error_message = VALUES(error_message)"""
+    )
+    db.upsert_intelligence_snapshot(
+        snapshot_key="doctrine_ai_briefings_status",
+        payload_json=json_dumps_safe({"row_count": rows_processed}),
+        metadata_json=json_dumps_safe({"source": "doctrine_fit_activity_1d", "job": "rebuild_ai_briefings"}),
+        expires_seconds=1200,
+    )
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": [] if rows_processed > 0 else ["No doctrine_fit_activity_1d rows available for AI briefing generation."],
+        "summary": f"Rebuilt {rows_written} doctrine AI briefings from deterministic fit activity inputs.",
+        "meta": {"entity_type": "fit", "snapshot_key": "doctrine_ai_briefings_status"},
+    }
+
+
 def run_rebuild_ai_briefings(db: SupplyCoreDb) -> dict[str, object]:
-    return run_sync_phase_job(db, job_key="rebuild_ai_briefings", phase="C", objective="ai briefings")
+    return run_sync_phase_job(db, job_key="rebuild_ai_briefings", phase="C", objective="ai briefings", processor=_processor)

--- a/python/orchestrator/jobs/sync_runtime.py
+++ b/python/orchestrator/jobs/sync_runtime.py
@@ -1,27 +1,57 @@
 from __future__ import annotations
 
+import time
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Callable
 
 from ..db import SupplyCoreDb
 
 
-def run_sync_phase_job(db: SupplyCoreDb, *, job_key: str, phase: str, objective: str) -> dict[str, Any]:
+def run_sync_phase_job(
+    db: SupplyCoreDb,
+    *,
+    job_key: str,
+    phase: str,
+    objective: str,
+    processor: Callable[[SupplyCoreDb], dict[str, Any]],
+) -> dict[str, Any]:
+    started = time.perf_counter()
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
-    db_now = db.fetch_one("SELECT UTC_TIMESTAMP() AS now_utc") or {}
-    return {
-        "status": "success",
-        "summary": f"{job_key} completed phase {phase} objective: {objective}.",
-        "rows_processed": 1,
-        "rows_written": 0,
-        "computed_at": now,
-        "warnings": [],
-        "meta": {
-            "job_key": job_key,
-            "phase": phase,
-            "objective": objective,
-            "execution_language": "python",
-            "subprocess_invoked": False,
-            "db_now_utc": str(db_now.get("now_utc") or ""),
-        },
-    }
+    try:
+        payload = processor(db)
+        db_now = db.fetch_one("SELECT UTC_TIMESTAMP() AS now_utc") or {}
+        return {
+            "status": str(payload.get("status") or "success"),
+            "summary": str(payload.get("summary") or f"{job_key} completed phase {phase} objective: {objective}."),
+            "rows_processed": max(0, int(payload.get("rows_processed") or 0)),
+            "rows_written": max(0, int(payload.get("rows_written") or 0)),
+            "computed_at": now,
+            "warnings": list(payload.get("warnings") or []),
+            "meta": {
+                "job_key": job_key,
+                "phase": phase,
+                "objective": objective,
+                "execution_language": "python",
+                "subprocess_invoked": False,
+                "db_now_utc": str(db_now.get("now_utc") or ""),
+                "duration_ms": int((time.perf_counter() - started) * 1000),
+                **dict(payload.get("meta") or {}),
+            },
+        }
+    except Exception as exc:
+        return {
+            "status": "failed",
+            "summary": f"{job_key} failed in phase {phase}: {exc}",
+            "rows_processed": 0,
+            "rows_written": 0,
+            "computed_at": now,
+            "warnings": [f"{type(exc).__name__}: {exc}"],
+            "meta": {
+                "job_key": job_key,
+                "phase": phase,
+                "objective": objective,
+                "execution_language": "python",
+                "subprocess_invoked": False,
+                "duration_ms": int((time.perf_counter() - started) * 1000),
+            },
+        }


### PR DESCRIPTION
### Motivation
- Centralize market data ingestion and projection logic and provide reusable DB helpers for snapshots and sync state tracking.
- Introduce an HTTP adapter for ESI to fetch region and structure market orders with robust datetime parsing.
- Move sync jobs to in-process Python processors to enable richer orchestration, metrics and error handling.
- Capture execution duration and standardized success/failure payloads from the job runtime.

### Description
- Added new ESI client `python/orchestrator/esi_market_adapter.py` with `EsiMarketAdapter`, `EsiOrdersResponse`, and `parse_esi_datetime` for fetching and normalizing ESI orders.
- Extended DB layer in `python/orchestrator/db.py` with helpers: `fetch_scalar`, `upsert_sync_state`, `upsert_intelligence_snapshot`, `refresh_market_order_current_projection`, `materialize_market_history_from_projection`, `fetch_market_hub_sources`, `fetch_alliance_structure_sources`, `fetch_latest_esi_access_token`, and `replace_market_orders_for_source` to ingest, project and materialize market data and snapshots.
- Converted many job modules to provide local `processor` functions (e.g. `market_hub_current_sync`, `alliance_current_sync`, `analytics_bucket_1h_sync`, `analytics_bucket_1d_sync`, `deal_alerts_sync`, `doctrine_intelligence_sync`, `loss_demand_summary_sync`, `forecasting_ai_sync`, `dashboard_summary_sync`, `current_state_refresh_sync`, `rebuild_ai_briefings`, `activity_priority_summary_sync`, historical counterparts) and wired them into `run_sync_phase_job` by passing `processor=...`.
- Updated `python/orchestrator/jobs/sync_runtime.py` to accept a `processor` callable, measure execution time (`duration_ms`), return standardized payload fields, and handle exceptions with a `failed` status and warnings.
- Jobs now upsert intelligence snapshots, maintain sync state keys, refresh projections, and return richer meta/warning information.

### Testing
- Ran the project's unit test suite with `pytest -q`, which completed without failures on the changeset.
- Exercised job processors via basic smoke runs invoking `run_sync_phase_job` for a subset of jobs to validate DB upserts and adapter behavior under mocked ESI responses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4966cb994832f942975fe30754c33)