### PR TITLE
Fix Groq integration, add AI connection test

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1021,7 +1021,40 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     Configure either the local Ollama API or the Runpod serverless endpoint here, then manage cadence under <a href="/settings?section=data-sync" class="font-medium text-slate-100 hover:text-white">Settings → Data Sync</a> for the <span class="font-medium text-slate-100">rebuild_ai_briefings</span> scheduler job. Runpod requests now submit asynchronously and poll for completion within the configured timeout window. Small tiers stay compact, medium tiers add explanation and deltas, and large tiers unlock richer operator briefings while still keeping deterministic calculations authoritative.
                 </div>
 
-                <button class="btn-primary">Save AI Briefing Settings</button>
+                <div class="flex items-center gap-4">
+                    <button class="btn-primary">Save AI Briefing Settings</button>
+                    <button type="button" id="test-ai-btn" class="btn-secondary" onclick="testAiConnection()">Test AI Connection</button>
+                    <span id="test-ai-result" class="text-sm"></span>
+                </div>
+                <script>
+                function testAiConnection() {
+                    const btn = document.getElementById('test-ai-btn');
+                    const result = document.getElementById('test-ai-result');
+                    btn.disabled = true;
+                    btn.textContent = 'Testing…';
+                    result.textContent = '';
+                    result.className = 'text-sm';
+                    fetch('/settings/test-ai.php', {method: 'POST', headers: {'X-Requested-With': 'XMLHttpRequest'}})
+                        .then(r => r.json())
+                        .then(data => {
+                            if (data.success) {
+                                result.textContent = 'OK — ' + data.provider + ' / ' + data.model + ' (' + data.elapsed_ms + 'ms)';
+                                result.className = 'text-sm text-green-400';
+                            } else {
+                                result.textContent = 'Failed — ' + data.provider + ': ' + (data.error || 'unknown error');
+                                result.className = 'text-sm text-red-400';
+                            }
+                        })
+                        .catch(err => {
+                            result.textContent = 'Request failed: ' + err.message;
+                            result.className = 'text-sm text-red-400';
+                        })
+                        .finally(() => {
+                            btn.disabled = false;
+                            btn.textContent = 'Test AI Connection';
+                        });
+                }
+                </script>
             </form>
         <?php elseif ($section === 'item-scope'): ?>
             <?php

--- a/public/settings/test-ai.php
+++ b/public/settings/test-ai.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'POST only']);
+    exit;
+}
+
+if (!supplycore_ai_ollama_enabled()) {
+    echo json_encode(['success' => false, 'error' => 'AI is not enabled or provider is not configured. Check your settings.', 'provider' => 'none']);
+    exit;
+}
+
+$result = supplycore_ai_test_connection();
+echo json_encode($result, JSON_UNESCAPED_SLASHES);

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -122,10 +122,16 @@ $anomaly = (float) ($theater['anomaly_score'] ?? 0);
 // ── Handle AAR regeneration request ──────────────────────────────────
 // Only generate/regenerate on explicit POST. On GET, read the stored summary.
 $aarRegenerated = false;
+$aarError = null;
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['regenerate_aar']) && $_POST['regenerate_aar'] === '1') {
     $aiSummary = theater_ai_summary_generate($theaterId, true);
+    if (is_array($aiSummary) && isset($aiSummary['error'])) {
+        $aarError = (string) $aiSummary['error'];
+        $aiSummary = null;
+    }
     $aarRegenerated = $aiSummary !== null;
 } else {
+    // On GET, only read existing summary — don't trigger generation
     $aiSummary = theater_ai_summary_read($theaterId);
 }
 
@@ -249,7 +255,11 @@ include __DIR__ . '/../../src/views/partials/header.php';
     <div class="flex items-center justify-between">
         <div>
             <h2 class="text-lg font-semibold text-slate-50">AI Briefing</h2>
-            <p class="text-sm text-muted mt-1">No AAR has been generated for this theater yet.</p>
+            <?php if ($aarError !== null): ?>
+                <p class="text-sm text-red-400 mt-1">AAR generation failed: <?= htmlspecialchars($aarError, ENT_QUOTES) ?></p>
+            <?php else: ?>
+                <p class="text-sm text-muted mt-1">No AAR has been generated for this theater yet.</p>
+            <?php endif; ?>
         </div>
         <form method="POST" class="inline">
             <input type="hidden" name="regenerate_aar" value="1">

--- a/src/functions.php
+++ b/src/functions.php
@@ -25469,15 +25469,83 @@ function supplycore_ai_ollama_enabled(): bool
 {
     $config = supplycore_ai_ollama_config();
 
-    if ($config['enabled'] !== true || $config['model'] === '') {
+    if ($config['enabled'] !== true) {
         return false;
     }
 
-    if (($config['provider'] ?? 'local') === 'runpod') {
-        return ($config['runpod_url'] ?? '') !== '' && ($config['runpod_api_key'] ?? '') !== '';
-    }
+    $provider = (string) ($config['provider'] ?? 'local');
 
-    return ($config['url'] ?? '') !== '';
+    return match ($provider) {
+        'claude' => ($config['claude_api_key'] ?? '') !== '',
+        'groq' => ($config['groq_api_key'] ?? '') !== '',
+        'runpod' => ($config['runpod_url'] ?? '') !== '' && ($config['runpod_api_key'] ?? '') !== '',
+        default => ($config['url'] ?? '') !== '' && ($config['model'] ?? '') !== '',
+    };
+}
+
+/**
+ * Test the current AI provider connection with a minimal request.
+ */
+function supplycore_ai_test_connection(): array
+{
+    $config = supplycore_ai_ollama_config();
+    $provider = (string) ($config['provider'] ?? 'local');
+
+    $systemPrompt = 'You are a test assistant. Return valid JSON only.';
+    $userPrompt = 'Respond with: {"status":"ok","provider":"' . $provider . '"}';
+    $schema = [
+        'type' => 'object',
+        'required' => ['status', 'provider'],
+        'properties' => [
+            'status' => ['type' => 'string'],
+            'provider' => ['type' => 'string'],
+        ],
+    ];
+
+    try {
+        $startTime = microtime(true);
+        if ($provider === 'claude') {
+            $decoded = supplycore_ai_claude_generate_json($config, $systemPrompt, $userPrompt, $schema);
+            $model = (string) ($config['claude_model'] ?? '');
+        } elseif ($provider === 'groq') {
+            $decoded = supplycore_ai_groq_generate_json($config, $systemPrompt, $userPrompt, $schema);
+            $model = (string) ($config['groq_model'] ?? '');
+        } elseif ($provider === 'runpod') {
+            $decoded = supplycore_ai_runpod_generate_json($config, $systemPrompt, $userPrompt, $schema);
+            $model = (string) ($config['model'] ?? '');
+        } else {
+            $response = http_get_json(
+                rtrim((string) $config['url'], '/') . '/tags',
+                [],
+                min(10, max(1, (int) ($config['timeout'] ?? 10)))
+            );
+            $status = (int) ($response['status'] ?? 0);
+            if ($status < 200 || $status >= 300) {
+                return ['success' => false, 'error' => 'Ollama returned HTTP ' . $status, 'provider' => $provider];
+            }
+            $models = $response['json']['models'] ?? [];
+            $modelNames = array_map(fn($m) => $m['name'] ?? '', $models);
+            $elapsed = round((microtime(true) - $startTime) * 1000);
+            return [
+                'success' => true,
+                'provider' => $provider,
+                'model' => (string) ($config['model'] ?? ''),
+                'response' => 'Connected. Available models: ' . (implode(', ', $modelNames) ?: 'none'),
+                'elapsed_ms' => $elapsed,
+            ];
+        }
+
+        $elapsed = round((microtime(true) - $startTime) * 1000);
+        return [
+            'success' => true,
+            'provider' => $provider,
+            'model' => $model,
+            'response' => json_encode($decoded, JSON_UNESCAPED_SLASHES),
+            'elapsed_ms' => $elapsed,
+        ];
+    } catch (Throwable $e) {
+        return ['success' => false, 'error' => $e->getMessage(), 'provider' => $provider];
+    }
 }
 
 function supplycore_ai_ollama_available(): bool
@@ -26481,13 +26549,15 @@ function supplycore_ai_groq_generate_json(array $config, string $systemPrompt, s
     $requestPayload = [
         'model' => $model,
         'temperature' => 0.2,
-        'max_tokens' => 4096,
+        'max_completion_tokens' => 4096,
         'response_format' => ['type' => 'json_object'],
         'messages' => [
-            ['role' => 'system', 'content' => $systemPrompt . "\n\nReturn valid JSON matching this schema:\n" . $schemaJson],
+            ['role' => 'system', 'content' => $systemPrompt . "\n\nYou MUST return valid JSON matching this schema:\n" . $schemaJson],
             ['role' => 'user', 'content' => $userPrompt],
         ],
     ];
+
+    error_log('[groq-api] Sending request: model=' . $model . ', system_len=' . strlen($requestPayload['messages'][0]['content']) . ', user_len=' . strlen($requestPayload['messages'][1]['content']));
 
     $response = http_post_json(
         'https://api.groq.com/openai/v1/chat/completions',
@@ -26499,16 +26569,31 @@ function supplycore_ai_groq_generate_json(array $config, string $systemPrompt, s
     );
 
     $status = (int) ($response['status'] ?? 0);
+    $body = (string) ($response['body'] ?? '');
     $json = is_array($response['json'] ?? null) ? $response['json'] : [];
+
+    error_log('[groq-api] Response: HTTP ' . $status . ', body_len=' . strlen($body));
+
     if ($status < 200 || $status >= 300) {
-        $errorMsg = (string) ($json['error']['message'] ?? 'unknown');
+        $errorMsg = (string) ($json['error']['message'] ?? $body);
+        error_log('[groq-api] Error: ' . $errorMsg);
         throw new RuntimeException('Groq API returned HTTP ' . $status . ': ' . $errorMsg);
     }
 
     $choices = $json['choices'] ?? [];
-    $rawResponse = trim((string) (($choices[0]['message']['content'] ?? '')));
+    if ($choices === []) {
+        error_log('[groq-api] No choices in response: ' . mb_substr($body, 0, 2000));
+        throw new RuntimeException('Groq API returned no choices');
+    }
+
+    $finishReason = (string) ($choices[0]['finish_reason'] ?? '');
+    $rawResponse = trim((string) ($choices[0]['message']['content'] ?? ''));
+
+    error_log('[groq-api] finish_reason=' . $finishReason . ', content_len=' . strlen($rawResponse));
+
     if ($rawResponse === '') {
-        throw new RuntimeException('Groq API returned empty response');
+        error_log('[groq-api] Empty content. Response: ' . mb_substr($body, 0, 2000));
+        throw new RuntimeException('Groq API returned empty response (finish_reason=' . $finishReason . ')');
     }
 
     // Strip markdown JSON fences if present
@@ -26645,8 +26730,9 @@ function theater_ai_summary_generate(string $theaterId, bool $forceRegenerate = 
     } catch (Throwable $e) {
         flock($lockFp, LOCK_UN);
         fclose($lockFp);
-        error_log('[theater-ai] Failed to generate AAR for ' . $theaterId . ': ' . $e->getMessage());
-        return null;
+        $errorMsg = $e->getMessage();
+        error_log('[theater-ai] Failed to generate AAR for ' . $theaterId . ': ' . $errorMsg);
+        return ['error' => $errorMsg];
     }
 }
 


### PR DESCRIPTION
## Summary
- **Fix Groq not working**: `supplycore_ai_ollama_enabled()` returned `false` for Groq/Claude providers because it required the Ollama URL to be set — cloud providers don't use that. Fixed with a proper `match` on provider.
- **Fix deprecated API param**: Groq's `max_tokens` is deprecated, changed to `max_completion_tokens` per current docs.
- **Show AAR errors**: Theater view now shows the error message in red when generation fails, instead of silently showing nothing.
- **Test AI Connection button**: New button on Settings page sends a minimal test request to the configured provider and shows success/failure with response time — verify your config works before generating AARs.

## Changes
- `src/functions.php`: Fix `supplycore_ai_ollama_enabled()`, fix Groq API params, add error logging, add `supplycore_ai_test_connection()`, return errors from `theater_ai_summary_generate()`
- `public/theater-intelligence/view.php`: Display AAR error messages
- `public/settings/index.php`: Add "Test AI Connection" button with AJAX
- `public/settings/test-ai.php`: New test endpoint

## Test plan
- [ ] Set provider to Groq, enter API key, click "Test AI Connection" — should show green OK with model name and ms
- [ ] Navigate to a theater, click "Generate AAR" — should produce an AAR
- [ ] Set an invalid API key, click "Test AI Connection" — should show red error
- [ ] Set provider to Local Ollama with no Ollama running — test should show connection error

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf