### PR TITLE
Standardize job result contract across all processors

### DIFF
--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -13,11 +13,13 @@ if __package__ in (None, ""):
     if package_root not in sys.path:
         sys.path.insert(0, package_root)
     from orchestrator.db import SupplyCoreDb
+    from orchestrator.job_result import JobResult
     from orchestrator.json_utils import json_dumps_safe
     from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
     from orchestrator.neo4j import Neo4jClient, Neo4jConfig
 else:
     from ..db import SupplyCoreDb
+    from ..job_result import JobResult
     from ..json_utils import json_dumps_safe
     from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
     from ..neo4j import Neo4jClient, Neo4jConfig
@@ -222,7 +224,7 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
     lock_key = "compute_battle_rollups"
     owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
     if owner is None:
-        result = {"rows_processed": 0, "rows_written": 0, "status": "skipped", "reason": "lock-not-acquired", "job_name": "compute_battle_rollups"}
+        result = JobResult.skipped(job_key="compute_battle_rollups", reason="lock-not-acquired").to_dict()
         _battle_log(runtime, "battle_intelligence.job.skipped", result)
         return result
 
@@ -504,19 +506,21 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
             meta={"computed_at": computed_at, "batch_count": batch_count, "cursor_start": cursor_start, "cursor_end": cursor_end},
         )
         duration_ms = int((datetime.now(UTC) - started_monotonic).total_seconds() * 1000)
-        result = {
-            "rows_processed": rows_processed,
-            "rows_written": 0 if dry_run else rows_written,
-            "rows_would_write": rows_written,
-            "batch_count": batch_count,
-            "cursor_start": cursor_start,
-            "cursor_end": cursor_end,
-            "computed_at": computed_at,
-            "duration_ms": duration_ms,
-            "dry_run": dry_run,
-            "job_name": "compute_battle_rollups",
-            "status": "success",
-        }
+        result = JobResult.success(
+            job_key="compute_battle_rollups",
+            summary=f"Rolled up {rows_processed} killmails into battles across {batch_count} batches.",
+            rows_processed=rows_processed,
+            rows_written=0 if dry_run else rows_written,
+            duration_ms=duration_ms,
+            batches_completed=batch_count,
+            meta={
+                "computed_at": computed_at,
+                "rows_would_write": rows_written,
+                "cursor_start": cursor_start,
+                "cursor_end": cursor_end,
+                "dry_run": dry_run,
+            },
+        ).to_dict()
         _battle_log(runtime, "battle_intelligence.job.success", result)
         return result
     except Exception as exc:
@@ -536,7 +540,7 @@ def run_compute_battle_target_metrics(db: SupplyCoreDb, runtime: dict[str, Any] 
     lock_key = "compute_battle_target_metrics"
     owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
     if owner is None:
-        result = {"rows_processed": 0, "rows_written": 0, "status": "skipped", "reason": "lock-not-acquired", "job_name": "compute_battle_target_metrics"}
+        result = JobResult.skipped(job_key="compute_battle_target_metrics", reason="lock-not-acquired").to_dict()
         _battle_log(runtime, "battle_intelligence.job.skipped", result)
         return result
 
@@ -704,20 +708,22 @@ def run_compute_battle_target_metrics(db: SupplyCoreDb, runtime: dict[str, Any] 
             meta={"computed_at": computed_at, "unscored_targets": unscored_targets, "batch_count": batch_count, "cursor_start": cursor_start, "cursor_end": cursor_end},
         )
         duration_ms = int((datetime.now(UTC) - started_monotonic).total_seconds() * 1000)
-        result = {
-            "rows_processed": rows_processed,
-            "rows_written": 0 if dry_run else rows_written,
-            "rows_would_write": rows_written,
-            "computed_at": computed_at,
-            "unscored_targets": unscored_targets,
-            "batch_count": batch_count,
-            "cursor_start": cursor_start,
-            "cursor_end": cursor_end,
-            "duration_ms": duration_ms,
-            "dry_run": dry_run,
-            "job_name": "compute_battle_target_metrics",
-            "status": "success",
-        }
+        result = JobResult.success(
+            job_key="compute_battle_target_metrics",
+            summary=f"Scored {rows_processed} target metrics across {batch_count} batches ({unscored_targets} unscored).",
+            rows_processed=rows_processed,
+            rows_written=0 if dry_run else rows_written,
+            duration_ms=duration_ms,
+            batches_completed=batch_count,
+            meta={
+                "computed_at": computed_at,
+                "rows_would_write": rows_written,
+                "unscored_targets": unscored_targets,
+                "cursor_start": cursor_start,
+                "cursor_end": cursor_end,
+                "dry_run": dry_run,
+            },
+        ).to_dict()
         _battle_log(runtime, "battle_intelligence.job.success", result)
         return result
     except Exception as exc:
@@ -733,7 +739,7 @@ def run_compute_battle_anomalies(db: SupplyCoreDb, runtime: dict[str, Any] | Non
     lock_key = "compute_battle_anomalies"
     owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
     if owner is None:
-        result = {"rows_processed": 0, "rows_written": 0, "status": "skipped", "reason": "lock-not-acquired", "job_name": "compute_battle_anomalies"}
+        result = JobResult.skipped(job_key="compute_battle_anomalies", reason="lock-not-acquired").to_dict()
         _battle_log(runtime, "battle_intelligence.job.skipped", result)
         return result
 
@@ -884,18 +890,20 @@ def run_compute_battle_anomalies(db: SupplyCoreDb, runtime: dict[str, Any] | Non
             if z_value > 2.0:
                 high_count += 1
         duration_ms = int((datetime.now(UTC) - started_monotonic).total_seconds() * 1000)
-        result = {
-            "rows_processed": rows_processed,
-            "rows_written": 0 if dry_run else rows_written,
-            "rows_would_write": rows_written if dry_run else rows_written,
-            "anomaly_count": len(shaped),
-            "high_sustain_count": high_count,
-            "computed_at": computed_at,
-            "duration_ms": duration_ms,
-            "dry_run": dry_run,
-            "job_name": "compute_battle_anomalies",
-            "status": "success",
-        }
+        result = JobResult.success(
+            job_key="compute_battle_anomalies",
+            summary=f"Detected {len(shaped)} anomalies ({high_count} high-sustain) from {rows_processed} rows.",
+            rows_processed=rows_processed,
+            rows_written=0 if dry_run else rows_written,
+            duration_ms=duration_ms,
+            meta={
+                "computed_at": computed_at,
+                "rows_would_write": rows_written if dry_run else rows_written,
+                "anomaly_count": len(shaped),
+                "high_sustain_count": high_count,
+                "dry_run": dry_run,
+            },
+        ).to_dict()
         _battle_log(runtime, "battle_intelligence.job.success", result)
         return result
     except Exception as exc:
@@ -916,7 +924,7 @@ def run_compute_battle_actor_features(
     lock_key = "compute_battle_actor_features"
     owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
     if owner is None:
-        result = {"rows_processed": 0, "rows_written": 0, "status": "skipped", "reason": "lock-not-acquired", "job_name": "compute_battle_actor_features"}
+        result = JobResult.skipped(job_key="compute_battle_actor_features", reason="lock-not-acquired").to_dict()
         _battle_log(runtime, "battle_intelligence.job.skipped", result)
         return result
 
@@ -995,17 +1003,19 @@ def run_compute_battle_actor_features(
             meta={"computed_at": computed_at, "neo4j": neo_result},
         )
         duration_ms = int((datetime.now(UTC) - started_monotonic).total_seconds() * 1000)
-        result = {
-            "rows_processed": rows_processed,
-            "rows_written": 0 if dry_run else rows_written,
-            "rows_would_write": rows_written if dry_run else rows_written,
-            "computed_at": computed_at,
-            "neo4j": neo_result,
-            "duration_ms": duration_ms,
-            "dry_run": dry_run,
-            "job_name": "compute_battle_actor_features",
-            "status": "success",
-        }
+        result = JobResult.success(
+            job_key="compute_battle_actor_features",
+            summary=f"Extracted actor features for {rows_processed} participants, wrote {rows_written} rows.",
+            rows_processed=rows_processed,
+            rows_written=0 if dry_run else rows_written,
+            duration_ms=duration_ms,
+            meta={
+                "computed_at": computed_at,
+                "rows_would_write": rows_written if dry_run else rows_written,
+                "neo4j": neo_result,
+                "dry_run": dry_run,
+            },
+        ).to_dict()
         _battle_log(runtime, "battle_intelligence.job.success", result)
         return result
     except Exception as exc:
@@ -1025,7 +1035,7 @@ def run_compute_suspicion_scores(db: SupplyCoreDb, runtime: dict[str, Any] | Non
     lock_key = "compute_suspicion_scores"
     owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
     if owner is None:
-        result = {"rows_processed": 0, "rows_written": 0, "status": "skipped", "reason": "lock-not-acquired", "job_name": "compute_suspicion_scores"}
+        result = JobResult.skipped(job_key="compute_suspicion_scores", reason="lock-not-acquired").to_dict()
         _battle_log(runtime, "battle_intelligence.job.skipped", result)
         return result
 
@@ -1290,18 +1300,20 @@ def run_compute_suspicion_scores(db: SupplyCoreDb, runtime: dict[str, Any] | Non
             meta={"computed_at": computed_at, "scored_characters": len(score_rows)},
         )
         duration_ms = int((datetime.now(UTC) - started_monotonic).total_seconds() * 1000)
-        result = {
-            "rows_processed": rows_processed,
-            "rows_written": 0 if dry_run else rows_written,
-            "rows_would_write": rows_written if dry_run else rows_written,
-            "computed_at": computed_at,
-            "scored_character_count": len(score_rows),
-            "minimum_sample_filtered_count": minimum_sample_filtered_count,
-            "duration_ms": duration_ms,
-            "dry_run": dry_run,
-            "job_name": "compute_suspicion_scores",
-            "status": "success",
-        }
+        result = JobResult.success(
+            job_key="compute_suspicion_scores",
+            summary=f"Scored {len(score_rows)} characters ({minimum_sample_filtered_count} filtered below sample threshold).",
+            rows_processed=rows_processed,
+            rows_written=0 if dry_run else rows_written,
+            duration_ms=duration_ms,
+            meta={
+                "computed_at": computed_at,
+                "rows_would_write": rows_written if dry_run else rows_written,
+                "scored_character_count": len(score_rows),
+                "minimum_sample_filtered_count": minimum_sample_filtered_count,
+                "dry_run": dry_run,
+            },
+        ).to_dict()
         _battle_log(runtime, "battle_intelligence.job.success", result)
         return result
     except Exception as exc:

--- a/python/orchestrator/jobs/behavioral_intelligence_v2.py
+++ b/python/orchestrator/jobs/behavioral_intelligence_v2.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from ..db import SupplyCoreDb
+from ..job_result import JobResult
 from ..json_utils import json_dumps_safe
 
 MIN_SAMPLE_COUNT = 5
@@ -180,14 +181,14 @@ def run_compute_behavioral_baselines(db: SupplyCoreDb, runtime: dict[str, Any] |
                 payload,
             )
 
-    return {
-        "status": "success",
-        "rows_processed": len(rows),
-        "rows_written": len(payload),
-        "computed_at": computed_at,
-        "duration_ms": int((time.perf_counter() - started) * 1000),
-        "job_name": "compute_behavioral_baselines",
-    }
+    return JobResult.success(
+        job_key="compute_behavioral_baselines",
+        summary=f"Computed behavioral baselines for {len(payload)} characters from {len(rows)} actor features.",
+        rows_processed=len(rows),
+        rows_written=len(payload),
+        duration_ms=int((time.perf_counter() - started) * 1000),
+        meta={"computed_at": computed_at},
+    ).to_dict()
 
 
 def run_compute_suspicion_scores_v2(db: SupplyCoreDb, runtime: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -407,11 +408,11 @@ def run_compute_suspicion_scores_v2(db: SupplyCoreDb, runtime: dict[str, Any] | 
                 ),
             )
 
-    return {
-        "status": "success",
-        "rows_processed": len(rows),
-        "rows_written": len(score_payload),
-        "computed_at": computed_at,
-        "duration_ms": int((time.perf_counter() - started) * 1000),
-        "job_name": "compute_suspicion_scores_v2",
-    }
+    return JobResult.success(
+        job_key="compute_suspicion_scores_v2",
+        summary=f"Scored {len(score_payload)} characters from {len(rows)} behavioral baselines.",
+        rows_processed=len(rows),
+        rows_written=len(score_payload),
+        duration_ms=int((time.perf_counter() - started) * 1000),
+        meta={"computed_at": computed_at},
+    ).to_dict()

--- a/python/orchestrator/jobs/compute_buy_all.py
+++ b/python/orchestrator/jobs/compute_buy_all.py
@@ -7,6 +7,7 @@ from hashlib import sha256
 from typing import Any
 
 from ..db import SupplyCoreDb
+from ..job_result import JobResult
 
 DEFAULT_REQUESTS: list[dict[str, Any]] = [
     {"mode": "blended", "sort": "blended_score", "filters": {}},
@@ -267,13 +268,17 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
 
         created += 1
 
-    return {
-        "computed_at": computed_at,
-        "requests": created,
-        "items_per_request": min(120, len(items)),
-        "rows_processed": rows_processed,
-        "rows_written": rows_written,
-    }
+    return JobResult.success(
+        job_key="compute_buy_all",
+        summary=f"Precomputed {created} buy-all request(s) with {rows_written} item rows.",
+        rows_processed=rows_processed,
+        rows_written=rows_written,
+        meta={
+            "computed_at": computed_at,
+            "requests": created,
+            "items_per_request": min(120, len(items)),
+        },
+    ).to_dict()
 
 
 def _decimal_json_default(value: Any) -> Any:

--- a/python/orchestrator/jobs/compute_graph_insights.py
+++ b/python/orchestrator/jobs/compute_graph_insights.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from typing import Any
 
 from ..db import SupplyCoreDb
+from ..job_result import JobResult
 from .graph_pipeline import run_compute_graph_insights as run_compute_graph_insights_pipeline
 
 
 def run_compute_graph_insights(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:
-    result = run_compute_graph_insights_pipeline(db, neo4j_raw)
-    result.setdefault("meta", {})
-    result["meta"]["execution_mode"] = "python"
-    return result
+    raw = run_compute_graph_insights_pipeline(db, neo4j_raw)
+    raw.setdefault("meta", {})
+    raw["meta"]["execution_mode"] = "python"
+    return JobResult.from_raw(raw, job_key="compute_graph_insights").to_dict()

--- a/python/orchestrator/jobs/compute_graph_sync.py
+++ b/python/orchestrator/jobs/compute_graph_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..job_result import JobResult
 from .graph_pipeline import (
     run_compute_graph_derived_relationships,
     run_compute_graph_prune,
@@ -24,11 +25,16 @@ def run_compute_graph_sync(db: SupplyCoreDb, neo4j_raw: dict[str, object] | None
     elif all(str(result.get("status")) == "skipped" for result in all_results):
         status = "skipped"
 
-    return {
-        "status": status,
-        "rows_processed": sum(int(result.get("rows_processed") or 0) for result in all_results),
-        "rows_written": sum(int(result.get("rows_written") or 0) for result in all_results),
-        "meta": {
+    total_processed = sum(int(result.get("rows_processed") or 0) for result in all_results)
+    total_written = sum(int(result.get("rows_written") or 0) for result in all_results)
+    return JobResult(
+        status=status,
+        summary=f"Graph sync pipeline (sync+derived+prune+topology) finished with status {status}.",
+        rows_seen=total_processed,
+        rows_processed=total_processed,
+        rows_written=total_written,
+        meta={
+            "job_key": "compute_graph_sync",
             "compute_graph_sync_doctrine_dependency": doctrine,
             "compute_graph_sync_battle_intelligence": battle,
             "compute_graph_derived_relationships": derived,
@@ -36,5 +42,4 @@ def run_compute_graph_sync(db: SupplyCoreDb, neo4j_raw: dict[str, object] | None
             "compute_graph_topology_metrics": topology,
             "execution_mode": "python",
         },
-        "summary": f"Graph sync pipeline (sync+derived+prune+topology) finished with status {status}.",
-    }
+    ).to_dict()

--- a/python/orchestrator/jobs/compute_signals.py
+++ b/python/orchestrator/jobs/compute_signals.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from ..db import SupplyCoreDb
 from ..influx import InfluxClient, InfluxConfig, InfluxQueryError
+from ..job_result import JobResult
 
 
 DECIMAL_ZERO = Decimal("0")
@@ -174,7 +175,13 @@ def run_compute_signals(db: SupplyCoreDb, influx_raw: dict[str, Any] | None = No
             )
             created += 1
 
-    return {"computed_at": computed_at, "signals_created": created, "rows_processed": len(rows), "rows_written": created}
+    return JobResult.success(
+        job_key="compute_signals",
+        summary=f"Generated {created} intelligence signals from {len(rows)} buy-all items.",
+        rows_processed=len(rows),
+        rows_written=created,
+        meta={"computed_at": computed_at, "signals_created": created},
+    ).to_dict()
 
 
 def _decimal_json_default(value: Any) -> Any:

--- a/python/orchestrator/jobs/counterintel_pipeline.py
+++ b/python/orchestrator/jobs/counterintel_pipeline.py
@@ -9,6 +9,7 @@ import urllib.request
 from typing import Any
 
 from ..db import SupplyCoreDb
+from ..job_result import JobResult
 from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
 from ..json_utils import json_dumps_safe
 from ..neo4j import Neo4jClient, Neo4jConfig
@@ -407,7 +408,7 @@ def run_compute_counterintel_pipeline(
     lock_key = "compute_counterintel_pipeline"
     owner = acquire_job_lock(db, lock_key, ttl_seconds=1200)
     if owner is None:
-        return {"status": "skipped", "rows_processed": 0, "rows_written": 0, "reason": "lock-not-acquired", "job_name": lock_key}
+        return JobResult.skipped(job_key=lock_key, reason="lock-not-acquired").to_dict()
 
     job = start_job_run(db, lock_key)
     started = time.perf_counter()
@@ -1028,22 +1029,24 @@ def run_compute_counterintel_pipeline(
             _sync_state_upsert(db, COUNTERINTEL_DATASET_KEY, last_battle_id, "success", rows_written)
 
         duration_ms = int((time.perf_counter() - started) * 1000)
-        result = {
-            "status": "success",
-            "job_name": lock_key,
-            "rows_processed": rows_processed,
-            "rows_written": 0 if dry_run else rows_written,
-            "rows_would_write": rows_written if dry_run else rows_written,
-            "computed_at": computed_at,
-            "cursor": last_battle_id,
-            "duration_ms": duration_ms,
-            "dry_run": dry_run,
-            "battle_assignment_validation": {
-                "mismatch_count": assignment_mismatch_count,
-                "sample_rows": assignment_mismatch_samples,
+        result = JobResult.success(
+            job_key=lock_key,
+            summary=f"Processed {processed_battles} eligible 100+ participant battles across {batch_count} batches.",
+            rows_processed=rows_processed,
+            rows_written=0 if dry_run else rows_written,
+            duration_ms=duration_ms,
+            batches_completed=batch_count,
+            meta={
+                "computed_at": computed_at,
+                "rows_would_write": rows_written if dry_run else rows_written,
+                "cursor": last_battle_id,
+                "dry_run": dry_run,
+                "battle_assignment_validation": {
+                    "mismatch_count": assignment_mismatch_count,
+                    "sample_rows": assignment_mismatch_samples,
+                },
             },
-            "summary": f"processed {processed_battles} eligible 100+ participant battles across {batch_count} batches",
-        }
+        ).to_dict()
         finish_job_run(db, job, status="success", rows_processed=rows_processed, rows_written=rows_written, meta=result)
         return result
     except Exception as exc:

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from ..db import SupplyCoreDb
+from ..job_result import JobResult
 from ..json_utils import json_dumps_safe
 from ..neo4j import Neo4jClient, Neo4jConfig, Neo4jError
 
@@ -150,21 +151,44 @@ def _emit_batch_telemetry(log_file: str, job_name: str, payload: dict[str, Any])
 
 
 def _job_payload(job_name: str, started_at: float, status: str, **kwargs: Any) -> dict[str, Any]:
-    payload = {
-        "job_name": job_name,
-        "status": status,
-        "duration_ms": int((time.perf_counter() - started_at) * 1000),
-        "rows_processed": int(kwargs.pop("rows_processed", 0)),
-        "rows_written": int(kwargs.pop("rows_written", 0)),
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    rows_processed = int(kwargs.pop("rows_processed", 0))
+    rows_written = int(kwargs.pop("rows_written", 0))
+    error_text = str(kwargs.pop("error_text", "")) or None
+
+    graph_meta = {
         "nodes_created": int(kwargs.pop("nodes_created", 0)),
         "nodes_merged": int(kwargs.pop("nodes_merged", 0)),
         "relationships_created": int(kwargs.pop("relationships_created", 0)),
         "relationships_merged": int(kwargs.pop("relationships_merged", 0)),
-        "error_text": str(kwargs.pop("error_text", "")),
         "timestamp": datetime.now(UTC).isoformat(),
     }
-    payload.update(kwargs)
-    return payload
+    graph_meta.update(kwargs)
+
+    if status == "skipped":
+        return JobResult.skipped(
+            job_key=job_name,
+            reason=error_text or "skipped",
+            meta=graph_meta,
+        ).to_dict()
+
+    if status == "failed":
+        return JobResult.failed(
+            job_key=job_name,
+            error=error_text or "unknown error",
+            duration_ms=duration_ms,
+            meta=graph_meta,
+        ).to_dict()
+
+    return JobResult.success(
+        job_key=job_name,
+        summary=f"{job_name} completed successfully.",
+        rows_processed=rows_processed,
+        rows_written=rows_written,
+        rows_seen=rows_processed,
+        duration_ms=duration_ms,
+        meta=graph_meta,
+    ).to_dict()
 
 
 def _ensure_constraints_and_indexes(client: Neo4jClient) -> None:

--- a/python/orchestrator/jobs/killmail.py
+++ b/python/orchestrator/jobs/killmail.py
@@ -6,6 +6,7 @@ import urllib.request
 from typing import Any
 
 from ..bridge import PhpBridge
+from ..job_result import JobResult
 from ..worker_runtime import payload_checksum, resident_memory_bytes, utc_now_iso
 
 
@@ -361,22 +362,15 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
     job_context = dict(bridge_response.get("context") or {})
 
     if not bool(job_context.get("enabled")):
-        return {
-            "status": "skipped",
-            "summary": "Killmail ingestion is disabled in settings.",
-            "rows_seen": 0,
-            "rows_written": 0,
-            "cursor": str(job_context.get("cursor") or "0"),
-            "checksum": payload_checksum({"cursor": job_context.get("cursor") or "0", "rows_written": 0}),
-            "duration_ms": 0,
-            "started_at": utc_now_iso(),
-            "finished_at": utc_now_iso(),
-            "warnings": ["Killmail ingestion disabled in settings."],
-            "meta": {
+        return JobResult.skipped(
+            job_key="killmail_r2z2_sync",
+            reason="Killmail ingestion is disabled in settings.",
+            meta={
                 "execution_mode": "python",
-                "outcome_reason": "Killmail ingestion is disabled.",
+                "cursor": str(job_context.get("cursor") or "0"),
+                "checksum": payload_checksum({"cursor": job_context.get("cursor") or "0", "rows_written": 0}),
             },
-        }
+        ).to_dict()
 
     sequence_url = str(job_context.get("sequence_url") or "").strip()
     base_url = str(job_context.get("base_url") or "").rstrip("/")
@@ -689,19 +683,22 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 "unknown": "Python worker completed without new killmail inserts and the zero-write cause requires follow-up.",
             }.get(reason_for_zero_write, "Python worker completed without new killmail inserts.")
 
-        result = {
-            "status": "success",
-            "summary": "Killmail R2Z2 ingestion ran in Python with continuous polling and bridge-backed batch persistence.",
-            "rows_seen": totals["rows_seen"],
-            "rows_written": totals["rows_written"],
-            "cursor": cursor_end,
-            "checksum": checksum,
-            "duration_ms": int((time.monotonic() - started_at) * 1000),
-            "started_at": start_iso,
-            "finished_at": utc_now_iso(),
-            "warnings": warnings[-10:],
-            "meta": {
+        result = JobResult.success(
+            job_key="killmail_r2z2_sync",
+            summary="Killmail R2Z2 ingestion ran in Python with continuous polling and bridge-backed batch persistence.",
+            rows_processed=totals["rows_seen"],
+            rows_written=totals["rows_written"],
+            rows_seen=totals["rows_seen"],
+            rows_failed=totals["rows_failed"],
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+            started_at=start_iso,
+            finished_at=utc_now_iso(),
+            warnings=warnings[-10:],
+            batches_completed=batches_flushed,
+            meta={
                 "execution_mode": "python",
+                "cursor": cursor_end,
+                "checksum": checksum,
                 "poll_sleep_seconds": poll_sleep_seconds,
                 "continuous_polling": True,
                 "sequence_files_fetched": total_sequence_files_fetched,
@@ -714,7 +711,6 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 "rows_skipped_existing": totals["rows_skipped_existing"],
                 "rows_filtered_out": totals["rows_filtered_out"],
                 "rows_write_attempted": totals["rows_write_attempted"],
-                "rows_failed": totals["rows_failed"],
                 "killmails_fetched": totals["rows_seen"],
                 "killmails_inserted": totals["rows_written"],
                 "first_sequence_seen": first_sequence_seen,
@@ -724,7 +720,6 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 "last_saved_sequence_before_run": last_saved_sequence,
                 "last_processed_sequence": last_processed_sequence,
                 "latest_remote_sequence": latest_remote_sequence,
-                "batches_flushed": batches_flushed,
                 "memory_usage_bytes": resident_memory_bytes(),
                 "checkpoint_updates": checkpoint_updates,
                 "checkpoint_failures": checkpoint_failures,
@@ -733,7 +728,7 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 "no_write_reason": reason_for_zero_write,
                 "outcome_reason": outcome_reason,
             },
-        }
+        ).to_dict()
         _sync_run_finish(bridge, job_context, run_id, result)
         return result
     except Exception as error:
@@ -743,28 +738,25 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
             bridge,
             job_context,
             run_id,
-            {
-                "status": "failed",
-                "summary": str(error),
-                "rows_seen": totals["rows_seen"],
-                "rows_written": totals["rows_written"],
-                "cursor": str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0)),
-                "checksum": "",
-                "error": str(error),
-                "meta": {
+            JobResult.failed(
+                job_key="sync_killmail_feed",
+                error=str(error),
+                rows_seen=totals["rows_seen"],
+                rows_written=totals["rows_written"],
+                rows_failed=max(1, totals["rows_failed"]),
+                checkpoint_before=str(last_saved_sequence or 0),
+                checkpoint_after=str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0)),
+                meta={
                     "rows_matched": totals["rows_matched"],
                     "rows_filtered_out": totals["rows_filtered_out"],
                     "rows_skipped_existing": totals["rows_skipped_existing"],
                     "rows_write_attempted": totals["rows_write_attempted"],
-                    "rows_failed": max(1, totals["rows_failed"]),
-                    "cursor_before": str(last_saved_sequence or 0),
-                    "cursor_after": str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0)),
                     "first_sequence_seen": first_sequence_seen,
                     "last_sequence_seen": last_sequence_seen,
                     "reason_for_zero_write": "transaction_rolled_back",
                     "checkpoint_state": "unchanged",
                     "outcome_reason": first_failure_message,
                 },
-            },
+            ).to_dict(),
         )
         raise

--- a/python/orchestrator/jobs/market_comparison.py
+++ b/python/orchestrator/jobs/market_comparison.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from ..bridge import PhpBridge
 from ..db import SupplyCoreDb
+from ..job_result import JobResult
 from ..worker_runtime import WorkerStats, payload_checksum, resident_memory_bytes, utc_now_iso
 
 
@@ -248,23 +249,20 @@ def run_market_comparison_summary(context: Any) -> dict[str, Any]:
     )
     freshness = ((snapshot_store.get("snapshot") or {}).get("_freshness") or {})
 
-    return {
-        "status": "success",
-        "summary": "Market comparison summaries were recomputed in Python batches and written to materialized storage.",
-        "rows_seen": len(snapshot_rows),
-        "rows_written": len(snapshot_rows),
-        "cursor": f"market_comparison:{utc_now_iso()}",
-        "checksum": payload_checksum({"rows": len(snapshot_rows), "computed_at": freshness.get("computed_at")}),
-        "duration_ms": stats.duration_ms(),
-        "started_at": stats.started_at_iso,
-        "finished_at": utc_now_iso(),
-        "warnings": [],
-        "meta": {
+    return JobResult.success(
+        job_key="compute_market_comparison_summary",
+        summary="Market comparison summaries were recomputed in Python batches and written to materialized storage.",
+        rows_seen=len(snapshot_rows),
+        rows_written=len(snapshot_rows),
+        rows_processed=stats.progress.rows_processed,
+        batches_completed=stats.progress.batches_completed,
+        started_at=stats.started_at_iso,
+        meta={
             "execution_mode": "python",
             "snapshot_generated_at": freshness.get("computed_at"),
-            "rows_processed": stats.progress.rows_processed,
-            "batches_completed": stats.progress.batches_completed,
             "memory_usage_bytes": resident_memory_bytes(),
+            "cursor": f"market_comparison:{utc_now_iso()}",
+            "checksum": payload_checksum({"rows": len(snapshot_rows), "computed_at": freshness.get("computed_at")}),
             "outcome_reason": "Python streamed summary snapshots in batches, pushed aggregation to SQL, and stored the materialized market comparison snapshot.",
         },
-    }
+    ).to_dict()

--- a/python/orchestrator/jobs/market_hub_local_history.py
+++ b/python/orchestrator/jobs/market_hub_local_history.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 
 from ..bridge import PhpBridge
 from ..db import SupplyCoreDb
+from ..job_result import JobResult
 from ..worker_runtime import WorkerStats, resident_memory_bytes, utc_now_iso
 
 
@@ -531,18 +532,11 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
 
     try:
         if source_id <= 0:
-            result = {
-                "status": "success",
-                "summary": "Hub snapshot history sync skipped because the configured market hub source could not be resolved.",
-                "rows_seen": 0,
-                "rows_written": 0,
-                "cursor": "source_type:market_hub;state:missing_source_id",
-                "checksum": _payload_checksum({"source_type": "market_hub", "source_id": source_id, "status": "missing_source_id"}),
-                "warnings": [f"Hub snapshot history sync skipped: could not resolve a valid local source id for {source_name}."],
-                "duration_ms": stats.duration_ms(),
-                "started_at": stats.started_at_iso,
-                "finished_at": utc_now_iso(),
-                "meta": {
+            result = JobResult.skipped(
+                job_key="sync_market_hub_local_history",
+                reason=f"Hub snapshot history sync skipped: could not resolve a valid local source id for {source_name}.",
+                started_at=stats.started_at_iso,
+                meta={
                     "execution_mode": "python",
                     "source_type": "market_hub",
                     "source_id": source_id,
@@ -557,10 +551,12 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
                     "snapshot_days_seen": 0,
                     "no_changes": True,
                     "outcome_reason": "missing_source_id",
-                }
-                | job_context,
-                "run_id": run_id,
-            }
+                    "cursor": "source_type:market_hub;state:missing_source_id",
+                    "checksum": _payload_checksum({"source_type": "market_hub", "source_id": source_id, "status": "missing_source_id"}),
+                    "run_id": run_id,
+                    **job_context,
+                },
+            ).to_dict()
             bridge.call(
                 "sync-run-finish",
                 payload={
@@ -570,8 +566,8 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
                     "status": "success",
                     "rows_seen": result["rows_seen"],
                     "rows_written": result["rows_written"],
-                    "cursor": result["cursor"],
-                    "checksum": result["checksum"],
+                    "cursor": result.get("meta", {}).get("cursor", ""),
+                    "checksum": result.get("meta", {}).get("checksum", ""),
                 },
             )
             return result
@@ -611,27 +607,11 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
         _guard_runtime(context, stats, "snapshot metrics build")
 
         if not snapshot_metrics:
-            result = {
-                "status": "success",
-                "summary": "Hub snapshot history sync found no local raw order snapshots in the configured window.",
-                "rows_seen": 0,
-                "rows_written": 0,
-                "cursor": f"source_type:market_hub;source_id:{source_id};state:awaiting_local_snapshots",
-                "checksum": _payload_checksum(
-                    {
-                        "source_type": "market_hub",
-                        "source_id": source_id,
-                        "window_days": window_days,
-                        "status": "awaiting_local_snapshots",
-                    }
-                ),
-                "warnings": [
-                    f"Hub snapshot history sync found no local raw order snapshots in the last {window_days} day(s) for {source_name}. Run the matching current sync first or widen --window-days."
-                ],
-                "duration_ms": stats.duration_ms(),
-                "started_at": stats.started_at_iso,
-                "finished_at": utc_now_iso(),
-                "meta": {
+            result = JobResult.skipped(
+                job_key="sync_market_hub_local_history",
+                reason=f"Hub snapshot history sync found no local raw order snapshots in the last {window_days} day(s) for {source_name}. Run the matching current sync first or widen --window-days.",
+                started_at=stats.started_at_iso,
+                meta={
                     "execution_mode": "python",
                     "source_type": "market_hub",
                     "source_id": source_id,
@@ -647,10 +627,12 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
                     "snapshot_summary_rows_written": summary_rows_written,
                     "no_changes": True,
                     "outcome_reason": "awaiting_local_snapshots",
-                }
-                | job_context,
-                "run_id": run_id,
-            }
+                    "cursor": f"source_type:market_hub;source_id:{source_id};state:awaiting_local_snapshots",
+                    "checksum": _payload_checksum({"source_type": "market_hub", "source_id": source_id, "window_days": window_days, "status": "awaiting_local_snapshots"}),
+                    "run_id": run_id,
+                    **job_context,
+                },
+            ).to_dict()
             bridge.call(
                 "sync-run-finish",
                 payload={
@@ -660,8 +642,8 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
                     "status": "success",
                     "rows_seen": result["rows_seen"],
                     "rows_written": result["rows_written"],
-                    "cursor": result["cursor"],
-                    "checksum": result["checksum"],
+                    "cursor": result.get("meta", {}).get("cursor", ""),
+                    "checksum": result.get("meta", {}).get("checksum", ""),
                 },
             )
             return result
@@ -673,25 +655,13 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
         _guard_runtime(context, stats, "daily rebuild")
 
         if not canonical_rows:
-            result = {
-                "status": "success",
-                "summary": "Hub snapshot history sync could not derive daily local-history rows from the available snapshots.",
-                "rows_seen": rows_seen,
-                "rows_written": 0,
-                "cursor": f"source_type:market_hub;source_id:{source_id};window_days:{window_days};state:no_canonical_rows",
-                "checksum": _payload_checksum(
-                    {
-                        "source_type": "market_hub",
-                        "source_id": source_id,
-                        "window_days": window_days,
-                        "status": "no_canonical_rows",
-                    }
-                ),
-                "warnings": [f"Hub snapshot history sync could not derive any daily rows from the local raw order snapshots for {source_name}."],
-                "duration_ms": stats.duration_ms(),
-                "started_at": stats.started_at_iso,
-                "finished_at": utc_now_iso(),
-                "meta": {
+            result = JobResult.skipped(
+                job_key="sync_market_hub_local_history",
+                reason=f"Hub snapshot history sync could not derive any daily rows from the local raw order snapshots for {source_name}.",
+                rows_seen=rows_seen,
+                rows_skipped=rows_seen,
+                started_at=stats.started_at_iso,
+                meta={
                     "execution_mode": "python",
                     "source_type": "market_hub",
                     "source_id": source_id,
@@ -707,10 +677,12 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
                     "snapshot_summary_rows_written": summary_rows_written,
                     "no_changes": True,
                     "outcome_reason": "no_canonical_rows",
-                }
-                | job_context,
-                "run_id": run_id,
-            }
+                    "cursor": f"source_type:market_hub;source_id:{source_id};window_days:{window_days};state:no_canonical_rows",
+                    "checksum": _payload_checksum({"source_type": "market_hub", "source_id": source_id, "window_days": window_days, "status": "no_canonical_rows"}),
+                    "run_id": run_id,
+                    **job_context,
+                },
+            ).to_dict()
             bridge.call(
                 "sync-run-finish",
                 payload={
@@ -720,8 +692,8 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
                     "status": "success",
                     "rows_seen": result["rows_seen"],
                     "rows_written": result["rows_written"],
-                    "cursor": result["cursor"],
-                    "checksum": result["checksum"],
+                    "cursor": result.get("meta", {}).get("cursor", ""),
+                    "checksum": result.get("meta", {}).get("checksum", ""),
                 },
             )
             return result
@@ -735,18 +707,15 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
         _emit_progress(context, stats, "local_history_upsert", rows_seen, rows_written)
         _guard_runtime(context, stats, "local history upsert")
 
-        result = {
-            "status": "success",
-            "summary": "Hub snapshot history sync rebuilt local-history daily candles in native Python.",
-            "rows_seen": rows_seen,
-            "rows_written": rows_written,
-            "cursor": cursor,
-            "checksum": checksum,
-            "warnings": [],
-            "duration_ms": stats.duration_ms(),
-            "started_at": stats.started_at_iso,
-            "finished_at": utc_now_iso(),
-            "meta": {
+        result = JobResult.success(
+            job_key="sync_market_hub_local_history",
+            summary="Hub snapshot history sync rebuilt local-history daily candles in native Python.",
+            rows_seen=rows_seen,
+            rows_written=rows_written,
+            rows_skipped=max(0, history_row_count - rows_written),
+            batches_completed=stats.progress.batches_completed,
+            started_at=stats.started_at_iso,
+            meta={
                 "execution_mode": "python",
                 "source_type": "market_hub",
                 "source_id": source_id,
@@ -763,10 +732,12 @@ def run_market_hub_local_history(context: Any) -> dict[str, Any]:
                 "snapshot_days_seen": len(trade_dates),
                 "no_changes": rows_written == 0,
                 "memory_usage_bytes": resident_memory_bytes(),
-            }
-            | job_context,
-            "run_id": run_id,
-        }
+                "cursor": cursor,
+                "checksum": checksum,
+                "run_id": run_id,
+                **job_context,
+            },
+        ).to_dict()
         bridge.call(
             "sync-run-finish",
             payload={


### PR DESCRIPTION
## Summary

- Introduces a canonical `JobResult` dataclass (`job_result.py`) with `success()`, `failed()`, `skipped()` builders and `from_raw()` normalization, replacing three inconsistent result shape normalizers (`_compute_result_shape`, `_graph_result_shape`, and the `run_sync_phase_job` wrapper's own schema)
- Replaces the 30-branch if/elif processor dispatch in `processor_registry.py` with a data-driven `_PROCESSOR_DISPATCH` table
- Adopts `JobResult` natively in all 11 bridge/compute processor files (27+ return paths total), so every processor constructs canonical envelopes directly rather than relying on the `from_raw()` shim

## Files changed (17)

| Area | Files |
|------|-------|
| **Core contract** | `job_result.py` (new), `processor_registry.py`, `sync_runtime.py` |
| **Runner/worker** | `job_runner.py`, `worker_pool.py` |
| **Compute processors** | `compute_buy_all.py`, `compute_signals.py`, `compute_graph_sync.py`, `compute_graph_insights.py` |
| **Graph pipeline** | `graph_pipeline.py` (covers 6 sub-jobs via `_job_payload` helper) |
| **Battle/intel** | `battle_intelligence.py`, `behavioral_intelligence_v2.py`, `counterintel_pipeline.py` |
| **Bridge processors** | `killmail.py`, `market_comparison.py`, `market_hub_local_history.py` |
| **Tests** | `test_compute_processor_routing.py` |

## Test plan

- [ ] Verify `python -m py_compile python/orchestrator/job_result.py` passes
- [ ] Confirm all 16 modified Python files pass AST syntax checks
- [ ] Run `test_compute_processor_routing.py` to validate dispatch table parity and result shape normalization
- [ ] Deploy to staging and run a full scheduler cycle — verify all job results in the dashboard carry the `job_result.v2` schema version and 16-field envelope

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf