### PR TITLE
Harden Python sync execution, remove PHP-fallback settings, and add operator audit/update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,41 @@ After import, runtime settings are read from `app_settings`; `local.php` is not 
 
 SupplyCore no longer relies on cron for execution. `bin/cron_tick.php` is intentionally disabled and only prints a deprecation notice so operators can detect stale cron-based deployments safely.
 
+### Operator utility scripts
+
+- `scripts/test-all-sync-jobs.sh`
+  - Runs the real Python sync/data jobs through the CLI `run-job` entrypoint.
+  - Reports per-job success/failure/skip, duration, and exit code.
+  - Default mode is safety-first and skips jobs that do not expose a dry-run interface.
+  - Use `--allow-live` to execute non-dry-run jobs directly.
+  - Supports `--app-root` and `--python-bin`.
+- `scripts/update-and-restart.sh`
+  - Performs `git fetch --all --prune` + `git pull --ff-only`.
+  - Optional flags:
+    - `--refresh-deps` to run `pip install --upgrade ./python`
+    - `--clear-cache` to clear `storage/cache/*`
+  - Restarts worker/orchestrator services and prints post-restart status.
+  - Supports `--dry-run` and `--verbose` for safe planning.
+
+#### Real sync/data jobs in scope
+
+- `market_hub_current_sync`
+- `alliance_current_sync`
+- `market_hub_historical_sync`
+- `alliance_historical_sync`
+- `current_state_refresh_sync`
+- `market_hub_local_history_sync`
+- `doctrine_intelligence_sync`
+- `market_comparison_summary_sync`
+- `loss_demand_summary_sync`
+- `dashboard_summary_sync`
+- `rebuild_ai_briefings`
+- `forecasting_ai_sync`
+- `activity_priority_summary_sync`
+- `analytics_bucket_1h_sync`
+- `analytics_bucket_1d_sync`
+- `deal_alerts_sync`
+
 ### Continuous worker model
 
 SupplyCore now runs three long-lived worker classes:

--- a/docs/PYTHON_ONLY_WORKERS.md
+++ b/docs/PYTHON_ONLY_WORKERS.md
@@ -1,106 +1,49 @@
 # Python-Only Worker Architecture Runbook
 
-> For the full architecture/runtime audit matrix and feature dependency map, see `docs/BACKGROUND_JOB_AUDIT.md`.
+This runbook reflects the post-migration state where recurring sync/compute execution is Python-native.
 
-## Job audit matrix (full recurring worker registry sweep)
+## Authoritative references
 
-| job_key | current_mode | actual_runtime_language | php_subprocess_invoked | target_action | notes |
-|---|---|---:|---:|---|---|
-| market_hub_current_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| deal_alerts_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| alliance_current_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| market_comparison_summary_sync | python | php bridge | yes | disable | Python job depended on PHP bridge context. |
-| dashboard_summary_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| doctrine_intelligence_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| loss_demand_summary_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| activity_priority_summary_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| current_state_refresh_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| market_hub_local_history_sync | python | php bridge | yes | disable | Python job depended on PHP bridge helper actions. |
-| market_hub_historical_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| alliance_historical_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| analytics_bucket_1h_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| analytics_bucket_1d_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| rebuild_ai_briefings | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| forecasting_ai_sync | python | php (fallback) | yes | disable | No Python processor in worker pool. |
-| killmail_r2z2_sync | python | php bridge | yes | disable | Python job depended on PHP bridge batch processing. |
-| compute_graph_sync | python | python | no | keep_python | Python-native processor. |
-| compute_graph_sync_doctrine_dependency | python | python | no | keep_python | Python-native processor. |
-| compute_graph_sync_battle_intelligence | python | python | no | keep_python | Python-native processor. |
-| compute_graph_derived_relationships | python | python | no | keep_python | Python-native processor. |
-| compute_graph_insights | python | python | no | keep_python | Python-native processor. |
-| compute_graph_prune | python | python | no | keep_python | Python-native processor. |
-| compute_graph_topology_metrics | python | python | no | keep_python | Python-native processor. |
-| compute_behavioral_baselines | python | python | no | keep_python | Python-native processor. |
-| compute_suspicion_scores_v2 | python | python | no | keep_python | Python-native processor. |
-| compute_buy_all | python | python | no | keep_python | Python-native processor. |
-| compute_signals | python | python | no | keep_python | Python-native processor. |
-| compute_battle_rollups | python | python | no | keep_python | Python-native processor. |
-| compute_battle_target_metrics | python | python | no | keep_python | Python-native processor. |
-| compute_battle_anomalies | python | python | no | keep_python | Python-native processor. |
-| compute_battle_actor_features | python | python | no | keep_python | Python-native processor. |
-| compute_suspicion_scores | python | python | no | keep_python | Python-native processor. |
+- Job registry: `src/functions.php` (`supplycore_authoritative_job_registry`)
+- Worker queue definitions: `python/orchestrator/worker_registry.py`
+- Python processor bindings: `python/orchestrator/processor_registry.py`
+- Full sync/data audit matrix: `docs/SYNC_JOB_AUDIT_2026-03.md`
 
-## Active topology
+## Runtime guardrails
 
-- `python/orchestrator/worker_pool.py` only claims and runs jobs with `execution_mode=python`.
-- Unknown jobs fail immediately and are not routed into PHP fallback lanes.
-- Recurring queue seeding is Python DB-native (`SupplyCoreDb.queue_due_recurring_jobs`).
+- Compute/sync jobs must execute in Python worker lanes.
+- PHP scheduler runtime must not execute Python-declared jobs directly.
+- Unknown jobs in `python/orchestrator/job_runner.py` now fail fast unless explicitly bridge-bound.
 
-## systemd (python workers only)
+## Services
 
-### Unit files
+Expected systemd services (environment-specific names may vary):
 
-- `ops/systemd/supplycore-compute-worker.service`
-- `ops/systemd/supplycore-compute-worker@.service`
-- `ops/systemd/supplycore-sync-worker.service`
-- `ops/systemd/supplycore-sync-worker@.service`
-- `ops/systemd/supplycore-zkill.service` (stream collector)
+- `supplycore-sync-worker.service`
+- `supplycore-compute-worker.service`
+- `supplycore-zkill.service`
+- `supplycore-orchestrator.service`
 
-All worker pool ExecStart commands now pass `--execution-modes python`.
-
-### Operator commands
+## Operator commands
 
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl restart supplycore-sync-worker.service
 sudo systemctl restart supplycore-compute-worker.service
 sudo systemctl restart supplycore-zkill.service
-sudo systemctl status supplycore-sync-worker.service supplycore-compute-worker.service supplycore-zkill.service
+sudo systemctl restart supplycore-orchestrator.service
+sudo systemctl status supplycore-sync-worker.service supplycore-compute-worker.service supplycore-zkill.service supplycore-orchestrator.service
 ```
 
-## Validation commands
+## Validation helpers
 
 ```bash
-# verify active worker rows are python-only
-SELECT job_key, execution_mode, status FROM worker_jobs WHERE status IN ('queued','retry','running');
+# Safe dry-run-aware sync job sweep (skips jobs without dry-run interfaces)
+./scripts/test-all-sync-jobs.sh
 
-# verify no worker rows request php execution
-SELECT COUNT(*) FROM worker_jobs WHERE execution_mode = 'php';
+# Live execution sweep for all sync jobs (use with care)
+./scripts/test-all-sync-jobs.sh --allow-live
 
-# verify core jobs exist in registry and run lane
-SELECT job_key, enabled, execution_mode FROM sync_schedules WHERE job_key IN (
-  'compute_graph_sync','compute_graph_insights','compute_buy_all','compute_signals',
-  'compute_battle_rollups','compute_battle_target_metrics','compute_battle_anomalies',
-  'compute_battle_actor_features','compute_suspicion_scores'
-);
-```
-
-## Memory sizing guidance
-
-- Keep one sync worker around **768M** (I/O and lighter write bursts).
-- Keep one compute worker around **1G** baseline.
-- Scale compute replicas first for throughput; scale sync workers only if queue wait becomes user-visible.
-- Tune using:
-  - service `MemoryMax`
-  - `SUPPLYCORE_WORKER_MEMORY_PAUSE_THRESHOLD_BYTES`
-  - `SUPPLYCORE_WORKER_MEMORY_ABORT_THRESHOLD_BYTES`
-
-## Manual debug execution
-
-```bash
-python bin/python_orchestrator.py worker-pool --app-root /var/www/SupplyCore --queues compute --workload-classes compute --execution-modes python --once --verbose
-python bin/python_orchestrator.py compute-graph-sync --app-root /var/www/SupplyCore
-python bin/python_orchestrator.py compute-graph-insights --app-root /var/www/SupplyCore
-python bin/python_orchestrator.py compute-buy-all --app-root /var/www/SupplyCore
-python bin/python_orchestrator.py compute-signals --app-root /var/www/SupplyCore
+# Deployment update + restart workflow (dry-run first)
+./scripts/update-and-restart.sh --dry-run --verbose
 ```

--- a/docs/SYNC_JOB_AUDIT_2026-03.md
+++ b/docs/SYNC_JOB_AUDIT_2026-03.md
@@ -1,0 +1,67 @@
+# Sync Job Audit & Hardening (March 26, 2026)
+
+This document is the operator-facing verification pass for Python-native sync/data jobs, legacy execution cleanup, and parity/tooling hardening.
+
+## Scope & method
+
+- Authoritative inventory source: `supplycore_authoritative_job_registry()`.
+- Worker parity source: `python/orchestrator/processor_registry.py` + `python/orchestrator/worker_registry.py`.
+- CLI parity source: `python/orchestrator/main.py` (`run-job` subcommand).
+- Legacy path checks: PHP scheduler runner guards + Python job-runner fallback handling.
+
+## Phase 1–2 inventory: real sync/data jobs
+
+| job_key | intended purpose | python implementation | worker-safe | scheduler-safe | cli-safe | old PHP implementation still exists | old bridge/fallback path exists | replacement status | notes |
+|---|---|---|---:|---:|---:|---:|---:|---|---|
+| market_hub_current_sync | pull current hub market snapshots | `run_market_hub_current_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| alliance_current_sync | pull current alliance structure snapshots | `run_alliance_current_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| market_hub_historical_sync | backfill hub history windows | `run_market_hub_historical_sync` | yes | yes | yes | yes | no | complete replacement | Batched historical sync.
+| alliance_historical_sync | backfill alliance history windows | `run_alliance_historical_sync` | yes | yes | yes | yes | no | complete replacement | Batched historical sync.
+| current_state_refresh_sync | refresh current-state materializations | `run_current_state_refresh_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| doctrine_intelligence_sync | recompute doctrine intelligence snapshots | `run_doctrine_intelligence_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| loss_demand_summary_sync | materialize loss-demand summary | `run_loss_demand_summary_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| dashboard_summary_sync | materialize dashboard summary payload | `run_dashboard_summary_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| rebuild_ai_briefings | rebuild AI briefing artifacts | `run_rebuild_ai_briefings` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| forecasting_ai_sync | refresh forecasting summary artifacts | `run_forecasting_ai_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| activity_priority_summary_sync | materialize activity-priority summary | `run_activity_priority_summary_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| analytics_bucket_1h_sync | hourly analytics rollups | `run_analytics_bucket_1h_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| analytics_bucket_1d_sync | daily analytics rollups | `run_analytics_bucket_1d_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| deal_alerts_sync | materialize deal alerts | `run_deal_alerts_sync` | yes | yes | yes | yes | no | complete replacement | Python-native processor in registry.
+| market_comparison_summary_sync | materialize alliance-vs-reference market comparison | `run_market_comparison_summary` | partial | partial | yes | yes | yes | partial replacement | Python job currently depends on bridge context/store actions.
+| market_hub_local_history_sync | rebuild local market history snapshots | `run_market_hub_local_history` | partial | partial | yes | yes | yes | partial replacement | Python job currently depends on bridge context/store actions.
+
+## Phase 3 legacy/fallback cleanup applied
+
+1. Removed scheduler runtime settings for legacy Python-heavy/PHP-fallback toggles.
+2. Removed unused PHP helper functions tied to those toggles.
+3. Hardened Python job runner fallback behavior:
+   - unknown jobs now fail fast instead of silently attempting generic PHP fallback.
+   - only explicitly bridge-bound jobs can bridge.
+
+## Phase 4–5 maintainability cleanup/improvements
+
+- Introduced operator-safe bulk sync test runner (`scripts/test-all-sync-jobs.sh`) with summary table, durations, and explicit dry-run limitations.
+- Introduced deployment/update automation (`scripts/update-and-restart.sh`) with dry-run support, optional dependency refresh, optional cache cleanup, service restarts, and post-restart status checks.
+- Updated worker architecture documentation to current Python-native state.
+
+## Phase 9 final validation matrix
+
+| job_key | purpose | python_implementation_exists | worker_safe | scheduler_safe | cli_safe | dry_run_supported | old_php_path_removed | cleanup_applied | notes |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| market_hub_current_sync | Current hub snapshots | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| alliance_current_sync | Current alliance snapshots | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| market_hub_historical_sync | Hub historical backfill | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| alliance_historical_sync | Alliance historical backfill | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| current_state_refresh_sync | Current-state materialization | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| doctrine_intelligence_sync | Doctrine intelligence materialization | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| market_comparison_summary_sync | Market comparison summary | yes | partial | partial | yes | no | no | yes | Bridge-coupled path remains.
+| loss_demand_summary_sync | Loss-demand summary | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| dashboard_summary_sync | Dashboard summary | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| rebuild_ai_briefings | AI briefing rebuild | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| market_hub_local_history_sync | Local history rebuild | yes | partial | partial | yes | no | no | yes | Bridge-coupled path remains.
+| forecasting_ai_sync | Forecasting summary | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| activity_priority_summary_sync | Activity-priority summary | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| analytics_bucket_1h_sync | Hourly rollups | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| analytics_bucket_1d_sync | Daily rollups | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+| deal_alerts_sync | Deal-alert materialization | yes | yes | yes | yes | no | no | yes | Use `run-job`; no dry-run mode yet.
+

--- a/python/orchestrator/job_runner.py
+++ b/python/orchestrator/job_runner.py
@@ -212,10 +212,8 @@ def process_job(context: PythonWorkerContext) -> dict[str, Any]:
     elif processor is None:
         if context.job_key in PHP_BRIDGED_JOB_KEYS:
             result = _run_php_fallback(context, bridge)
-        elif not bool(context.scheduler_config.get("python_php_fallback_enabled", True)):
-            raise RuntimeError(f"No Python processor is registered for job {context.job_key} and PHP fallback is disabled.")
         else:
-            result = _run_php_fallback(context, bridge)
+            raise RuntimeError(f"No Python processor is registered for job {context.job_key}.")
     else:
         result = processor(context)
 

--- a/scripts/test-all-sync-jobs.sh
+++ b/scripts/test-all-sync-jobs.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+APP_ROOT_DEFAULT=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+APP_ROOT=${APP_ROOT:-${APP_ROOT_DEFAULT}}
+PYTHON_BIN=${PYTHON_BIN:-python3}
+ALLOW_LIVE=0
+VERBOSE=0
+
+SYNC_JOBS=(
+  market_hub_current_sync
+  alliance_current_sync
+  market_hub_historical_sync
+  alliance_historical_sync
+  current_state_refresh_sync
+  market_hub_local_history_sync
+  doctrine_intelligence_sync
+  market_comparison_summary_sync
+  loss_demand_summary_sync
+  dashboard_summary_sync
+  rebuild_ai_briefings
+  forecasting_ai_sync
+  activity_priority_summary_sync
+  analytics_bucket_1h_sync
+  analytics_bucket_1d_sync
+  deal_alerts_sync
+)
+
+# Jobs that have no safe dry-run interface today.
+NO_DRY_RUN_JOBS=("${SYNC_JOBS[@]}")
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Options:
+  --app-root PATH        SupplyCore repository root (default: ${APP_ROOT_DEFAULT})
+  --python-bin PATH      Python interpreter to use (default: python3)
+  --allow-live           Execute jobs without dry-run support (unsafe in prod)
+  --verbose              Stream command output while running
+  -h, --help             Show this help
+USAGE
+}
+
+contains_job() {
+  local needle=$1
+  shift
+  for candidate in "$@"; do
+    [[ "$candidate" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+parse_args() {
+  while (($# > 0)); do
+    case "$1" in
+      --app-root)
+        APP_ROOT=$2
+        shift 2
+        ;;
+      --python-bin)
+        PYTHON_BIN=$2
+        shift 2
+        ;;
+      --allow-live)
+        ALLOW_LIVE=1
+        shift
+        ;;
+      --verbose)
+        VERBOSE=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+  done
+}
+
+parse_args "$@"
+
+if [[ ! -d "${APP_ROOT}" ]]; then
+  echo "App root does not exist: ${APP_ROOT}" >&2
+  exit 1
+fi
+
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  echo "Python interpreter not found: ${PYTHON_BIN}" >&2
+  exit 1
+fi
+
+START_TS=$(date +%s)
+printf "\n== SupplyCore sync job test runner ==\n"
+printf "App root: %s\n" "${APP_ROOT}"
+printf "Python:   %s\n" "${PYTHON_BIN}"
+printf "Mode:     %s\n\n" "$([[ ${ALLOW_LIVE} -eq 1 ]] && echo 'live-allowed' || echo 'dry-run-only')"
+
+declare -a SUMMARY=()
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+run_job() {
+  local job_key=$1
+  local started ended duration exit_code tmpfile
+  tmpfile=$(mktemp)
+  started=$(date +%s)
+
+  if contains_job "${job_key}" "${NO_DRY_RUN_JOBS[@]}" && [[ ${ALLOW_LIVE} -ne 1 ]]; then
+    echo "[SKIP] ${job_key} (no dry-run support; rerun with --allow-live to execute)"
+    SUMMARY+=("${job_key}|SKIPPED|0|SKIPPED|dry-run unsupported")
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+    rm -f "${tmpfile}"
+    return
+  fi
+
+  local cmd=("${PYTHON_BIN}" -m orchestrator.main run-job --app-root "${APP_ROOT}" --job-key "${job_key}")
+  echo "[RUN ] ${job_key}"
+  if [[ ${VERBOSE} -eq 1 ]]; then
+    (
+      cd "${APP_ROOT}/python"
+      "${cmd[@]}"
+    ) | tee "${tmpfile}"
+    exit_code=${PIPESTATUS[0]}
+  else
+    (
+      cd "${APP_ROOT}/python"
+      "${cmd[@]}"
+    ) >"${tmpfile}" 2>&1 || exit_code=$?
+    : "${exit_code:=0}"
+  fi
+
+  ended=$(date +%s)
+  duration=$((ended - started))
+
+  if [[ ${exit_code} -eq 0 ]]; then
+    echo "[PASS] ${job_key} (${duration}s, exit=${exit_code})"
+    SUMMARY+=("${job_key}|PASS|${duration}|${exit_code}|ok")
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "[FAIL] ${job_key} (${duration}s, exit=${exit_code})"
+    tail -n 40 "${tmpfile}" | sed 's/^/       /'
+    SUMMARY+=("${job_key}|FAIL|${duration}|${exit_code}|command failed")
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+
+  rm -f "${tmpfile}"
+}
+
+for job in "${SYNC_JOBS[@]}"; do
+  run_job "${job}"
+done
+
+TOTAL_DURATION=$(( $(date +%s) - START_TS ))
+printf "\n== Summary ==\n"
+printf "%-34s | %-7s | %-10s | %-8s | %s\n" "job_key" "status" "duration_s" "exit" "notes"
+printf -- "%.0s-" {1..95}
+printf "\n"
+for row in "${SUMMARY[@]}"; do
+  IFS='|' read -r job status duration exit_code notes <<<"${row}"
+  printf "%-34s | %-7s | %-10s | %-8s | %s\n" "${job}" "${status}" "${duration}" "${exit_code}" "${notes}"
+done
+
+printf "\nTotals: pass=%d fail=%d skipped=%d total_duration=%ss\n" "${PASS_COUNT}" "${FAIL_COUNT}" "${SKIP_COUNT}" "${TOTAL_DURATION}"
+
+if [[ ${FAIL_COUNT} -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+APP_ROOT_DEFAULT=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+APP_ROOT=${APP_ROOT:-${APP_ROOT_DEFAULT}}
+DRY_RUN=0
+VERBOSE=0
+REFRESH_DEPS=0
+CLEAR_CACHE=0
+BRANCH=""
+
+SERVICES=(
+  supplycore-sync-worker.service
+  supplycore-compute-worker.service
+  supplycore-zkill.service
+  supplycore-orchestrator.service
+)
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Options:
+  --app-root PATH        SupplyCore repository root (default: ${APP_ROOT_DEFAULT})
+  --branch NAME          Optional branch to checkout before pull
+  --refresh-deps         Run python dependency refresh (pip install --upgrade ./python)
+  --clear-cache          Clear runtime cache files under storage/cache
+  --service NAME         Add a service to restart (repeatable)
+  --dry-run              Print actions without executing mutating commands
+  --verbose              Print each command before executing
+  -h, --help             Show this help
+USAGE
+}
+
+log() {
+  printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+run_cmd() {
+  if [[ ${VERBOSE} -eq 1 || ${DRY_RUN} -eq 1 ]]; then
+    log "CMD: $*"
+  fi
+  if [[ ${DRY_RUN} -eq 1 ]]; then
+    return 0
+  fi
+  "$@"
+}
+
+parse_args() {
+  while (($# > 0)); do
+    case "$1" in
+      --app-root)
+        APP_ROOT=$2
+        shift 2
+        ;;
+      --branch)
+        BRANCH=$2
+        shift 2
+        ;;
+      --refresh-deps)
+        REFRESH_DEPS=1
+        shift
+        ;;
+      --clear-cache)
+        CLEAR_CACHE=1
+        shift
+        ;;
+      --service)
+        SERVICES+=("$2")
+        shift 2
+        ;;
+      --dry-run)
+        DRY_RUN=1
+        shift
+        ;;
+      --verbose)
+        VERBOSE=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+  done
+}
+
+parse_args "$@"
+
+if [[ ! -d "${APP_ROOT}/.git" ]]; then
+  echo "App root is not a git repository: ${APP_ROOT}" >&2
+  exit 1
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  echo "systemctl is required for service restart operations." >&2
+  exit 1
+fi
+
+log "Starting update-and-restart"
+log "app_root=${APP_ROOT} dry_run=${DRY_RUN} refresh_deps=${REFRESH_DEPS} clear_cache=${CLEAR_CACHE}"
+
+cd "${APP_ROOT}"
+
+if [[ -n "${BRANCH}" ]]; then
+  run_cmd git checkout "${BRANCH}"
+fi
+
+run_cmd git fetch --all --prune
+run_cmd git pull --ff-only
+
+if [[ ${REFRESH_DEPS} -eq 1 ]]; then
+  if [[ -x "${APP_ROOT}/.venv-orchestrator/bin/python" ]]; then
+    run_cmd "${APP_ROOT}/.venv-orchestrator/bin/python" -m pip install --upgrade "${APP_ROOT}/python"
+  else
+    run_cmd python3 -m pip install --upgrade "${APP_ROOT}/python"
+  fi
+fi
+
+if [[ ${CLEAR_CACHE} -eq 1 ]]; then
+  run_cmd bash -lc "rm -rf '${APP_ROOT}/storage/cache/'*"
+fi
+
+run_cmd systemctl daemon-reload
+
+for svc in "${SERVICES[@]}"; do
+  run_cmd systemctl restart "${svc}"
+done
+
+log "Post-restart status checks"
+for svc in "${SERVICES[@]}"; do
+  run_cmd systemctl --no-pager --full status "${svc}"
+done
+
+log "Completed update-and-restart"

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -58,8 +58,6 @@ return [
         'supervisor_mode' => 'php',
         'systemd_service' => 'supplycore-scheduler.service',
         'python_service_name' => 'supplycore-orchestrator.service',
-        'python_heavy_jobs_enabled' => true,
-        'python_php_fallback_enabled' => true,
     ],
     'orchestrator' => [
         'heartbeat_file' => 'storage/run/orchestrator-heartbeat.json',

--- a/src/config/runtime_settings.php
+++ b/src/config/runtime_settings.php
@@ -65,8 +65,6 @@ return [
         'fields' => [
             'scheduler.default_timeout_seconds' => ['type' => 'int', 'default' => 300, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
             'scheduler.supervisor_mode' => ['type' => 'string', 'default' => 'php', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
-            'scheduler.python_heavy_jobs_enabled' => ['type' => 'bool', 'default' => true, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
-            'scheduler.python_php_fallback_enabled' => ['type' => 'bool', 'default' => true, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
         ],
     ],
     'workers' => [

--- a/src/functions.php
+++ b/src/functions.php
@@ -4476,16 +4476,6 @@ function scheduler_runtime_guard(float $startedAtUnix, int $timeoutSeconds, stri
     }
 }
 
-function scheduler_python_heavy_jobs_enabled(): bool
-{
-    return (bool) config('scheduler.python_heavy_jobs_enabled', true);
-}
-
-function scheduler_python_php_fallback_enabled(): bool
-{
-    return (bool) config('scheduler.python_php_fallback_enabled', true);
-}
-
 function scheduler_job_execution_mode(array $job, ?array $definition = null): string
 {
     $jobKey = trim((string) ($job['job_key'] ?? ''));


### PR DESCRIPTION
### Motivation

- After migrating recurring sync/compute work to Python-native processors, the runtime needed an operations hardening pass to remove legacy PHP fallback paths, provide an authoritative audit, and add safe operator tooling for verification and updates.

### Description

- Hardened Python job execution by making unknown jobs fail fast instead of silently invoking a PHP fallback in `process_job()` (`python/orchestrator/job_runner.py`).
- Removed legacy scheduler fallback toggles and defaults by deleting `python_heavy_jobs_enabled` / `python_php_fallback_enabled` from `src/config/app.php` and `src/config/runtime_settings.php` and removing the now-unused helper guards from `src/functions.php`.
- Added operator-facing audit and runbooks: `docs/SYNC_JOB_AUDIT_2026-03.md` (full job inventory + validation matrix) and updated `docs/PYTHON_ONLY_WORKERS.md` and `README.md` to reflect the Python-only worker model and scripts.
- Added two safe operator scripts: `scripts/test-all-sync-jobs.sh` (dry-run-first sweep of real sync/data jobs with per-job results and summary) and `scripts/update-and-restart.sh` (git pull, optional deps refresh, optional cache clear, `systemctl daemon-reload` and service restart with `--dry-run`/`--verbose`).
- Marked explicit PHP-bridged jobs and ensured bridge use remains explicit-only via `PHP_BRIDGED_JOB_KEYS` and registry checks (`python/orchestrator/processor_registry.py` / `python/orchestrator/job_runner.py`).

### Testing

- Validated shell syntax for the new scripts with `bash -n scripts/test-all-sync-jobs.sh` and `bash -n scripts/update-and-restart.sh` (both succeeded).
- Ensured Python orchestrator modules compile with `python3 -m py_compile python/orchestrator/job_runner.py python/orchestrator/main.py python/orchestrator/processor_registry.py python/orchestrator/worker_registry.py` (succeeded).
- Exercised CLI help for the new scripts with `./scripts/test-all-sync-jobs.sh --help` and `./scripts/update-and-restart.sh --help` (both succeeded).
- Ran repository-wide grep checks to ensure removed fallback toggles are not referenced (`rg -n "scheduler_python_php_fallback_enabled|scheduler.python_php_fallback_enabled|scheduler.python_heavy_jobs_enabled|scheduler_python_heavy_jobs_enabled" ...`) and found no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4a1065580832f8935421cb904360b)