### PR TITLE
Harden ESI structure auth token handling

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -606,6 +606,7 @@ class SupplyCoreDb:
                 FROM esi_cache_entries
                 WHERE namespace_key = 'cache.esi.oauth.token'
                   AND cache_key = 'latest'
+                  AND (expires_at IS NULL OR expires_at > UTC_TIMESTAMP())
                 ORDER BY updated_at DESC, id DESC
                 LIMIT 1"""
         ) or {}
@@ -613,14 +614,7 @@ class SupplyCoreDb:
         if cached_token != "":
             return cached_token
 
-        latest = self.fetch_one(
-            """SELECT access_token
-                FROM esi_oauth_tokens
-                ORDER BY updated_at DESC, id DESC
-                LIMIT 1"""
-        ) or {}
-        latest_token = str(latest.get("access_token") or "").strip()
-        return latest_token or None
+        return None
 
     def replace_market_orders_for_source(
         self,

--- a/python/orchestrator/esi_market_adapter.py
+++ b/python/orchestrator/esi_market_adapter.py
@@ -30,7 +30,7 @@ class EsiMarketAdapter:
         return self._request_json(url)
 
     def fetch_structure_orders(self, *, structure_id: int, access_token: str, page: int = 1) -> EsiOrdersResponse:
-        query = urlencode({"page": page})
+        query = urlencode({"datasource": "tranquility", "page": page})
         url = f"{ESI_BASE}/latest/markets/structures/{structure_id}/?{query}"
         return self._request_json(url, token=access_token)
 
@@ -43,7 +43,11 @@ class EsiMarketAdapter:
             "User-Agent": "SupplyCore-Orchestrator/1.0",
         }
         if token:
-            headers["Authorization"] = f"Bearer {token}"
+            sanitized_token = token.strip()
+            if sanitized_token.lower().startswith("bearer "):
+                sanitized_token = sanitized_token[7:].strip()
+            if sanitized_token:
+                headers["Authorization"] = f"Bearer {sanitized_token}"
         request = Request(url, headers=headers, method="GET")
         try:
             with urlopen(request, timeout=self._timeout_seconds) as response:

--- a/python/tests/test_esi_market_adapter.py
+++ b/python/tests/test_esi_market_adapter.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from orchestrator.esi_market_adapter import EsiMarketAdapter
+
+
+class _FakeHeaders(dict):
+    def get(self, key: str, default: str = "1") -> str:
+        return str(super().get(key, default))
+
+
+class _FakeHttpResponse:
+    def __init__(self, body: str = "[]", pages: int = 1, status: int = 200) -> None:
+        self._body = body.encode("utf-8")
+        self.headers = _FakeHeaders({"X-Pages": str(pages)})
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeHttpResponse":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb) -> bool:
+        return False
+
+
+class EsiMarketAdapterTests(unittest.TestCase):
+    def test_fetch_structure_orders_includes_datasource_query_param(self) -> None:
+        captured_url: str | None = None
+
+        def _fake_urlopen(request, timeout: int):  # type: ignore[no-untyped-def]
+            nonlocal captured_url
+            captured_url = request.full_url
+            return _FakeHttpResponse()
+
+        adapter = EsiMarketAdapter()
+        with patch("orchestrator.esi_market_adapter.urlopen", side_effect=_fake_urlopen):
+            adapter.fetch_structure_orders(structure_id=10203040, access_token="abc123", page=3)
+
+        self.assertIsNotNone(captured_url)
+        self.assertIn("datasource=tranquility", str(captured_url))
+        self.assertIn("page=3", str(captured_url))
+
+    def test_bearer_prefix_in_token_is_sanitized(self) -> None:
+        captured_auth: str | None = None
+
+        def _fake_urlopen(request, timeout: int):  # type: ignore[no-untyped-def]
+            nonlocal captured_auth
+            captured_auth = request.headers.get("Authorization")
+            return _FakeHttpResponse()
+
+        adapter = EsiMarketAdapter()
+        with patch("orchestrator.esi_market_adapter.urlopen", side_effect=_fake_urlopen):
+            adapter.fetch_structure_orders(structure_id=10203040, access_token="Bearer abc123", page=1)
+
+        self.assertEqual(captured_auth, "Bearer abc123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Structure-order syncs were failing with 401s due to either invalid tokens or malformed `Authorization` headers. 
- The adapter omitted an explicit ESI `datasource` query parameter for structure endpoints which can cause inconsistent API behavior. 
- The token fallback path could silently return stale tokens, masking expired/invalid token failures.

### Description

- Always include `datasource=tranquility` when building structure orders URLs in `EsiMarketAdapter.fetch_structure_orders` to make requests explicit. 
- Sanitize supplied OAuth tokens in `_request_json` by trimming whitespace and stripping a leading `Bearer ` prefix before constructing the `Authorization` header to avoid `Bearer Bearer ...` headers. 
- Tighten `SupplyCoreDb.fetch_latest_esi_access_token()` to only return an active DB token or a non-expired cached token and remove the fallback to the latest historical token, returning `None` when none are available. 
- Add unit tests `python/tests/test_esi_market_adapter.py` that assert the `datasource` query param is present and that `Bearer`-prefixed tokens are sanitized correctly.

### Testing

- Ran the adapter and sync coverage tests with `python -m pytest -q python/tests/test_esi_market_adapter.py python/tests/test_sync_processors.py::SyncProcessorCoverageTests::test_market_hub_and_alliance_processors_fetch_sources_and_write_projection` and all tests passed (`3 passed`).
- The new adapter tests exercise the URL construction and header behavior, and the existing sync processor test validates end-to-end usage in the sync path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4cb428670832f900390ccf521b7eb)