### PR TITLE
Fix failing sync jobs: missing tables, error logging, item_scope

### DIFF
--- a/database/migrations/20260326_create_missing_analytics_tables.sql
+++ b/database/migrations/20260326_create_missing_analytics_tables.sql
@@ -1,0 +1,146 @@
+-- Create analytics and doctrine time-series tables that sync jobs depend on.
+-- These tables are defined in schema.sql but may be missing from servers
+-- that were set up before they were added.
+
+CREATE TABLE IF NOT EXISTS market_item_stock_1h (
+    bucket_start DATETIME NOT NULL,
+    source_type ENUM('alliance_structure', 'market_hub') NOT NULL,
+    source_id BIGINT UNSIGNED NOT NULL,
+    type_id INT UNSIGNED NOT NULL,
+    sample_count INT UNSIGNED NOT NULL DEFAULT 0,
+    stock_units_sum DECIMAL(20, 2) NOT NULL DEFAULT 0.00,
+    listing_count_sum DECIMAL(20, 2) NOT NULL DEFAULT 0.00,
+    local_stock_units BIGINT NOT NULL DEFAULT 0,
+    listing_count INT UNSIGNED NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (bucket_start, source_type, source_id, type_id),
+    KEY idx_market_item_stock_1h_bucket_type (bucket_start, type_id),
+    KEY idx_market_item_stock_1h_type_bucket (type_id, bucket_start),
+    KEY idx_market_item_stock_1h_bucket (bucket_start),
+    KEY idx_market_item_stock_1h_source_bucket (source_type, source_id, bucket_start)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS market_item_stock_1d (
+    bucket_start DATE NOT NULL,
+    source_type ENUM('alliance_structure', 'market_hub') NOT NULL,
+    source_id BIGINT UNSIGNED NOT NULL,
+    type_id INT UNSIGNED NOT NULL,
+    sample_count INT UNSIGNED NOT NULL DEFAULT 0,
+    stock_units_sum DECIMAL(20, 2) NOT NULL DEFAULT 0.00,
+    listing_count_sum DECIMAL(20, 2) NOT NULL DEFAULT 0.00,
+    local_stock_units BIGINT NOT NULL DEFAULT 0,
+    listing_count INT UNSIGNED NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (bucket_start, source_type, source_id, type_id),
+    KEY idx_market_item_stock_1d_bucket_type (bucket_start, type_id),
+    KEY idx_market_item_stock_1d_type_bucket (type_id, bucket_start),
+    KEY idx_market_item_stock_1d_bucket (bucket_start),
+    KEY idx_market_item_stock_1d_source_bucket (source_type, source_id, bucket_start)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS market_item_price_1h (
+    bucket_start DATETIME NOT NULL,
+    source_type ENUM('alliance_structure', 'market_hub') NOT NULL,
+    source_id BIGINT UNSIGNED NOT NULL,
+    type_id INT UNSIGNED NOT NULL,
+    sample_count INT UNSIGNED NOT NULL DEFAULT 0,
+    listing_count_sum DECIMAL(20, 2) NOT NULL DEFAULT 0.00,
+    avg_price_sum DECIMAL(20, 2) NOT NULL DEFAULT 0.00,
+    weighted_price_numerator DECIMAL(24, 2) NOT NULL DEFAULT 0.00,
+    weighted_price_denominator DECIMAL(24, 2) NOT NULL DEFAULT 0.00,
+    listing_count INT UNSIGNED NOT NULL DEFAULT 0,
+    min_price DECIMAL(20, 2) DEFAULT NULL,
+    max_price DECIMAL(20, 2) DEFAULT NULL,
+    avg_price DECIMAL(20, 2) DEFAULT NULL,
+    weighted_price DECIMAL(20, 2) DEFAULT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (bucket_start, source_type, source_id, type_id),
+    KEY idx_market_item_price_1h_bucket_type (bucket_start, type_id),
+    KEY idx_market_item_price_1h_type_bucket (type_id, bucket_start),
+    KEY idx_market_item_price_1h_bucket (bucket_start),
+    KEY idx_market_item_price_1h_source_bucket (source_type, source_id, bucket_start)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS market_item_price_1d (
+    bucket_start DATE NOT NULL,
+    source_type ENUM('alliance_structure', 'market_hub') NOT NULL,
+    source_id BIGINT UNSIGNED NOT NULL,
+    type_id INT UNSIGNED NOT NULL,
+    sample_count INT UNSIGNED NOT NULL DEFAULT 0,
+    listing_count_sum DECIMAL(20, 2) NOT NULL DEFAULT 0.00,
+    avg_price_sum DECIMAL(20, 2) NOT NULL DEFAULT 0.00,
+    weighted_price_numerator DECIMAL(24, 2) NOT NULL DEFAULT 0.00,
+    weighted_price_denominator DECIMAL(24, 2) NOT NULL DEFAULT 0.00,
+    listing_count INT UNSIGNED NOT NULL DEFAULT 0,
+    min_price DECIMAL(20, 2) DEFAULT NULL,
+    max_price DECIMAL(20, 2) DEFAULT NULL,
+    avg_price DECIMAL(20, 2) DEFAULT NULL,
+    weighted_price DECIMAL(20, 2) DEFAULT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (bucket_start, source_type, source_id, type_id),
+    KEY idx_market_item_price_1d_bucket_type (bucket_start, type_id),
+    KEY idx_market_item_price_1d_type_bucket (type_id, bucket_start),
+    KEY idx_market_item_price_1d_bucket (bucket_start),
+    KEY idx_market_item_price_1d_source_bucket (source_type, source_id, bucket_start)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS doctrine_item_stock_1d (
+    bucket_start DATE NOT NULL,
+    fit_id INT UNSIGNED NOT NULL,
+    doctrine_group_id INT UNSIGNED DEFAULT NULL,
+    type_id INT UNSIGNED NOT NULL,
+    required_units INT UNSIGNED NOT NULL DEFAULT 0,
+    local_stock_units BIGINT NOT NULL DEFAULT 0,
+    complete_fits_supported INT UNSIGNED NOT NULL DEFAULT 0,
+    fit_gap INT UNSIGNED NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (bucket_start, fit_id, type_id),
+    KEY idx_doctrine_item_stock_1d_group_bucket (doctrine_group_id, bucket_start),
+    KEY idx_doctrine_item_stock_1d_type_bucket (type_id, bucket_start)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS doctrine_fit_activity_1d (
+    bucket_start DATE NOT NULL,
+    fit_id INT UNSIGNED NOT NULL,
+    hull_type_id INT UNSIGNED DEFAULT NULL,
+    doctrine_group_id INT UNSIGNED DEFAULT NULL,
+    hull_loss_count INT UNSIGNED NOT NULL DEFAULT 0,
+    doctrine_item_loss_count INT UNSIGNED NOT NULL DEFAULT 0,
+    complete_fits_available INT UNSIGNED NOT NULL DEFAULT 0,
+    target_fits INT UNSIGNED NOT NULL DEFAULT 0,
+    fit_gap INT UNSIGNED NOT NULL DEFAULT 0,
+    readiness_state VARCHAR(32) NOT NULL DEFAULT 'unknown',
+    resupply_pressure VARCHAR(64) NOT NULL DEFAULT 'stable',
+    priority_score DECIMAL(8,2) NOT NULL DEFAULT 0.00,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (bucket_start, fit_id),
+    KEY idx_doctrine_fit_activity_1d_bucket_fit (bucket_start, fit_id),
+    KEY idx_doctrine_fit_activity_1d_bucket_group (bucket_start, doctrine_group_id),
+    KEY idx_doctrine_fit_activity_1d_bucket (bucket_start),
+    KEY idx_doctrine_fit_activity_1d_group_bucket (doctrine_group_id, bucket_start),
+    KEY idx_doctrine_fit_activity_1d_hull_bucket (hull_type_id, bucket_start),
+    KEY idx_doctrine_fit_activity_1d_priority (priority_score, bucket_start)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS killmail_item_loss_1d (
+    bucket_start DATE NOT NULL,
+    type_id INT UNSIGNED NOT NULL,
+    doctrine_fit_id INT UNSIGNED DEFAULT NULL,
+    doctrine_group_id INT UNSIGNED DEFAULT NULL,
+    hull_type_id INT UNSIGNED DEFAULT NULL,
+    doctrine_fit_key INT UNSIGNED GENERATED ALWAYS AS (COALESCE(doctrine_fit_id, 0)) STORED,
+    doctrine_group_key INT UNSIGNED GENERATED ALWAYS AS (COALESCE(doctrine_group_id, 0)) STORED,
+    hull_type_key INT UNSIGNED GENERATED ALWAYS AS (COALESCE(hull_type_id, 0)) STORED,
+    loss_count INT UNSIGNED NOT NULL DEFAULT 0,
+    quantity_lost BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    victim_count INT UNSIGNED NOT NULL DEFAULT 0,
+    killmail_count INT UNSIGNED NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_killmail_item_loss_1d_dimensions (bucket_start, type_id, doctrine_fit_key, doctrine_group_key, hull_type_key),
+    KEY idx_killmail_item_loss_1d_bucket_type (bucket_start, type_id),
+    KEY idx_killmail_item_loss_1d_type_bucket (type_id, bucket_start),
+    KEY idx_killmail_item_loss_1d_bucket (bucket_start),
+    KEY idx_killmail_item_loss_1d_group_bucket (doctrine_group_id, bucket_start),
+    KEY idx_killmail_item_loss_1d_fit_bucket (doctrine_fit_id, bucket_start),
+    KEY idx_killmail_item_loss_1d_hull_bucket (hull_type_id, bucket_start)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/python/orchestrator/jobs/market_comparison_summary_sync.py
+++ b/python/orchestrator/jobs/market_comparison_summary_sync.py
@@ -113,11 +113,14 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         (alliance_structure_id, reference_source_id, alliance_structure_id, reference_source_id),
     )
 
-    # Filter by item scope if configured
-    allowed_type_ids_raw = db.fetch_all(
-        "SELECT type_id FROM item_scope WHERE enabled = 1"
-    )
-    allowed_type_ids = {int(row["type_id"]) for row in allowed_type_ids_raw} if allowed_type_ids_raw else set()
+    # Filter by item scope if the table exists
+    try:
+        allowed_type_ids_raw = db.fetch_all(
+            "SELECT type_id FROM item_scope WHERE enabled = 1"
+        )
+        allowed_type_ids = {int(row["type_id"]) for row in allowed_type_ids_raw} if allowed_type_ids_raw else set()
+    except Exception:
+        allowed_type_ids = set()
 
     evaluated = []
     for row in aggregate_rows:

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -136,7 +136,7 @@ def _finalize_job(db: SupplyCoreDb, job_key: str, result: dict[str, Any], logger
     rows_seen = max(0, int(result.get("rows_seen") or result.get("rows_processed") or 0))
     rows_written = max(0, int(result.get("rows_written") or 0))
     duration_ms = max(0, int(result.get("duration_ms") or 0))
-    error_text = str(result.get("error") or "") if status == "failed" else None
+    error_text = str(result.get("error_text") or result.get("error") or result.get("summary") or "") if status == "failed" else None
 
     dataset_key = f"scheduler.job.{job_key}"
     try:
@@ -410,6 +410,8 @@ def main(argv: list[str] | None = None) -> int:
             result = _process_job(context)
             db.complete_worker_job(int(job.get("id") or 0), worker_id, result)
             completed_payload = {"event": "worker_pool.job_completed", "worker_id": worker_id, "job_id": int(job.get("id") or 0), "job_key": context.job_key, "status": result.get("status", "success"), "execution_language": "python", "subprocess_invoked": False, "duration_ms": result.get("duration_ms", 0), "rows_processed": result.get("rows_processed", 0), "rows_written": result.get("rows_written", 0)}
+            if result.get("status") == "failed":
+                completed_payload["error"] = str(result.get("error_text") or result.get("summary") or "")
             logger.info("worker job completed", payload=completed_payload)
             job_log.write_event("worker_pool.job_completed", completed_payload)
             _finalize_job(db, context.job_key, result, logger)


### PR DESCRIPTION
## Summary

- **Add migration for missing analytics tables** that sync jobs depend on: `market_item_stock_1h`, `market_item_stock_1d`, `market_item_price_1h`, `market_item_price_1d`, `doctrine_item_stock_1d`, `doctrine_fit_activity_1d`, `killmail_item_loss_1d`
- **Fix `item_scope` table not existing** — `market_comparison_summary_sync` queried a nonexistent `item_scope` table causing every run to fail; now gracefully skips the filter
- **Fix lost error messages** — `_finalize_job()` read `result.get("error")` but `JobResult` stores errors under `"error_text"`, so all failure reasons were silently discarded from `sync_state` and `sync_runs`
- **Add error text to sync-job logs** — failed jobs now include the error message in the log JSON so failures are diagnosable
- **Snapshot expiry and format recovery** from previous commits (already in this branch)

## Root cause of failing jobs

| Job | Failure cause |
|-----|--------------|
| `doctrine_intelligence_sync` | Missing `doctrine_item_stock_1d` / `doctrine_fit_activity_1d` tables |
| `market_comparison_summary_sync` | Missing `item_scope` table (never existed in schema) |
| `analytics_bucket_1h_sync` | Missing `market_item_stock_1h` / `market_item_price_1h` tables |
| `dashboard_summary_sync` | Likely missing `market_deal_alerts_current` or related table |

All errors were invisible because the error text was lost during finalization.

## Test plan

- [ ] Run migration via Settings page or CLI: creates missing tables
- [ ] Restart sync workers: `systemctl restart supplycore-sync-worker`
- [ ] Verify `doctrine_intelligence_sync` succeeds (check sync-jobs log)
- [ ] Verify `market_comparison_summary_sync` succeeds
- [ ] Verify failed jobs now show error text in logs: `grep error sync-jobs/*.log`
- [ ] Dashboard "Top Missing Doctrine Items" updates to reflect current stock

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf