### PR TITLE
Fix MariaDB syntax error: CAST(... AS JSON) is not supported

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -14633,7 +14633,7 @@ function db_graph_motif_detections_recent(int $limit = 50): array
            AND EXISTS (
                SELECT 1 FROM battle_participants bp
                WHERE bp.alliance_id IN (' . $placeholders . ')
-                 AND JSON_CONTAINS(gmd.member_ids_json, CAST(bp.character_id AS JSON))
+                 AND JSON_CONTAINS(gmd.member_ids_json, CAST(bp.character_id AS CHAR))
            )
          ORDER BY gmd.suspicion_relevance DESC, gmd.occurrence_count DESC
          LIMIT ' . $safeLimit,


### PR DESCRIPTION
MariaDB does not support CAST(... AS JSON). The motif detection query used JSON_CONTAINS(gmd.member_ids_json, CAST(bp.character_id AS JSON)) which caused a fatal SQL syntax error. Changed to CAST(... AS CHAR) which produces the correct string representation for JSON_CONTAINS.

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf