### PR TITLE
Fix PDO unbuffered query error in migration runner

### DIFF
--- a/bin/run-migrations.php
+++ b/bin/run-migrations.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
  *   php bin/run-migrations.php --status     # Show migration status
  */
 
-require_once __DIR__ . '/../src/bootstrap.php';
+// Load functions directly — skip bootstrap.php which auto-runs migrations
+// and starts a session (neither needed in CLI context).
+require_once __DIR__ . '/../src/functions.php';
 
 $dryRun = in_array('--dry-run', $argv, true);
 $statusOnly = in_array('--status', $argv, true);

--- a/src/db.php
+++ b/src/db.php
@@ -189,6 +189,7 @@ function db(): PDO
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
                 PDO::ATTR_EMULATE_PREPARES => false,
+                PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
             ]
         );
     } catch (Throwable $exception) {


### PR DESCRIPTION
## Summary

- Added `PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true` to the database connection to prevent "Cannot execute queries while other unbuffered queries are active" when `db()->exec()` is called after a `db_select()` leaves an open cursor
- Fixed `bin/run-migrations.php` to load `functions.php` directly instead of `bootstrap.php`, avoiding double migration execution (bootstrap auto-runs migrations) and unnecessary `session_start()` in CLI context

## Test plan

- [ ] Run `./scripts/update-and-restart.sh` and verify it completes without PDO errors
- [ ] Run `php bin/run-migrations.php --status` to confirm CLI works

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf