### PR TITLE
Unify Python item-scope enforcement with PHP authoritative context

### DIFF
--- a/python/orchestrator/item_scope.py
+++ b/python/orchestrator/item_scope.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Callable, TypeVar
+
+from .bridge import PhpBridge
+
+T = TypeVar("T")
+
+
+def load_allowed_type_ids(*, php_binary: str | None = None, app_root: Path | None = None) -> set[int]:
+    """Load authoritative allowed type IDs from PHP settings-driven scope context."""
+    resolved_php_binary = php_binary or os.environ.get("SUPPLYCORE_PHP_BINARY", "php")
+    resolved_app_root = app_root or Path(__file__).resolve().parents[2]
+    bridge = PhpBridge(resolved_php_binary, resolved_app_root)
+    response = bridge.call("item-scope-context")
+    context = dict(response.get("context", {}))
+
+    allowed: set[int] = set()
+    for raw_type_id in context.get("allowed_type_ids", []):
+        try:
+            type_id = int(raw_type_id)
+        except (TypeError, ValueError):
+            continue
+        if type_id > 0:
+            allowed.add(type_id)
+    return allowed
+
+
+def filter_rows_by_allowed_type_ids(
+    rows: list[T],
+    allowed_type_ids: set[int],
+    *,
+    type_id_getter: Callable[[T], Any],
+) -> tuple[list[T], dict[str, int]]:
+    """Filter rows by allowed type IDs and return consistency metrics."""
+    rows_before_scope = len(rows)
+    if not allowed_type_ids:
+        return rows, {
+            "scope_allowed_count": 0,
+            "rows_before_scope": rows_before_scope,
+            "rows_after_scope": rows_before_scope,
+        }
+
+    filtered_rows: list[T] = []
+    for row in rows:
+        try:
+            type_id = int(type_id_getter(row))
+        except (TypeError, ValueError):
+            continue
+        if type_id in allowed_type_ids:
+            filtered_rows.append(row)
+
+    return filtered_rows, {
+        "scope_allowed_count": len(allowed_type_ids),
+        "rows_before_scope": rows_before_scope,
+        "rows_after_scope": len(filtered_rows),
+    }

--- a/python/orchestrator/jobs/compute_buy_all.py
+++ b/python/orchestrator/jobs/compute_buy_all.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 import json
-import os
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from hashlib import sha256
-from pathlib import Path
 from typing import Any
 
-from ..bridge import PhpBridge
 from ..db import SupplyCoreDb
+from ..item_scope import filter_rows_by_allowed_type_ids, load_allowed_type_ids
 from ..job_result import JobResult
 
 _MODE_DEFINITIONS: dict[str, dict[str, Any]] = {
@@ -159,15 +157,6 @@ def _load_market_rows(db: SupplyCoreDb, limit: int = 600) -> list[dict[str, Any]
     )
 
 
-def _load_allowed_type_ids_from_scope_bridge() -> set[int]:
-    php_binary = os.environ.get("SUPPLYCORE_PHP_BINARY", "php")
-    app_root = Path(__file__).resolve().parents[3]
-    bridge = PhpBridge(php_binary, app_root)
-    response = bridge.call("item-scope-context")
-    context = dict(response.get("context", {}))
-    return {int(type_id) for type_id in context.get("allowed_type_ids", []) if int(type_id) > 0}
-
-
 def _ranked_items(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ranked: list[dict[str, Any]] = []
     for row in rows:
@@ -312,14 +301,16 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
     computed_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
     planned_requests = requests or DEFAULT_REQUESTS
     market_rows = _load_market_rows(db)
-    allowed_type_ids = _load_allowed_type_ids_from_scope_bridge()
-    scoped_market_rows = [row for row in market_rows if int(row.get("type_id") or 0) in allowed_type_ids]
+    allowed_type_ids = load_allowed_type_ids()
+    scoped_market_rows, scope_metrics = filter_rows_by_allowed_type_ids(
+        market_rows,
+        allowed_type_ids,
+        type_id_getter=lambda row: int(row.get("type_id") or 0),
+    )
     items = _ranked_items(scoped_market_rows)
     created = 0
     rows_written = 0
     rows_processed = len(scoped_market_rows)
-    market_rows_before_scope = len(market_rows)
-    market_rows_after_scope = len(scoped_market_rows)
     ranked_items_after_scope = len(items)
 
     # Build freshness cards once for all requests
@@ -492,9 +483,12 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
             "requests": created,
             "items_per_request": min(120, len(items)),
             "scope_filter_source": "php_bridge:item-scope-context",
-            "scope_allowed_type_ids_count": len(allowed_type_ids),
-            "scope_market_rows_before_filter": market_rows_before_scope,
-            "scope_market_rows_after_filter": market_rows_after_scope,
+            "scope_allowed_count": scope_metrics["scope_allowed_count"],
+            "rows_before_scope": scope_metrics["rows_before_scope"],
+            "rows_after_scope": scope_metrics["rows_after_scope"],
+            "scope_allowed_type_ids_count": scope_metrics["scope_allowed_count"],
+            "scope_market_rows_before_filter": scope_metrics["rows_before_scope"],
+            "scope_market_rows_after_filter": scope_metrics["rows_after_scope"],
             "scope_ranked_rows_after_filter": ranked_items_after_scope,
         },
     ).to_dict()

--- a/python/orchestrator/jobs/market_comparison.py
+++ b/python/orchestrator/jobs/market_comparison.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from ..bridge import PhpBridge
 from ..db import SupplyCoreDb
+from ..item_scope import load_allowed_type_ids
 from ..job_result import JobResult
 from ..worker_runtime import WorkerStats, payload_checksum, resident_memory_bytes, utc_now_iso
 
@@ -92,11 +93,13 @@ def run_market_comparison_summary(context: Any) -> dict[str, Any]:
     if alliance_structure_id <= 0 or reference_source_id <= 0:
         raise RuntimeError("Market comparison Python worker requires configured alliance and reference market sources.")
 
-    allowed_type_ids = {int(type_id) for type_id in job_context.get("allowed_type_ids", []) if int(type_id) > 0}
+    allowed_type_ids = load_allowed_type_ids(php_binary=context.php_binary, app_root=context.app_root)
     thresholds = dict(job_context.get("thresholds", {}))
     db = SupplyCoreDb(context.db_config)
     stats = WorkerStats()
     snapshot_rows: list[dict[str, Any]] = []
+    rows_before_scope = 0
+    rows_after_scope = 0
 
     latest_alliance = db.fetch_one(
         "SELECT COALESCE(NULLIF(latest_summary_observed_at, ''), latest_current_observed_at) AS observed_at FROM market_source_snapshot_state WHERE source_type = %s AND source_id = %s LIMIT 1",
@@ -149,8 +152,10 @@ def run_market_comparison_summary(context: Any) -> dict[str, Any]:
             break
 
         batch_type_ids = [int(row["type_id"]) for row in batch_type_rows if int(row.get("type_id") or 0) > 0]
+        rows_before_scope += len(batch_type_ids)
         if allowed_type_ids:
             batch_type_ids = [type_id for type_id in batch_type_ids if type_id in allowed_type_ids]
+        rows_after_scope += len(batch_type_ids)
         stats.progress.last_type_id = max(int(row["type_id"]) for row in batch_type_rows)
         if not batch_type_ids:
             stats.progress.batches_completed += 1
@@ -213,6 +218,9 @@ def run_market_comparison_summary(context: Any) -> dict[str, Any]:
                 "rows_processed": stats.progress.rows_processed,
                 "rows_written": stats.progress.rows_written,
                 "last_type_id": stats.progress.last_type_id,
+                "scope_allowed_count": len(allowed_type_ids),
+                "rows_before_scope": rows_before_scope,
+                "rows_after_scope": rows_after_scope,
                 "memory_usage_bytes": memory_bytes,
                 "duration_ms": stats.duration_ms(),
             },
@@ -243,6 +251,10 @@ def run_market_comparison_summary(context: Any) -> dict[str, Any]:
                 "execution_mode": "python",
                 "batches_completed": stats.progress.batches_completed,
                 "rows_processed": stats.progress.rows_processed,
+                "scope_filter_source": "php_bridge:item-scope-context",
+                "scope_allowed_count": len(allowed_type_ids),
+                "rows_before_scope": rows_before_scope,
+                "rows_after_scope": rows_after_scope,
                 "memory_peak_bytes": resident_memory_bytes(),
             },
         },
@@ -263,6 +275,10 @@ def run_market_comparison_summary(context: Any) -> dict[str, Any]:
             "memory_usage_bytes": resident_memory_bytes(),
             "cursor": f"market_comparison:{utc_now_iso()}",
             "checksum": payload_checksum({"rows": len(snapshot_rows), "computed_at": freshness.get("computed_at")}),
+            "scope_filter_source": "php_bridge:item-scope-context",
+            "scope_allowed_count": len(allowed_type_ids),
+            "rows_before_scope": rows_before_scope,
+            "rows_after_scope": rows_after_scope,
             "outcome_reason": "Python streamed summary snapshots in batches, pushed aggregation to SQL, and stored the materialized market comparison snapshot.",
         },
     ).to_dict()

--- a/python/orchestrator/jobs/market_comparison_summary_sync.py
+++ b/python/orchestrator/jobs/market_comparison_summary_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..item_scope import filter_rows_by_allowed_type_ids, load_allowed_type_ids
 from ..json_utils import json_dumps_safe
 from .sync_runtime import run_sync_phase_job
 
@@ -113,23 +114,14 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         (alliance_structure_id, reference_source_id, alliance_structure_id, reference_source_id),
     )
 
-    # Filter by item scope if the table exists
-    try:
-        allowed_type_ids_raw = db.fetch_all(
-            "SELECT type_id FROM item_scope WHERE enabled = 1"
-        )
-        allowed_type_ids = {int(row["type_id"]) for row in allowed_type_ids_raw} if allowed_type_ids_raw else set()
-    except Exception:
-        allowed_type_ids = set()
-
-    evaluated = []
-    for row in aggregate_rows:
-        type_id = int(row.get("type_id") or 0)
-        if type_id <= 0:
-            continue
-        if allowed_type_ids and type_id not in allowed_type_ids:
-            continue
-        evaluated.append(_evaluate_market_row(row, thresholds))
+    allowed_type_ids = load_allowed_type_ids()
+    valid_rows = [row for row in aggregate_rows if int(row.get("type_id") or 0) > 0]
+    scoped_rows, scope_metrics = filter_rows_by_allowed_type_ids(
+        valid_rows,
+        allowed_type_ids,
+        type_id_getter=lambda row: int(row.get("type_id") or 0),
+    )
+    evaluated = [_evaluate_market_row(row, thresholds) for row in scoped_rows]
 
     snapshot = {
         "thresholds": thresholds,
@@ -150,6 +142,10 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
             "row_count": len(evaluated),
             "alliance_structure_id": alliance_structure_id,
             "reference_source_id": reference_source_id,
+            "scope_filter_source": "php_bridge:item-scope-context",
+            "scope_allowed_count": scope_metrics["scope_allowed_count"],
+            "rows_before_scope": scope_metrics["rows_before_scope"],
+            "rows_after_scope": scope_metrics["rows_after_scope"],
         }),
         expires_seconds=600,
     )
@@ -167,7 +163,14 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         "rows_written": len(evaluated),
         "warnings": [],
         "summary": f"Market comparison: {len(evaluated)} items evaluated ({len([r for r in evaluated if r['in_both_markets']])} in both markets).",
-        "meta": {"snapshot_key": "market_comparison_summaries", "row_count": len(evaluated)},
+        "meta": {
+            "snapshot_key": "market_comparison_summaries",
+            "row_count": len(evaluated),
+            "scope_filter_source": "php_bridge:item-scope-context",
+            "scope_allowed_count": scope_metrics["scope_allowed_count"],
+            "rows_before_scope": scope_metrics["rows_before_scope"],
+            "rows_after_scope": scope_metrics["rows_after_scope"],
+        },
     }
 
 


### PR DESCRIPTION
### Motivation

- Ensure Python jobs use the same authoritative item-scope computed by PHP (settings-driven) instead of ad-hoc table reads or duplicated bridge logic to avoid drift between runtimes. 
- Add simple, consistent consistency metrics per run so regressions in scope filtering can be detected and monitored.

### Description

- Added a shared helper module `python/orchestrator/item_scope.py` with `load_allowed_type_ids()` to call PHP's `item-scope-context` and `filter_rows_by_allowed_type_ids()` which returns filtered rows plus scope metrics. 
- Replaced one-off scope loading in `python/orchestrator/jobs/compute_buy_all.py` to use the shared helper and updated metadata to include standardized metrics (`scope_allowed_count`, `rows_before_scope`, `rows_after_scope`) while keeping legacy metric keys for compatibility. 
- Replaced direct `item_scope` table reads in `python/orchestrator/jobs/market_comparison_summary_sync.py` with the shared helper and added the same scope metrics into snapshot metadata and returned job meta. 
- Updated the streaming worker `python/orchestrator/jobs/market_comparison.py` to use the shared helper and to emit scope consistency metrics in batch progress events, snapshot metadata, and final job-result metadata.

### Testing

- Compiled the modified modules with `python -m compileall python/orchestrator/item_scope.py python/orchestrator/jobs/compute_buy_all.py python/orchestrator/jobs/market_comparison.py python/orchestrator/jobs/market_comparison_summary_sync.py` and the compilation completed successfully. 
- No automated test failures were produced by the syntax/compile check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58bcf25f8832fbd2ff08fbd7bea65)