### PR TITLE
Add json_loads_safe helper to json_utils (fix ESI adapter import)

### DIFF
--- a/python/orchestrator/json_utils.py
+++ b/python/orchestrator/json_utils.py
@@ -28,3 +28,12 @@ def json_dumps_safe(value: Any, *, indent: int | None = None, sort_keys: bool = 
         indent=indent,
         sort_keys=sort_keys,
     )
+
+
+def json_loads_safe(value: str | bytes | bytearray, *, fallback: Any = None) -> Any:
+    try:
+        if isinstance(value, (bytes, bytearray)):
+            value = value.decode("utf-8", errors="replace")
+        return json.loads(value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return fallback


### PR DESCRIPTION
### Motivation
- The ESI market adapter expected a `json_loads_safe` helper which was missing, causing an `ImportError` and preventing the orchestrator from starting.

### Description
- Add `json_loads_safe` to `python/orchestrator/json_utils.py`; the function accepts `str | bytes | bytearray`, decodes bytes as UTF-8 with replacement, parses JSON with `json.loads`, and returns a configurable `fallback` on invalid input or parse errors.

### Testing
- Verified module import with `python3 -c "from python.orchestrator.main import main; print('import-ok')"` and confirmed CLI startup/help via `python3 bin/python_orchestrator.py --help`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c49a29db80832f95e57e48d5c89acd)