### PR TITLE
Handle missing systemd units in update-and-restart

### DIFF
--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -16,6 +16,7 @@ SERVICES=(
   supplycore-zkill.service
   supplycore-orchestrator.service
 )
+RESTART_SERVICES=()
 
 usage() {
   cat <<USAGE
@@ -45,6 +46,20 @@ run_cmd() {
     return 0
   fi
   "$@"
+}
+
+service_exists() {
+  local service_name=$1
+  if [[ ${DRY_RUN} -eq 1 ]]; then
+    return 0
+  fi
+  if systemctl list-unit-files --type=service --all --no-legend --plain 2>/dev/null | awk '{print $1}' | grep -Fxq "${service_name}"; then
+    return 0
+  fi
+  if systemctl list-units --type=service --all --no-legend --plain 2>/dev/null | awk '{print $1}' | grep -Fxq "${service_name}"; then
+    return 0
+  fi
+  return 1
 }
 
 parse_args() {
@@ -130,11 +145,23 @@ fi
 run_cmd systemctl daemon-reload
 
 for svc in "${SERVICES[@]}"; do
+  if service_exists "${svc}"; then
+    RESTART_SERVICES+=("${svc}")
+  else
+    log "Skipping restart for missing unit: ${svc}"
+  fi
+done
+
+if [[ ${#RESTART_SERVICES[@]} -eq 0 ]]; then
+  log "No configured services found on this host; nothing to restart."
+fi
+
+for svc in "${RESTART_SERVICES[@]}"; do
   run_cmd systemctl restart "${svc}"
 done
 
 log "Post-restart status checks"
-for svc in "${SERVICES[@]}"; do
+for svc in "${RESTART_SERVICES[@]}"; do
   run_cmd systemctl --no-pager --full status "${svc}"
 done
 


### PR DESCRIPTION
### Motivation
- Make `scripts/update-and-restart.sh` tolerant of hosts that do not have every default SupplyCore systemd unit installed so an update won't fail if a unit like `supplycore-orchestrator.service` is absent. 
- Improve operational safety by skipping missing units and running restart/status checks only for units that actually exist on the host.

### Description
- Add `RESTART_SERVICES` array and populate it only with units confirmed present on the host. 
- Add `service_exists()` helper that checks `systemctl list-unit-files` and `systemctl list-units` before attempting a restart. 
- Skip and log missing units instead of failing, and only run post-restart `systemctl status` checks for units that were found.

### Testing
- `bash -n scripts/update-and-restart.sh` was run and returned no syntax errors. 
- `./scripts/update-and-restart.sh --dry-run` was executed and produced the expected dry-run restart/status command list (no failures). 
- Changes were committed locally with the message `Handle missing systemd units in update-and-restart` and validated via `git show` output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4a70f6af0832fb3e602b5ef43bc18)