### PR TITLE
Fix NameError crash in market_hub_current_sync from merge conflict

### DIFF
--- a/python/orchestrator/jobs/market_hub_current_sync.py
+++ b/python/orchestrator/jobs/market_hub_current_sync.py
@@ -117,15 +117,16 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         warnings.append("No market-hub orders were fetched from ESI during this run.")
     hub_ref = db.fetch_app_setting("market_station_id", "")
     dataset_key = f"market.hub.{hub_ref}.orders.current" if hub_ref else "market_hub.orders.current"
+    sync_state_status = "failed" if (failed_sources > 0 and successful_sources == 0) else "success"
     db.upsert_sync_state(
         dataset_key=dataset_key,
-        status="success",
+        status=sync_state_status,
         row_count=rows_written,
         cursor=None,
         error_message=warnings[0] if sync_state_status == "failed" and warnings else None,
     )
     return {
-        "status": status,
+        "status": sync_state_status,
         "rows_processed": rows_processed,
         "rows_written": rows_written,
         "warnings": warnings,


### PR DESCRIPTION
## Summary

- Fix `NameError: name 'sync_state_status' is not defined` that crashes `market_hub_current_sync` — the merge of PR #300 left two undefined variable references (`sync_state_status` and `status`)
- Compute `sync_state_status` from `successful_sources` / `failed_sources` counters: marks as `"failed"` only when all sources fail, otherwise `"success"`
- Use `sync_state_status` consistently for both `upsert_sync_state()` and the returned result dict

## Test plan

- [ ] Run `python -m orchestrator run-job --job-key market_hub_current_sync` and confirm it no longer crashes with NameError
- [ ] Verify sync completes successfully and writes correct status to `sync_state` table

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf