### PR TITLE
Fix dashboard, sync pipeline, zkill streaming, and job scheduling

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -515,15 +515,15 @@ class SupplyCoreDb:
 
     def insert_sync_run(self, *, dataset_key: str, rows_seen: int, rows_written: int, status: str, error: str | None = None) -> int:
         return self.insert(
-            """INSERT INTO sync_runs (dataset_key, run_mode, run_status, started_at, finished_at, cursor_start, cursor_end, rows_seen, rows_written, error_message)
+            """INSERT INTO sync_runs (dataset_key, run_mode, run_status, started_at, finished_at, cursor_start, cursor_end, source_rows, written_rows, error_message)
                VALUES (%s, 'incremental', %s, UTC_TIMESTAMP(), UTC_TIMESTAMP(), NULL, NULL, %s, %s, %s)""",
             (dataset_key[:190], status[:20], max(0, rows_seen), max(0, rows_written), error[:500] if error else None),
         )
 
     def insert_scheduler_job_event(self, *, job_key: str, event_type: str, payload_json: str, duration_seconds: float) -> int:
         return self.insert(
-            """INSERT INTO scheduler_job_events (job_key, event_type, payload_json, rows_written, duration_seconds)
-               VALUES (%s, %s, %s, 0, %s)""",
+            """INSERT INTO scheduler_job_events (job_key, event_type, detail_json, duration_seconds)
+               VALUES (%s, %s, %s, %s)""",
             (job_key[:120], event_type[:40], payload_json, round(duration_seconds, 2)),
         )
 
@@ -532,10 +532,9 @@ class SupplyCoreDb:
             """UPDATE sync_schedules
                SET last_status = %s,
                    last_run_at = UTC_TIMESTAMP(),
-                   locked_until = NULL,
-                   runtime_snapshot_json = %s
+                   locked_until = NULL
                WHERE job_key = %s AND execution_mode = 'python'""",
-            (status[:20], snapshot_json, job_key[:120]),
+            (status[:20], job_key[:120]),
         )
 
     def refresh_market_order_current_projection(self, *, source_type: str) -> dict[str, int]:


### PR DESCRIPTION
## Summary

- **Fix empty dashboard**: Resolve snapshot key collision between Python `dashboard_summary_sync` and PHP dashboard bootstrap — Python now writes to `dashboard_operational_kpis` instead of overwriting the PHP dashboard payload. Added format validation that rebuilds if `priority_queues` key is missing.
- **Remove Redis from snapshot pipeline**: Snapshots now go direct to DB, eliminating stale-data bugs from Redis/DB inconsistencies. Normal Redis cache for other features is untouched.
- **Auto-rebuild expired snapshots**: `supplycore_materialized_snapshot_read_or_bootstrap()` and `doctrine_snapshot_cache_payload()` now check `expires_at` and trigger fresh rebuilds instead of serving 23h-old data indefinitely.
- **Fix failing sync jobs**: Added migration for 7 missing analytics tables (`market_item_stock_1h/1d`, `market_item_price_1h/1d`, `doctrine_item_stock_1d`, `doctrine_fit_activity_1d`, `killmail_item_loss_1d`). Fixed `item_scope` table not existing (graceful fallback). Fixed lost error messages in `_finalize_job()` reading wrong key (`error` vs `error_text`).
- **Fix zkill streaming**: Removed duplicate `killmail_r2z2_sync` from worker queue that competed with the dedicated streaming service for the same cursor. Fixed `JobResult.failed()` TypeError crash in error handler.
- **Fix stuck jobs blocking scheduler**: Added dead-job reaper — jobs stuck in `running` status after worker crashes now get reset so the rolling planner can re-queue them. This was the root cause of market syncs, compute jobs, and deal alerts not running for 3+ hours.
- **Fix buy_all planner**: Added migration for `buy_all_summary` and `buy_all_items` tables.
- **Fix column mismatches in finalize queries**: `sync_runs` (`rows_seen` → `source_rows`), `scheduler_job_events` (`payload_json` → `detail_json`), `sync_schedules` (removed nonexistent `runtime_snapshot_json`).
- **Run all systemd services as root** across all service files.

## Test plan

- [ ] Dashboard shows populated KPI cards and priority queues
- [ ] Doctrine "Top Missing Items" no longer shows already-stocked items
- [ ] All sync jobs run without finalize warnings in logs
- [ ] Market syncs, compute jobs, deal alerts run every few minutes (not stuck for hours)
- [ ] Buy all planner produces results after market data syncs
- [ ] zkill streaming service resumes ingesting killmails
- [ ] No duplicate killmail_r2z2_sync jobs in worker queue

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf