### PR TITLE
Expand sync processor test coverage with per-job, failure, and integration tests

### DIFF
--- a/python/orchestrator/jobs/dashboard_summary_sync.py
+++ b/python/orchestrator/jobs/dashboard_summary_sync.py
@@ -15,7 +15,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
     ) or {}
     alert_count = db.fetch_scalar("SELECT COUNT(*) FROM market_deal_alerts_current WHERE status = 'active'")
     schedules = db.fetch_scalar("SELECT COUNT(*) FROM sync_schedules WHERE enabled = 1")
-    rows_processed = 3
+    rows_processed = int(queue_stats.get("queued_jobs") or 0) + int(queue_stats.get("running_jobs") or 0) + int(queue_stats.get("dead_jobs") or 0) + int(alert_count or 0) + int(schedules or 0)
     payload = {
         "kpis": {
             "queued_jobs": int(queue_stats.get("queued_jobs") or 0),

--- a/python/tests/test_python_sync_processor_parity.py
+++ b/python/tests/test_python_sync_processor_parity.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
+from orchestrator.esi_market_adapter import EsiOrdersResponse
 from orchestrator.job_runner import PHP_BRIDGED_JOB_KEYS
 from orchestrator.processor_registry import PYTHON_PROCESSOR_JOB_KEYS, run_registered_processor
 from orchestrator.worker_registry import DISABLED_WORKER_JOBS, WORKER_JOB_DEFINITIONS
@@ -29,7 +31,40 @@ TARGET_JOB_KEYS = [
 class PythonSyncProcessorParityTests(unittest.TestCase):
     class _DbStub:
         def fetch_one(self, _query: str):
-            return {"now_utc": "2026-03-26 00:00:00"}
+            return {"now_utc": "2026-03-26 00:00:00", "queued_jobs": 0, "running_jobs": 0, "dead_jobs": 0}
+
+        def fetch_scalar(self, _query: str):
+            return 2
+
+        def execute(self, _query: str):
+            return 2
+
+        def fetch_all(self, _query: str):
+            return [{"id": 1}, {"id": 2}]
+
+        def upsert_intelligence_snapshot(self, **_kwargs):
+            return 1
+
+        def materialize_market_history_from_projection(self, *, source_type: str):
+            return {"rows_processed": 2, "rows_written": 2}
+
+        def upsert_sync_state(self, **_kwargs):
+            return 1
+
+        def fetch_latest_esi_access_token(self):
+            return "token"
+
+        def fetch_alliance_structure_sources(self, *, limit: int):
+            return [10203040]
+
+        def fetch_market_hub_sources(self, *, limit: int):
+            return [{"source_id": 60003760, "region_id": 10000002}]
+
+        def replace_market_orders_for_source(self, **_kwargs):
+            return {"rows_processed": 1, "rows_written": 1}
+
+        def refresh_market_order_current_projection(self, *, source_type: str):
+            return {"rows_processed": 1, "rows_written": 1}
 
     def test_jobs_have_python_processor_bindings(self) -> None:
         for key in TARGET_JOB_KEYS:
@@ -46,12 +81,29 @@ class PythonSyncProcessorParityTests(unittest.TestCase):
 
     def test_phase_sync_processors_have_no_placeholder_warning(self) -> None:
         db = self._DbStub()
-        for key in TARGET_JOB_KEYS:
-            if key.startswith("compute_"):
-                continue
-            result = run_registered_processor(key, db=db, raw_config={})
-            self.assertEqual(result["status"], "success")
-            self.assertEqual(result["warnings"], [])
+        with (
+            patch("orchestrator.jobs.market_hub_current_sync.EsiMarketAdapter.fetch_region_orders", return_value=EsiOrdersResponse(orders=[{"issued": "2026-03-26T00:00:00Z", "expires": "2026-03-27T00:00:00Z"}], pages=1, status_code=200)),
+            patch("orchestrator.jobs.alliance_current_sync.EsiMarketAdapter.fetch_structure_orders", return_value=EsiOrdersResponse(orders=[{"issued": "2026-03-26T00:00:00Z", "expires": "2026-03-27T00:00:00Z"}], pages=1, status_code=200)),
+        ):
+            for key in TARGET_JOB_KEYS:
+                if key.startswith("compute_"):
+                    continue
+                result = run_registered_processor(key, db=db, raw_config={})
+                self.assertEqual(result["status"], "success")
+                self.assertEqual(result["warnings"], [])
+
+    def test_production_jobs_do_not_use_placeholder_summary_or_rows(self) -> None:
+        db = self._DbStub()
+        with (
+            patch("orchestrator.jobs.market_hub_current_sync.EsiMarketAdapter.fetch_region_orders", return_value=EsiOrdersResponse(orders=[{"issued": "2026-03-26T00:00:00Z", "expires": "2026-03-27T00:00:00Z"}], pages=1, status_code=200)),
+            patch("orchestrator.jobs.alliance_current_sync.EsiMarketAdapter.fetch_structure_orders", return_value=EsiOrdersResponse(orders=[{"issued": "2026-03-26T00:00:00Z", "expires": "2026-03-27T00:00:00Z"}], pages=1, status_code=200)),
+        ):
+            for key in TARGET_JOB_KEYS:
+                if key.startswith("compute_"):
+                    continue
+                result = run_registered_processor(key, db=db, raw_config={})
+                status = str(result.get("status") or "success")
+                self.assertNotEqual(result.get("summary"), f"{key} completed with status {status}.")
 
 
 if __name__ == "__main__":

--- a/python/tests/test_sync_processors.py
+++ b/python/tests/test_sync_processors.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import sqlite3
+import unittest
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import patch
+
+from orchestrator.esi_market_adapter import EsiOrdersResponse
+from orchestrator.jobs.activity_priority_summary_sync import run_activity_priority_summary_sync
+from orchestrator.jobs.alliance_current_sync import run_alliance_current_sync
+from orchestrator.jobs.alliance_historical_sync import run_alliance_historical_sync
+from orchestrator.jobs.analytics_bucket_1d_sync import run_analytics_bucket_1d_sync
+from orchestrator.jobs.analytics_bucket_1h_sync import run_analytics_bucket_1h_sync
+from orchestrator.jobs.current_state_refresh_sync import run_current_state_refresh_sync
+from orchestrator.jobs.dashboard_summary_sync import run_dashboard_summary_sync
+from orchestrator.jobs.deal_alerts_sync import run_deal_alerts_sync
+from orchestrator.jobs.doctrine_intelligence_sync import run_doctrine_intelligence_sync
+from orchestrator.jobs.forecasting_ai_sync import run_forecasting_ai_sync
+from orchestrator.jobs.loss_demand_summary_sync import run_loss_demand_summary_sync
+from orchestrator.jobs.market_hub_current_sync import run_market_hub_current_sync
+from orchestrator.jobs.market_hub_historical_sync import run_market_hub_historical_sync
+from orchestrator.jobs.rebuild_ai_briefings import run_rebuild_ai_briefings
+
+
+class _SpyDb:
+    def __init__(self) -> None:
+        self.fetch_scalar_values: list[int] = [0]
+        self.fetch_all_values: list[list[dict[str, Any]]] = [[]]
+        self.fetch_one_values: list[dict[str, Any]] = [{"now_utc": "2026-03-26 00:00:00"}]
+        self.execute_values: list[int] = [0]
+        self.upsert_snapshot_values: list[int] = [0]
+        self.history_stats = {"rows_processed": 0, "rows_written": 0}
+        self.replace_stats = {"rows_processed": 0, "rows_written": 0}
+        self.projection_stats = {"rows_processed": 0, "rows_written": 0}
+        self.alliance_structures: list[int] = []
+        self.market_hub_sources: list[dict[str, int]] = []
+        self.access_token: str | None = None
+        self.calls: list[tuple[str, Any]] = []
+
+    def fetch_one(self, query: str) -> dict[str, Any]:
+        self.calls.append(("fetch_one", query))
+        return self.fetch_one_values.pop(0) if self.fetch_one_values else {"now_utc": "2026-03-26 00:00:00"}
+
+    def fetch_scalar(self, query: str) -> int:
+        self.calls.append(("fetch_scalar", query))
+        return int(self.fetch_scalar_values.pop(0) if self.fetch_scalar_values else 0)
+
+    def execute(self, query: str) -> int:
+        self.calls.append(("execute", query))
+        return int(self.execute_values.pop(0) if self.execute_values else 0)
+
+    def fetch_all(self, query: str) -> list[dict[str, Any]]:
+        self.calls.append(("fetch_all", query))
+        return self.fetch_all_values.pop(0) if self.fetch_all_values else []
+
+    def upsert_intelligence_snapshot(self, **kwargs: Any) -> int:
+        self.calls.append(("upsert_intelligence_snapshot", kwargs))
+        return int(self.upsert_snapshot_values.pop(0) if self.upsert_snapshot_values else 0)
+
+    def materialize_market_history_from_projection(self, *, source_type: str) -> dict[str, int]:
+        self.calls.append(("materialize_market_history_from_projection", source_type))
+        return dict(self.history_stats)
+
+    def upsert_sync_state(self, **kwargs: Any) -> int:
+        self.calls.append(("upsert_sync_state", kwargs))
+        return 1
+
+    def fetch_latest_esi_access_token(self) -> str | None:
+        self.calls.append(("fetch_latest_esi_access_token", None))
+        return self.access_token
+
+    def fetch_alliance_structure_sources(self, *, limit: int) -> list[int]:
+        self.calls.append(("fetch_alliance_structure_sources", limit))
+        return list(self.alliance_structures)
+
+    def fetch_market_hub_sources(self, *, limit: int) -> list[dict[str, int]]:
+        self.calls.append(("fetch_market_hub_sources", limit))
+        return list(self.market_hub_sources)
+
+    def replace_market_orders_for_source(self, **kwargs: Any) -> dict[str, int]:
+        self.calls.append(("replace_market_orders_for_source", kwargs))
+        return dict(self.replace_stats)
+
+    def refresh_market_order_current_projection(self, *, source_type: str) -> dict[str, int]:
+        self.calls.append(("refresh_market_order_current_projection", source_type))
+        return dict(self.projection_stats)
+
+
+class SyncProcessorCoverageTests(unittest.TestCase):
+    def test_sql_backed_sync_processors_cover_fetch_and_write_paths(self) -> None:
+        jobs = [
+            (run_current_state_refresh_sync, [4], [4], 1, "upsert_intelligence_snapshot", 4, 4),
+            (run_analytics_bucket_1h_sync, [6], [3, 2], 0, None, 6, 5),
+            (run_analytics_bucket_1d_sync, [7], [4, 1], 0, None, 7, 5),
+            (run_activity_priority_summary_sync, [8], [5], 0, None, 8, 5),
+            (run_deal_alerts_sync, [10], [6], 0, None, 10, 6),
+            (run_doctrine_intelligence_sync, [9], [4, 3], 0, None, 9, 7),
+            (run_dashboard_summary_sync, [2, 11], [], 1, "upsert_intelligence_snapshot", 20, 1),
+            (run_loss_demand_summary_sync, [], [], 1, "upsert_intelligence_snapshot", 2, 1),
+            (run_forecasting_ai_sync, [], [], 1, "upsert_intelligence_snapshot", 3, 1),
+            (run_rebuild_ai_briefings, [5], [4], 1, "upsert_intelligence_snapshot", 5, 4),
+        ]
+
+        for runner, scalar_values, execute_values, snapshot_writes, write_api, expected_processed, expected_written in jobs:
+            with self.subTest(job=runner.__name__):
+                db = _SpyDb()
+                db.fetch_scalar_values = list(scalar_values) or [0]
+                db.execute_values = list(execute_values) or [0]
+                db.fetch_all_values = [[{"id": 1}, {"id": 2}]] if runner is run_loss_demand_summary_sync else [[{"id": 1}, {"id": 2}, {"id": 3}]]
+                if runner is run_dashboard_summary_sync:
+                    db.fetch_one_values = [{"queued_jobs": 4, "running_jobs": 2, "dead_jobs": 1}, {"now_utc": "2026-03-26 00:00:00"}]
+                db.upsert_snapshot_values = [snapshot_writes]
+
+                result = runner(db)
+
+                self.assertEqual(result["status"], "success")
+                self.assertEqual(result["rows_processed"], expected_processed)
+                self.assertEqual(result["rows_written"], expected_written)
+                self.assertTrue(any(call[0] == "fetch_one" for call in db.calls))
+                if scalar_values:
+                    self.assertTrue(any(call[0] == "fetch_scalar" for call in db.calls))
+                if execute_values:
+                    self.assertTrue(any(call[0] == "execute" for call in db.calls))
+                if write_api is not None:
+                    self.assertTrue(any(call[0] == write_api for call in db.calls))
+
+    def test_market_hub_and_alliance_processors_fetch_sources_and_write_projection(self) -> None:
+        db = _SpyDb()
+        db.market_hub_sources = [{"source_id": 60003760, "region_id": 10000002}]
+        db.alliance_structures = [10203040]
+        db.access_token = "token"
+        db.replace_stats = {"rows_processed": 2, "rows_written": 2}
+        db.projection_stats = {"rows_processed": 1, "rows_written": 1}
+
+        with (
+            patch("orchestrator.jobs.market_hub_current_sync.EsiMarketAdapter.fetch_region_orders", return_value=EsiOrdersResponse(orders=[{"issued": "2026-03-26T00:00:00Z", "expires": "2026-03-27T00:00:00Z"}], pages=1, status_code=200)) as region_fetch,
+            patch("orchestrator.jobs.alliance_current_sync.EsiMarketAdapter.fetch_structure_orders", return_value=EsiOrdersResponse(orders=[{"issued": "2026-03-26T00:00:00Z", "expires": "2026-03-27T00:00:00Z"}], pages=1, status_code=200)) as structure_fetch,
+        ):
+            market_result = run_market_hub_current_sync(db)
+            alliance_result = run_alliance_current_sync(db)
+
+        region_fetch.assert_called_once()
+        structure_fetch.assert_called_once()
+        self.assertEqual(market_result["rows_processed"], 3)
+        self.assertEqual(market_result["rows_written"], 3)
+        self.assertEqual(alliance_result["rows_processed"], 3)
+        self.assertEqual(alliance_result["rows_written"], 3)
+        self.assertTrue(any(call[0] == "replace_market_orders_for_source" for call in db.calls))
+        self.assertTrue(any(call[0] == "refresh_market_order_current_projection" for call in db.calls))
+
+    def test_historical_sync_processors_write_sync_state(self) -> None:
+        db = _SpyDb()
+        db.history_stats = {"rows_processed": 4, "rows_written": 4}
+
+        market_result = run_market_hub_historical_sync(db)
+        alliance_result = run_alliance_historical_sync(db)
+
+        self.assertEqual(market_result["rows_processed"], 4)
+        self.assertEqual(market_result["rows_written"], 4)
+        self.assertEqual(alliance_result["rows_processed"], 4)
+        self.assertEqual(alliance_result["rows_written"], 4)
+        self.assertGreaterEqual(sum(1 for call in db.calls if call[0] == "upsert_sync_state"), 2)
+
+    def test_failure_paths_emit_meaningful_status_and_warnings(self) -> None:
+        db_source_unavailable = _SpyDb()
+        db_source_unavailable.market_hub_sources = [{"source_id": 60003760, "region_id": 10000002}]
+        db_source_unavailable.projection_stats = {"rows_processed": 0, "rows_written": 0}
+
+        with patch("orchestrator.jobs.market_hub_current_sync.EsiMarketAdapter.fetch_region_orders", side_effect=RuntimeError("esi unavailable")):
+            unavailable_result = run_market_hub_current_sync(db_source_unavailable)
+
+        self.assertEqual(unavailable_result["status"], "success")
+        self.assertTrue(any("fetch failed" in warning for warning in unavailable_result["warnings"]))
+
+        db_malformed = _SpyDb()
+        db_malformed.market_hub_sources = [{"source_id": 60003760, "region_id": 10000002}]
+        db_malformed.projection_stats = {"rows_processed": 0, "rows_written": 0}
+        with patch(
+            "orchestrator.jobs.market_hub_current_sync.EsiMarketAdapter.fetch_region_orders",
+            return_value=EsiOrdersResponse(orders=["invalid-order"], pages=1, status_code=200),
+        ):
+            malformed_result = run_market_hub_current_sync(db_malformed)
+
+        self.assertEqual(malformed_result["status"], "failed")
+        self.assertTrue(any("ValueError" in warning for warning in malformed_result["warnings"]))
+
+        db_write_error = _SpyDb()
+        db_write_error.fetch_scalar_values = [2]
+        with patch.object(db_write_error, "execute", side_effect=RuntimeError("write failed")):
+            write_error_result = run_deal_alerts_sync(db_write_error)
+
+        self.assertEqual(write_error_result["status"], "failed")
+        self.assertTrue(any("RuntimeError: write failed" in warning for warning in write_error_result["warnings"]))
+
+
+@dataclass
+class _SqliteAllianceFixtureDb:
+    connection: sqlite3.Connection
+
+    @classmethod
+    def build(cls) -> "_SqliteAllianceFixtureDb":
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE market_orders_current (source_type TEXT, source_id INTEGER, observed_at TEXT, issued TEXT, expires TEXT)")
+        conn.execute("CREATE TABLE market_order_current_projection (source_type TEXT, source_id INTEGER, row_count INTEGER)")
+        conn.execute("CREATE TABLE sync_state (dataset_key TEXT PRIMARY KEY, status TEXT, row_count INTEGER)")
+        return cls(conn)
+
+    def fetch_one(self, _query: str) -> dict[str, Any]:
+        return {"now_utc": "2026-03-26 00:00:00"}
+
+    def fetch_latest_esi_access_token(self) -> str | None:
+        return "token"
+
+    def fetch_alliance_structure_sources(self, *, limit: int) -> list[int]:
+        return [10203040][:limit]
+
+    def replace_market_orders_for_source(self, *, source_type: str, source_id: int, observed_at: str, orders: list[dict[str, Any]]) -> dict[str, int]:
+        for order in orders:
+            self.connection.execute(
+                "INSERT INTO market_orders_current (source_type, source_id, observed_at, issued, expires) VALUES (?, ?, ?, ?, ?)",
+                (source_type, source_id, observed_at, str(order.get("issued") or ""), str(order.get("expires") or "")),
+            )
+        self.connection.commit()
+        return {"rows_processed": len(orders), "rows_written": len(orders)}
+
+    def refresh_market_order_current_projection(self, *, source_type: str) -> dict[str, int]:
+        row = self.connection.execute(
+            "SELECT COUNT(*) FROM market_orders_current WHERE source_type = ?", (source_type,)
+        ).fetchone()
+        processed = int(row[0] if row else 0)
+        self.connection.execute("DELETE FROM market_order_current_projection WHERE source_type = ?", (source_type,))
+        self.connection.execute(
+            "INSERT INTO market_order_current_projection (source_type, source_id, row_count) VALUES (?, ?, ?)",
+            (source_type, 10203040, processed),
+        )
+        self.connection.commit()
+        return {"rows_processed": processed, "rows_written": 1 if processed > 0 else 0}
+
+    def upsert_sync_state(self, *, dataset_key: str, status: str, row_count: int, cursor: str | None) -> int:
+        self.connection.execute(
+            "INSERT INTO sync_state (dataset_key, status, row_count) VALUES (?, ?, ?) ON CONFLICT(dataset_key) DO UPDATE SET status=excluded.status, row_count=excluded.row_count",
+            (dataset_key, status, row_count),
+        )
+        self.connection.commit()
+        return 1
+
+
+class AllianceCurrentSyncIntegrationTests(unittest.TestCase):
+    def test_alliance_current_sync_e2e_with_sqlite_fixture_layer(self) -> None:
+        db = _SqliteAllianceFixtureDb.build()
+        fixture_orders = [
+            {"issued": "2026-03-26T00:00:00Z", "expires": "2026-03-27T00:00:00Z"},
+            {"issued": "2026-03-26T01:00:00Z", "expires": "2026-03-27T01:00:00Z"},
+        ]
+        with patch(
+            "orchestrator.jobs.alliance_current_sync.EsiMarketAdapter.fetch_structure_orders",
+            return_value=EsiOrdersResponse(orders=fixture_orders, pages=1, status_code=200),
+        ):
+            result = run_alliance_current_sync(db)
+
+        projected = db.connection.execute("SELECT row_count FROM market_order_current_projection WHERE source_type = 'alliance_structure'").fetchone()
+        sync_state = db.connection.execute("SELECT status, row_count FROM sync_state WHERE dataset_key = 'alliance.structure.orders.current'").fetchone()
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["rows_processed"], 4)
+        self.assertEqual(result["rows_written"], 3)
+        self.assertEqual(int(projected[0]), 2)
+        self.assertEqual(sync_state[0], "success")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Improve automated coverage for Python sync processors beyond simple registration checks by exercising real fetch/write codepaths. 
- Validate failure modes (upstream unavailable, malformed payloads, DB write errors) so jobs emit meaningful statuses and warnings. 
- Add at least one lightweight integration-style test to assert end-to-end behavior for a representative job and remove placeholder metrics from production code.

### Description
- Add `python/tests/test_sync_processors.py` with per-job unit tests that execute each SQL-backed sync processor using a `._SpyDb` test double to assert expected source fetch calls, write/upsert API usage, and that `rows_processed`/`rows_written` match fixture-driven expectations. 
- Add failure-path tests in the new test module covering source unavailability, malformed payloads, and DB write errors, and assert the job `status` and `warnings` are meaningful. 
- Add an integration-style `AllianceCurrentSyncIntegrationTests.test_alliance_current_sync_e2e_with_sqlite_fixture_layer` which uses an in-memory SQLite fixture layer to validate ingest → projection materialization → `upsert_sync_state` persistence. 
- Tighten parity tests in `python/tests/test_python_sync_processor_parity.py` by providing a deterministic DB stub and patching ESI adapters so the suite asserts production sync jobs do not fall back to placeholder summary text or constant placeholder metrics. 
- Update `python/orchestrator/jobs/dashboard_summary_sync.py` so `rows_processed` is computed from real observed counts (`worker_jobs` queue counts + alert + schedule counts) instead of a constant literal.

### Testing
- Ran `python -m unittest python.tests.test_sync_processors python.tests.test_python_sync_processor_parity` and all tests passed. 
- Test run output: 10 tests ran and completed successfully (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c49b57a888832f84e986c54ede9b72)