### PR TITLE
Fix merge conflict markers in bridge file

### DIFF
--- a/bin/python_scheduler_bridge.php
+++ b/bin/python_scheduler_bridge.php
@@ -38,7 +38,6 @@ try {
         python_scheduler_bridge_output(['ok' => true, 'context' => python_bridge_killmail_context()]);
     }
 
-<<<<<<< claude/killmail-backfill
     if ($action === 'killmail-backfill-context') {
         python_scheduler_bridge_output(['ok' => true, 'context' => python_bridge_killmail_backfill_context()]);
     }
@@ -51,20 +50,6 @@ try {
             save_settings([$key => $value]);
         }
         python_scheduler_bridge_output(['ok' => true]);
-=======
-    if ($action === 'killmail-debug') {
-        $rawValue = get_setting('killmail_ingestion_enabled', '__NOT_SET__');
-        $boolResult = killmail_ingestion_enabled();
-        python_scheduler_bridge_output([
-            'ok' => true,
-            'debug' => [
-                'raw_setting_value' => $rawValue,
-                'raw_type' => gettype($rawValue),
-                'killmail_ingestion_enabled_returns' => $boolResult,
-                'context_enabled' => python_bridge_killmail_context()['enabled'],
-            ],
-        ]);
->>>>>>> main
     }
 
     if ($action === 'market-hub-local-history-context') {


### PR DESCRIPTION
## Summary

- Removes git merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) that were accidentally committed to `python_scheduler_bridge.php`
- This caused a PHP parse error on line 41, breaking the zkill worker completely
- Keeps the `killmail-backfill-context` and `update-setting` actions, drops the temporary `killmail-debug` action

## Test plan

- [ ] Merge and deploy — zkill worker should start without PHP parse errors

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf