### PR TITLE
Fix killmail settings save DDL-in-transaction error

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -18737,11 +18737,14 @@ function save_killmail_intelligence_settings(array $request): array
     $saved = false;
 
     try {
-        db_transaction(static function () use ($payload): void {
-            db_app_settings_upsert_many((array) ($payload['settings'] ?? []));
-            db_killmail_tracked_alliances_replace((array) ($payload['alliances'] ?? []));
-            db_killmail_tracked_corporations_replace((array) ($payload['corporations'] ?? []));
-        });
+        // Each function manages its own transaction internally.
+        // An outer db_transaction() is not possible here because the tracked-entity
+        // replace functions use CREATE TABLE IF NOT EXISTS as a safety net, and MySQL
+        // implicitly commits on any DDL, which destroys the outer transaction.
+        db_app_settings_upsert_many((array) ($payload['settings'] ?? []));
+        db_killmail_tracked_alliances_replace((array) ($payload['alliances'] ?? []));
+        db_killmail_tracked_corporations_replace((array) ($payload['corporations'] ?? []));
+
         $reloadedSettings = get_settings(array_keys((array) ($payload['settings'] ?? [])));
         foreach ((array) ($payload['settings'] ?? []) as $key => $value) {
             if ((string) ($reloadedSettings[$key] ?? '') !== (string) $value) {


### PR DESCRIPTION
## Summary

- Removes the outer `db_transaction()` wrapper in `save_killmail_intelligence_settings()` that was causing "Database unavailable" errors
- The tracked entity replace functions use `CREATE TABLE IF NOT EXISTS` as a safety net, but MySQL implicitly commits on DDL, destroying the outer transaction
- Each sub-function already manages its own transaction internally, so the outer wrapper is unnecessary

## Test plan

- [ ] Go to Settings > Killmail Intelligence
- [ ] Click "Save Killmail Intelligence Settings" — should succeed without error
- [ ] Click "Backfill 2026" — should start without error
- [ ] Verify tracked alliances/corporations are preserved after save

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf