### PR TITLE
Make sums Decimal-safe and tighten type check in zkill worker state handling

### DIFF
--- a/python/orchestrator/jobs/compute_buy_all.py
+++ b/python/orchestrator/jobs/compute_buy_all.py
@@ -332,17 +332,17 @@ def run_compute_buy_all(db: SupplyCoreDb, requests: list[dict[str, Any]] | None 
         page_items = items[:120]
 
         generated_at_iso = datetime.now(UTC).isoformat()
-        total_buy_cost = _q2(sum(
+        total_buy_cost = _q2(sum((
             to_decimal(item.get("buy_price")) * Decimal(item.get("quantity", 0))
             for item in page_items
             if item.get("buy_price") is not None
-        ))
-        total_sell_value = _q2(sum(
+        ), DECIMAL_ZERO))
+        total_sell_value = _q2(sum((
             to_decimal(item.get("sell_price")) * Decimal(item.get("quantity", 0))
             for item in page_items
             if item.get("sell_price") is not None
-        ))
-        total_volume = _q2(sum(to_decimal(item.get("total_volume")) for item in page_items))
+        ), DECIMAL_ZERO))
+        total_volume = _q2(sum((to_decimal(item.get("total_volume")) for item in page_items), DECIMAL_ZERO))
         total_hauling = _q2(total_volume * Decimal("320"))
         total_gross_profit = _q2(total_sell_value - total_buy_cost)
         total_net_profit = _q2(total_gross_profit - total_hauling)

--- a/python/orchestrator/zkill_worker.py
+++ b/python/orchestrator/zkill_worker.py
@@ -66,7 +66,7 @@ def _no_progress_state(previous_state: dict[str, Any], result: dict[str, Any], t
     previous_result = previous_state.get("result")
     previous_meta = previous_result.get("meta") if isinstance(previous_result, dict) else {}
     previous_cursor_after = ""
-    if isinstance(previous_meta, dict):
+    if isinstance(previous_meta, dict) and isinstance(previous_result, dict):
         previous_cursor_after = str(previous_meta.get("cursor_after") or previous_result.get("cursor") or "").strip()
     repeated_count = int(previous_state.get("same_cursor_no_progress_count") or 0)
     if rows_written == 0 and cursor_after != "" and cursor_after == previous_cursor_after:


### PR DESCRIPTION
### Motivation
- Prevent type-mixing and errors when summing Decimal values by ensuring the `sum()` start value is a `Decimal` instead of the integer `0`.
- Avoid crashes when reading previous worker state by ensuring `previous_result` is a dict before accessing nested metadata.

### Description
- Updated `python/orchestrator/jobs/compute_buy_all.py` to pass `DECIMAL_ZERO` as the second argument to `sum()` for `total_buy_cost`, `total_sell_value`, and `total_volume` so results are Decimal-typed even when the iterable is empty.
- Wrapped generator expressions in parentheses for the `sum()` calls to allow the explicit start value to be provided.
- Updated `python/orchestrator/zkill_worker.py` in `_no_progress_state` to check that `previous_result` is a dict before reading `previous_meta` fields, preventing errors when previous state is missing or malformed.

### Testing
- Ran the project unit test suite with `pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69376eb2c832fa72a3eca2449ded0)