### PR TITLE
Lower battle eligibility threshold from 100 to 10 participants

### DIFF
--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -25,7 +25,7 @@ else:
     from ..neo4j import Neo4jClient, Neo4jConfig
 
 WINDOW_SECONDS = 15 * 60
-MIN_ELIGIBLE_PARTICIPANTS = 100
+MIN_ELIGIBLE_PARTICIPANTS = 10
 MIN_SAMPLE_COUNT = 5
 EPSILON = 1e-6
 ROLLUP_BATCH_SIZE = 1000
@@ -79,7 +79,9 @@ def _battle_size_class(participant_count: int) -> str:
         return "large"
     if participant_count >= 50:
         return "medium"
-    return "small"
+    if participant_count >= 20:
+        return "small"
+    return "micro"
 
 
 def _percentile(sorted_values: list[float], value: float) -> float:

--- a/python/orchestrator/jobs/counterintel_pipeline.py
+++ b/python/orchestrator/jobs/counterintel_pipeline.py
@@ -440,7 +440,7 @@ def run_compute_counterintel_pipeline(
                 SELECT br.battle_id, br.system_id, br.started_at, br.ended_at, br.participant_count
                 FROM battle_rollups br
                 WHERE br.eligible_for_suspicion = 1
-                  AND br.participant_count >= 100
+                  AND br.participant_count >= 10
                   AND br.battle_id > %s
                 ORDER BY br.battle_id ASC
                 LIMIT %s


### PR DESCRIPTION
## Summary

- Lower `MIN_ELIGIBLE_PARTICIPANTS` from **100 → 10** in `battle_intelligence.py`
- Lower hardcoded `participant_count >= 100` to `>= 10` in `counterintel_pipeline.py`
- Add `"micro"` size class (< 20 participants) for better peer normalization of small engagements

### Why
Small-gang engagements (10-30 pilots) are where spy activity has the most impact — one compromised pilot in a 15-man fleet has ~7% influence on the outcome vs ~1% in a 100-man blob. The previous 100-participant floor excluded the vast majority of meaningful intelligence opportunities. Most EVE fights worth analyzing happen at the 10-50 person scale.

### Size classes (updated)
| Class | Participants |
|-------|-------------|
| mega | 200+ |
| large | 100-199 |
| medium | 50-99 |
| small | 20-49 |
| micro | 10-19 |

## Test plan
- [ ] After merge, existing battles with 10-99 participants should become `eligible_for_suspicion = 1` on next `compute_battle_rollups` run
- [ ] Counterintel pipeline should now process these smaller battles
- [ ] Suspicion scores should populate for characters active in small-gang content

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf