### PR TITLE
Include access_token in cached ESI OAuth payload

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -16853,6 +16853,7 @@ function esi_store_oauth_and_cache(array $tokenPayload, array $verifyPayload): v
 
         db_esi_cache_put('cache.esi.oauth.verify', 'latest', json_encode($verifyPayload, JSON_THROW_ON_ERROR));
         db_esi_cache_put('cache.esi.oauth.token', 'latest', json_encode([
+            'access_token' => $tokenPayload['access_token'] ?? '',
             'token_type' => $tokenPayload['token_type'] ?? 'Bearer',
             'expires_in' => $tokenPayload['expires_in'] ?? null,
             'scope' => $scopes,
@@ -16910,6 +16911,7 @@ function esi_refresh_oauth_token(array $storedToken): array
     );
 
     db_esi_cache_put('cache.esi.oauth.token', 'latest', json_encode([
+        'access_token' => $nextAccessToken,
         'token_type' => $tokenType !== '' ? $tokenType : 'Bearer',
         'expires_in' => $tokenPayload['expires_in'] ?? null,
         'scope' => $scopes,


### PR DESCRIPTION
### Motivation
- Ensure the Python execution plane can fall back to the cached OAuth payload because Python looks for `$.access_token` in `esi_cache_entries` when no non-expired row is available in `esi_oauth_tokens`.

### Description
- Add `access_token` to the JSON written to `cache.esi.oauth.token` in `esi_store_oauth_and_cache()` so the initial OAuth exchange cache includes the access token.
- Add `access_token` to the JSON written to `cache.esi.oauth.token` in `esi_refresh_oauth_token()` so refreshes also populate the cached `access_token`.

### Testing
- Ran `php -l src/functions.php` to validate PHP syntax and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4ca04f638832fb883d03fa04a7cd1)