### PR TITLE
Apply canonical item-scope filtering in compute_buy_all precompute

### DIFF
--- a/bin/python_scheduler_bridge.php
+++ b/bin/python_scheduler_bridge.php
@@ -46,6 +46,10 @@ try {
         python_scheduler_bridge_output(['ok' => true, 'context' => python_bridge_market_history_tables_context()]);
     }
 
+    if ($action === 'item-scope-context') {
+        python_scheduler_bridge_output(['ok' => true, 'context' => python_bridge_item_scope_context()]);
+    }
+
     if ($action === 'rebuild-partitioned-history') {
         $input = python_scheduler_bridge_read_stdin_json();
         $window = is_array($input['window'] ?? null) ? $input['window'] : [];

--- a/python/orchestrator/jobs/compute_buy_all.py
+++ b/python/orchestrator/jobs/compute_buy_all.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from hashlib import sha256
+from pathlib import Path
 from typing import Any
 
+from ..bridge import PhpBridge
 from ..db import SupplyCoreDb
 from ..job_result import JobResult
 
@@ -156,6 +159,15 @@ def _load_market_rows(db: SupplyCoreDb, limit: int = 600) -> list[dict[str, Any]
     )
 
 
+def _load_allowed_type_ids_from_scope_bridge() -> set[int]:
+    php_binary = os.environ.get("SUPPLYCORE_PHP_BINARY", "php")
+    app_root = Path(__file__).resolve().parents[3]
+    bridge = PhpBridge(php_binary, app_root)
+    response = bridge.call("item-scope-context")
+    context = dict(response.get("context", {}))
+    return {int(type_id) for type_id in context.get("allowed_type_ids", []) if int(type_id) > 0}
+
+
 def _ranked_items(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ranked: list[dict[str, Any]] = []
     for row in rows:
@@ -300,10 +312,15 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
     computed_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
     planned_requests = requests or DEFAULT_REQUESTS
     market_rows = _load_market_rows(db)
-    items = _ranked_items(market_rows)
+    allowed_type_ids = _load_allowed_type_ids_from_scope_bridge()
+    scoped_market_rows = [row for row in market_rows if int(row.get("type_id") or 0) in allowed_type_ids]
+    items = _ranked_items(scoped_market_rows)
     created = 0
     rows_written = 0
-    rows_processed = len(market_rows)
+    rows_processed = len(scoped_market_rows)
+    market_rows_before_scope = len(market_rows)
+    market_rows_after_scope = len(scoped_market_rows)
+    ranked_items_after_scope = len(items)
 
     # Build freshness cards once for all requests
     hub_freshness = _freshness_card(db, "market_hub", "Hub pricing")
@@ -474,6 +491,11 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
             "computed_at": computed_at,
             "requests": created,
             "items_per_request": min(120, len(items)),
+            "scope_filter_source": "php_bridge:item-scope-context",
+            "scope_allowed_type_ids_count": len(allowed_type_ids),
+            "scope_market_rows_before_filter": market_rows_before_scope,
+            "scope_market_rows_after_filter": market_rows_after_scope,
+            "scope_ranked_rows_after_filter": ranked_items_after_scope,
         },
     ).to_dict()
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -14772,6 +14772,13 @@ function python_bridge_market_comparison_context(): array
     ];
 }
 
+function python_bridge_item_scope_context(): array
+{
+    return [
+        'allowed_type_ids' => item_scope_allowed_type_ids(),
+    ];
+}
+
 function python_bridge_killmail_context(): array
 {
     $datasetKey = killmail_sync_dataset_key();


### PR DESCRIPTION
### Motivation
- Ensure `compute_buy_all` uses the canonical PHP item-scope logic (not ad‑hoc SQL) so candidate sets are consistent with control-plane policy. 
- Make ranking, payload construction and `buy_all_items` inserts operate on the same scoped set and add observability so operators can validate filtering behavior.

### Description
- Added a PHP bridge context endpoint `python_bridge_item_scope_context()` (returns `item_scope_allowed_type_ids()`) and wired a new `--action=item-scope-context` in `bin/python_scheduler_bridge.php` so Python can request the canonical allowed type IDs. 
- Updated `python/orchestrator/jobs/compute_buy_all.py` to call the bridge via `PhpBridge`, load `allowed_type_ids`, filter `market_rows` before calling `_ranked_items`, and use the filtered set throughout page construction and DB inserts so `summary`, `items`, `pages`, and `buy_all_items` are all derived from the same scoped candidates. 
- Preserved request/filter hash semantics and left filters/hash construction unchanged for deterministic cache keys. 
- Added structured job meta fields in the job result (`scope_filter_source`, `scope_allowed_type_ids_count`, `scope_market_rows_before_filter`, `scope_market_rows_after_filter`, `scope_ranked_rows_after_filter`) and allowed PHP binary override via `SUPPLYCORE_PHP_BINARY` for bridge calls.

### Testing
- Ran Python syntax check: `python -m py_compile python/orchestrator/jobs/compute_buy_all.py` which completed successfully. 
- Ran PHP lint on modified PHP files: `php -l src/functions.php` and `php -l bin/python_scheduler_bridge.php`, both of which reported no syntax errors. 
- No other automated tests were modified or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58a8a8050832f8b3a02570d898145)