### PR TITLE
Fix backfill button not triggering

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -115,11 +115,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'killmail_backfill_start_date' => $backfillStart,
                     'killmail_backfill_end_date' => $backfillEnd,
                     'killmail_backfill_progress' => json_encode([
-                        'current_date' => str_replace('-', '', $backfillStart),
-                        'days_processed' => 0,
-                        'killmails_seen' => 0,
-                        'written' => 0,
-                        'status' => 'starting',
+                        'phase' => 'collecting',
+                        'entity' => 'starting...',
+                        'entities_done' => 0,
+                        'entities_total' => 0,
+                        'killmails_found' => 0,
                         'updated_at' => gmdate('Y-m-d\TH:i:s\Z'),
                     ]),
                 ]);
@@ -1736,12 +1736,12 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             <div>
                                 <p class="text-sm font-semibold text-blue-200">History Backfill Available</p>
                                 <p class="mt-1 text-xs text-muted">
-                                    Fetch historical killmails from zKillboard's R2Z2 history API for <?= date('Y') ?>.
-                                    Each day's killmail IDs are fetched from R2Z2, then full details are loaded from ESI.
-                                    Only killmails matching your tracked alliances and corporations will be stored.
+                                    Fetch historical killmails from the zKillboard API for <?= date('Y') ?>,
+                                    filtered by your tracked alliances and corporations. Full killmail details
+                                    are then loaded from ESI. Already-stored killmails are skipped automatically.
                                 </p>
                             </div>
-                            <button type="submit" name="killmail_backfill_start" value="1" class="shrink-0 rounded-lg border border-blue-400/40 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-100 hover:bg-blue-500/20" onclick="this.disabled=true;this.textContent='Starting…';this.form.submit();">
+                            <button type="submit" name="killmail_backfill_start" value="1" class="shrink-0 rounded-lg border border-blue-400/40 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-100 hover:bg-blue-500/20" onclick="this.textContent='Starting…';var h=document.createElement('input');h.type='hidden';h.name='killmail_backfill_start';h.value='1';this.form.appendChild(h);this.disabled=true;">
                                 Backfill <?= date('Y') ?>
                             </button>
                         </div>


### PR DESCRIPTION
## Summary

- The "Backfill 2026" button's onclick disabled the button before form submission, which removed the `killmail_backfill_start` name/value from POST data
- The server never saw the backfill trigger and fell through to the regular settings save — that's why it showed "Settings saved successfully" instead of starting the backfill
- Fix: inject a hidden input with the button's name/value before disabling, so the value survives form submission
- Also updated the initial progress JSON to match the new two-phase format (collecting/fetching)

## Test plan

- [ ] Click "Backfill 2026" — should show "Killmail history backfill started..." message and progress card
- [ ] Button should show "Starting..." text while submitting
- [ ] Progress card should appear on page reload with "collecting" phase

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf