### PR TITLE
Fix influx export service failure on restart

### DIFF
--- a/ops/systemd/supplycore-influx-rollup-export.service
+++ b/ops/systemd/supplycore-influx-rollup-export.service
@@ -8,8 +8,9 @@ Type=oneshot
 User=www-data
 Group=www-data
 WorkingDirectory=/var/www/SupplyCore
+Environment=SUPPLYCORE_INFLUX_EXPORT_ARGS=
 EnvironmentFile=-/etc/default/supplycore-influx-rollup-export
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py influx-rollup-export --app-root /var/www/SupplyCore $SUPPLYCORE_INFLUX_EXPORT_ARGS
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py influx-rollup-export --app-root /var/www/SupplyCore ${SUPPLYCORE_INFLUX_EXPORT_ARGS}
 Nice=10
 IOSchedulingClass=best-effort
 StandardOutput=append:/var/www/SupplyCore/storage/logs/influx-rollup-export.log

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -448,6 +448,12 @@ render_unit "${REPO_ROOT}/ops/systemd/supplycore-zkill.service" "${SYSTEMD_DIR}/
 if [[ ${INSTALL_INFLUX} == true ]]; then
   render_unit "${REPO_ROOT}/ops/systemd/supplycore-influx-rollup-export.service" "${SYSTEMD_DIR}/supplycore-influx-rollup-export.service"
   cp "${REPO_ROOT}/ops/systemd/supplycore-influx-rollup-export.timer" "${SYSTEMD_DIR}/supplycore-influx-rollup-export.timer"
+  # Ensure the InfluxDB env file exists so the service doesn't warn about unset vars
+  INFLUX_ENV_FILE="/etc/default/supplycore-influx-rollup-export"
+  if [[ ! -f ${INFLUX_ENV_FILE} ]]; then
+    install -D -m 0644 "${REPO_ROOT}/ops/systemd/supplycore-influx-rollup-export.env.example" "${INFLUX_ENV_FILE}"
+    echo "Wrote InfluxDB env file to ${INFLUX_ENV_FILE}"
+  fi
 fi
 
 # ===========================  Enable and start  ===========================

--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -202,11 +202,35 @@ discover_services() {
   local -a discovered=()
   local unit load_state
 
+  # Collect timer-triggered service names so we skip them (only restart the timer)
+  local -a timer_triggered=()
+  local triggers_line
+  while read -r timer_unit _rest; do
+    [[ -z "${timer_unit}" ]] && continue
+    triggers_line=$(systemctl show -p Triggers --value "${timer_unit}" 2>/dev/null || true)
+    if [[ -n "${triggers_line}" ]]; then
+      timer_triggered+=("${triggers_line}")
+    fi
+  done < <(systemctl list-units --type=timer --no-legend --plain 2>/dev/null \
+    | awk '/^supplycore-/ {print $1}' \
+    || true)
+
   while read -r unit load_state _rest; do
     [[ -z "${unit}" ]] && continue
     [[ "${unit}" == *'@.service' ]] && continue
     [[ "${load_state}" == "not-found" ]] && continue
     [[ "${load_state}" == "masked" ]] && continue
+    # Skip services that are triggered by timers — we restart the timer instead
+    local is_timer_triggered=false
+    for tt in "${timer_triggered[@]+"${timer_triggered[@]}"}"; do
+      if [[ "${tt}" == "${unit}" ]]; then
+        is_timer_triggered=true
+        break
+      fi
+    done
+    if [[ ${is_timer_triggered} == true ]]; then
+      continue
+    fi
     discovered+=("${unit}")
   done < <(systemctl list-units --type=service --no-legend --plain 2>/dev/null \
     | awk '/^supplycore-/ {print $1, $2}' \


### PR DESCRIPTION
## Summary

- **Service unit**: Add `Environment=SUPPLYCORE_INFLUX_EXPORT_ARGS=` default so systemd doesn't warn about unset variable
- **install-services.sh**: Create the influx env file from the example when user opts in to InfluxDB export
- **update-and-restart.sh**: Skip timer-triggered oneshot services during auto-discovery — only restart the timer, not the oneshot directly (which would try to re-run the export immediately and fail if InfluxDB isn't configured)

### Root cause
`update-and-restart.sh` discovers ALL `supplycore-*` services including `supplycore-influx-rollup-export.service` (a oneshot). Running `systemctl restart` on a oneshot triggers an immediate execution, which fails because InfluxDB isn't configured on the new machine. The timer should be restarted instead — it will fire the oneshot on schedule.

## Test plan
- [ ] Run `update-and-restart.sh` — influx export service should NOT be restarted, only the timer
- [ ] Verify no "WARNING: failed to restart" in output
- [ ] Timer should still be active and waiting

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf