### PR TITLE
Theater intelligence: tracked alliance-aware side labels

### DIFF
--- a/public/theater-intelligence/index.php
+++ b/public/theater-intelligence/index.php
@@ -14,6 +14,12 @@ $offset = ($page - 1) * $perPage;
 
 $theaters = db_theaters_list($perPage, $offset, $regionFilter, $minAnomaly);
 
+// Load tracked alliances and side labels for matchup display
+$trackedAlliances = db_killmail_tracked_alliances_active();
+$trackedAllianceIds = array_map('intval', array_column($trackedAlliances, 'alliance_id'));
+$theaterIds = array_column($theaters, 'theater_id');
+$sideLabelsMap = db_theater_side_labels($theaterIds);
+
 // Load distinct regions that have theaters for the filter dropdown
 $theaterRegions = db_select(
     'SELECT DISTINCT t.region_id, rr.region_name
@@ -70,8 +76,9 @@ include __DIR__ . '/../../src/views/partials/header.php';
         <table class="table-ui">
             <thead>
                 <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                    <th class="px-3 py-2 text-left">Matchup</th>
                     <th class="px-3 py-2 text-left">Region</th>
-                    <th class="px-3 py-2 text-left">Primary System</th>
+                    <th class="px-3 py-2 text-left">System</th>
                     <th class="px-3 py-2 text-right">Battles</th>
                     <th class="px-3 py-2 text-right">Systems</th>
                     <th class="px-3 py-2 text-right">Participants</th>
@@ -85,7 +92,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
             </thead>
             <tbody>
                 <?php if ($theaters === []): ?>
-                    <tr><td colspan="11" class="px-3 py-6 text-sm text-muted">No theaters found. Run the theater clustering job to generate data.</td></tr>
+                    <tr><td colspan="12" class="px-3 py-6 text-sm text-muted">No theaters found. Run the theater clustering job to generate data.</td></tr>
                 <?php else: ?>
                     <?php foreach ($theaters as $t): ?>
                         <?php
@@ -96,7 +103,30 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             $battleCount = (int) ($t['battle_count'] ?? 0);
                             $sizeLabel = $battleCount > 5 ? 'bg-red-900/60 text-red-300' : ($battleCount > 2 ? 'bg-orange-900/60 text-orange-300' : 'bg-slate-700 text-slate-300');
                         ?>
+                        <?php
+                            // Determine matchup label for this theater
+                            $tid = (string) ($t['theater_id'] ?? '');
+                            $sides = $sideLabelsMap[$tid] ?? [];
+                            $listOurSide = null;
+                            $listEnemySide = null;
+                            foreach ($sides as $sKey => $sData) {
+                                if (in_array($sData['top_alliance_id'], $trackedAllianceIds, true)) {
+                                    $listOurSide = $sKey;
+                                }
+                            }
+                            if ($listOurSide === null) {
+                                $listOurSide = isset($sides['side_a']) ? 'side_a' : array_key_first($sides);
+                            }
+                            $listEnemySide = ($listOurSide === 'side_a') ? 'side_b' : 'side_a';
+                            $ourLabel = isset($sides[$listOurSide]) ? $sides[$listOurSide]['top_name'] . ($sides[$listOurSide]['count'] > 1 ? ' +' . ($sides[$listOurSide]['count'] - 1) : '') : '?';
+                            $enemyLabel = isset($sides[$listEnemySide]) ? $sides[$listEnemySide]['top_name'] . ($sides[$listEnemySide]['count'] > 1 ? ' +' . ($sides[$listEnemySide]['count'] - 1) : '') : '?';
+                        ?>
                         <tr class="border-b border-border/50">
+                            <td class="px-3 py-2 text-sm">
+                                <span class="text-blue-300"><?= htmlspecialchars($ourLabel, ENT_QUOTES) ?></span>
+                                <span class="text-slate-500 mx-1">vs</span>
+                                <span class="text-red-300"><?= htmlspecialchars($enemyLabel, ENT_QUOTES) ?></span>
+                            </td>
                             <td class="px-3 py-2 text-slate-100"><?= htmlspecialchars((string) ($t['region_name'] ?? 'Unknown'), ENT_QUOTES) ?></td>
                             <td class="px-3 py-2 text-slate-100"><?= htmlspecialchars((string) ($t['primary_system_name'] ?? '-'), ENT_QUOTES) ?></td>
                             <td class="px-3 py-2 text-right">

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -65,6 +65,52 @@ foreach ($entityRequests as $type => $ids) {
 }
 $resolvedEntities = killmail_entity_resolve_batch($entityRequests, true);
 
+// ── Determine meaningful side labels from tracked alliances ──────────
+$trackedAlliances = db_killmail_tracked_alliances_active();
+$trackedAllianceIds = array_column($trackedAlliances, 'alliance_id');
+$trackedAllianceIds = array_map('intval', $trackedAllianceIds);
+
+// Find which internal side (side_a/side_b) contains our tracked alliances
+$ourSide = null;
+$sideAlliancesByPilots = ['side_a' => [], 'side_b' => []]; // alliance_id => participant_count
+foreach ($allianceSummary as $a) {
+    $side = (string) ($a['side'] ?? '');
+    $aid = (int) ($a['alliance_id'] ?? 0);
+    $pilots = (int) ($a['participant_count'] ?? 0);
+    if (isset($sideAlliancesByPilots[$side])) {
+        $sideAlliancesByPilots[$side][$aid] = $pilots;
+    }
+    if ($ourSide === null && in_array($aid, $trackedAllianceIds, true)) {
+        $ourSide = $side;
+    }
+}
+$enemySide = ($ourSide === 'side_a') ? 'side_b' : 'side_a';
+
+// Build human-readable label for each side (dominant alliance name by pilot count)
+$sideLabels = [];
+foreach (['side_a', 'side_b'] as $side) {
+    $alliances = $sideAlliancesByPilots[$side];
+    if ($alliances === []) {
+        $sideLabels[$side] = $side === $ourSide ? 'Our Side' : 'Enemy';
+        continue;
+    }
+    arsort($alliances); // sort by pilot count descending
+    $topAllianceId = array_key_first($alliances);
+    $topName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $topAllianceId, '', 'Alliance');
+    $otherCount = count($alliances) - 1;
+    $sideLabels[$side] = $topName . ($otherCount > 0 ? " +{$otherCount}" : '');
+}
+
+// Color scheme: our side = blue, enemy = red
+$sideColorClass = [
+    $ourSide ?? 'side_a' => 'text-blue-300',
+    $enemySide => 'text-red-300',
+];
+$sideBgClass = [
+    $ourSide ?? 'side_a' => 'bg-blue-900/60',
+    $enemySide => 'bg-red-900/60',
+];
+
 $title = htmlspecialchars((string) ($theater['primary_system_name'] ?? 'Theater'), ENT_QUOTES) . ' Theater';
 $durationSec = max(1, (int) ($theater['duration_seconds'] ?? 0));
 $durationLabel = $durationSec >= 120 ? number_format($durationSec / 60, 0) . 'm' : $durationSec . 's';
@@ -85,6 +131,14 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <span class="text-sm text-muted">+<?= (int) ($theater['system_count'] ?? 0) - 1 ?> systems</span>
                 <?php endif; ?>
             </h1>
+            <p class="mt-1 text-base text-slate-200">
+                <span class="<?= $sideColorClass[$ourSide ?? 'side_a'] ?? 'text-blue-300' ?> font-semibold"><?= htmlspecialchars($sideLabels[$ourSide ?? 'side_a'] ?? 'Side A', ENT_QUOTES) ?></span>
+                <?php if ($ourSide !== null): ?>
+                    <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Tracked</span>
+                <?php endif; ?>
+                <span class="text-slate-500 mx-2">vs</span>
+                <span class="<?= $sideColorClass[$enemySide] ?? 'text-red-300' ?> font-semibold"><?= htmlspecialchars($sideLabels[$enemySide] ?? 'Side B', ENT_QUOTES) ?></span>
+            </p>
             <p class="mt-1 text-sm text-slate-300">
                 <?= htmlspecialchars((string) ($theater['region_name'] ?? ''), ENT_QUOTES) ?>
                 &middot; <?= htmlspecialchars((string) ($theater['start_time'] ?? ''), ENT_QUOTES) ?>
@@ -189,17 +243,23 @@ include __DIR__ . '/../../src/views/partials/header.php';
 <?php if ($timeline !== []): ?>
 <section class="surface-primary mt-4">
     <h2 class="text-lg font-semibold text-slate-50">Timeline</h2>
-    <p class="text-xs text-muted mt-1"><?= count($timeline) ?> buckets (1-minute intervals). Momentum: positive = side A winning, negative = side B winning.</p>
+    <p class="text-xs text-muted mt-1"><?= count($timeline) ?> buckets (1-minute intervals). Momentum: positive = <span class="<?= $sideColorClass[$ourSide ?? 'side_a'] ?? '' ?>"><?= htmlspecialchars($sideLabels[$ourSide ?? 'side_a'] ?? 'Side A', ENT_QUOTES) ?></span> winning, negative = <span class="<?= $sideColorClass[$enemySide] ?? '' ?>"><?= htmlspecialchars($sideLabels[$enemySide] ?? 'Side B', ENT_QUOTES) ?></span> winning.</p>
 
     <?php if ($turningPoints !== []): ?>
         <div class="mt-2">
             <p class="text-xs uppercase tracking-[0.15em] text-muted mb-1">Turning Points</p>
             <?php foreach ($turningPoints as $tp): ?>
+                <?php
+                    $tpDir = (string) ($tp['direction'] ?? '');
+                    $tpSide = str_contains($tpDir, 'side_a') ? 'side_a' : 'side_b';
+                    $tpColor = $sideColorClass[$tpSide] ?? 'text-slate-300';
+                    $tpSideLabel = $sideLabels[$tpSide] ?? $tpSide;
+                ?>
                 <p class="text-xs text-slate-300">
-                    <span class="<?= str_contains((string) ($tp['direction'] ?? ''), 'side_a') ? 'text-blue-400' : 'text-red-400' ?>">
+                    <span class="<?= $tpColor ?>">
                         <?= htmlspecialchars((string) ($tp['turning_point_at'] ?? ''), ENT_QUOTES) ?>
                     </span>
-                    &mdash; <?= htmlspecialchars((string) ($tp['description'] ?? ''), ENT_QUOTES) ?>
+                    &mdash; <span class="<?= $tpColor ?>"><?= htmlspecialchars($tpSideLabel, ENT_QUOTES) ?></span> <?= htmlspecialchars((string) ($tp['description'] ?? ''), ENT_QUOTES) ?>
                     (magnitude: <?= number_format((float) ($tp['magnitude'] ?? 0), 3) ?>)
                 </p>
             <?php endforeach; ?>
@@ -215,8 +275,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <th class="px-3 py-2 text-left">Time</th>
                         <th class="px-3 py-2 text-right">Kills</th>
                         <th class="px-3 py-2 text-right">ISK</th>
-                        <th class="px-3 py-2 text-right">Side A Kills</th>
-                        <th class="px-3 py-2 text-right">Side B Kills</th>
+                        <th class="px-3 py-2 text-right <?= $sideColorClass[$ourSide ?? 'side_a'] ?? '' ?>"><?= htmlspecialchars($sideLabels[$ourSide ?? 'side_a'] ?? 'Side A', ENT_QUOTES) ?> Kills</th>
+                        <th class="px-3 py-2 text-right <?= $sideColorClass[$enemySide] ?? '' ?>"><?= htmlspecialchars($sideLabels[$enemySide] ?? 'Side B', ENT_QUOTES) ?> Kills</th>
                         <th class="px-3 py-2 text-right">Momentum</th>
                     </tr>
                 </thead>
@@ -227,8 +287,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             <td class="px-3 py-2 text-xs text-slate-300"><?= htmlspecialchars((string) ($t['bucket_time'] ?? ''), ENT_QUOTES) ?></td>
                             <td class="px-3 py-2 text-right"><?= (int) ($t['kills'] ?? 0) ?></td>
                             <td class="px-3 py-2 text-right"><?= number_format((float) ($t['isk_destroyed'] ?? 0), 0) ?></td>
-                            <td class="px-3 py-2 text-right text-blue-300"><?= (int) ($t['side_a_kills'] ?? 0) ?></td>
-                            <td class="px-3 py-2 text-right text-red-300"><?= (int) ($t['side_b_kills'] ?? 0) ?></td>
+                            <td class="px-3 py-2 text-right <?= $sideColorClass[$ourSide ?? 'side_a'] ?? 'text-blue-300' ?>"><?= (int) ($t['side_a_kills'] ?? 0) ?></td>
+                            <td class="px-3 py-2 text-right <?= $sideColorClass[$enemySide] ?? 'text-red-300' ?>"><?= (int) ($t['side_b_kills'] ?? 0) ?></td>
                             <td class="px-3 py-2 text-right <?= $mom > 0 ? 'text-blue-400' : ($mom < 0 ? 'text-red-400' : 'text-slate-300') ?>">
                                 <?= number_format($mom, 3) ?>
                             </td>
@@ -262,15 +322,23 @@ include __DIR__ . '/../../src/views/partials/header.php';
             <tbody>
                 <?php foreach ($allianceSummary as $a): ?>
                     <?php
+                        $aSide = (string) ($a['side'] ?? '');
                         $eff = (float) ($a['efficiency'] ?? 0);
                         $effClass = $eff >= 0.6 ? 'text-green-400' : ($eff >= 0.4 ? 'text-yellow-400' : 'text-red-400');
-                        $sideClass = (string) ($a['side'] ?? '') === 'side_a' ? 'text-blue-300' : 'text-red-300';
+                        $aSideColor = $sideColorClass[$aSide] ?? 'text-slate-300';
+                        $aSideBg = $sideBgClass[$aSide] ?? 'bg-slate-700';
+                        $isTracked = in_array((int) ($a['alliance_id'] ?? 0), $trackedAllianceIds, true);
                     ?>
                     <tr class="border-b border-border/50">
-                        <td class="px-3 py-2 text-slate-100"><?= htmlspecialchars(killmail_entity_preferred_name($resolvedEntities, 'alliance', (int) ($a['alliance_id'] ?? 0), (string) ($a['alliance_name'] ?? ''), 'Alliance'), ENT_QUOTES) ?></td>
-                        <td class="px-3 py-2 <?= $sideClass ?>">
-                            <span class="inline-block rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider <?= (string) ($a['side'] ?? '') === 'side_a' ? 'bg-blue-900/60' : 'bg-red-900/60' ?>">
-                                <?= htmlspecialchars((string) ($a['side'] ?? ''), ENT_QUOTES) ?>
+                        <td class="px-3 py-2 text-slate-100">
+                            <?= htmlspecialchars(killmail_entity_preferred_name($resolvedEntities, 'alliance', (int) ($a['alliance_id'] ?? 0), (string) ($a['alliance_name'] ?? ''), 'Alliance'), ENT_QUOTES) ?>
+                            <?php if ($isTracked): ?>
+                                <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Tracked</span>
+                            <?php endif; ?>
+                        </td>
+                        <td class="px-3 py-2 <?= $aSideColor ?>">
+                            <span class="inline-block rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider <?= $aSideBg ?>">
+                                <?= htmlspecialchars($sideLabels[$aSide] ?? $aSide, ENT_QUOTES) ?>
                             </span>
                         </td>
                         <td class="px-3 py-2 text-right"><?= number_format((int) ($a['participant_count'] ?? 0)) ?></td>
@@ -293,8 +361,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
         <h2 class="text-lg font-semibold text-slate-50">Participants</h2>
         <div class="flex gap-2 text-sm">
             <a href="?theater_id=<?= urlencode($theaterId) ?>" class="<?= $sideFilter === null && !$suspiciousOnly ? 'text-slate-50 font-semibold' : 'text-accent' ?>">All</a>
-            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=side_a" class="<?= $sideFilter === 'side_a' ? 'text-blue-300 font-semibold' : 'text-accent' ?>">Side A</a>
-            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=side_b" class="<?= $sideFilter === 'side_b' ? 'text-red-300 font-semibold' : 'text-accent' ?>">Side B</a>
+            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=<?= urlencode($ourSide ?? 'side_a') ?>" class="<?= $sideFilter === ($ourSide ?? 'side_a') ? ($sideColorClass[$ourSide ?? 'side_a'] ?? 'text-blue-300') . ' font-semibold' : 'text-accent' ?>"><?= htmlspecialchars($sideLabels[$ourSide ?? 'side_a'] ?? 'Side A', ENT_QUOTES) ?></a>
+            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=<?= urlencode($enemySide) ?>" class="<?= $sideFilter === $enemySide ? ($sideColorClass[$enemySide] ?? 'text-red-300') . ' font-semibold' : 'text-accent' ?>"><?= htmlspecialchars($sideLabels[$enemySide] ?? 'Side B', ENT_QUOTES) ?></a>
             <a href="?theater_id=<?= urlencode($theaterId) ?>&suspicious=1" class="<?= $suspiciousOnly ? 'text-yellow-300 font-semibold' : 'text-accent' ?>">Suspicious</a>
         </div>
     </div>
@@ -321,7 +389,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <?php foreach ($participants as $p): ?>
                         <?php
                             $pSide = (string) ($p['side'] ?? '');
-                            $pSideClass = $pSide === 'side_a' ? 'text-blue-300' : 'text-red-300';
+                            $pSideClass = $sideColorClass[$pSide] ?? 'text-slate-300';
                             $pSusp = (float) ($p['suspicion_score'] ?? 0);
                             $pSuspClass = $pSusp >= 0.5 ? 'text-red-400 font-semibold' : ($pSusp >= 0.3 ? 'text-yellow-400' : 'text-slate-300');
                             $isSusp = (int) ($p['is_suspicious'] ?? 0);
@@ -347,8 +415,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 <?php endif; ?>
                             </td>
                             <td class="px-3 py-2 <?= $pSideClass ?>">
-                                <span class="inline-block rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider <?= $pSide === 'side_a' ? 'bg-blue-900/60' : 'bg-red-900/60' ?>">
-                                    <?= htmlspecialchars($pSide, ENT_QUOTES) ?>
+                                <span class="inline-block rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider <?= $sideBgClass[$pSide] ?? 'bg-slate-700' ?>">
+                                    <?= htmlspecialchars($sideLabels[$pSide] ?? $pSide, ENT_QUOTES) ?>
                                 </span>
                             </td>
                             <td class="px-3 py-2">
@@ -451,7 +519,12 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                         <?= htmlspecialchars(killmail_entity_preferred_name($resolvedEntities, 'character', (int) ($gp['character_id'] ?? 0), (string) ($gp['character_name'] ?? ''), 'Character'), ENT_QUOTES) ?>
                                     </a>
                                 </td>
-                                <td class="px-3 py-2 text-xs"><?= htmlspecialchars((string) ($gp['side'] ?? '-'), ENT_QUOTES) ?></td>
+                                <?php $gpSide = (string) ($gp['side'] ?? ''); ?>
+                                <td class="px-3 py-2 text-xs <?= $sideColorClass[$gpSide] ?? 'text-slate-300' ?>">
+                                    <span class="inline-block rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider <?= $sideBgClass[$gpSide] ?? 'bg-slate-700' ?>">
+                                        <?= htmlspecialchars($sideLabels[$gpSide] ?? ($gpSide ?: '-'), ENT_QUOTES) ?>
+                                    </span>
+                                </td>
                                 <td class="px-3 py-2 text-right"><?= (int) ($gp['cluster_id'] ?? 0) ?></td>
                                 <td class="px-3 py-2 text-right <?= $bridge >= 0.3 ? 'text-yellow-400' : 'text-slate-300' ?>"><?= number_format($bridge, 3) ?></td>
                                 <td class="px-3 py-2 text-right"><?= number_format((float) ($gp['co_occurrence_density'] ?? 0), 3) ?></td>

--- a/src/db.php
+++ b/src/db.php
@@ -14853,6 +14853,39 @@ function db_theater_turning_points(string $theaterId): array
     );
 }
 
+function db_theater_side_labels(array $theaterIds): array
+{
+    if ($theaterIds === []) {
+        return [];
+    }
+    $placeholders = implode(',', array_fill(0, count($theaterIds), '?'));
+    $rows = db_select(
+        "SELECT tas.theater_id, tas.alliance_id, tas.side, tas.participant_count,
+                COALESCE(emc.entity_name, tas.alliance_name, CONCAT('Alliance #', tas.alliance_id)) AS alliance_name
+         FROM theater_alliance_summary tas
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = tas.alliance_id
+         WHERE tas.theater_id IN ({$placeholders})
+         ORDER BY tas.participant_count DESC",
+        $theaterIds
+    );
+    // Group by theater → side → pick top alliance by pilot count
+    $grouped = [];
+    foreach ($rows as $r) {
+        $tid = (string) $r['theater_id'];
+        $side = (string) $r['side'];
+        if (!isset($grouped[$tid][$side])) {
+            $grouped[$tid][$side] = [
+                'top_name' => (string) $r['alliance_name'],
+                'top_alliance_id' => (int) $r['alliance_id'],
+                'count' => 0,
+            ];
+        }
+        $grouped[$tid][$side]['count']++;
+    }
+    return $grouped;
+}
+
 // ---------------------------------------------------------------------------
 // Database migrations
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Tracked alliance-aware side labels**: Uses `killmail_tracked_alliances` to identify "our" side, labels each side by its dominant alliance name (e.g., "WinterCo +2" vs "Pandemic Horde +1")
- **Theater header**: Shows matchup headline with "Tracked" badge on our side
- **Timeline**: Momentum description uses alliance names ("WinterCo winning" instead of "Side A winning")
- **Alliance summary**: "Tracked" badge on tracked alliances, side column shows alliance coalition name
- **Participants**: Filter tabs show alliance names, side badges show coalition names
- **Turning points**: Show which side by alliance name with color coding
- **Listing page**: New "Matchup" column showing the vs headline for each theater
- **Color scheme**: Blue = our tracked side, Red = enemy side (consistent everywhere)

Also includes prior commits:
- Entity ID → name resolution via `entity_metadata_cache` JOINs
- ESI batch resolution with `killmail_entity_resolve_batch()` for unknown entities
- Region filter dropdown with human-readable names

## Test plan
- [ ] Configure tracked alliances in settings (if not already done)
- [ ] Theater listing shows "WinterCo vs X" matchup column
- [ ] Theater detail header shows alliance vs alliance with Tracked badge
- [ ] Alliance summary shows Tracked badge on tracked alliances
- [ ] Participant filter tabs show alliance names instead of Side A/B
- [ ] Timeline momentum labels use alliance names
- [ ] Turning points reference alliances by name
- [ ] Color coding: blue = our side, red = enemy (consistent across all sections)

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf