### PR TITLE
Make processor KeyError message generic and add diagnostic tests

### DIFF
--- a/python/orchestrator/processor_registry.py
+++ b/python/orchestrator/processor_registry.py
@@ -143,7 +143,12 @@ def run_registered_processor(job_key: str, db: Any, raw_config: dict[str, Any]) 
         return _compute_result_shape(run_rebuild_ai_briefings(db), job_key)
     if job_key == "forecasting_ai_sync":
         return _compute_result_shape(run_forecasting_ai_sync(db), job_key)
-    raise KeyError(f"No Python processor is registered for compute job {job_key}.")
+    in_compute_registry = job_key in PYTHON_COMPUTE_PROCESSOR_JOB_KEYS
+    in_sync_registry = job_key in PYTHON_SYNC_PROCESSOR_JOB_KEYS
+    raise KeyError(
+        "No Python processor is registered for job "
+        f"{job_key} (in_compute_registry={in_compute_registry}, in_sync_registry={in_sync_registry})."
+    )
 
 
 def audit_enabled_python_jobs(db: Any) -> dict[str, Any]:

--- a/python/tests/test_compute_processor_routing.py
+++ b/python/tests/test_compute_processor_routing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 import unittest
+import re
 from unittest.mock import patch
 
 from orchestrator import processor_registry
@@ -57,6 +58,24 @@ class ComputeProcessorRoutingTests(unittest.TestCase):
         sample = shaped["meta"]["result"]["sample"]
         self.assertEqual(sample["ts"], "2026-03-25T00:00:00+00:00")
         self.assertEqual(sample["score"], "0.1250")
+
+    def test_unknown_compute_job_key_error_text_is_generic_and_diagnostic(self) -> None:
+        missing_job_key = "compute_missing_job"
+        expected_message = (
+            f"No Python processor is registered for job {missing_job_key} "
+            "(in_compute_registry=False, in_sync_registry=False)."
+        )
+        with self.assertRaisesRegex(KeyError, re.escape(expected_message)):
+            processor_registry.run_registered_processor(missing_job_key, db=object(), raw_config={})
+
+    def test_unknown_sync_job_key_error_text_is_generic_and_diagnostic(self) -> None:
+        missing_job_key = "market_hub_missing_sync"
+        expected_message = (
+            f"No Python processor is registered for job {missing_job_key} "
+            "(in_compute_registry=False, in_sync_registry=False)."
+        )
+        with self.assertRaisesRegex(KeyError, re.escape(expected_message)):
+            processor_registry.run_registered_processor(missing_job_key, db=object(), raw_config={})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Avoid implying the registry only handles compute jobs when an unknown job key is requested.
- Provide faster operator diagnosis by indicating whether the missing key appears in the compute or sync registries.

### Description

- Replace the final `KeyError` in `python/orchestrator/processor_registry.py` with a generic message `No Python processor is registered for job {job_key}` and include diagnostic flags `in_compute_registry` and `in_sync_registry` in the message.
- Add unit tests in `python/tests/test_compute_processor_routing.py` that assert the updated `KeyError` text for an unknown compute job key and an unknown sync job key.
- Add `re` import in the test module to assert the error text using `assertRaisesRegex`.

### Testing

- Ran `python -m unittest python.tests.test_compute_processor_routing python.tests.test_python_sync_processor_parity` which executed the updated tests.
- All tests passed (`OK`, 12 tests ran).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c49cea2eb4832fb65dc21b6b6e1f89)