### PR TITLE
Fix install-services.sh broken venv handling and pip bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.pyc
 *.egg-info/
 /python/build/
+.venv*/

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -384,9 +384,28 @@ configure_local_php "${LOCAL_CONFIG_PATH}" "${APP_ENV}" "${APP_BASE_URL}" "${APP
 
 # ===========================  Python venv  ================================
 
-if [[ ! -x ${VENV_PATH}/bin/python ]]; then
+# The venv may exist from git (checked-in or pulled) but contain broken
+# symlinks and paths from the machine it was originally created on.
+# Always verify the venv's Python actually runs; recreate if it doesn't.
+VENV_OK=false
+if [[ -x ${VENV_PATH}/bin/python ]] && "${VENV_PATH}/bin/python" -c "import sys; sys.exit(0)" 2>/dev/null; then
+  VENV_OK=true
+fi
+
+if [[ ${VENV_OK} == false ]]; then
   echo "Creating orchestrator virtualenv at ${VENV_PATH}"
+  # Remove broken venv if it exists (e.g. pulled from git with wrong symlinks)
+  if [[ -d ${VENV_PATH} ]]; then
+    echo "Removing stale/broken virtualenv"
+    rm -rf "${VENV_PATH}"
+  fi
   "${PYTHON_BIN}" -m venv "${VENV_PATH}"
+fi
+
+# Ensure pip is available inside the venv (some distros create venvs without it)
+if ! "${VENV_PATH}/bin/python" -m pip --version >/dev/null 2>&1; then
+  echo "Bootstrapping pip inside virtualenv"
+  "${VENV_PATH}/bin/python" -m ensurepip --upgrade
 fi
 
 "${VENV_PATH}/bin/python" -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

- Fix venv detection: test if the venv's Python actually executes instead of just checking if the file exists — a venv pulled from git has broken symlinks from the build machine
- Bootstrap pip via `ensurepip --upgrade` when missing (some distros create venvs without pip)
- Add `.venv*/` to `.gitignore` to prevent venvs from being committed

## Test plan
- [ ] Run `install-services.sh` on a fresh machine where `.venv-orchestrator` exists from git pull — should detect broken venv, remove it, and recreate
- [ ] Run on a machine where venv doesn't exist — should create normally
- [ ] Confirm pip installs succeed after venv creation

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf