### PR TITLE
Link doctrine group names and validate activity-priority snapshot before rendering

### DIFF
--- a/public/activity-priority/index.php
+++ b/public/activity-priority/index.php
@@ -51,7 +51,14 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <div class="flex flex-wrap items-start justify-between gap-3">
                         <div class="min-w-0 flex-1">
                             <div class="flex flex-wrap items-center gap-2">
-                                <h3 class="truncate text-lg font-semibold text-white"><?= htmlspecialchars((string) ($row['doctrine_name'] ?? ''), ENT_QUOTES) ?></h3>
+                                <?php $doctrineGroupId = (int) ($row['entity_id'] ?? 0); ?>
+                                <?php if ($doctrineGroupId > 0): ?>
+                                    <a href="/doctrine/group?group_id=<?= $doctrineGroupId ?>" class="truncate text-lg font-semibold text-cyan-100 transition hover:text-cyan-50 hover:underline">
+                                        <?= htmlspecialchars((string) ($row['doctrine_name'] ?? ''), ENT_QUOTES) ?>
+                                    </a>
+                                <?php else: ?>
+                                    <h3 class="truncate text-lg font-semibold text-white"><?= htmlspecialchars((string) ($row['doctrine_name'] ?? ''), ENT_QUOTES) ?></h3>
+                                <?php endif; ?>
                                 <span class="badge <?= htmlspecialchars($tone, ENT_QUOTES) ?>"><?= htmlspecialchars(ucfirst((string) ($row['activity_level'] ?? 'low')), ENT_QUOTES) ?></span>
                                 <span class="badge border-white/10 bg-white/5 text-slate-200">#<?= (int) ($row['rank_position'] ?? 0) ?></span>
                                 <span class="badge border-white/10 bg-white/5 text-slate-300"><?= htmlspecialchars((string) ($row['movement_label'] ?? 'Holding'), ENT_QUOTES) ?></span>

--- a/src/functions.php
+++ b/src/functions.php
@@ -26591,7 +26591,33 @@ function activity_priority_refresh_summary_job_result(string $reason = 'manual')
 
 function activity_priority_page_data(): array
 {
-    return activity_priority_snapshot_payload();
+    $snapshot = activity_priority_snapshot_payload();
+    if (!activity_priority_snapshot_has_computed_metrics($snapshot)) {
+        $snapshot = activity_priority_refresh_summary('page-contract-repair');
+    }
+
+    return $snapshot;
+}
+
+function activity_priority_snapshot_has_computed_metrics(array $snapshot): bool
+{
+    $rows = array_values((array) ($snapshot['active_doctrines'] ?? []));
+    if ($rows === []) {
+        return true;
+    }
+
+    $row = (array) ($rows[0] ?? []);
+    $hasDoctrineIdentity = array_key_exists('entity_id', $row)
+        || array_key_exists('id', $row);
+    $hasDoctrineName = array_key_exists('doctrine_name', $row)
+        || array_key_exists('group_name', $row)
+        || array_key_exists('entity_name', $row);
+    $hasScore = array_key_exists('activity_score', $row);
+    $hasLossMetrics = array_key_exists('hull_losses_24h', $row)
+        || array_key_exists('module_losses_24h', $row)
+        || array_key_exists('fit_equivalent_losses_24h', $row);
+
+    return $hasDoctrineIdentity && $hasDoctrineName && $hasScore && $hasLossMetrics;
 }
 
 


### PR DESCRIPTION
### Motivation

- Make doctrine group names in the activity-priority page navigable when a valid group identity is available. 
- Ensure the activity-priority page does not render an incomplete snapshot by detecting missing computed metrics and recomputing the summary on-demand. 

### Description

- Update `public/activity-priority/index.php` to render the doctrine name as a link to `/doctrine/group?group_id=...` when `entity_id` is a positive integer, and fall back to an `h3` title when no valid id is present. 
- Change `activity_priority_page_data()` to fetch the stored snapshot and call `activity_priority_refresh_summary('page-contract-repair')` when the snapshot lacks computed metrics. 
- Add `activity_priority_snapshot_has_computed_metrics(array $snapshot): bool` which checks for presence of identity, name, score, and loss metrics in the first row to determine whether the snapshot is complete. 

### Testing

- Ran a PHP syntax check with `php -l` against the modified files, which reported no parse errors. 
- No automated unit tests were added or modified as part of this change and no test failures were observed during local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6260eb924832fbbe25ebc15ed4489)