### PR TITLE
Fix zkill streaming, stuck job scheduling, and buy_all planner

### DIFF
--- a/database/migrations/20260326_create_buy_all_tables.sql
+++ b/database/migrations/20260326_create_buy_all_tables.sql
@@ -1,0 +1,39 @@
+-- Create buy_all_summary and buy_all_items tables if they don't exist.
+-- These are defined in schema.sql but were never in a migration,
+-- so incrementally-migrated servers may not have them.
+
+CREATE TABLE IF NOT EXISTS buy_all_summary (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    mode_key VARCHAR(40) NOT NULL,
+    sort_key VARCHAR(40) NOT NULL,
+    filters_hash CHAR(64) NOT NULL,
+    summary_json LONGTEXT NOT NULL,
+    payload_json LONGTEXT NOT NULL,
+    computed_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_buy_all_summary_request (mode_key, sort_key, filters_hash),
+    KEY idx_buy_all_summary_lookup (mode_key, sort_key, filters_hash, computed_at),
+    KEY idx_buy_all_summary_computed (computed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS buy_all_items (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    summary_id BIGINT UNSIGNED NOT NULL,
+    page_number INT UNSIGNED NOT NULL DEFAULT 1,
+    rank_position INT UNSIGNED NOT NULL DEFAULT 0,
+    type_id INT UNSIGNED NOT NULL,
+    quantity INT UNSIGNED NOT NULL DEFAULT 0,
+    mode_rank_score DECIMAL(8,2) DEFAULT NULL,
+    necessity_score DECIMAL(8,2) DEFAULT NULL,
+    profit_score DECIMAL(8,2) DEFAULT NULL,
+    item_json LONGTEXT NOT NULL,
+    computed_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_buy_all_items_summary_type_page (summary_id, type_id, page_number),
+    KEY idx_buy_all_items_summary_page_rank (summary_id, page_number, rank_position),
+    KEY idx_buy_all_items_item_id (type_id),
+    KEY idx_buy_all_items_type_computed (type_id, computed_at),
+    KEY idx_buy_all_items_computed (computed_at),
+    CONSTRAINT fk_buy_all_items_summary FOREIGN KEY (summary_id) REFERENCES buy_all_summary(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -93,6 +93,22 @@ class SupplyCoreDb:
         finally:
             connection.close()
 
+    def reap_stale_running_jobs(self) -> int:
+        """Mark stuck running jobs as dead when their lock has expired."""
+        return self.execute(
+            """UPDATE worker_jobs
+               SET status = CASE WHEN attempts >= max_attempts THEN 'dead' ELSE 'failed' END,
+                   last_error = 'Reaped: lock expired while still running (worker likely crashed)',
+                   last_finished_at = UTC_TIMESTAMP(),
+                   locked_at = NULL,
+                   lock_expires_at = NULL,
+                   locked_by = NULL,
+                   heartbeat_at = NULL
+               WHERE status = 'running'
+                 AND lock_expires_at IS NOT NULL
+                 AND lock_expires_at < UTC_TIMESTAMP()"""
+        )
+
     def queue_due_recurring_jobs(self, definitions: dict[str, dict[str, Any]], *, only_job_keys: list[str] | None = None) -> dict[str, int]:
         scoped = definitions
         if only_job_keys:

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -329,6 +329,9 @@ def main(argv: list[str] | None = None) -> int:
             time.sleep(min(30, idle_sleep))
 
         try:
+            reaped = db.reap_stale_running_jobs()
+            if reaped > 0:
+                logger.info("reaped stale running jobs", payload={"event": "worker_pool.reaped_stale", "worker_id": worker_id, "reaped": reaped})
             seed_result = db.queue_due_recurring_jobs(WORKER_JOB_DEFINITIONS)
             job = db.claim_next_worker_job(worker_id, queues=queue_names, workload_classes=workload_classes, execution_modes=execution_modes, lease_seconds=lease_seconds)
             diagnostics = db.worker_claim_diagnostics(queues=queue_names, workload_classes=workload_classes)


### PR DESCRIPTION
## Summary

- **Fix zkill streaming service**: Remove duplicate `killmail_r2z2_sync` from worker queue (was competing with the dedicated `supplycore-zkill.service` for the same cursor). Fix `JobResult.failed()` crash in error handler that passed unsupported kwargs, causing TypeError on any stream error.
- **Fix stuck jobs blocking scheduler**: Worker pool had no dead-job reaping — if a worker crashed mid-execution, the job stayed in `running` status forever, blocking the rolling planner from re-queueing that job_key. This is why market syncs, compute jobs, and deal alerts stopped running after deploys. Added `reap_stale_running_jobs()` that marks jobs as failed/dead when their `lock_expires_at` has passed.
- **Fix buy_all planner**: Added migration for `buy_all_summary` and `buy_all_items` tables (defined in schema.sql but never migrated, so production server doesn't have them).
- **Fix column mismatches in finalize queries**: `sync_runs` used wrong column names (`rows_seen`/`rows_written` → `source_rows`/`written_rows`), `scheduler_job_events` used `payload_json` instead of `detail_json`, `sync_schedules` referenced nonexistent `runtime_snapshot_json` column.
- **Run all systemd services as root** instead of www-data across all service files.

## Test plan

- [ ] Deploy and verify the 3 finalize warnings no longer appear in logs
- [ ] Check that previously-stuck jobs (market_hub_current_sync, alliance_current_sync, compute_buy_all, graph_sync, deal_alerts) start running within minutes
- [ ] Verify buy_all planner produces results after market data syncs
- [ ] Verify zkill streaming service resumes ingesting killmails
- [ ] Confirm no duplicate killmail_r2z2_sync jobs appear in worker queue

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf