### PR TITLE
Skip killmail sync when no tracked entities; expose counts in PHP bridge and include run metadata

### DIFF
--- a/python/orchestrator/jobs/killmail.py
+++ b/python/orchestrator/jobs/killmail.py
@@ -375,6 +375,23 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
             },
         ).to_dict()
 
+    tracked_alliance_count = max(0, int(job_context.get("tracked_alliance_count") or 0))
+    tracked_corporation_count = max(0, int(job_context.get("tracked_corporation_count") or 0))
+    tracked_entity_count = tracked_alliance_count + tracked_corporation_count
+    if tracked_entity_count <= 0:
+        return JobResult.skipped(
+            job_key="killmail_r2z2_sync",
+            reason="Killmail ingestion is enabled, but no tracked alliances or corporations are configured.",
+            meta={
+                "execution_mode": "python",
+                "cursor": str(job_context.get("cursor") or "0"),
+                "checksum": payload_checksum({"cursor": job_context.get("cursor") or "0", "rows_written": 0}),
+                "tracked_alliance_count": tracked_alliance_count,
+                "tracked_corporation_count": tracked_corporation_count,
+                "tracked_entity_count": tracked_entity_count,
+            },
+        ).to_dict()
+
     sequence_url = str(job_context.get("sequence_url") or "").strip()
     base_url = str(job_context.get("base_url") or "").rstrip("/")
     user_agent = str(job_context.get("user_agent") or "SupplyCore killmail-ingestion/2.0")
@@ -734,6 +751,9 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
                 "outcome_reason": outcome_reason,
             },
         ).to_dict()
+        result["cursor"] = cursor_end
+        result["checksum"] = checksum
+        result["run_id"] = run_id
         _sync_run_finish(bridge, job_context, run_id, result)
         return result
     except Exception as error:

--- a/python/tests/test_killmail_r2z2_stream.py
+++ b/python/tests/test_killmail_r2z2_stream.py
@@ -27,6 +27,8 @@ class FakeBridge:
                     "cursor": "100",
                     "dataset_key": "killmail",
                     "job_key": "killmail_r2z2_sync",
+                    "tracked_alliance_count": 1,
+                    "tracked_corporation_count": 0,
                 }
             }
         if action == "sync-run-start":
@@ -197,6 +199,22 @@ class KillmailStreamTests(unittest.TestCase):
         with patch.object(killmail, "PhpBridge", FakeBridge), patch.object(killmail, "_http_json", side_effect=fake_http_json):
             with self.assertRaisesRegex(RuntimeError, "HTTP 200 with malformed non-object JSON payload"):
                 killmail.run_killmail_r2z2_stream(self.context)
+
+    def test_skips_when_no_tracked_entities_configured(self) -> None:
+        class FakeBridgeNoTracked(FakeBridge):
+            def call(self, action: str, payload: dict | None = None) -> dict:
+                response = super().call(action, payload)
+                if action == "killmail-context":
+                    response["context"]["tracked_alliance_count"] = 0
+                    response["context"]["tracked_corporation_count"] = 0
+                return response
+
+        with patch.object(killmail, "PhpBridge", FakeBridgeNoTracked):
+            result = killmail.run_killmail_r2z2_stream(self.context)
+
+        self.assertEqual(result["status"], "skipped")
+        self.assertIn("no tracked alliances or corporations", result["summary"].lower())
+        self.assertEqual(result["meta"]["tracked_entity_count"], 0)
 
 
 if __name__ == "__main__":

--- a/src/functions.php
+++ b/src/functions.php
@@ -15017,6 +15017,8 @@ function python_bridge_killmail_context(): array
 {
     $datasetKey = killmail_sync_dataset_key();
     $cursor = db_sync_cursor_get($datasetKey);
+    $trackedAllianceCount = count(db_killmail_tracked_alliances_active());
+    $trackedCorporationCount = count(db_killmail_tracked_corporations_active());
     $userAgent = trim((string) get_setting('app_name', 'SupplyCore'));
     if ($userAgent === '') {
         $userAgent = 'SupplyCore';
@@ -15032,6 +15034,8 @@ function python_bridge_killmail_context(): array
         'poll_sleep_seconds' => killmail_poll_sleep_seconds(),
         'max_sequences_per_run' => killmail_max_sequences_per_run(),
         'user_agent' => $userAgent . ' killmail-ingestion/2.0 (+https://github.com/cvweiss/supplycore)',
+        'tracked_alliance_count' => $trackedAllianceCount,
+        'tracked_corporation_count' => $trackedCorporationCount,
     ];
 }
 


### PR DESCRIPTION
### Motivation

- Prevent running expensive killmail ingestion when there are no tracked alliances or corporations configured by early-skipping in the Python worker.  
- Ensure the Python worker receives the configured tracked-entity counts from PHP so it can make that decision.  
- Surface additional run metadata (`cursor`, `checksum`, `run_id`) to the bridge when finishing a successful run for better observability.

### Description

- Added `tracked_alliance_count` and `tracked_corporation_count` to the `python_bridge_killmail_context()` return payload in `src/functions.php`.  
- In `run_killmail_r2z2_stream` (`python/orchestrator/jobs/killmail.py`) read and sum the tracked counts and early-return a `JobResult.skipped` when the total tracked entity count is zero, including counts in the `meta`.  
- Added `cursor`, `checksum`, and `run_id` to the success result passed to `_sync_run_finish` so the bridge receives those values.  
- Updated unit tests in `python/tests/test_killmail_r2z2_stream.py` to include the tracked counts in the fake bridge context and added `test_skips_when_no_tracked_entities_configured` to verify the early-skip behavior.

### Testing

- Ran the unit tests in `python/tests/test_killmail_r2z2_stream.py`, including the new `test_skips_when_no_tracked_entities_configured`, and they passed.  
- Verified existing killmail stream tests that exercise sequence fetch, payload handling, and sync-run lifecycle still succeed after the changes.  
- No other automated checks were modified or required by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6feba4b18832fbe56767f6b8c6cd9)