### PR TITLE
Fix losses page: mail_type filter, victim portrait, pod kill sub-rows

### DIFF
--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -236,9 +236,16 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <?php foreach ($rows as $index => $row): ?>
                     <tr class="border-b border-border/60 text-slate-200 transition hover:bg-accent/10 <?= $index % 2 === 1 ? 'bg-white/[0.01]' : '' ?>">
                         <td class="px-3 py-3 align-top">
-                            <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['victim_corporation'] ?? '—'), ENT_QUOTES) ?></p>
-                            <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($row['victim_alliance'] ?? '—'), ENT_QUOTES) ?></p>
-                            <p class="mt-2 text-xs text-muted"><?= htmlspecialchars((string) ($row['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
+                            <div class="flex items-start gap-3">
+                                <?php if ((string) ($row['victim_portrait_url'] ?? '') !== ''): ?>
+                                    <img src="<?= htmlspecialchars((string) $row['victim_portrait_url'], ENT_QUOTES) ?>" alt="" class="h-10 w-10 rounded-xl object-cover">
+                                <?php endif; ?>
+                                <div>
+                                    <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['victim_corporation'] ?? '—'), ENT_QUOTES) ?></p>
+                                    <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($row['victim_alliance'] ?? '—'), ENT_QUOTES) ?></p>
+                                    <p class="mt-2 text-xs text-muted"><?= htmlspecialchars((string) ($row['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
+                                </div>
+                            </div>
                         </td>
                         <td class="px-3 py-3 align-top">
                             <div class="flex items-start gap-3">
@@ -294,6 +301,26 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             <a href="<?= htmlspecialchars((string) ($row['inspect_url'] ?? '#'), ENT_QUOTES) ?>" class="inline-flex items-center btn-primary px-3 py-2">Inspect loss</a>
                         </td>
                     </tr>
+                    <?php if (isset($row['pod_kill'])): $pod = $row['pod_kill']; ?>
+                    <tr class="border-b border-border/40 text-slate-400 text-xs bg-white/[0.02]">
+                        <td class="pl-10 pr-3 py-2 align-top">
+                            <span class="text-muted">↳ Pod</span>
+                            <p class="text-slate-400"><?= htmlspecialchars((string) ($pod['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
+                        </td>
+                        <td class="px-3 py-2 align-top text-slate-400">
+                            <?= htmlspecialchars((string) ($pod['final_blow_character'] ?? '—'), ENT_QUOTES) ?>
+                        </td>
+                        <td class="px-3 py-2 align-top">
+                            <p class="text-slate-400"><?= htmlspecialchars((string) ($pod['ship_type'] ?? 'Capsule'), ENT_QUOTES) ?></p>
+                        </td>
+                        <td class="px-3 py-2 align-top" colspan="2">
+                            <span class="text-muted"><?= htmlspecialchars((string) ($pod['estimated_value_display'] ?? '—'), ENT_QUOTES) ?></span>
+                        </td>
+                        <td class="px-3 py-2 align-top">
+                            <a href="<?= htmlspecialchars((string) ($pod['inspect_url'] ?? '#'), ENT_QUOTES) ?>" class="text-xs text-sky-400 hover:underline">Inspect</a>
+                        </td>
+                    </tr>
+                    <?php endif; ?>
                 <?php endforeach; ?>
             <?php endif; ?>
             </tbody>

--- a/src/db.php
+++ b/src/db.php
@@ -11231,6 +11231,7 @@ function db_killmail_overview_page(array $filters = []): array
     $allianceId = max(0, (int) ($filters['alliance_id'] ?? 0));
     $corporationId = max(0, (int) ($filters['corporation_id'] ?? 0));
     $trackedOnly = (bool) ($filters['tracked_only'] ?? false);
+    $mailType = in_array((string) ($filters['mail_type'] ?? 'loss'), ['kill', 'loss', ''], true) ? (string) ($filters['mail_type'] ?? 'loss') : 'loss';
     $search = trim((string) ($filters['search'] ?? ''));
     $trackedMatchesSql = db_killmail_tracked_matches_sql();
     $latestSequencesSql = db_killmail_latest_sequences_sql();
@@ -11276,6 +11277,11 @@ function db_killmail_overview_page(array $filters = []): array
         $conditions[] = 'tracked.sequence_id IS NOT NULL';
     }
 
+    if ($mailType !== '') {
+        $conditions[] = 'e.mail_type = ?';
+        $params[] = $mailType;
+    }
+
     if ($search !== '') {
         $needle = '%' . $search . '%';
         $conditions[] = '(
@@ -11310,9 +11316,11 @@ function db_killmail_overview_page(array $filters = []): array
             e.killmail_time,
             e.uploaded_at,
             e.created_at,
+            e.victim_character_id,
             e.victim_corporation_id,
             e.victim_alliance_id,
             e.victim_ship_type_id,
+            e.mail_type,
             e.solar_system_id,
             e.region_id,
             final_blow_attacker.character_id AS final_blow_character_id,

--- a/src/functions.php
+++ b/src/functions.php
@@ -10945,10 +10945,11 @@ function killmail_overview_data(): array
         'alliance_id' => max(0, (int) ($_GET['alliance_id'] ?? 0)),
         'corporation_id' => max(0, (int) ($_GET['corporation_id'] ?? 0)),
         'tracked_only' => sanitize_enabled_flag($_GET['tracked_only'] ?? '0') === '1',
+        'mail_type' => in_array($_GET['mail_type'] ?? 'loss', ['kill', 'loss', ''], true) ? ($_GET['mail_type'] ?? 'loss') : 'loss',
         'page' => max(1, (int) ($_GET['page'] ?? 1)),
         'page_size' => $pageSize,
     ];
-    $useCache = $filters['search'] === '' && $filters['alliance_id'] === 0 && $filters['corporation_id'] === 0 && $filters['tracked_only'] === false && $filters['page'] === 1 && $filters['page_size'] === 25;
+    $useCache = $filters['search'] === '' && $filters['alliance_id'] === 0 && $filters['corporation_id'] === 0 && $filters['tracked_only'] === false && $filters['mail_type'] === 'loss' && $filters['page'] === 1 && $filters['page_size'] === 25;
 
     $resolver = static function () use ($recentHours, $filters, $allowedPageSizes, $pageSize): array {
         try {
@@ -11035,6 +11036,7 @@ function killmail_overview_data(): array
         foreach ((array) ($listing['rows'] ?? []) as $row) {
             $allianceId = (int) ($row['victim_alliance_id'] ?? 0);
             $corporationId = (int) ($row['victim_corporation_id'] ?? 0);
+            $victimCharacterId = (int) ($row['victim_character_id'] ?? 0);
             $shipTypeId = (int) ($row['victim_ship_type_id'] ?? 0);
             $systemId = (int) ($row['solar_system_id'] ?? 0);
             $regionId = (int) ($row['region_id'] ?? 0);
@@ -11049,6 +11051,9 @@ function killmail_overview_data(): array
             }
             if ($corporationId > 0) {
                 $overviewResolutionRequests['corporation'][$corporationId] = $corporationId;
+            }
+            if ($victimCharacterId > 0) {
+                $overviewResolutionRequests['character'][$victimCharacterId] = $victimCharacterId;
             }
             if ($shipTypeId > 0) {
                 $overviewResolutionRequests['type'][$shipTypeId] = $shipTypeId;
@@ -11132,6 +11137,7 @@ function killmail_overview_data(): array
                 killmail_overview_flag_enabled($row, 'zkb_awox') ? 'Awox' : null,
             ]));
 
+            $victimCharacterId = isset($row['victim_character_id']) ? (int) $row['victim_character_id'] : null;
             return [
                 'sequence_id' => (int) ($row['sequence_id'] ?? 0),
                 'killmail_id' => (int) ($row['killmail_id'] ?? 0),
@@ -11153,6 +11159,10 @@ function killmail_overview_data(): array
                 'final_blow_alliance' => killmail_entity_preferred_name($resolvedOverviewEntities, 'alliance', $finalBlowAllianceId, '', 'Alliance'),
                 'final_blow_ship' => killmail_entity_preferred_name($resolvedOverviewEntities, 'type', $finalBlowShipTypeId, '', 'Ship'),
                 'final_blow_weapon' => killmail_entity_preferred_name($resolvedOverviewEntities, 'type', $finalBlowWeaponTypeId, '', 'Weapon'),
+                'victim_character_id' => $victimCharacterId,
+                'victim_ship_type_id' => isset($row['victim_ship_type_id']) ? (int) $row['victim_ship_type_id'] : null,
+                'victim_portrait_url' => $victimCharacterId !== null && $victimCharacterId > 0 ? killmail_entity_image_url('character', $victimCharacterId, 'portrait', 64) : null,
+                'mail_type' => (string) ($row['mail_type'] ?? 'loss'),
                 'matched_tracked' => (int) ($row['matched_tracked'] ?? 0) === 1,
                 'match_context' => $matchSources === [] ? 'No tracked entity currently matches this stored killmail.' : ('Matched on ' . implode(', ', $matchSources) . '.'),
                 'ship_icon_url' => $shipTypeId !== null ? killmail_entity_image_url('type', $shipTypeId, 'icon', 64) : null,
@@ -11169,6 +11179,45 @@ function killmail_overview_data(): array
         }, (array) ($listing['rows'] ?? []));
         $rows = supplycore_rows_unique_by($rows, static fn (array $row): string => 'killmail:' . trim((string) ($row['esi_killmail_key'] ?? '')));
         supplycore_sort_rows_by_newest($rows, ['killmail_time_raw', 'uploaded_at_raw', 'created_at_raw'], ['sequence_id', 'killmail_id']);
+
+        // Pod kill grouping: attach capsule kills as sub-rows on the preceding ship kill.
+        // Capsule type IDs: 670 (Capsule), 33328 (Capsule - Genolution 'Auroral' 197-Epsilon).
+        $capsuleTypeIds = [670, 33328, 42132];
+        $podWindow = 10 * 60; // 10-minute window
+        $shipKillsByChar = []; // character_id => [index => i, time => t]
+        foreach ($rows as $i => $row) {
+            $charId = (int) ($row['victim_character_id'] ?? 0);
+            if ($charId <= 0) {
+                continue;
+            }
+            $t = strtotime((string) ($row['killmail_time_raw'] ?? '')) ?: 0;
+            $isCapsule = in_array((int) ($row['victim_ship_type_id'] ?? 0), $capsuleTypeIds, true)
+                || stripos((string) ($row['ship_type'] ?? ''), 'capsule') !== false;
+            if (!$isCapsule) {
+                $shipKillsByChar[$charId] = ['index' => $i, 'time' => $t];
+            }
+        }
+        $podIndices = [];
+        foreach ($rows as $i => $row) {
+            $charId = (int) ($row['victim_character_id'] ?? 0);
+            if ($charId <= 0) {
+                continue;
+            }
+            $isCapsule = in_array((int) ($row['victim_ship_type_id'] ?? 0), $capsuleTypeIds, true)
+                || stripos((string) ($row['ship_type'] ?? ''), 'capsule') !== false;
+            if (!$isCapsule) {
+                continue;
+            }
+            $podTime = strtotime((string) ($row['killmail_time_raw'] ?? '')) ?: 0;
+            $ship = $shipKillsByChar[$charId] ?? null;
+            if ($ship !== null && $podTime >= $ship['time'] && ($podTime - $ship['time']) <= $podWindow) {
+                $rows[$ship['index']]['pod_kill'] = $row;
+                $podIndices[] = $i;
+            }
+        }
+        foreach (array_reverse($podIndices) as $idx) {
+            array_splice($rows, $idx, 1);
+        }
 
         $emptyMessage = $totalCount === 0
             ? 'No killmails have been stored yet. Enable killmail ingestion, run the sync worker, and this view will populate as local killmails arrive.'


### PR DESCRIPTION
## Summary

- **Kills shown on losses page**: `db_killmail_overview_page` now filters by `mail_type = 'loss'` by default (filterable via `?mail_type=kill` to view the attacker side). `mail_type` and `victim_character_id` added to the SELECT.
- **Missing victim portrait**: `victim_character_id` is now resolved via the entity batch lookup and `victim_portrait_url` rendered in the VICTIM column alongside corporation/alliance name.
- **Pod kill sub-rows**: Capsule kills (type IDs 670, 33328, 42132) within 10 minutes of a ship kill by the same victim character are removed from the main list and rendered as an indented sub-row (↳ Pod) under the parent ship kill row.

## Test plan
- [ ] Losses page shows only losses (mail_type = 'loss'), not kills by tracked entities
- [ ] Victim character portrait appears in the VICTIM column
- [ ] A ship kill followed by a pod kill for the same character within 10 min shows the pod as a sub-row
- [ ] `?mail_type=kill` shows the kills view (tracked entity was attacker)

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf