### PR TITLE
Fix influx export: empty env var causes argparse exit 2

### DIFF
--- a/ops/systemd/supplycore-influx-rollup-export.service
+++ b/ops/systemd/supplycore-influx-rollup-export.service
@@ -10,7 +10,7 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 Environment=SUPPLYCORE_INFLUX_EXPORT_ARGS=
 EnvironmentFile=-/etc/default/supplycore-influx-rollup-export
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py influx-rollup-export --app-root /var/www/SupplyCore ${SUPPLYCORE_INFLUX_EXPORT_ARGS}
+ExecStart=/bin/bash -c 'exec /var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py influx-rollup-export --app-root /var/www/SupplyCore $SUPPLYCORE_INFLUX_EXPORT_ARGS'
 Nice=10
 IOSchedulingClass=best-effort
 StandardOutput=append:/var/www/SupplyCore/storage/logs/influx-rollup-export.log


### PR DESCRIPTION
## Summary

- Systemd's `${SUPPLYCORE_INFLUX_EXPORT_ARGS}` expansion passes `""` (empty string) as a positional argument to argparse when the var is empty, causing exit code 2 (INVALIDARGUMENT)
- Manual runs work fine because there's no empty string arg on the command line
- Fix: wrap ExecStart in `bash -c` so shell word-splitting drops the empty var instead of passing it as `""`

## Test plan
- [ ] `systemctl daemon-reload && systemctl restart supplycore-influx-rollup-export` should succeed
- [ ] Setting `SUPPLYCORE_INFLUX_EXPORT_ARGS=--dataset market_item_price_1h` in the env file should still work

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf