### PR TITLE
Fix market hub source typing and NPC region routing

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -618,7 +618,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <p id="market_station_status" class="text-xs text-muted">
                         <?= htmlspecialchars($marketStationId === ''
                             ? 'Type at least 2 characters to search reference market hubs.'
-                            : ('Selected market hub: ' . ($marketStationName ?? ('Station #' . $marketStationId)) . ' (#' . $marketStationId . ').'), ENT_QUOTES) ?>
+                            : ('Selected market hub (NPC station): ' . ($marketStationName ?? ('Station #' . $marketStationId)) . ' (#' . $marketStationId . ').'), ENT_QUOTES) ?>
                     </p>
                     <ul id="market_station_results" class="hidden max-h-60 overflow-y-auto surface-tertiary"></ul>
                 </label>
@@ -715,7 +715,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 button.addEventListener('click', () => {
                                     hidden.value = String(item.id);
                                     input.value = item.name;
-                                    status.textContent = selectionStatusPrefix + item.name + ' (#' + item.id + ').';
+                                    const selectedType = item.type ? ' [' + item.type + ']' : '';
+                                    status.textContent = selectionStatusPrefix + item.name + selectedType + ' (#' + item.id + ').';
                                     clearResults();
                                 });
 
@@ -764,7 +765,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         statusId: 'market_station_status',
                         minimumQueryLength: 2,
                         searchingLabel: 'Searching…',
-                        selectionStatusPrefix: 'Selected market hub: ',
+                        selectionStatusPrefix: 'Selected market hub (NPC station): ',
                         emptyQueryMessage: 'Type at least 2 characters to search reference market hubs.',
                         noResultsMessage: 'No matching reference market hubs found.',
                         fetchResults: async (query) => {

--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -570,7 +570,16 @@ class SupplyCoreDb:
         if int(npc.get("station_id") or 0) > 0 and int(npc.get("region_id") or 0) > 0:
             return [{"source_id": source_id, "region_id": int(npc["region_id"]), "source_kind": "npc_station"}]
 
-        return [{"source_id": source_id, "region_id": 0, "source_kind": "structure"}]
+        return [{"source_id": source_id, "region_id": 0, "source_kind": "player_structure"}]
+
+    def fetch_region_id_for_npc_station(self, *, station_id: int) -> int:
+        if station_id <= 0:
+            return 0
+        row = self.fetch_one(
+            "SELECT region_id FROM ref_npc_stations WHERE station_id = %s LIMIT 1",
+            (station_id,),
+        ) or {}
+        return int(row.get("region_id") or 0)
 
     def fetch_region_id_for_system(self, *, system_id: int) -> int:
         if system_id <= 0:

--- a/python/orchestrator/jobs/market_hub_current_sync.py
+++ b/python/orchestrator/jobs/market_hub_current_sync.py
@@ -5,6 +5,17 @@ from ..esi_market_adapter import EsiMarketAdapter, parse_esi_datetime
 from .sync_runtime import run_sync_phase_job
 
 
+def _normalize_source_kind(source_kind: str, source_id: int) -> str:
+    normalized = source_kind.strip().lower()
+    if normalized == "npc_station":
+        return "npc_station"
+    if normalized in {"player_structure", "structure"}:
+        return "player_structure"
+    # Fallback guard for stale/legacy metadata: NPC stations are 64-bit IDs
+    # in known low ranges, while Upwell structure IDs are significantly larger.
+    return "npc_station" if 0 < source_id < 1_000_000_00000 else "player_structure"
+
+
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
     adapter = EsiMarketAdapter(timeout_seconds=30)
     sources: list[dict[str, object]] = []
@@ -19,19 +30,26 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
     warnings: list[str] = []
     rows_processed = 0
     rows_written = 0
+    successful_sources = 0
+    failed_sources = 0
     for source in sources:
         source_id = int(source.get("source_id") or 0)
         region_id = int(source.get("region_id") or 0)
-        source_kind = str(source.get("source_kind") or "npc_station")
+        source_kind = _normalize_source_kind(str(source.get("source_kind") or "npc_station"), source_id)
         if source_id <= 0:
             continue
         orders: list[dict[str, object]] = []
         resolved_region_id = region_id
-        filter_location_id: int | None = source_id if source_kind == "structure" else None
+        filter_location_id: int | None = source_id if source_kind == "player_structure" else None
         structure_orders_mode = False
 
         try:
-            if source_kind == "structure" and resolved_region_id <= 0 and access_token:
+            if source_kind == "npc_station" and resolved_region_id <= 0:
+                fetch_npc_region = getattr(db, "fetch_region_id_for_npc_station", None)
+                if callable(fetch_npc_region):
+                    resolved_region_id = int(fetch_npc_region(station_id=source_id))
+
+            if source_kind == "player_structure" and resolved_region_id <= 0 and access_token:
                 structure_meta = adapter.fetch_structure_metadata(structure_id=source_id, access_token=access_token)
                 system_id = int(structure_meta.get("solar_system_id") or 0)
                 fetch_region = getattr(db, "fetch_region_id_for_system", None)
@@ -40,14 +58,16 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
 
             if resolved_region_id > 0:
                 first_page = adapter.fetch_region_orders(region_id=resolved_region_id, order_type="all", page=1)
-            elif source_kind == "structure":
+            elif source_kind == "player_structure":
                 if not access_token:
-                    warnings.append(f"market_hub source {source_id} is a structure, but no active ESI OAuth token is available.")
+                    warnings.append(f"market_hub source {source_id} is a player structure, but no active ESI OAuth token is available.")
+                    failed_sources += 1
                     continue
                 first_page = adapter.fetch_structure_orders(structure_id=source_id, access_token=access_token, page=1)
                 structure_orders_mode = True
             else:
-                warnings.append(f"market_hub source {source_id} is missing region metadata.")
+                warnings.append(f"market_hub source {source_id} is an NPC station but region metadata could not be resolved.")
+                failed_sources += 1
                 continue
             orders.extend(first_page.orders)
             max_pages = min(20, first_page.pages)
@@ -59,6 +79,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
                 orders.extend(response.orders)
         except Exception as exc:
             warnings.append(f"market_hub source {source_id} fetch failed: {exc}")
+            failed_sources += 1
             continue
 
         if filter_location_id is not None:
@@ -85,6 +106,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         )
         rows_processed += int(ingest_stats["rows_processed"])
         rows_written += int(ingest_stats["rows_written"])
+        successful_sources += 1
 
     stats = db.refresh_market_order_current_projection(source_type="market_hub")
     rows_processed += int(stats["rows_processed"])
@@ -93,18 +115,32 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         warnings.append("No configured market hub source was found. Save Settings → Trading Stations before running this sync.")
     if rows_processed == 0:
         warnings.append("No market-hub orders were fetched from ESI during this run.")
+    status = "success"
+    sync_state_status = "success"
+    if sources and successful_sources == 0:
+        status = "failed"
+        sync_state_status = "failed"
+
     db.upsert_sync_state(
         dataset_key="market_hub.orders.current",
-        status="success",
+        status=sync_state_status,
         row_count=rows_written,
         cursor=None,
+        error_message=warnings[0] if sync_state_status == "failed" and warnings else None,
     )
     return {
+        "status": status,
         "rows_processed": rows_processed,
         "rows_written": rows_written,
         "warnings": warnings,
         "summary": f"Ingested/projected market-hub orders ({rows_written} writes across {len(sources)} sources).",
-        "meta": {"dataset_key": "market_hub.orders.current"},
+        "meta": {
+            "dataset_key": "market_hub.orders.current",
+            "sources_total": len(sources),
+            "sources_succeeded": successful_sources,
+            "sources_failed": failed_sources,
+            "outcome": "partial_success" if successful_sources > 0 and failed_sources > 0 else status,
+        },
     }
 
 

--- a/python/tests/test_sync_processors.py
+++ b/python/tests/test_sync_processors.py
@@ -79,6 +79,13 @@ class _SpyDb:
         self.calls.append(("fetch_market_hub_sources", limit))
         return list(self.market_hub_sources)
 
+    def fetch_region_id_for_npc_station(self, *, station_id: int) -> int:
+        self.calls.append(("fetch_region_id_for_npc_station", station_id))
+        for source in self.market_hub_sources:
+            if int(source.get("source_id") or 0) == station_id:
+                return int(source.get("region_id") or 0)
+        return 0
+
     def fetch_region_id_for_system(self, *, system_id: int) -> int:
         self.calls.append(("fetch_region_id_for_system", system_id))
         return int(self.region_by_system_id.get(system_id, 0))
@@ -169,7 +176,7 @@ class SyncProcessorCoverageTests(unittest.TestCase):
 
     def test_market_hub_structure_source_can_resolve_region_and_filter_location(self) -> None:
         db = _SpyDb()
-        db.market_hub_sources = [{"source_id": 102030405060, "region_id": 0, "source_kind": "structure"}]
+        db.market_hub_sources = [{"source_id": 102030405060, "region_id": 0, "source_kind": "player_structure"}]
         db.access_token = "token"
         db.region_by_system_id = {30000142: 10000002}
         db.replace_stats = {"rows_processed": 1, "rows_written": 1}
@@ -193,6 +200,22 @@ class SyncProcessorCoverageTests(unittest.TestCase):
         region_fetch.assert_called_once_with(region_id=10000002, order_type="all", page=1)
         structure_orders_fetch.assert_not_called()
 
+    def test_market_hub_npc_station_never_routes_to_structure_endpoint(self) -> None:
+        db = _SpyDb()
+        db.market_hub_sources = [{"source_id": 60003760, "region_id": 10000002, "source_kind": "player_structure"}]
+        db.projection_stats = {"rows_processed": 1, "rows_written": 1}
+        db.replace_stats = {"rows_processed": 1, "rows_written": 1}
+
+        with (
+            patch("orchestrator.jobs.market_hub_current_sync.EsiMarketAdapter.fetch_region_orders", return_value=EsiOrdersResponse(orders=[{"issued": "2026-03-26T00:00:00Z", "expires": "2026-03-27T00:00:00Z"}], pages=1, status_code=200)) as region_fetch,
+            patch("orchestrator.jobs.market_hub_current_sync.EsiMarketAdapter.fetch_structure_orders") as structure_orders_fetch,
+        ):
+            result = run_market_hub_current_sync(db)
+
+        self.assertEqual(result["status"], "success")
+        region_fetch.assert_called_once_with(region_id=10000002, order_type="all", page=1)
+        structure_orders_fetch.assert_not_called()
+
     def test_failure_paths_emit_meaningful_status_and_warnings(self) -> None:
         db_source_unavailable = _SpyDb()
         db_source_unavailable.market_hub_sources = [{"source_id": 60003760, "region_id": 10000002}]
@@ -201,7 +224,7 @@ class SyncProcessorCoverageTests(unittest.TestCase):
         with patch("orchestrator.jobs.market_hub_current_sync.EsiMarketAdapter.fetch_region_orders", side_effect=RuntimeError("esi unavailable")):
             unavailable_result = run_market_hub_current_sync(db_source_unavailable)
 
-        self.assertEqual(unavailable_result["status"], "success")
+        self.assertEqual(unavailable_result["status"], "failed")
         self.assertTrue(any("fetch failed" in warning for warning in unavailable_result["warnings"]))
 
         db_malformed = _SpyDb()


### PR DESCRIPTION
### Motivation

- The market hub current sync was treating NPC stations like structures and calling the structure orders endpoint for NPC station IDs, producing misleading 0-write successes for hubs such as Jita.
- The intent is to ensure NPC stations are routed to regional market endpoints and player structures use the structure endpoint, with clearer result semantics when no usable data is collected.

### Description

- Introduced explicit source-kind normalization (`npc_station` vs `player_structure`) with legacy `structure` compatibility in `python/orchestrator/jobs/market_hub_current_sync.py` via `_normalize_source_kind` and updated routing logic to never call the structure endpoint for NPC stations. 
- Added `fetch_region_id_for_npc_station()` to `python/orchestrator/db.py` and changed settings-backed source fallback to return `source_kind: "player_structure"` instead of the ambiguous `structure` string.
- Enhanced `market_hub_current_sync` to resolve NPC station region IDs via DB metadata when needed and to preserve the existing structure metadata/system->region resolution for player structures. 
- Improved job result semantics so that if configured hub sources exist but none produce usable data the job returns `failed`, writes failed `sync_state`, and the processor meta includes `sources_total`, `sources_succeeded`, `sources_failed`, and an `outcome` flag (including `partial_success`).
- Small UI copy and selection-status updates to clearly label the configured market hub as an NPC station and to include the returned item type in the selection status string (`public/settings/index.php`).
- Added/updated unit tests in `python/tests/test_sync_processors.py` to validate player-structure region resolution, that NPC stations do not route to the structure endpoint even if mis-typed, and that fetch-failure paths emit a failed status.

### Testing

- Ran targeted unit tests: `PYTHONPATH=python pytest -q python/tests/test_sync_processors.py python/tests/test_python_sync_processor_parity.py` which passed (`12 passed, 10 subtests passed`).
- An initial test run without `PYTHONPATH` failed during collection due to the local test environment import path, then the rerun with `PYTHONPATH=python` succeeded as noted above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c504adb4f0832fb4aad9ceb4464126)