### PR TITLE
Standardize job result contract with unified JobResult dataclass

### DIFF
--- a/python/orchestrator/job_result.py
+++ b/python/orchestrator/job_result.py
@@ -1,0 +1,317 @@
+"""Canonical job result contract for all SupplyCore processors.
+
+Every job processor — compute, sync, graph, bridge — must ultimately produce
+a result that conforms to this shape.  Raw processor dicts are normalized via
+``JobResult.from_raw()`` so that all downstream consumers (worker pool,
+job runner, PHP finalizer, status UI) see the same fields.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from .json_utils import make_json_safe
+
+# ---------------------------------------------------------------------------
+# Schema version — bump when adding/removing top-level fields.
+# ---------------------------------------------------------------------------
+RESULT_SCHEMA_VERSION = "job_result.v2"
+
+# All valid top-level status values.
+VALID_STATUSES = frozenset({"success", "failed", "skipped"})
+
+
+def _utc_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _safe_int(value: Any, *, minimum: int = 0) -> int:
+    try:
+        return max(minimum, int(value))
+    except (TypeError, ValueError):
+        return minimum
+
+
+def _safe_str(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+@dataclass(slots=True)
+class JobResult:
+    """Canonical result shape returned by every SupplyCore job processor.
+
+    Fields
+    ------
+    status : str
+        One of ``"success"``, ``"failed"``, or ``"skipped"``.
+    summary : str
+        Human-readable one-line description of what happened.
+    started_at : str
+        ISO-8601 UTC timestamp when the job began.
+    finished_at : str
+        ISO-8601 UTC timestamp when the job ended.
+    duration_ms : int
+        Wall-clock runtime in milliseconds.
+    rows_seen : int
+        Total input rows considered (before filtering/skipping).
+    rows_processed : int
+        Rows that were actually processed (seen minus skipped).
+    rows_written : int
+        Rows written/upserted to output tables.
+    rows_skipped : int
+        Rows skipped (seen minus processed).
+    rows_failed : int
+        Rows that encountered errors during processing.
+    batches_completed : int
+        Number of batch iterations completed.
+    checkpoint_before : str | None
+        Cursor/checkpoint value before this run.
+    checkpoint_after : str | None
+        Cursor/checkpoint value after this run.
+    error_text : str | None
+        Error description if status is ``"failed"``, else ``None``.
+    warnings : list[str]
+        Non-fatal warnings produced during execution.
+    meta : dict[str, Any]
+        Processor-specific metadata.  Must be JSON-serializable.
+        Always includes ``schema_version`` and ``job_key``.
+    """
+
+    status: str = "success"
+    summary: str = ""
+    started_at: str = ""
+    finished_at: str = ""
+    duration_ms: int = 0
+    rows_seen: int = 0
+    rows_processed: int = 0
+    rows_written: int = 0
+    rows_skipped: int = 0
+    rows_failed: int = 0
+    batches_completed: int = 0
+    checkpoint_before: str | None = None
+    checkpoint_after: str | None = None
+    error_text: str | None = None
+    warnings: list[str] = field(default_factory=list)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_raw(cls, raw: dict[str, Any], *, job_key: str = "") -> JobResult:
+        """Normalize an arbitrary processor return dict into the canonical shape.
+
+        This is the *single* normalization entry-point that replaces the old
+        ``_compute_result_shape`` and ``_graph_result_shape`` helpers.
+        """
+        safe = make_json_safe(raw)
+
+        status = _safe_str(raw.get("status"), "success")
+        if status not in VALID_STATUSES:
+            status = "success"
+
+        rows_seen = _safe_int(raw.get("rows_seen") or raw.get("rows_processed"))
+        rows_processed = _safe_int(raw.get("rows_processed"))
+        rows_written = _safe_int(raw.get("rows_written"))
+        rows_skipped = _safe_int(raw.get("rows_skipped") or (rows_seen - rows_processed))
+        rows_failed = _safe_int(raw.get("rows_failed"))
+
+        now = _utc_iso()
+        started_at = _safe_str(raw.get("started_at"), now)
+        finished_at = _safe_str(raw.get("finished_at"), now)
+        duration_ms = _safe_int(raw.get("duration_ms"))
+
+        summary = _safe_str(
+            raw.get("summary"),
+            f"{job_key or 'job'} completed with status {status}.",
+        )
+
+        error_text = _safe_str(raw.get("error_text") or raw.get("error"), "") or None
+
+        warnings = [str(w) for w in list(safe.get("warnings") or [])]
+
+        # Build meta — preserve processor-specific keys, inject contract keys.
+        raw_meta = dict(safe.get("meta") or {})
+        raw_meta.setdefault("job_key", job_key)
+        raw_meta.setdefault("schema_version", RESULT_SCHEMA_VERSION)
+        if "computed_at" not in raw_meta:
+            computed_at = _safe_str(raw.get("computed_at"))
+            if computed_at:
+                raw_meta["computed_at"] = computed_at
+
+        # Preserve non-canonical root-level fields (e.g. cursor, checksum,
+        # run_id) that processors may return.  These are moved into meta so
+        # they remain accessible without polluting the canonical envelope.
+        _CANONICAL_KEYS = {
+            "status", "summary", "started_at", "finished_at", "duration_ms",
+            "rows_seen", "rows_processed", "rows_written", "rows_skipped",
+            "rows_failed", "batches_completed", "checkpoint_before",
+            "checkpoint_after", "error_text", "error", "warnings", "meta",
+            "computed_at",
+        }
+        for key, value in safe.items():
+            if key not in _CANONICAL_KEYS and key not in raw_meta:
+                raw_meta[key] = value
+
+        return cls(
+            status=status,
+            summary=summary,
+            started_at=started_at,
+            finished_at=finished_at,
+            duration_ms=duration_ms,
+            rows_seen=rows_seen,
+            rows_processed=rows_processed,
+            rows_written=rows_written,
+            rows_skipped=rows_skipped,
+            rows_failed=rows_failed,
+            batches_completed=_safe_int(raw.get("batches_completed")),
+            checkpoint_before=raw.get("checkpoint_before"),
+            checkpoint_after=raw.get("checkpoint_after"),
+            error_text=error_text,
+            warnings=warnings,
+            meta=raw_meta,
+        )
+
+    @classmethod
+    def success(
+        cls,
+        *,
+        job_key: str,
+        summary: str,
+        rows_processed: int = 0,
+        rows_written: int = 0,
+        started_at: str = "",
+        finished_at: str = "",
+        duration_ms: int = 0,
+        meta: dict[str, Any] | None = None,
+        warnings: list[str] | None = None,
+        **kwargs: Any,
+    ) -> JobResult:
+        """Convenience builder for a successful result."""
+        now = _utc_iso()
+        return cls(
+            status="success",
+            summary=summary,
+            started_at=started_at or now,
+            finished_at=finished_at or now,
+            duration_ms=duration_ms,
+            rows_seen=kwargs.get("rows_seen", rows_processed),
+            rows_processed=rows_processed,
+            rows_written=rows_written,
+            rows_skipped=kwargs.get("rows_skipped", 0),
+            rows_failed=kwargs.get("rows_failed", 0),
+            batches_completed=kwargs.get("batches_completed", 0),
+            checkpoint_before=kwargs.get("checkpoint_before"),
+            checkpoint_after=kwargs.get("checkpoint_after"),
+            error_text=None,
+            warnings=warnings or [],
+            meta={
+                "job_key": job_key,
+                "schema_version": RESULT_SCHEMA_VERSION,
+                **(meta or {}),
+            },
+        )
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        job_key: str,
+        error: str | Exception,
+        started_at: str = "",
+        finished_at: str = "",
+        duration_ms: int = 0,
+        meta: dict[str, Any] | None = None,
+    ) -> JobResult:
+        """Convenience builder for a failed result."""
+        now = _utc_iso()
+        error_text = f"{type(error).__name__}: {error}" if isinstance(error, Exception) else str(error)
+        return cls(
+            status="failed",
+            summary=error_text,
+            started_at=started_at or now,
+            finished_at=finished_at or now,
+            duration_ms=duration_ms,
+            error_text=error_text,
+            warnings=[error_text],
+            meta={
+                "job_key": job_key,
+                "schema_version": RESULT_SCHEMA_VERSION,
+                **(meta or {}),
+            },
+        )
+
+    @classmethod
+    def skipped(
+        cls,
+        *,
+        job_key: str,
+        reason: str,
+        meta: dict[str, Any] | None = None,
+    ) -> JobResult:
+        """Convenience builder for a skipped result."""
+        now = _utc_iso()
+        return cls(
+            status="skipped",
+            summary=reason,
+            started_at=now,
+            finished_at=now,
+            meta={
+                "job_key": job_key,
+                "schema_version": RESULT_SCHEMA_VERSION,
+                "skip_reason": reason,
+                **(meta or {}),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict suitable for JSON encoding and DB storage."""
+        return make_json_safe({
+            "status": self.status,
+            "summary": self.summary,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "duration_ms": self.duration_ms,
+            "rows_seen": self.rows_seen,
+            "rows_processed": self.rows_processed,
+            "rows_written": self.rows_written,
+            "rows_skipped": self.rows_skipped,
+            "rows_failed": self.rows_failed,
+            "batches_completed": self.batches_completed,
+            "checkpoint_before": self.checkpoint_before,
+            "checkpoint_after": self.checkpoint_after,
+            "error_text": self.error_text,
+            "warnings": list(self.warnings),
+            "meta": dict(self.meta),
+        })
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate(self) -> list[str]:
+        """Return a list of contract violations (empty if valid)."""
+        issues: list[str] = []
+        if self.status not in VALID_STATUSES:
+            issues.append(f"Invalid status: {self.status!r} (expected one of {sorted(VALID_STATUSES)})")
+        if not self.summary:
+            issues.append("Missing summary")
+        if self.status == "failed" and not self.error_text:
+            issues.append("Status is 'failed' but error_text is empty")
+        if self.rows_processed > self.rows_seen:
+            issues.append(f"rows_processed ({self.rows_processed}) > rows_seen ({self.rows_seen})")
+        if self.rows_written > self.rows_processed:
+            issues.append(f"rows_written ({self.rows_written}) > rows_processed ({self.rows_processed})")
+        if self.duration_ms < 0:
+            issues.append(f"Negative duration_ms: {self.duration_ms}")
+        return issues

--- a/python/orchestrator/job_runner.py
+++ b/python/orchestrator/job_runner.py
@@ -12,6 +12,7 @@ from typing import Any
 from .bridge import PhpBridge
 from .config import load_php_runtime_config
 from .db import SupplyCoreDb
+from .job_result import JobResult
 from .json_utils import json_dumps_safe
 from .jobs import (
     run_killmail_r2z2_stream,
@@ -177,19 +178,15 @@ def _run_php_fallback(context: PythonWorkerContext, bridge: PhpBridge) -> dict[s
         "run-job-handler",
         args=[f"--job-key={context.job_key}", "--reason=python-fallback"],
     )
-    result = dict(response.get("result") or {})
-    result.setdefault("status", "success")
-    result.setdefault("summary", f"Executed {context.job_key} via PHP fallback inside Python worker mode.")
-    result.setdefault("duration_ms", 0)
-    result.setdefault("started_at", utc_now_iso())
-    result.setdefault("finished_at", utc_now_iso())
-    result.setdefault("meta", {})
-    meta = dict(result.get("meta") or {})
-    meta["execution_mode"] = "python"
-    meta["fallback_runtime"] = "php"
-    meta.setdefault("outcome_reason", "Job used the PHP handler through the Python-worker fallback bridge.")
-    result["meta"] = meta
-    return result
+    raw = dict(response.get("result") or {})
+    raw.setdefault("summary", f"Executed {context.job_key} via PHP fallback inside Python worker mode.")
+    raw.setdefault("meta", {})
+    raw_meta = dict(raw.get("meta") or {})
+    raw_meta["execution_mode"] = "python"
+    raw_meta["fallback_runtime"] = "php"
+    raw_meta.setdefault("outcome_reason", "Job used the PHP handler through the Python-worker fallback bridge.")
+    raw["meta"] = raw_meta
+    return JobResult.from_raw(raw, job_key=context.job_key).to_dict()
 
 
 def process_job(context: PythonWorkerContext) -> dict[str, Any]:
@@ -220,11 +217,17 @@ def process_job(context: PythonWorkerContext) -> dict[str, Any]:
         else:
             raise RuntimeError(f"No Python processor is registered for job {context.job_key}.")
     else:
-        result = processor(context)
+        raw = processor(context)
+        result = JobResult.from_raw(raw, job_key=context.job_key).to_dict()
 
-    result.setdefault("duration_ms", int((time.time() - start) * 1000))
-    result.setdefault("started_at", utc_now_iso())
-    result.setdefault("finished_at", utc_now_iso())
+    # Back-fill timing if the processor didn't provide it.
+    elapsed = int((time.time() - start) * 1000)
+    if not result.get("duration_ms"):
+        result["duration_ms"] = elapsed
+    if not result.get("started_at"):
+        result["started_at"] = utc_now_iso()
+    if not result.get("finished_at"):
+        result["finished_at"] = utc_now_iso()
     result.setdefault("meta", {})
     result["meta"] = dict(result.get("meta") or {})
     result["meta"]["cli_options"] = dict(context.cli_options)
@@ -273,22 +276,15 @@ def main() -> int:
         result = process_job(context)
         result["run_id"] = run_id
     except Exception as error:  # noqa: BLE001
-        result = {
-            "status": "failed",
-            "error": str(error),
-            "summary": str(error),
-            "rows_seen": 0,
-            "rows_written": 0,
-            "warnings": [],
-            "duration_ms": 0,
-            "started_at": utc_now_iso(),
-            "finished_at": utc_now_iso(),
-            "run_id": run_id,
-            "meta": {
+        result = JobResult.failed(
+            job_key=context.job_key,
+            error=error,
+            meta={
                 "execution_mode": "python",
                 "memory_usage_bytes": resident_memory_bytes(),
             },
-        }
+        ).to_dict()
+        result["run_id"] = run_id
         exit_code = 1
 
     try:

--- a/python/orchestrator/jobs/sync_runtime.py
+++ b/python/orchestrator/jobs/sync_runtime.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any, Callable
 
 from ..db import SupplyCoreDb
+from ..job_result import JobResult, RESULT_SCHEMA_VERSION
 
 
 SYNC_JOB_CONTRACTS: dict[str, dict[str, Any]] = {
@@ -146,6 +147,17 @@ def run_sync_phase_job(
     started_at = datetime.now(UTC)
     started_at_iso = started_at.strftime("%Y-%m-%dT%H:%M:%SZ")
     contract = get_sync_job_contract(job_key)
+
+    sync_meta = {
+        "job_key": job_key,
+        "phase": phase,
+        "objective": objective,
+        "job_contract": contract,
+        "execution_language": "python",
+        "subprocess_invoked": False,
+        "schema_version": RESULT_SCHEMA_VERSION,
+    }
+
     try:
         payload = processor(db)
         db_now = db.fetch_one("SELECT UTC_TIMESTAMP() AS now_utc") or {}
@@ -154,66 +166,48 @@ def run_sync_phase_job(
         rows_processed = max(0, int(payload.get("rows_processed") or 0))
         rows_written = max(0, int(payload.get("rows_written") or 0))
         rows_seen = max(0, int(payload.get("rows_seen") or rows_processed))
-        return {
-            "status": str(payload.get("status") or "success"),
-            "summary": str(payload.get("summary") or f"{job_key} completed phase {phase} objective: {objective}."),
-            "started_at": started_at_iso,
-            "finished_at": finished_at_iso,
-            "duration_ms": duration_ms,
-            "rows_seen": rows_seen,
-            "rows_processed": rows_processed,
-            "rows_written": rows_written,
-            "rows_skipped": max(0, rows_seen - rows_processed),
-            "rows_failed": max(0, int(payload.get("rows_failed") or 0)),
-            "batches_completed": max(1, int(payload.get("batches_completed") or 1)),
-            "checkpoint_before": payload.get("checkpoint_before"),
-            "checkpoint_after": payload.get("checkpoint_after"),
-            "warnings": [str(item) for item in list(payload.get("warnings") or [])],
-            "error_text": None,
-            "computed_at": started_at.strftime("%Y-%m-%d %H:%M:%S"),
-            "meta": {
-                "job_key": job_key,
-                "phase": phase,
-                "objective": objective,
-                "job_contract": contract,
-                "execution_language": "python",
-                "subprocess_invoked": False,
+
+        result = JobResult(
+            status=str(payload.get("status") or "success"),
+            summary=str(payload.get("summary") or f"{job_key} completed phase {phase} objective: {objective}."),
+            started_at=started_at_iso,
+            finished_at=finished_at_iso,
+            duration_ms=duration_ms,
+            rows_seen=rows_seen,
+            rows_processed=rows_processed,
+            rows_written=rows_written,
+            rows_skipped=max(0, rows_seen - rows_processed),
+            rows_failed=max(0, int(payload.get("rows_failed") or 0)),
+            batches_completed=max(1, int(payload.get("batches_completed") or 1)),
+            checkpoint_before=payload.get("checkpoint_before"),
+            checkpoint_after=payload.get("checkpoint_after"),
+            error_text=None,
+            warnings=[str(item) for item in list(payload.get("warnings") or [])],
+            meta={
+                **sync_meta,
                 "error_classification": None,
-                "event_schema_version": "sync_result.v1",
                 "db_now_utc": str(db_now.get("now_utc") or ""),
+                "computed_at": started_at.strftime("%Y-%m-%d %H:%M:%S"),
                 **_serialize_value(dict(payload.get("meta") or {})),
             },
-        }
+        )
+        return result.to_dict()
+
     except Exception as exc:
         finished_at_iso = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         duration_ms = int((time.perf_counter() - started_perf) * 1000)
-        error_text = f"{type(exc).__name__}: {exc}"
         error_class = _classify_error(exc)
-        return {
-            "status": "failed",
-            "summary": f"{job_key} failed in phase {phase}: {exc}",
-            "started_at": started_at_iso,
-            "finished_at": finished_at_iso,
-            "duration_ms": duration_ms,
-            "rows_seen": 0,
-            "rows_processed": 0,
-            "rows_written": 0,
-            "rows_skipped": 0,
-            "rows_failed": 0,
-            "batches_completed": 0,
-            "checkpoint_before": None,
-            "checkpoint_after": None,
-            "warnings": [error_text],
-            "error_text": error_text,
-            "computed_at": started_at.strftime("%Y-%m-%d %H:%M:%S"),
-            "meta": {
-                "job_key": job_key,
-                "phase": phase,
-                "objective": objective,
-                "job_contract": contract,
-                "execution_language": "python",
-                "subprocess_invoked": False,
+
+        result = JobResult.failed(
+            job_key=job_key,
+            error=exc,
+            started_at=started_at_iso,
+            finished_at=finished_at_iso,
+            duration_ms=duration_ms,
+            meta={
+                **sync_meta,
                 "error_classification": error_class,
-                "event_schema_version": "sync_result.v1",
+                "computed_at": started_at.strftime("%Y-%m-%d %H:%M:%S"),
             },
-        }
+        )
+        return result.to_dict()

--- a/python/orchestrator/processor_registry.py
+++ b/python/orchestrator/processor_registry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from .job_context import battle_runtime, influx_runtime, neo4j_runtime
-from .json_utils import make_json_safe
+from .job_result import JobResult
 from .jobs import (
     run_compute_battle_actor_features,
     run_compute_battle_anomalies,
@@ -77,78 +77,57 @@ PYTHON_SYNC_PROCESSOR_JOB_KEYS: set[str] = {
 PYTHON_PROCESSOR_JOB_KEYS: set[str] = PYTHON_COMPUTE_PROCESSOR_JOB_KEYS | PYTHON_SYNC_PROCESSOR_JOB_KEYS
 
 
+_PROCESSOR_DISPATCH: dict[str, tuple] = {
+    # Graph pipeline jobs — (callable, arg_factory)
+    "compute_graph_sync": (run_compute_graph_sync, lambda db, cfg: (db, neo4j_runtime(cfg))),
+    "compute_graph_sync_doctrine_dependency": (run_compute_graph_sync_doctrine_dependency, lambda db, cfg: (db, neo4j_runtime(cfg))),
+    "compute_graph_sync_battle_intelligence": (run_compute_graph_sync_battle_intelligence, lambda db, cfg: (db, neo4j_runtime(cfg))),
+    "compute_graph_derived_relationships": (run_compute_graph_derived_relationships, lambda db, cfg: (db, neo4j_runtime(cfg))),
+    "compute_graph_insights": (run_compute_graph_insights, lambda db, cfg: (db, neo4j_runtime(cfg))),
+    "compute_graph_prune": (run_compute_graph_prune, lambda db, cfg: (db, neo4j_runtime(cfg))),
+    "compute_graph_topology_metrics": (run_compute_graph_topology_metrics, lambda db, cfg: (db, neo4j_runtime(cfg))),
+    # Battle intelligence jobs
+    "compute_behavioral_baselines": (run_compute_behavioral_baselines, lambda db, cfg: (db, battle_runtime(cfg))),
+    "compute_suspicion_scores_v2": (run_compute_suspicion_scores_v2, lambda db, cfg: (db, battle_runtime(cfg))),
+    "compute_battle_rollups": (run_compute_battle_rollups, lambda db, cfg: (db, battle_runtime(cfg))),
+    "compute_battle_target_metrics": (run_compute_battle_target_metrics, lambda db, cfg: (db, battle_runtime(cfg))),
+    "compute_battle_anomalies": (run_compute_battle_anomalies, lambda db, cfg: (db, battle_runtime(cfg))),
+    "compute_battle_actor_features": (run_compute_battle_actor_features, lambda db, cfg: (db, neo4j_runtime(cfg), battle_runtime(cfg))),
+    "compute_suspicion_scores": (run_compute_suspicion_scores, lambda db, cfg: (db, battle_runtime(cfg))),
+    "compute_counterintel_pipeline": (run_compute_counterintel_pipeline, lambda db, cfg: (db, neo4j_runtime(cfg), battle_runtime(cfg))),
+    # Market / supply intelligence jobs
+    "compute_buy_all": (run_compute_buy_all, lambda db, cfg: (db,)),
+    "compute_signals": (run_compute_signals, lambda db, cfg: (db, influx_runtime(cfg))),
+    # Sync phase jobs
+    "market_hub_current_sync": (run_market_hub_current_sync, lambda db, cfg: (db,)),
+    "alliance_current_sync": (run_alliance_current_sync, lambda db, cfg: (db,)),
+    "market_hub_historical_sync": (run_market_hub_historical_sync, lambda db, cfg: (db,)),
+    "alliance_historical_sync": (run_alliance_historical_sync, lambda db, cfg: (db,)),
+    "current_state_refresh_sync": (run_current_state_refresh_sync, lambda db, cfg: (db,)),
+    "analytics_bucket_1h_sync": (run_analytics_bucket_1h_sync, lambda db, cfg: (db,)),
+    "analytics_bucket_1d_sync": (run_analytics_bucket_1d_sync, lambda db, cfg: (db,)),
+    "activity_priority_summary_sync": (run_activity_priority_summary_sync, lambda db, cfg: (db,)),
+    "dashboard_summary_sync": (run_dashboard_summary_sync, lambda db, cfg: (db,)),
+    "loss_demand_summary_sync": (run_loss_demand_summary_sync, lambda db, cfg: (db,)),
+    "doctrine_intelligence_sync": (run_doctrine_intelligence_sync, lambda db, cfg: (db,)),
+    "deal_alerts_sync": (run_deal_alerts_sync, lambda db, cfg: (db,)),
+    "rebuild_ai_briefings": (run_rebuild_ai_briefings, lambda db, cfg: (db,)),
+    "forecasting_ai_sync": (run_forecasting_ai_sync, lambda db, cfg: (db,)),
+}
+
+
 def run_registered_processor(job_key: str, db: Any, raw_config: dict[str, Any]) -> dict[str, Any]:
-    if job_key == "compute_graph_sync":
-        return _graph_result_shape(run_compute_graph_sync(db, neo4j_runtime(raw_config)), job_key)
-    if job_key == "compute_graph_sync_doctrine_dependency":
-        return _graph_result_shape(run_compute_graph_sync_doctrine_dependency(db, neo4j_runtime(raw_config)), job_key)
-    if job_key == "compute_graph_sync_battle_intelligence":
-        return _graph_result_shape(run_compute_graph_sync_battle_intelligence(db, neo4j_runtime(raw_config)), job_key)
-    if job_key == "compute_graph_derived_relationships":
-        return _graph_result_shape(run_compute_graph_derived_relationships(db, neo4j_runtime(raw_config)), job_key)
-    if job_key == "compute_graph_insights":
-        return _graph_result_shape(run_compute_graph_insights(db, neo4j_runtime(raw_config)), job_key)
-    if job_key == "compute_graph_prune":
-        return _graph_result_shape(run_compute_graph_prune(db, neo4j_runtime(raw_config)), job_key)
-    if job_key == "compute_graph_topology_metrics":
-        return _graph_result_shape(run_compute_graph_topology_metrics(db, neo4j_runtime(raw_config)), job_key)
-    if job_key == "compute_behavioral_baselines":
-        return _compute_result_shape(run_compute_behavioral_baselines(db, battle_runtime(raw_config)), job_key)
-    if job_key == "compute_suspicion_scores_v2":
-        return _compute_result_shape(run_compute_suspicion_scores_v2(db, battle_runtime(raw_config)), job_key)
-    if job_key == "compute_buy_all":
-        return _compute_result_shape(run_compute_buy_all(db), job_key)
-    if job_key == "compute_signals":
-        return _compute_result_shape(run_compute_signals(db, influx_runtime(raw_config)), job_key)
-    if job_key == "compute_battle_rollups":
-        return _compute_result_shape(run_compute_battle_rollups(db, battle_runtime(raw_config)), job_key)
-    if job_key == "compute_battle_target_metrics":
-        return _compute_result_shape(run_compute_battle_target_metrics(db, battle_runtime(raw_config)), job_key)
-    if job_key == "compute_battle_anomalies":
-        return _compute_result_shape(run_compute_battle_anomalies(db, battle_runtime(raw_config)), job_key)
-    if job_key == "compute_battle_actor_features":
-        return _compute_result_shape(run_compute_battle_actor_features(db, neo4j_runtime(raw_config), battle_runtime(raw_config)), job_key)
-    if job_key == "compute_suspicion_scores":
-        return _compute_result_shape(run_compute_suspicion_scores(db, battle_runtime(raw_config)), job_key)
-    if job_key == "compute_counterintel_pipeline":
-        return _compute_result_shape(
-            run_compute_counterintel_pipeline(db, neo4j_runtime(raw_config), battle_runtime(raw_config)),
-            job_key,
+    entry = _PROCESSOR_DISPATCH.get(job_key)
+    if entry is None:
+        in_compute_registry = job_key in PYTHON_COMPUTE_PROCESSOR_JOB_KEYS
+        in_sync_registry = job_key in PYTHON_SYNC_PROCESSOR_JOB_KEYS
+        raise KeyError(
+            "No Python processor is registered for job "
+            f"{job_key} (in_compute_registry={in_compute_registry}, in_sync_registry={in_sync_registry})."
         )
-    if job_key == "market_hub_current_sync":
-        return _compute_result_shape(run_market_hub_current_sync(db), job_key)
-    if job_key == "alliance_current_sync":
-        return _compute_result_shape(run_alliance_current_sync(db), job_key)
-    if job_key == "market_hub_historical_sync":
-        return _compute_result_shape(run_market_hub_historical_sync(db), job_key)
-    if job_key == "alliance_historical_sync":
-        return _compute_result_shape(run_alliance_historical_sync(db), job_key)
-    if job_key == "current_state_refresh_sync":
-        return _compute_result_shape(run_current_state_refresh_sync(db), job_key)
-    if job_key == "analytics_bucket_1h_sync":
-        return _compute_result_shape(run_analytics_bucket_1h_sync(db), job_key)
-    if job_key == "analytics_bucket_1d_sync":
-        return _compute_result_shape(run_analytics_bucket_1d_sync(db), job_key)
-    if job_key == "activity_priority_summary_sync":
-        return _compute_result_shape(run_activity_priority_summary_sync(db), job_key)
-    if job_key == "dashboard_summary_sync":
-        return _compute_result_shape(run_dashboard_summary_sync(db), job_key)
-    if job_key == "loss_demand_summary_sync":
-        return _compute_result_shape(run_loss_demand_summary_sync(db), job_key)
-    if job_key == "doctrine_intelligence_sync":
-        return _compute_result_shape(run_doctrine_intelligence_sync(db), job_key)
-    if job_key == "deal_alerts_sync":
-        return _compute_result_shape(run_deal_alerts_sync(db), job_key)
-    if job_key == "rebuild_ai_briefings":
-        return _compute_result_shape(run_rebuild_ai_briefings(db), job_key)
-    if job_key == "forecasting_ai_sync":
-        return _compute_result_shape(run_forecasting_ai_sync(db), job_key)
-    in_compute_registry = job_key in PYTHON_COMPUTE_PROCESSOR_JOB_KEYS
-    in_sync_registry = job_key in PYTHON_SYNC_PROCESSOR_JOB_KEYS
-    raise KeyError(
-        "No Python processor is registered for job "
-        f"{job_key} (in_compute_registry={in_compute_registry}, in_sync_registry={in_sync_registry})."
-    )
+    processor_fn, arg_factory = entry
+    raw_result = processor_fn(*arg_factory(db, raw_config))
+    return JobResult.from_raw(raw_result, job_key=job_key).to_dict()
 
 
 def audit_enabled_python_jobs(db: Any) -> dict[str, Any]:
@@ -175,51 +154,6 @@ def audit_enabled_python_jobs(db: Any) -> dict[str, Any]:
     return {"jobs": matrix, "issues": issues}
 
 
-def _graph_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
-    safe_result = make_json_safe(result)
-    rows_seen = max(0, int(result.get("rows_processed") or result.get("rows_seen") or 0))
-    rows_written = max(0, int(result.get("rows_written") or 0))
-    status = str(result.get("status") or "success")
-    summary = str(result.get("summary") or f"{job_key} finished with status {status}.")
-    return {
-        "status": status,
-        "summary": summary,
-        "rows_processed": rows_seen,
-        "rows_written": rows_written,
-        "warnings": list(safe_result.get("warnings") or []),
-        "meta": dict(safe_result.get("meta") or {}),
-    }
-
-
-def _compute_result_shape(result: dict[str, Any], job_key: str) -> dict[str, Any]:
-    safe_result = make_json_safe(result)
-    status = str(result.get("status") or "success")
-    rows_seen = max(0, int(result.get("rows_seen") or result.get("rows_processed") or 0))
-    rows_processed = max(0, int(result.get("rows_processed") or 0))
-    rows_written = max(0, int(result.get("rows_written") or 0))
-    return {
-        "status": status,
-        "summary": str(result.get("summary") or f"{job_key} completed with status {status}."),
-        "started_at": str(result.get("started_at") or ""),
-        "finished_at": str(result.get("finished_at") or ""),
-        "duration_ms": max(0, int(result.get("duration_ms") or 0)),
-        "rows_seen": rows_seen,
-        "rows_processed": rows_processed,
-        "rows_written": rows_written,
-        "rows_skipped": max(0, int(result.get("rows_skipped") or (rows_seen - rows_processed))),
-        "rows_failed": max(0, int(result.get("rows_failed") or 0)),
-        "batches_completed": max(0, int(result.get("batches_completed") or 0)),
-        "checkpoint_before": result.get("checkpoint_before"),
-        "checkpoint_after": result.get("checkpoint_after"),
-        "error_text": str(result.get("error_text") or "") or None,
-        "warnings": list(safe_result.get("warnings") or []),
-        "meta": {
-            "job_name": job_key,
-            "computed_at": str(result.get("computed_at") or ""),
-            "result": dict(safe_result),
-        },
-    }
-
-
 def run_compute_processor(job_key: str, db: Any, raw_config: dict[str, Any]) -> dict[str, Any]:
+    """Backward-compatible alias for ``run_registered_processor``."""
     return run_registered_processor(job_key, db, raw_config)

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -14,6 +14,7 @@ import pymysql
 
 from .config import load_php_runtime_config
 from .db import SupplyCoreDb
+from .job_result import JobResult
 from .json_utils import json_dumps_safe, make_json_safe
 from .logging_utils import LoggerAdapter, configure_logging
 from .processor_registry import audit_enabled_python_jobs, run_registered_processor
@@ -86,11 +87,17 @@ def _write_state_file(path: Path, payload: dict[str, Any]) -> None:
 def _process_job(context: WorkerPoolContext) -> dict[str, Any]:
     started = time.monotonic()
     result = run_registered_processor(context.job_key, context.db, context.raw_config)
-    result.setdefault("duration_ms", int((time.monotonic() - started) * 1000))
-    result.setdefault("started_at", utc_now_iso())
-    result.setdefault("finished_at", utc_now_iso())
-    result["execution_language"] = "python"
-    result["subprocess_invoked"] = False
+    # Back-fill timing if the processor didn't provide it.
+    elapsed = int((time.monotonic() - started) * 1000)
+    if not result.get("duration_ms"):
+        result["duration_ms"] = elapsed
+    if not result.get("started_at"):
+        result["started_at"] = utc_now_iso()
+    if not result.get("finished_at"):
+        result["finished_at"] = utc_now_iso()
+    result.setdefault("meta", {})
+    result["meta"]["execution_language"] = "python"
+    result["meta"]["subprocess_invoked"] = False
     return make_json_safe(result)
 
 
@@ -209,7 +216,12 @@ def main(argv: list[str] | None = None) -> int:
             db.complete_worker_job(int(job.get("id") or 0), worker_id, result)
             logger.info("worker job completed", payload={"event": "worker_pool.job_completed", "worker_id": worker_id, "job_id": int(job.get("id") or 0), "job_key": context.job_key, "status": result.get("status", "success"), "execution_language": "python", "subprocess_invoked": False, "duration_ms": result.get("duration_ms", 0), "rows_processed": result.get("rows_processed", 0), "rows_written": result.get("rows_written", 0)})
         except Exception as error:  # noqa: BLE001
-            db.retry_worker_job(int(job.get("id") or 0), worker_id, str(error), retry_backoff, {"status": "failed", "error": str(error), "summary": str(error), "finished_at": utc_now_iso(), "execution_language": "python", "subprocess_invoked": False})
+            fail_result = JobResult.failed(
+                job_key=context.job_key,
+                error=error,
+                meta={"execution_language": "python", "subprocess_invoked": False},
+            ).to_dict()
+            db.retry_worker_job(int(job.get("id") or 0), worker_id, str(error), retry_backoff, fail_result)
             logger.warning("worker job failed", payload={"event": "worker_pool.job_failed", "worker_id": worker_id, "job_id": int(job.get("id") or 0), "job_key": context.job_key, "error": str(error)})
             if args.once:
                 return 1

--- a/python/tests/test_compute_processor_routing.py
+++ b/python/tests/test_compute_processor_routing.py
@@ -7,6 +7,7 @@ import re
 from unittest.mock import patch
 
 from orchestrator import processor_registry
+from orchestrator.job_result import JobResult
 from orchestrator.job_runner import PHP_BRIDGED_JOB_KEYS
 
 
@@ -43,8 +44,8 @@ class ComputeProcessorRoutingTests(unittest.TestCase):
         runtime.assert_called_once()
         self.assertEqual(result["status"], "success")
 
-    def test_compute_result_shape_serializes_datetime_and_decimal_metadata(self) -> None:
-        shaped = processor_registry._compute_result_shape(  # noqa: SLF001
+    def test_job_result_from_raw_serializes_datetime_and_decimal_metadata(self) -> None:
+        result = JobResult.from_raw(
             {
                 "status": "success",
                 "rows_processed": 1,
@@ -53,9 +54,9 @@ class ComputeProcessorRoutingTests(unittest.TestCase):
                 "warnings": [],
                 "sample": {"ts": datetime(2026, 3, 25, tzinfo=UTC), "score": Decimal("0.1250")},
             },
-            "compute_suspicion_scores_v2",
-        )
-        sample = shaped["meta"]["result"]["sample"]
+            job_key="compute_suspicion_scores_v2",
+        ).to_dict()
+        sample = result["meta"]["sample"]
         self.assertEqual(sample["ts"], "2026-03-25T00:00:00+00:00")
         self.assertEqual(sample["score"], "0.1250")
 


### PR DESCRIPTION
Replace three separate normalization paths (_compute_result_shape, _graph_result_shape, and the sync_runtime wrapper) with a single JobResult dataclass that enforces a canonical 16-field envelope across all 30 processors.

- Add python/orchestrator/job_result.py with from_raw(), success(), failed(), skipped() builders and to_dict()/validate() methods
- Replace processor_registry if/elif chain with data-driven _PROCESSOR_DISPATCH table
- Update sync_runtime.py, job_runner.py, and worker_pool.py error handlers to produce JobResult
- Non-canonical processor fields (cursor, checksum, etc.) are preserved in meta automatically
- Update test to use JobResult instead of removed _compute_result_shape

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf