### PR TITLE
Fix activity priority showing 1,000,000.0 scores

### DIFF
--- a/python/orchestrator/jobs/activity_priority_summary_sync.py
+++ b/python/orchestrator/jobs/activity_priority_summary_sync.py
@@ -73,7 +73,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         "total_rows": rows_written,
     }
     db.upsert_intelligence_snapshot(
-        snapshot_key="activity_priority_summaries",
+        snapshot_key="doctrine_activity_db_state",
         payload_json=json_dumps_safe(snapshot_payload),
         metadata_json=json_dumps_safe({
             "source": "doctrine_activity_snapshots",

--- a/python/orchestrator/jobs/doctrine_intelligence_sync.py
+++ b/python/orchestrator/jobs/doctrine_intelligence_sync.py
@@ -46,9 +46,9 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
                 CASE WHEN COALESCE(MIN(dis.complete_fits_supported), 0) >= COALESCE(f.target_fleet_size_override, 0) THEN 'ready' ELSE 'degraded' END,
                 CASE WHEN COALESCE(SUM(il.quantity_lost), 0) > 0 THEN 'elevated' ELSE 'stable' END,
                 LEAST(
-                    999999.99,
+                    999.99,
                     (COALESCE(SUM(il.quantity_lost), 0) * 1.0)
-                    + GREATEST(0, COALESCE(f.target_fleet_size_override, 0) - COALESCE(MIN(dis.complete_fits_supported), 0))
+                    + LEAST(500.0, GREATEST(0, COALESCE(f.target_fleet_size_override, 0) - COALESCE(MIN(dis.complete_fits_supported), 0)))
                 )
             FROM doctrine_fits f
             LEFT JOIN doctrine_item_stock_1d dis ON dis.fit_id = f.id AND dis.bucket_start = CURDATE()


### PR DESCRIPTION
## Summary
- **Root cause**: PR #332 fixed the DECIMAL overflow so `activity_priority_summary_sync` now completes successfully. But it was writing raw `priority_score` values (up to 999,999.99) to `intelligence_snapshots` under key `activity_priority_summaries` — the same key the PHP display page reads. PHP then rendered `number_format(999999.99, 1)` as "1,000,000.0" for every doctrine.
- Before #332 the Python job was crashing before the snapshot write, so PHP's own computation (0–100 scores) was the source of truth. After #332, Python ran to completion and overwrote the good data.

## Fixes
1. **`activity_priority_summary_sync.py`** — write to key `doctrine_activity_db_state` instead of `activity_priority_summaries`, so Python no longer clobbers the PHP-computed display snapshot
2. **`doctrine_intelligence_sync.py`** — cap `fit_gap` at 500 and overall `priority_score` at 999.99 to guard against unreasonably large `target_fleet_size_override` values in the DB causing future score explosions

## Test plan
- [ ] Run `doctrine_intelligence_sync` + `activity_priority_summary_sync` Python jobs
- [ ] Verify Activity Priority page shows scores 0–100 range, not 1,000,000.0
- [ ] Verify doctrine `activity_level` labels (Critical/Elevated/Low) are correct
- [ ] Confirm `intelligence_snapshots` has a new row with key `doctrine_activity_db_state` and the old `activity_priority_summaries` row is from PHP

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf