### PR TITLE
Fix AAR auto-generation on page load, add ship size to peer normalization

### DIFF
--- a/public/theater-intelligence/index.php
+++ b/public/theater-intelligence/index.php
@@ -14,9 +14,6 @@ $offset = ($page - 1) * $perPage;
 
 $theaters = db_theaters_list($perPage, $offset, $regionFilter, $minAnomaly);
 
-// Auto-generate AI battle reports for new theaters that don't have one yet
-theater_ai_summary_generate_pending();
-
 // Load tracked alliances and side labels for matchup display
 $trackedAlliances = db_killmail_tracked_alliances_active();
 $trackedAllianceIds = array_map('intval', array_column($trackedAlliances, 'alliance_id'));

--- a/python/orchestrator/eve_constants.py
+++ b/python/orchestrator/eve_constants.py
@@ -72,3 +72,46 @@ HIGH_LOSS_ROLES: frozenset[str] = frozenset({
 LOW_KILL_ROLES: frozenset[str] = frozenset({
     "logistics", "capital_logistics", "command", "ewar", "scout",
 })
+
+# ── Ship size class by group_id ──────────────────────────────────────────────
+# Used for peer normalization: only compare pilots who flew similar-sized hulls.
+# A battleship naturally out-damages a frigate — comparing them is meaningless.
+
+SHIP_SIZE_BY_GROUP: dict[int, str] = {
+    # Small (frigates, destroyers)
+    25: "small",        # Frigate
+    324: "small",       # Assault Frigate
+    380: "small",       # Destroyer
+    420: "small",       # Destroyer (alt)
+    831: "small",       # Interceptor
+    541: "small",       # Interdictor
+    830: "small",       # Covert Ops
+    834: "small",       # Stealth Bomber
+    893: "small",       # Electronic Attack Frigate
+    1283: "small",      # Expedition Frigate
+    1305: "small",      # Tactical Destroyer
+    1527: "small",      # Logistics Frigate
+    1534: "small",      # Command Destroyer
+    # Medium (cruisers, battlecruisers)
+    26: "medium",       # Cruiser
+    358: "medium",      # Heavy Assault Cruiser
+    419: "medium",      # Battlecruiser
+    540: "medium",      # Command Ship
+    832: "medium",      # Logistics Cruiser
+    833: "medium",      # Force Recon
+    894: "medium",      # Heavy Interdictor
+    906: "medium",      # Combat Recon
+    963: "medium",      # Strategic Cruiser
+    1201: "medium",     # Attack Battlecruiser
+    1972: "medium",     # Flag Cruiser
+    # Large (battleships)
+    27: "large",        # Battleship
+    898: "large",       # Black Ops
+    900: "large",       # Marauder
+    # Capital
+    485: "capital",     # Dreadnought
+    547: "capital",     # Carrier
+    659: "capital",     # Supercarrier
+    30: "capital",      # Titan
+    1973: "capital",    # Force Auxiliary
+}

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from ..db import SupplyCoreDb
-from ..eve_constants import FLEET_FUNCTION_BY_GROUP
+from ..eve_constants import FLEET_FUNCTION_BY_GROUP, SHIP_SIZE_BY_GROUP
 from ..job_result import JobResult
 from ..json_utils import json_dumps_safe
 from ..neo4j import Neo4jClient, Neo4jConfig, Neo4jError
@@ -444,10 +444,11 @@ def run_compute_graph_sync_battle_intelligence(db: SupplyCoreDb, neo4j_raw: dict
                 cursor_character_id = 0
             break
 
-        # Enrich rows with fleet function from group_id
+        # Enrich rows with fleet function and ship size from group_id
         for row in rows:
             gid = int(row.get("ship_group_id") or 0)
             row["fleet_function"] = FLEET_FUNCTION_BY_GROUP.get(gid, "mainline_dps")
+            row["ship_size"] = SHIP_SIZE_BY_GROUP.get(gid, "medium")
 
         client.query(
             """
@@ -474,7 +475,8 @@ def run_compute_graph_sync_battle_intelligence(db: SupplyCoreDb, neo4j_raw: dict
 
             FOREACH(_ IN CASE WHEN toInteger(COALESCE(row.ship_type_id, 0)) > 0 THEN [1] ELSE [] END |
                 MERGE (ship:ShipType {type_id: toInteger(row.ship_type_id)})
-                  SET ship.fleet_function = row.fleet_function
+                  SET ship.fleet_function = row.fleet_function,
+                      ship.ship_size = row.ship_size
                 MERGE (c)-[:USED_SHIP]->(ship)
             )
 

--- a/python/orchestrator/jobs/intelligence_pipeline.py
+++ b/python/orchestrator/jobs/intelligence_pipeline.py
@@ -307,14 +307,15 @@ def _compute_battle_presence(client: Neo4jClient) -> None:
 
 
 def _compute_fleet_function(client: Neo4jClient) -> None:
-    """Compute primary fleet function per character from most-used ship type."""
+    """Compute primary fleet function and ship size per character from most-used ship type."""
     client.query(
         """MATCH (c:Character)-[:USED_SHIP]->(s:ShipType)
            WHERE c.tracked = true AND s.fleet_function IS NOT NULL
-           WITH c, s.fleet_function AS ff, count(*) AS usage
+           WITH c, s.fleet_function AS ff, s.ship_size AS sz, count(*) AS usage
            ORDER BY usage DESC
-           WITH c, collect(ff)[0] AS primary_ff
-           SET c.primary_fleet_function = primary_ff"""
+           WITH c, collect(ff)[0] AS primary_ff, collect(sz)[0] AS primary_sz
+           SET c.primary_fleet_function = primary_ff,
+               c.primary_ship_size = COALESCE(primary_sz, 'medium')"""
     )
 
 
@@ -341,19 +342,22 @@ def _compute_encounter_vs_engagement(client: Neo4jClient) -> None:
 
 
 def _compute_peer_normalisation(client: Neo4jClient) -> None:
-    """Step 5.3: Peer normalisation by fleet function.
+    """Step 5.3: Peer normalisation by fleet function and ship size.
 
     Compares each character against peers who fly the same fleet function
-    (e.g., tackle vs tackle, logi vs logi) rather than exact ship type.
-    Falls back to ship type if fleet_function is not set.
+    AND same ship size class (small/medium/large/capital). A battleship
+    pilot is only compared to other battleship pilots, not cruiser pilots.
     """
     client.query(
         """MATCH (c:Character)-[:USED_SHIP]->(sc:ShipType)
            WHERE c.tracked = true AND c.battles_present > 0
-           WITH c, COALESCE(c.primary_fleet_function, sc.fleet_function, 'mainline_dps') AS my_ff
+           WITH c,
+                COALESCE(c.primary_fleet_function, sc.fleet_function, 'mainline_dps') AS my_ff,
+                COALESCE(c.primary_ship_size, sc.ship_size, 'medium') AS my_sz
            MATCH (peer:Character)-[:USED_SHIP]->(ps:ShipType)
            WHERE peer <> c AND peer.battles_present > 0
              AND COALESCE(peer.primary_fleet_function, ps.fleet_function, 'mainline_dps') = my_ff
+             AND COALESCE(peer.primary_ship_size, ps.ship_size, 'medium') = my_sz
            WITH c,
                 avg(toFloat(peer.kills_total) / peer.battles_present) AS peer_avg_kpb,
                 avg(toFloat(peer.damage_total) / peer.battles_present) AS peer_avg_dpb


### PR DESCRIPTION
## Summary
- **Stop auto-generating AARs on page load**: `theater_ai_summary_generate_pending()` was called synchronously on every GET to the theater index page, blocking page load while calling the AI API. Removed — AARs now only generate when the user clicks "Regenerate AAR".
- **Add ship size to peer normalization**: A battleship naturally out-damages a cruiser — comparing them creates false suspicion signals. Peer normalization now matches by fleet function AND ship size class (small/medium/large/capital). A HAC pilot is only compared to other medium-sized DPS pilots.

### Ship Size Classes
| Size | Ship Groups |
|---|---|
| Small | Frigates, Destroyers, Interceptors, Interdictors, Stealth Bombers, EAFs, Tac Destros... |
| Medium | Cruisers, HACs, BCs, Command Ships, Recons, HICs, T3Cs... |
| Large | Battleships, Black Ops, Marauders |
| Capital | Dreads, Carriers, Supers, Titans, FAXes |

## Test plan
- [ ] Load theater index — should be fast, no AI generation on page load
- [ ] Click "Regenerate AAR" on a theater — should still work
- [ ] Re-run graph + intelligence pipeline — verify peer normalization groups by size
- [ ] Check that a cruiser pilot flagged as "low output" against BS peers is no longer flagged

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf