### PR TITLE
Fix market/alliance sync source resolution, reduce settings noise, and make deal-alert popup closable

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -389,6 +389,7 @@ foreach ($configuredSyncJobs as $schedule) {
 }
 
 $settingsLiveRefreshSummary = supplycore_live_refresh_summary(null);
+$showSyncDiagnostics = sanitize_enabled_flag($_GET['show_sync_diagnostics'] ?? '0') === '1';
 $pageHeaderBadge = 'Business settings';
 $pageHeaderSummary = 'Keep settings focused on business choices, data freshness, and only show deep runtime detail when you need it.';
 $pageHeaderMeta = [
@@ -1884,6 +1885,11 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <div>
                         <p class="text-sm text-slate-100">Data freshness summary</p>
                         <p class="mt-1 text-xs text-muted">Keep the visible view centered on datasets, last successful refreshes, freshness, and only the latest failures.</p>
+                        <p class="mt-2 text-xs text-muted">
+                            <a class="underline decoration-dotted underline-offset-4 hover:text-slate-100" href="/settings?section=data-sync&amp;show_sync_diagnostics=<?= $showSyncDiagnostics ? '0' : '1' ?>">
+                                <?= $showSyncDiagnostics ? 'Hide advanced diagnostics' : 'Show advanced diagnostics' ?>
+                            </a>
+                        </p>
                     </div>
                     <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                         <?php foreach ($runtimeDatasetCards as $datasetCard): ?>
@@ -1911,6 +1917,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <?php endif; ?>
                     </div>
 
+                    <?php if ($showSyncDiagnostics): ?>
                     <details class="rounded-xl border border-border bg-black/20 p-4">
                         <summary class="cursor-pointer list-none">
                             <div class="flex items-start justify-between gap-3">
@@ -2287,6 +2294,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             </div>
                         </div>
                     </details>
+                    <?php endif; ?>
                 </div>
 
                 <div class="rounded-lg border border-border bg-black/20 p-3 text-sm text-muted">
@@ -2321,6 +2329,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <?php $partitionDiagnostics = (array) ($syncDashboard['partition_diagnostics'] ?? []); ?>
                 <?php $partitionedTables = array_values((array) ($partitionDiagnostics['partitioned_tables'] ?? [])); ?>
                 <?php $evaluatedPartitionTables = array_values((array) ($partitionDiagnostics['evaluation_tables'] ?? [])); ?>
+                <?php if ($showSyncDiagnostics): ?>
                 <div class="space-y-3 rounded-lg border border-border bg-black/20 p-4">
                     <div>
                         <p class="text-sm text-slate-100">Raw partition health</p>
@@ -2385,6 +2394,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         </div>
                     <?php endif; ?>
                 </div>
+                <?php endif; ?>
 
                 <label class="block space-y-2">
                     <span class="text-sm text-muted">Static Data JSONL ZIP Source URL</span>

--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -550,6 +550,28 @@ class SupplyCoreDb:
         )
         return [{"source_id": int(row.get("source_id") or 0), "region_id": int(row.get("region_id") or 0)} for row in rows]
 
+    def fetch_app_setting(self, key: str, default: str = "") -> str:
+        row = self.fetch_one("SELECT setting_value FROM app_settings WHERE setting_key = %s LIMIT 1", (key[:120],)) or {}
+        value = str(row.get("setting_value") or "").strip()
+        return value if value != "" else default
+
+    def fetch_market_hub_sources_from_settings(self, *, limit: int = 4) -> list[dict[str, object]]:
+        configured = self.fetch_app_setting("market_station_id", "").strip()
+        if configured == "":
+            return []
+        source_id = int(configured) if configured.isdigit() else 0
+        if source_id <= 0:
+            return []
+
+        npc = self.fetch_one(
+            "SELECT station_id, region_id FROM ref_npc_stations WHERE station_id = %s LIMIT 1",
+            (source_id,),
+        ) or {}
+        if int(npc.get("station_id") or 0) > 0 and int(npc.get("region_id") or 0) > 0:
+            return [{"source_id": source_id, "region_id": int(npc["region_id"]), "source_kind": "npc_station"}]
+
+        return [{"source_id": source_id, "region_id": 0, "source_kind": "structure"}]
+
     def fetch_alliance_structure_sources(self, *, limit: int = 5) -> list[int]:
         rows = self.fetch_all(
             """SELECT structure_id
@@ -559,6 +581,13 @@ class SupplyCoreDb:
             (max(1, limit),),
         )
         return [int(row.get("structure_id") or 0) for row in rows if int(row.get("structure_id") or 0) > 0]
+
+    def fetch_alliance_structure_sources_from_settings(self, *, limit: int = 3) -> list[int]:
+        configured = self.fetch_app_setting("alliance_station_id", "").strip()
+        structure_id = int(configured) if configured.isdigit() else 0
+        if structure_id > 0:
+            return [structure_id]
+        return self.fetch_alliance_structure_sources(limit=max(1, limit))
 
     def fetch_latest_esi_access_token(self) -> str | None:
         row = self.fetch_one(

--- a/python/orchestrator/jobs/alliance_current_sync.py
+++ b/python/orchestrator/jobs/alliance_current_sync.py
@@ -8,7 +8,7 @@ from .sync_runtime import run_sync_phase_job
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
     adapter = EsiMarketAdapter(timeout_seconds=30)
     access_token = db.fetch_latest_esi_access_token()
-    structure_ids = db.fetch_alliance_structure_sources(limit=3)
+    structure_ids = db.fetch_alliance_structure_sources_from_settings(limit=3)
     warnings: list[str] = []
     if not access_token:
         warnings.append("No active ESI OAuth token found; alliance structure orders were not fetched from ESI.")
@@ -20,7 +20,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
             try:
                 first_page = adapter.fetch_structure_orders(structure_id=structure_id, access_token=access_token, page=1)
                 orders.extend(first_page.orders)
-                max_pages = min(4, first_page.pages)
+                max_pages = min(20, first_page.pages)
                 for page in range(2, max_pages + 1):
                     response = adapter.fetch_structure_orders(structure_id=structure_id, access_token=access_token, page=page)
                     orders.extend(response.orders)
@@ -47,7 +47,9 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
     rows_processed += int(stats["rows_processed"])
     rows_written += int(stats["rows_written"])
     if not structure_ids:
-        warnings.append("No alliance_structure_metadata sources were available for ESI structure sync.")
+        warnings.append("No configured alliance market structure was found. Save Settings → Trading Stations before running this sync.")
+    if rows_processed == 0:
+        warnings.append("No alliance structure orders were fetched from ESI during this run.")
     db.upsert_sync_state(
         dataset_key="alliance.structure.orders.current",
         status="success",

--- a/python/orchestrator/jobs/market_hub_current_sync.py
+++ b/python/orchestrator/jobs/market_hub_current_sync.py
@@ -7,26 +7,43 @@ from .sync_runtime import run_sync_phase_job
 
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
     adapter = EsiMarketAdapter(timeout_seconds=30)
-    sources = db.fetch_market_hub_sources(limit=4)
+    sources = db.fetch_market_hub_sources_from_settings(limit=4)
+    access_token = db.fetch_latest_esi_access_token()
     warnings: list[str] = []
     rows_processed = 0
     rows_written = 0
     for source in sources:
         source_id = int(source.get("source_id") or 0)
         region_id = int(source.get("region_id") or 0)
-        if source_id <= 0 or region_id <= 0:
+        source_kind = str(source.get("source_kind") or "npc_station")
+        if source_id <= 0:
             continue
         orders: list[dict[str, object]] = []
         try:
-            first_page = adapter.fetch_region_orders(region_id=region_id, order_type="all", page=1)
+            if source_kind == "structure":
+                if not access_token:
+                    warnings.append(f"market_hub source {source_id} is a structure, but no active ESI OAuth token is available.")
+                    continue
+                first_page = adapter.fetch_structure_orders(structure_id=source_id, access_token=access_token, page=1)
+            else:
+                if region_id <= 0:
+                    warnings.append(f"market_hub source {source_id} is missing region metadata.")
+                    continue
+                first_page = adapter.fetch_region_orders(region_id=region_id, order_type="all", page=1)
             orders.extend(first_page.orders)
-            max_pages = min(4, first_page.pages)
+            max_pages = min(20, first_page.pages)
             for page in range(2, max_pages + 1):
-                response = adapter.fetch_region_orders(region_id=region_id, order_type="all", page=page)
+                if source_kind == "structure":
+                    response = adapter.fetch_structure_orders(structure_id=source_id, access_token=access_token, page=page)
+                else:
+                    response = adapter.fetch_region_orders(region_id=region_id, order_type="all", page=page)
                 orders.extend(response.orders)
         except Exception as exc:
-            warnings.append(f"market_hub source {source_id} region {region_id} fetch failed: {exc}")
+            warnings.append(f"market_hub source {source_id} fetch failed: {exc}")
             continue
+
+        if source_kind == "npc_station":
+            orders = [order for order in orders if int(order.get("location_id") or 0) == source_id]
 
         normalized_orders: list[dict[str, object]] = []
         for order in orders:
@@ -48,7 +65,9 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
     rows_processed += int(stats["rows_processed"])
     rows_written += int(stats["rows_written"])
     if not sources:
-        warnings.append("No configured NPC market-hub sources were found (trading_stations + ref_npc_stations join returned empty).")
+        warnings.append("No configured market hub source was found. Save Settings → Trading Stations before running this sync.")
+    if rows_processed == 0:
+        warnings.append("No market-hub orders were fetched from ESI during this run.")
     db.upsert_sync_state(
         dataset_key="market_hub.orders.current",
         status="success",

--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -292,7 +292,7 @@ def main() -> int:
             return 1
         result = run_registered_processor(job_key, db, config.raw)
         print(result)
-        return 0
+        return 1 if str(result.get("status") or "success").lower() == "failed" else 0
 
     if command in {
         "compute-battle-rollups",

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -73,7 +73,10 @@ $pageFreshnessLine = $pageFreshness !== []
             <!-- ui-section:page-freshness:end -->
         <?php endif; ?>
         <?php if ($dealAlertPopupRows !== []): ?>
-            <div class="fixed inset-x-4 top-4 z-50 ml-auto max-w-xl">
+            <?php
+            $dealAlertPopupSignature = sha1(json_encode(array_values(array_map(static fn (array $row): string => (string) ($row['alert_key'] ?? ''), $dealAlertPopupRows)), JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE) ?: '');
+            ?>
+            <div class="fixed inset-x-4 top-4 z-50 ml-auto max-w-xl" data-deal-alert-popup data-deal-alert-signature="<?= htmlspecialchars($dealAlertPopupSignature, ENT_QUOTES) ?>" data-deal-alert-dismiss-minutes="<?= max(5, $dealAlertDismissMinutes) ?>">
                 <section class="rounded-[1.6rem] border border-rose-400/35 bg-gradient-to-br from-[#2a0911]/96 via-[#1a0c14]/96 to-[#120811]/96 px-5 py-4 text-rose-50 shadow-[0_28px_90px_rgba(244,63,94,0.28)] backdrop-blur-xl">
                     <div class="flex items-start justify-between gap-4">
                         <div>
@@ -81,7 +84,10 @@ $pageFreshnessLine = $pageFreshness !== []
                             <h2 class="mt-2 text-lg font-semibold text-white">Critical / high-confidence deal alerts are active</h2>
                             <p class="mt-1 text-sm text-rose-100/90">SupplyCore detected listings far below their local historical baseline in the alliance market or reference hub.</p>
                         </div>
-                        <a href="/deal-alerts" class="rounded-full border border-rose-200/20 bg-white/8 px-3 py-1 text-xs font-medium text-white hover:bg-white/12">Open deals page</a>
+                        <div class="flex items-center gap-2">
+                            <a href="/deal-alerts" class="rounded-full border border-rose-200/20 bg-white/8 px-3 py-1 text-xs font-medium text-white hover:bg-white/12">Open deals page</a>
+                            <button type="button" class="rounded-full border border-white/20 bg-black/20 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-white hover:bg-black/35" data-deal-alert-close>Close</button>
+                        </div>
                     </div>
 
                     <div class="mt-4 space-y-3">
@@ -121,4 +127,38 @@ $pageFreshnessLine = $pageFreshness !== []
                     </div>
                 </section>
             </div>
+            <script>
+                (() => {
+                    const popup = document.querySelector('[data-deal-alert-popup]');
+                    if (!popup) return;
+                    const signature = popup.getAttribute('data-deal-alert-signature') || '';
+                    const ttlMinutes = Number.parseInt(popup.getAttribute('data-deal-alert-dismiss-minutes') || '120', 10);
+                    const key = `deal-alert-popup:${signature}`;
+                    try {
+                        const raw = window.sessionStorage.getItem(key);
+                        if (raw) {
+                            const expiresAt = Number.parseInt(raw, 10);
+                            if (Number.isFinite(expiresAt) && Date.now() < expiresAt) {
+                                popup.remove();
+                                return;
+                            }
+                            window.sessionStorage.removeItem(key);
+                        }
+                    } catch (error) {
+                        // ignore storage access failures and still allow close interaction
+                    }
+                    const closeButton = popup.querySelector('[data-deal-alert-close]');
+                    if (!closeButton) return;
+                    closeButton.addEventListener('click', () => {
+                        try {
+                            const minutes = Number.isFinite(ttlMinutes) ? Math.max(5, ttlMinutes) : 120;
+                            const expiresAt = Date.now() + (minutes * 60 * 1000);
+                            window.sessionStorage.setItem(key, String(expiresAt));
+                        } catch (error) {
+                            // no-op
+                        }
+                        popup.remove();
+                    });
+                })();
+            </script>
         <?php endif; ?>


### PR DESCRIPTION
### Motivation
- Jobs that sync market hub and alliance data must run end-to-end against the configured hub/structure and avoid returning empty/quick runs when the source was resolved incorrectly or only partially paged. 
- The settings page exposed too much runtime diagnostic noise by default and the deal-alert popup could not be closed from the UI, harming operator UX and testing parity.

### Description
- Added DB helpers `fetch_app_setting`, `fetch_market_hub_sources_from_settings`, and `fetch_alliance_structure_sources_from_settings` to resolve authoritative `market_station_id` and `alliance_station_id` settings in the Python orchestrator. 
- Updated `market_hub_current_sync` to support both NPC-station hubs and structure hubs, use the ESI structure endpoint when required, filter region results by `location_id` for NPC hubs, and increase page depth to 20 pages to avoid shallow fetches. 
- Updated `alliance_current_sync` to resolve structure IDs from settings and increase paging depth to 20 pages. 
- Changed `orchestrator.main` `run-job` return code to return non-zero when the processor returns a `failed` status so CLI test runners reflect real job outcomes. 
- Reduced Settings page noise by gating advanced sync diagnostics behind an explicit `Show advanced diagnostics` toggle on the Data Sync section. 
- Fixed the deal-alert popup UX by adding a client-side `Close` button and a sessionStorage-based temporary close state keyed to the active alert signature so the popup can be dismissed locally without invoking server-side dismissal. 

### Testing
- Ran Python syntax checks: `python3 -m py_compile python/orchestrator/db.py python/orchestrator/jobs/market_hub_current_sync.py python/orchestrator/jobs/alliance_current_sync.py python/orchestrator/main.py`, and all files compiled successfully. (success)
- Ran PHP lint on updated views: `php -l public/settings/index.php` and `php -l src/views/partials/header.php`, and both returned no syntax errors. (success)
- Verified the updated `run-job` CLI path returns non-zero on processor `status='failed'` by inspecting `orchestrator.main` behavior and incorporated that into the test-runner flow. (validated)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4a4dc79d0832fb29ca1b3450d6821)