### PR TITLE
Fix MariaDB unbuffered query error in migration runner

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -28499,8 +28499,9 @@ function supplycore_migration_files(): array
 
 function supplycore_migration_pdo(): PDO
 {
-    // Dedicated connection for migrations to avoid conflicts with the main
-    // app connection's open cursors on MariaDB / MySQL.
+    // Dedicated connection for migrations.  Emulated prepares are enabled so
+    // that MariaDB never leaves an unconsumed result set from exec()/query()
+    // blocking a subsequent prepared-statement execute().
     $dsn = sprintf(
         'mysql:host=%s;port=%d;dbname=%s;charset=%s',
         (string) supplycore_base_config_value('db.host', '127.0.0.1'),
@@ -28516,7 +28517,7 @@ function supplycore_migration_pdo(): PDO
         [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-            PDO::ATTR_EMULATE_PREPARES => false,
+            PDO::ATTR_EMULATE_PREPARES => true,
         ]
     );
 }
@@ -28603,7 +28604,13 @@ function supplycore_run_migrations(bool $dryRun = false, bool $statusOnly = fals
                 if ($trimmed === '') {
                     continue;
                 }
-                $pdo->exec($trimmed);
+                // Use query() + closeCursor() instead of exec() so that
+                // SELECT statements (e.g. validation queries) have their
+                // result sets fully consumed before the next statement.
+                $result = $pdo->query($trimmed);
+                if ($result instanceof PDOStatement) {
+                    $result->closeCursor();
+                }
             }
             $durationMs = (int) ((microtime(true) - $startedAt) * 1000);
             $recordStmt->execute([$filename, $fileHash, $durationMs, 'applied', null]);
@@ -28611,7 +28618,11 @@ function supplycore_run_migrations(bool $dryRun = false, bool $statusOnly = fals
         } catch (Throwable $e) {
             $durationMs = (int) ((microtime(true) - $startedAt) * 1000);
             $errorMsg = mb_substr($e->getMessage(), 0, 2000);
-            $recordStmt->execute([$filename, $fileHash, $durationMs, 'failed', $errorMsg]);
+            try {
+                $recordStmt->execute([$filename, $fileHash, $durationMs, 'failed', $errorMsg]);
+            } catch (Throwable) {
+                // If recording fails too, just capture the original error.
+            }
             $errors[] = ['file' => $filename, 'message' => $errorMsg];
         }
     }


### PR DESCRIPTION
## Summary

- **Root cause**: Migration SQL files can contain `SELECT` statements (e.g. validation queries). MariaDB's PDO with native prepared statements leaves the result set from `exec()` unconsumed, blocking the next `$recordStmt->execute()` with "Cannot execute queries while other unbuffered queries are active"

- **Fix 1**: Enable `PDO::ATTR_EMULATE_PREPARES => true` on the migration PDO connection so MariaDB doesn't hold server-side cursors between statements

- **Fix 2**: Replace `$pdo->exec()` with `$pdo->query()` + `closeCursor()` in the statement execution loop so any result sets (from SELECT validation queries) are fully consumed before the next statement runs

- **Fix 3**: Wrap the failure-recording `$recordStmt->execute()` in try/catch so a PDO error during error recording doesn't mask the original migration error

## Test plan

- [ ] Run `./scripts/update-and-restart.sh` — migrations should complete without PDO errors
- [ ] Click "Run migrations now" on Settings > Sync behavior — should apply pending migrations
- [ ] Run `php bin/run-migrations.php --status` — should show all migrations as applied

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf