### PR TITLE
Fix PDO unbuffered query conflict during streamed reads

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -473,12 +473,9 @@ function db_select(string $sql, array $params = []): array
 
 function db_select_stream(string $sql, array $params, callable $callback): int
 {
-    $driverOptions = [];
-    if (defined('PDO::MYSQL_ATTR_USE_BUFFERED_QUERY')) {
-        $driverOptions[PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = false;
-    }
-
-    $stmt = db()->prepare($sql, $driverOptions);
+    // Keep the connection's default buffered-query behavior so callbacks can
+    // safely execute follow-up queries while iterating the result set.
+    $stmt = db()->prepare($sql);
     $stmt->execute($params);
     $stmt->setFetchMode(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
### Motivation
- `db_select_stream()` previously forced unbuffered MySQL queries which caused fatal `SQLSTATE[HY000]: General error: 2014 Cannot execute queries while other unbuffered queries are active` when callback code executed follow-up SQL, so the stream implementation must preserve buffered behavior to allow safe nested queries.

### Description
- Removed the per-call `PDO::MYSQL_ATTR_USE_BUFFERED_QUERY = false` override in `db_select_stream()` so the function uses the connection's default (buffered) behavior and added an inline comment documenting the rationale.

### Testing
- Verified syntax with `php -l src/db.php`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c53acbfb08832f98d316588dd3713e)