### PR TITLE
Fix service discovery field splitting in update-and-restart.sh

### DIFF
--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -203,7 +203,7 @@ discover_services() {
   local -a discovered=()
   local unit load_state
 
-  while IFS= read -r unit load_state; do
+  while read -r unit load_state _rest; do
     [[ -z "${unit}" ]] && continue
     [[ "${unit}" == *'@.service' ]] && continue
     [[ "${load_state}" == "not-found" ]] && continue
@@ -213,7 +213,7 @@ discover_services() {
     | awk '/^supplycore-/ {print $1, $2}' \
     || true)
 
-  while IFS= read -r unit load_state; do
+  while read -r unit load_state _rest; do
     [[ -z "${unit}" ]] && continue
     [[ "${load_state}" == "not-found" ]] && continue
     [[ "${load_state}" == "masked" ]] && continue


### PR DESCRIPTION
## Summary

- `IFS=` in the `read` loop disabled word splitting, so `"supplycore-compute-worker.service loaded"` was read entirely into the `unit` variable instead of being split into `unit="supplycore-compute-worker.service"` and `load_state="loaded"`
- This caused `systemctl restart "supplycore-compute-worker.service loaded"` which systemd escaped as `supplycore-compute-worker.service\x20loaded`
- Fix: removed `IFS=` and added `_rest` variable to consume any extra fields

## Test plan

- [ ] Run `./scripts/update-and-restart.sh` — services should restart cleanly without `\x20loaded` in names

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf