### PR TITLE
Fix dashboard, sync pipeline, zkill, scheduling, and market pages

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -7500,8 +7500,9 @@ function market_comparison_top_rows(callable $predicate, string $sortKey, int $l
     return array_slice($rows, 0, max(1, $limit));
 }
 
-function market_format_isk(?float $price): string
+function market_format_isk(mixed $price): string
 {
+    $price = $price !== null && $price !== '' ? (float) $price : null;
     if ($price === null || $price <= 0) {
         return '—';
     }


### PR DESCRIPTION
## Summary

- **Fix empty dashboard**: Resolve snapshot key collision between Python and PHP, add format validation, remove Redis from snapshot pipeline, auto-rebuild expired snapshots
- **Fix failing sync jobs**: Migration for 7 missing analytics tables, graceful `item_scope` fallback, fix lost error messages in `_finalize_job()`
- **Fix zkill streaming**: Remove duplicate `killmail_r2z2_sync`, fix `JobResult.failed()` TypeError crash
- **Fix stuck jobs blocking scheduler**: Add dead-job reaper for jobs stuck in `running` status after worker crashes
- **Fix buy_all planner**: Migration for `buy_all_summary` and `buy_all_items` tables
- **Fix column mismatches**: `sync_runs` (`rows_seen` → `source_rows`), `scheduler_job_events` (`payload_json` → `detail_json`), removed nonexistent `runtime_snapshot_json`
- **Fix market pages crashing**: `market_format_isk()` had strict `?float` type hint but MariaDB returns DECIMAL columns as strings — changed to accept mixed with explicit cast
- **Run all systemd services as root**

## Test plan

- [ ] Dashboard shows populated KPI cards and priority queues
- [ ] Market status pages (current-alliance, reference-comparison, missing-items, price-deviations) load without errors
- [ ] All sync jobs run without finalize warnings in logs
- [ ] Market syncs, compute jobs, deal alerts run every few minutes
- [ ] Buy all planner produces results
- [ ] zkill streaming resumes

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf