### PR TITLE
Theater Intelligence Platform + Enhanced Intelligence (KGv2)

### DIFF
--- a/python/orchestrator/config.py
+++ b/python/orchestrator/config.py
@@ -120,12 +120,24 @@ def _load_dotenv_defaults(app_root: Path) -> None:
         os.environ.setdefault(key, parsed[0] if parsed else "")
 
 
+def _resolve_php_binary() -> str:
+    explicit = os.getenv("PHP_BINARY", "").strip()
+    if explicit:
+        return explicit
+    import shutil
+    for candidate in ("php", "php8.4", "php8.3", "php8.2", "php8.1"):
+        found = shutil.which(candidate)
+        if found:
+            return found
+    return "php"
+
+
 def _load_live_php_runtime_config(app_root: Path) -> dict[str, Any]:
     script_path = app_root / "bin/orchestrator_config.php"
     if not script_path.is_file():
         return {}
 
-    php_binary = os.getenv("PHP_BINARY", "php").strip() or "php"
+    php_binary = _resolve_php_binary()
     try:
         completed = subprocess.run(
             [php_binary, str(script_path)],
@@ -135,7 +147,9 @@ def _load_live_php_runtime_config(app_root: Path) -> dict[str, Any]:
             text=True,
             timeout=10,
         )
-    except Exception:
+    except Exception as exc:
+        import sys
+        print(f"[config] WARNING: failed to load PHP config via {php_binary}: {exc}", file=sys.stderr)
         return {}
 
     payload = (completed.stdout or "").strip()


### PR DESCRIPTION
## Summary

- **Theater Intelligence module**: Groups battles into multi-system theaters by time proximity, system proximity (constellation/region), and participant overlap using union-find clustering
- **Theater analysis pipeline**: Computes per-theater timelines (1-min buckets with momentum), alliance summaries, participant stats, turning point detection, and composite anomaly scoring
- **Theater graph integration**: Enriches theaters with Neo4j community/centrality metrics and cross-side bridge detection
- **Theater suspicion scoring**: Joins character suspicion signals into theater context with per-theater suspicion summaries
- **Enhanced Intelligence Platform (KGv2)**: Migration for 8 Neo4j features — temporal metrics, typed interactions, community detection, motif detection, evidence paths, analyst feedback, query presets, data quality gates
- **PHP UI**: Theater listing page with region/anomaly filters + detailed view page with timeline, alliances, participants, graph intel, and suspicion sections
- **Config bridge fix**: Auto-discover PHP binary (`php8.4`, `php8.3`, etc.) so `run-job` CLI reads DB credentials from `local.php` without needing env vars

## New files
- `python/orchestrator/jobs/theater_clustering.py` — Union-find battle grouping
- `python/orchestrator/jobs/theater_analysis.py` — Timeline, alliance, participant, anomaly computation
- `python/orchestrator/jobs/theater_graph_integration.py` — Neo4j enrichment per theater
- `python/orchestrator/jobs/theater_suspicion.py` — Suspicion signal integration
- `public/theater-intelligence/index.php` — Theater listing page
- `public/theater-intelligence/view.php` — Theater detail page
- 2 SQL migrations (enhanced intelligence platform + theater intelligence tables)

## Test plan
- [ ] Run migration: verify 10 theater tables + 9 KGv2 tables created
- [ ] Run `theater_clustering` job: verify `theaters`, `theater_battles`, `theater_systems` populated
- [ ] Run `theater_analysis` job: verify kills, duration, participants, timeline, anomaly scores non-zero
- [ ] Verify theater listing page loads with filters working
- [ ] Verify theater detail view shows all sections (timeline, alliances, participants, graph, suspicion)
- [ ] Test `run-job --job-key theater_analysis` without env vars — should auto-discover PHP binary and read credentials from `local.php`

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf