### PR TITLE
Fleet function classification + role-aware intelligence

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -903,6 +903,10 @@ function ai_briefing_settings_from_request(array $request): array
         'ollama_capability_tier' => sanitize_ollama_capability_tier($request['ollama_capability_tier'] ?? null),
         'ollama_runpod_url' => sanitize_ollama_runpod_url($request['ollama_runpod_url'] ?? null),
         'ollama_runpod_api_key' => sanitize_ollama_runpod_api_key($request['ollama_runpod_api_key'] ?? null),
+        'claude_api_key' => trim((string) ($request['claude_api_key'] ?? '')),
+        'claude_model' => trim((string) ($request['claude_model'] ?? 'claude-sonnet-4-20250514')),
+        'groq_api_key' => trim((string) ($request['groq_api_key'] ?? '')),
+        'groq_model' => trim((string) ($request['groq_model'] ?? 'meta-llama/llama-4-scout-17b-16e-instruct')),
         'theater_aar_prompt' => mb_substr(trim((string) ($request['theater_aar_prompt'] ?? '')), 0, 8000),
     ];
 }


### PR DESCRIPTION
## Summary
- **Fix AI settings save**: `ai_briefing_settings_from_request()` was missing `claude_api_key`, `claude_model`, `groq_api_key`, `groq_model` — settings silently dropped on save
- **Fix kill count inflation**: Alliance summary and participant stats were counting per-attacker-row instead of per-unique-killmail, causing 3,778 kills shown vs 145 actual
- **Add fleet function classification**: Replace basic 4-role system (dps/logi/command/capital) with 16 granular EVE fleet functions mapped by ship group ID
- **Neo4j graph integration**: Set `fleet_function` on ShipType nodes, compute `primary_fleet_function` on Character nodes from most-used ship
- **Role-aware suspicion scoring**: Tackle/bubble/bomber pilots no longer penalized for dying often; logi/EWAR/command pilots no longer penalized for low kills
- **Peer normalization by fleet function**: Compare pilots against peers in the same role (tackle vs tackle) instead of same ship type

### Fleet Functions Added
Mainline DPS, Capital DPS, Logistics, Capital Logi, Tackle, Heavy Tackle, Bubble Control, Command, EWAR, Bomber, Scout, Supercapital, Non-Combat — with color-coded badges in the UI

## Test plan
- [ ] Save Groq/Claude API keys in settings — verify they persist after reload
- [ ] Re-run theater analysis job — verify kill counts match theater total
- [ ] Check participant table shows color-coded fleet function badges
- [ ] Run migration `20260329_add_fleet_function_column.sql`
- [ ] Re-run intelligence pipeline — verify tackle/logi pilots get lower suspicion scores
- [ ] Regenerate AAR — verify AI uses correct role labels

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf