### PR TITLE
Fix stale dashboard and doctrine data: snapshot expiry and format recovery

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -23190,7 +23190,14 @@ function supplycore_materialized_snapshot_mark_updating(string $snapshotKey, str
 function supplycore_materialized_snapshot_read_or_bootstrap(string $snapshotKey, callable $builder, string $reason): array
 {
     $snapshot = supplycore_materialized_snapshot_fetch($snapshotKey);
-    if ($snapshot !== null && is_array($snapshot['payload'] ?? null) && $snapshot['payload'] !== []) {
+    $expired = false;
+    if ($snapshot !== null) {
+        $expiresAt = trim((string) ($snapshot['meta']['expires_at'] ?? ''));
+        if ($expiresAt !== '' && strtotime($expiresAt) !== false && strtotime($expiresAt) < time()) {
+            $expired = true;
+        }
+    }
+    if (!$expired && $snapshot !== null && is_array($snapshot['payload'] ?? null) && $snapshot['payload'] !== []) {
         return supplycore_materialized_snapshot_attach_meta($snapshot['payload'], is_array($snapshot['meta'] ?? null) ? $snapshot['meta'] : []);
     }
 
@@ -24174,6 +24181,13 @@ function doctrine_snapshot_cache_payload(): ?array
 
     if (!is_array($fitSnapshot) || !is_array($groupSnapshot)) {
         return null;
+    }
+
+    foreach ([$fitSnapshot, $groupSnapshot] as $snap) {
+        $expiresAt = trim((string) ($snap['meta']['expires_at'] ?? ''));
+        if ($expiresAt !== '' && strtotime($expiresAt) !== false && strtotime($expiresAt) < time()) {
+            return null;
+        }
     }
 
     $fitPayload = is_array($fitSnapshot['payload'] ?? null) ? $fitSnapshot['payload'] : [];


### PR DESCRIPTION
## Summary

- **Auto-rebuild expired snapshots** — `supplycore_materialized_snapshot_read_or_bootstrap()` now checks `expires_at` and triggers the builder when stale, instead of serving 23h-old data indefinitely
- **Doctrine snapshot expiry** — `doctrine_snapshot_cache_payload()` returns null when either doctrine snapshot is expired, forcing a fresh rebuild from current market data
- **Dashboard format recovery** — `dashboard_snapshot_payload()` detects stale Python-format data (missing `priority_queues` key) and rebuilds from scratch
- **Remove Redis from snapshot pipeline** — snapshots read/write directly to DB, eliminating the Redis caching layer that caused stale-data bugs. Normal Redis cache for other features is untouched.
- **Fix snapshot key collision** — Python `dashboard_summary_sync` now writes to `dashboard_operational_kpis` instead of overwriting the PHP dashboard's `dashboard_summaries` key

## Root causes

1. Dashboard showed 5 empty "Pricing upside" cards because old Python-format data was still in the `dashboard_summaries` DB row
2. "Top Missing Doctrine Items" showed items that were already stocked because the doctrine snapshot (23h old) was served without expiry checking
3. Redis snapshot caching layer added complexity and could serve stale data after TTL expiry

## Test plan

- [ ] Dashboard loads with actual KPI values and priority queues after first page load rebuilds expired snapshots
- [ ] "Top Missing Doctrine Items" reflects current alliance inventory (stocked items disappear)
- [ ] Other snapshot-backed pages (market comparison, loss demand) also auto-rebuild when expired
- [ ] Doctrine readiness section continues to render correctly

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf