### PR TITLE
Fix SQL errors in doctrine and forecasting sync processors

### DIFF
--- a/python/orchestrator/jobs/doctrine_intelligence_sync.py
+++ b/python/orchestrator/jobs/doctrine_intelligence_sync.py
@@ -16,15 +16,15 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
                 f.id AS fit_id,
                 f.doctrine_group_id,
                 i.type_id,
-                i.required_quantity,
+                i.quantity AS required_units,
                 COALESCE(SUM(s.local_stock_units), 0) AS local_stock_units,
-                FLOOR(COALESCE(SUM(s.local_stock_units), 0) / NULLIF(i.required_quantity, 0)) AS complete_fits_supported,
-                GREATEST(0, i.required_quantity - COALESCE(SUM(s.local_stock_units), 0)) AS fit_gap
+                FLOOR(COALESCE(SUM(s.local_stock_units), 0) / NULLIF(i.quantity, 0)) AS complete_fits_supported,
+                GREATEST(0, i.quantity - COALESCE(SUM(s.local_stock_units), 0)) AS fit_gap
             FROM doctrine_fits f
             INNER JOIN doctrine_fit_items i ON i.doctrine_fit_id = f.id
             LEFT JOIN market_item_stock_1d s ON s.type_id = i.type_id AND s.bucket_start = CURDATE()
             WHERE f.parse_status = 'ready'
-            GROUP BY f.id, f.doctrine_group_id, i.type_id, i.required_quantity
+            GROUP BY f.id, f.doctrine_group_id, i.type_id, i.quantity
             ON DUPLICATE KEY UPDATE
                 local_stock_units = VALUES(local_stock_units), complete_fits_supported = VALUES(complete_fits_supported), fit_gap = VALUES(fit_gap)"""
     )

--- a/python/orchestrator/jobs/forecasting_ai_sync.py
+++ b/python/orchestrator/jobs/forecasting_ai_sync.py
@@ -8,14 +8,20 @@ from .sync_runtime import run_sync_phase_job
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
     rows = db.fetch_all(
         """SELECT
-                d.type_id,
-                AVG(CASE WHEN d.bucket_start >= DATE_SUB(CURDATE(), INTERVAL 3 DAY) THEN d.weighted_price END) AS avg_3d,
-                AVG(d.weighted_price) AS avg_14d
-            FROM market_item_price_1d d
-            WHERE d.bucket_start >= DATE_SUB(CURDATE(), INTERVAL 14 DAY)
-            GROUP BY d.type_id
-            HAVING avg_14d IS NOT NULL
-            ORDER BY ABS((avg_3d - avg_14d) / NULLIF(avg_14d, 0)) DESC
+                agg.type_id,
+                agg.avg_3d,
+                agg.avg_14d
+            FROM (
+                SELECT
+                    d.type_id,
+                    AVG(CASE WHEN d.bucket_start >= DATE_SUB(CURDATE(), INTERVAL 3 DAY) THEN d.weighted_price END) AS avg_3d,
+                    AVG(d.weighted_price) AS avg_14d
+                FROM market_item_price_1d d
+                WHERE d.bucket_start >= DATE_SUB(CURDATE(), INTERVAL 14 DAY)
+                GROUP BY d.type_id
+            ) AS agg
+            WHERE agg.avg_14d IS NOT NULL
+            ORDER BY ABS((agg.avg_3d - agg.avg_14d) / NULLIF(agg.avg_14d, 0)) DESC
             LIMIT 300"""
     )
     rows_processed = len(rows)


### PR DESCRIPTION
### Motivation

- Resolve runtime SQL errors observed in worker logs: a missing column reference in doctrine sync and an aggregate-alias reference error in forecasting sync.

### Description

- Update `python/orchestrator/jobs/doctrine_intelligence_sync.py` to use the schema-backed `doctrine_fit_items.quantity` field (aliased to `required_units`) and adjust the related aggregates and `GROUP BY` to reference `i.quantity`.
- Refactor `python/orchestrator/jobs/forecasting_ai_sync.py` to compute `avg_3d`/`avg_14d` inside a derived table and perform ordering in the outer query to avoid referencing aggregate aliases in the `HAVING`/`ORDER BY` phase.
- Changes are limited to the two job processors and keep the SQL compatible with MySQL/MariaDB aggregate rules and the declared schema.

### Testing

- Ran bytecode check with `python -m py_compile python/orchestrator/jobs/doctrine_intelligence_sync.py python/orchestrator/jobs/forecasting_ai_sync.py`, which succeeded.
- Executed unit tests with `PYTHONPATH=python pytest -q python/tests/test_sync_processors.py`, which ran the suite but produced failures (5 failed, 2 passed); the failing tests exercise market/alliance sync logic and appear unrelated to these SQL fixes.
- Also attempted a targeted pytest run without `PYTHONPATH` which failed to import the test package (resolved by setting `PYTHONPATH`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5883b84c4832fbeac4b66eea5a432)