### PR TITLE
Fix SQL parameter handling and align doctrine/dashboard jobs with schema

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -52,28 +52,42 @@ class SupplyCoreDb:
 
     def fetch_one(self, sql: str, params: Sequence[Any] | None = None) -> dict[str, Any] | None:
         with self.cursor() as (_, cursor):
-            cursor.execute(sql, params or ())
+            if params is None:
+                cursor.execute(sql)
+            else:
+                cursor.execute(sql, params)
             row = cursor.fetchone()
             return dict(row) if row else None
 
     def fetch_all(self, sql: str, params: Sequence[Any] | None = None) -> list[dict[str, Any]]:
         with self.cursor() as (_, cursor):
-            cursor.execute(sql, params or ())
+            if params is None:
+                cursor.execute(sql)
+            else:
+                cursor.execute(sql, params)
             return [dict(row) for row in cursor.fetchall()]
 
     def execute(self, sql: str, params: Sequence[Any] | None = None) -> int:
         with self.cursor() as (_, cursor):
-            return int(cursor.execute(sql, params or ()))
+            if params is None:
+                return int(cursor.execute(sql))
+            return int(cursor.execute(sql, params))
 
     def insert(self, sql: str, params: Sequence[Any] | None = None) -> int:
         with self.cursor() as (connection, cursor):
-            cursor.execute(sql, params or ())
+            if params is None:
+                cursor.execute(sql)
+            else:
+                cursor.execute(sql, params)
             connection.commit()
             return int(cursor.lastrowid or 0)
 
     def iterate_batches(self, sql: str, params: Sequence[Any] | None = None, *, batch_size: int = 1000) -> Generator[list[dict[str, Any]], None, None]:
         with self.cursor(stream=True) as (_, cursor):
-            cursor.execute(sql, params or ())
+            if params is None:
+                cursor.execute(sql)
+            else:
+                cursor.execute(sql, params)
             while True:
                 rows = cursor.fetchmany(batch_size)
                 if not rows:

--- a/python/orchestrator/jobs/dashboard_summary_sync.py
+++ b/python/orchestrator/jobs/dashboard_summary_sync.py
@@ -39,7 +39,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
 
     # Pull freshness info from sync_state for key datasets
     freshness_rows = db.fetch_all(
-        "SELECT dataset_key, status, last_success_at, row_count FROM sync_state WHERE dataset_key IN ('market_hub', 'alliance_structure', 'market_comparison') ORDER BY dataset_key"
+        "SELECT dataset_key, status, last_success_at, last_row_count FROM sync_state WHERE dataset_key IN ('market_hub', 'alliance_structure', 'market_comparison') ORDER BY dataset_key"
     )
     freshness: dict[str, object] = {}
     for row in (freshness_rows or []):
@@ -47,7 +47,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         freshness[key] = {
             "status": str(row.get("status") or "unknown"),
             "last_success_at": str(row.get("last_success_at") or ""),
-            "row_count": int(row.get("row_count") or 0),
+            "row_count": int(row.get("last_row_count") or 0),
         }
 
     rows_processed = int(queue_stats.get("queued_jobs") or 0) + int(queue_stats.get("running_jobs") or 0) + int(queue_stats.get("dead_jobs") or 0) + int(alert_count or 0) + int(schedules or 0)

--- a/python/orchestrator/jobs/doctrine_intelligence_sync.py
+++ b/python/orchestrator/jobs/doctrine_intelligence_sync.py
@@ -6,7 +6,7 @@ from .sync_runtime import run_sync_phase_job
 
 
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
-    rows_processed = db.fetch_scalar("SELECT COUNT(*) FROM doctrine_fits WHERE is_active = 1")
+    rows_processed = db.fetch_scalar("SELECT COUNT(*) FROM doctrine_fits WHERE parse_status = 'ready'")
     stock_written = db.execute(
         """INSERT INTO doctrine_item_stock_1d (
                 bucket_start, fit_id, doctrine_group_id, type_id, required_units, local_stock_units, complete_fits_supported, fit_gap
@@ -23,7 +23,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
             FROM doctrine_fits f
             INNER JOIN doctrine_fit_items i ON i.doctrine_fit_id = f.id
             LEFT JOIN market_item_stock_1d s ON s.type_id = i.type_id AND s.bucket_start = CURDATE()
-            WHERE f.is_active = 1
+            WHERE f.parse_status = 'ready'
             GROUP BY f.id, f.doctrine_group_id, i.type_id, i.required_quantity
             ON DUPLICATE KEY UPDATE
                 local_stock_units = VALUES(local_stock_units), complete_fits_supported = VALUES(complete_fits_supported), fit_gap = VALUES(fit_gap)"""
@@ -36,21 +36,21 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
             SELECT
                 CURDATE(),
                 f.id,
-                f.hull_type_id,
+                f.ship_type_id,
                 f.doctrine_group_id,
                 0,
                 COALESCE(SUM(il.quantity_lost), 0) AS doctrine_item_loss_count,
                 COALESCE(MIN(dis.complete_fits_supported), 0) AS complete_fits_available,
-                f.target_fleet_size,
-                GREATEST(0, f.target_fleet_size - COALESCE(MIN(dis.complete_fits_supported), 0)) AS fit_gap,
-                CASE WHEN COALESCE(MIN(dis.complete_fits_supported), 0) >= f.target_fleet_size THEN 'ready' ELSE 'degraded' END,
+                COALESCE(f.target_fleet_size_override, 0),
+                GREATEST(0, COALESCE(f.target_fleet_size_override, 0) - COALESCE(MIN(dis.complete_fits_supported), 0)) AS fit_gap,
+                CASE WHEN COALESCE(MIN(dis.complete_fits_supported), 0) >= COALESCE(f.target_fleet_size_override, 0) THEN 'ready' ELSE 'degraded' END,
                 CASE WHEN COALESCE(SUM(il.quantity_lost), 0) > 0 THEN 'elevated' ELSE 'stable' END,
-                (COALESCE(SUM(il.quantity_lost), 0) * 1.0) + GREATEST(0, f.target_fleet_size - COALESCE(MIN(dis.complete_fits_supported), 0))
+                (COALESCE(SUM(il.quantity_lost), 0) * 1.0) + GREATEST(0, COALESCE(f.target_fleet_size_override, 0) - COALESCE(MIN(dis.complete_fits_supported), 0))
             FROM doctrine_fits f
             LEFT JOIN doctrine_item_stock_1d dis ON dis.fit_id = f.id AND dis.bucket_start = CURDATE()
             LEFT JOIN killmail_item_loss_1d il ON il.type_id = dis.type_id AND il.bucket_start >= DATE_SUB(CURDATE(), INTERVAL 1 DAY)
-            WHERE f.is_active = 1
-            GROUP BY f.id, f.hull_type_id, f.doctrine_group_id, f.target_fleet_size
+            WHERE f.parse_status = 'ready'
+            GROUP BY f.id, f.ship_type_id, f.doctrine_group_id, f.target_fleet_size_override
             ON DUPLICATE KEY UPDATE
                 doctrine_item_loss_count = VALUES(doctrine_item_loss_count), complete_fits_available = VALUES(complete_fits_available),
                 target_fits = VALUES(target_fits), fit_gap = VALUES(fit_gap), readiness_state = VALUES(readiness_state),
@@ -65,7 +65,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
                   fa.complete_fits_available, fa.target_fits, fa.fit_gap, fa.priority_score
            FROM doctrine_fit_activity_1d fa
            JOIN doctrine_fits f ON f.id = fa.fit_id
-           WHERE fa.bucket_start = CURDATE() AND f.is_active = 1
+           WHERE fa.bucket_start = CURDATE() AND f.parse_status = 'ready'
            ORDER BY fa.priority_score DESC
            LIMIT 200"""
     )


### PR DESCRIPTION
### Motivation
- Worker logs showed three recurring failures stemming from schema mismatches and SQL formatting: `analytics_bucket_1h_sync` raised `TypeError: not enough arguments for format string` from `%` tokens in `DATE_FORMAT`, `dashboard_summary_sync` selected a non-existent `row_count` column, and `doctrine_intelligence_sync` referenced removed/renamed doctrine columns (`is_active`, `hull_type_id`, `target_fleet_size`).
- The intent is to make the Python orchestrator resilient to SQL literals containing `%` and to align job queries with the authoritative `schema.sql` to prevent runtime `Unknown column` errors.

### Description
- Updated the DB helper to avoid passing an empty params tuple when there are no bound parameters, so `cursor.execute(sql)` is used when `params is None` and `cursor.execute(sql, params)` otherwise, preventing PyMySQL from interpreting `%` in SQL literals as format placeholders (`python/orchestrator/db.py`).
- Fixed `dashboard_summary_sync` to query `last_row_count` from `sync_state` and map that value into the freshness payload instead of the non-existent `row_count` (`python/orchestrator/jobs/dashboard_summary_sync.py`).
- Aligned `doctrine_intelligence_sync` with the schema by replacing `is_active` checks with `parse_status = 'ready'`, switching `hull_type_id` references to `ship_type_id`, and using `COALESCE(target_fleet_size_override, 0)` in place of `target_fleet_size` (including updated grouping and derived math) (`python/orchestrator/jobs/doctrine_intelligence_sync.py`).

### Testing
- Ran syntax checks via `python -m py_compile python/orchestrator/db.py python/orchestrator/jobs/dashboard_summary_sync.py python/orchestrator/jobs/doctrine_intelligence_sync.py`, which succeeded.
- Ran the sync processor test module with `python -m pytest python/tests/test_sync_processors.py -q`, which produced failures unrelated to the schema alignment fixes (5 failed, 2 passed) and are captured in the test output; the failing tests were `test_failure_paths_emit_meaningful_status_and_warnings`, `test_market_hub_and_alliance_processors_fetch_sources_and_write_projection`, `test_market_hub_npc_station_never_routes_to_structure_endpoint`, `test_market_hub_structure_source_can_resolve_region_and_filter_location`, and `test_alliance_current_sync_e2e_with_sqlite_fixture_layer`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58545d378832fab7a9f683697e76c)