### PR TITLE
Remove auto-migration from bootstrap to fix PDO errors on page load

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -5,13 +5,3 @@ declare(strict_types=1);
 session_start();
 
 require_once __DIR__ . '/functions.php';
-
-// Auto-apply pending database migrations on every page load.
-// The check is cheap (single SELECT on schema_migrations) and only runs
-// actual SQL when new or updated migration files are detected.
-try {
-    supplycore_auto_run_migrations_if_pending();
-} catch (Throwable) {
-    // Silently ignore — migrations will be retried on next request.
-    // The settings page shows migration status for manual intervention.
-}


### PR DESCRIPTION
## Summary

- Removed `supplycore_auto_run_migrations_if_pending()` call from `bootstrap.php` that ran on every page load
- This was causing `PDOException: Cannot execute queries while other unbuffered queries are active` when the migration check's DB calls conflicted with the page's own queries (e.g. dashboard loading market comparison snapshots)
- Migrations are now only run via `bin/run-migrations.php` CLI or the "Run migrations now" button on the Settings data-sync page

## Test plan

- [ ] Verify pages load without PDO errors after deploying
- [ ] Run `php bin/run-migrations.php --status` to confirm CLI still works
- [ ] Verify the Settings data-sync "Run migrations now" button still works

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf