### PR TITLE
Add killmail ingestion debug diagnostics

### DIFF
--- a/bin/python_scheduler_bridge.php
+++ b/bin/python_scheduler_bridge.php
@@ -38,6 +38,20 @@ try {
         python_scheduler_bridge_output(['ok' => true, 'context' => python_bridge_killmail_context()]);
     }
 
+    if ($action === 'killmail-debug') {
+        $rawValue = get_setting('killmail_ingestion_enabled', '__NOT_SET__');
+        $boolResult = killmail_ingestion_enabled();
+        python_scheduler_bridge_output([
+            'ok' => true,
+            'debug' => [
+                'raw_setting_value' => $rawValue,
+                'raw_type' => gettype($rawValue),
+                'killmail_ingestion_enabled_returns' => $boolResult,
+                'context_enabled' => python_bridge_killmail_context()['enabled'],
+            ],
+        ]);
+    }
+
     if ($action === 'market-hub-local-history-context') {
         python_scheduler_bridge_output(['ok' => true, 'context' => python_bridge_market_hub_local_history_context()]);
     }

--- a/python/orchestrator/jobs/killmail.py
+++ b/python/orchestrator/jobs/killmail.py
@@ -364,11 +364,13 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
     if not bool(job_context.get("enabled")):
         return JobResult.skipped(
             job_key="killmail_r2z2_sync",
-            reason="Killmail ingestion is disabled in settings.",
+            reason=f"Killmail ingestion is disabled in settings. (bridge returned enabled={job_context.get('enabled')!r})",
             meta={
                 "execution_mode": "python",
                 "cursor": str(job_context.get("cursor") or "0"),
                 "checksum": payload_checksum({"cursor": job_context.get("cursor") or "0", "rows_written": 0}),
+                "bridge_context_keys": list(job_context.keys()),
+                "bridge_enabled_raw": job_context.get("enabled"),
             },
         ).to_dict()
 


### PR DESCRIPTION
## Summary
- Log the raw `enabled` value from the PHP bridge in the skip reason, so syslog shows exactly what the bridge returned
- Add `killmail-debug` bridge action to directly inspect the DB setting value

## After merging, run these on the server:

```bash
# 1. Check what the DB actually has:
php bin/python_scheduler_bridge.php --action=killmail-debug

# 2. If it shows '0' or '__NOT_SET__', force-set it:
mysql supplycore -e "SELECT setting_key, setting_value FROM app_settings WHERE setting_key = 'killmail_ingestion_enabled'"

# 3. If needed, force enable:
mysql supplycore -e "INSERT INTO app_settings (setting_key, setting_value) VALUES ('killmail_ingestion_enabled', '1') ON DUPLICATE KEY UPDATE setting_value = '1'"

# 4. Restart the worker:
systemctl restart supplycore-zkill
```

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf