### PR TITLE
Fix empty dashboard: remove Redis from snapshots, recover stale data

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -7254,11 +7254,21 @@ function dashboard_intelligence_data_build(): array
 
 function dashboard_snapshot_payload(): array
 {
-    return supplycore_materialized_snapshot_read_or_bootstrap(
+    $result = supplycore_materialized_snapshot_read_or_bootstrap(
         dashboard_snapshot_key(),
         static fn (): array => dashboard_intelligence_data_build(),
         'dashboard-bootstrap'
     );
+
+    if (!isset($result['priority_queues'])) {
+        $payload = dashboard_intelligence_data_build();
+        return supplycore_materialized_snapshot_store(dashboard_snapshot_key(), $payload, [
+            'reason' => 'dashboard-format-recovery',
+            'status' => 'ready',
+        ]);
+    }
+
+    return $result;
 }
 
 function dashboard_refresh_summary(string $reason = 'manual'): array


### PR DESCRIPTION
## Summary

- **Fix empty dashboard** caused by Python `dashboard_summary_sync` writing incompatible data to the `dashboard_summaries` snapshot key — changed Python to write to `dashboard_operational_kpis` instead
- **Remove Redis from materialized snapshot pipeline** — snapshots now read/write directly to the `intelligence_snapshots` DB table, eliminating the stale-cache complexity layer. Normal Redis cache (`supplycore_cache_aside`) is untouched.
- **Add format validation** in `dashboard_snapshot_payload()` — detects stale Python-format data still in the DB (missing `priority_queues` key) and forces a fresh PHP rebuild, overwriting the bad row

## Details

The dashboard was showing 5 identical "Pricing upside" cards with "—" values because:
1. Python wrote `{kpis: {queued_jobs: 4, running_jobs: 2, ...}}` to `dashboard_summaries`
2. PHP read this, iterated over the flat counters as KPI cards, and rendered empty cards with the default theme

The Redis snapshot layer added unnecessary complexity — snapshots went Redis → DB → bootstrap, and Redis TTL expiry could surface stale or incompatible data from the DB. Now it's just DB → bootstrap.

## Test plan

- [ ] Dashboard loads with actual KPI values, priority queues, and market comparison data
- [ ] Doctrine readiness section continues to render (already working)
- [ ] Page freshness shows "Fresh" after rebuild
- [ ] Other pages using snapshots (market comparison, loss demand, doctrine) still work

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf