### PR TITLE
Show victim character name in losses overview

### DIFF
--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -242,8 +242,9 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                     <img src="<?= htmlspecialchars((string) $row['victim_portrait_url'], ENT_QUOTES) ?>" alt="" class="h-10 w-10 rounded-xl object-cover">
                                 <?php endif; ?>
                                 <div>
-                                    <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['victim_corporation'] ?? '—'), ENT_QUOTES) ?></p>
-                                    <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($row['victim_alliance'] ?? '—'), ENT_QUOTES) ?></p>
+                                    <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['victim_character'] ?? '—'), ENT_QUOTES) ?></p>
+                                    <p class="mt-1 text-xs text-slate-300"><?= htmlspecialchars((string) ($row['victim_corporation'] ?? '—'), ENT_QUOTES) ?></p>
+                                    <p class="mt-1 text-xs text-muted"><?= htmlspecialchars((string) ($row['victim_alliance'] ?? '—'), ENT_QUOTES) ?></p>
                                     <p class="mt-2 text-xs text-muted"><?= htmlspecialchars((string) ($row['killmail_time_display'] ?? '—'), ENT_QUOTES) ?></p>
                                 </div>
                             </div>

--- a/src/functions.php
+++ b/src/functions.php
@@ -11159,6 +11159,7 @@ function killmail_overview_data(): array
                 'final_blow_alliance' => killmail_entity_preferred_name($resolvedOverviewEntities, 'alliance', $finalBlowAllianceId, '', 'Alliance'),
                 'final_blow_ship' => killmail_entity_preferred_name($resolvedOverviewEntities, 'type', $finalBlowShipTypeId, '', 'Ship'),
                 'final_blow_weapon' => killmail_entity_preferred_name($resolvedOverviewEntities, 'type', $finalBlowWeaponTypeId, '', 'Weapon'),
+                'victim_character' => killmail_entity_preferred_name($resolvedOverviewEntities, 'character', $victimCharacterId, '', 'Character'),
                 'victim_character_id' => $victimCharacterId,
                 'victim_ship_type_id' => isset($row['victim_ship_type_id']) ? (int) $row['victim_ship_type_id'] : null,
                 'victim_portrait_url' => $victimCharacterId !== null && $victimCharacterId > 0 ? killmail_entity_image_url('character', $victimCharacterId, 'portrait', 64) : null,


### PR DESCRIPTION
## Summary

- Resolve `victim_character_id` to a character name via the entity batch lookup
- Display victim character name as the first line in the Victim column (above corporation and alliance)

## Test plan
- [ ] Victim column now shows: character name, corporation, alliance, timestamp

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf