### PR TITLE
Fix backfill killmails never being written

### DIFF
--- a/python/orchestrator/jobs/killmail_history_backfill.py
+++ b/python/orchestrator/jobs/killmail_history_backfill.py
@@ -104,8 +104,8 @@ def _fetch_esi_killmail(killmail_id: int, killmail_hash: str, user_agent: str) -
         "hash": killmail_hash,
         "esi": esi_data,
         "zkb": {},
-        "sequence_id": 0,
-        "requested_sequence_id": 0,
+        "sequence_id": killmail_id,
+        "requested_sequence_id": killmail_id,
         "uploaded_at": int(time.time()),
     }
 


### PR DESCRIPTION
## Summary
- Backfill pipeline fetched killmails from ESI successfully but set `sequence_id` to `0` in every payload
- PHP `killmail_persist_r2z2_payload()` treats `sequence_id <= 0` as `invalid` and skips immediately — resulting in `written=0` for every batch
- Fix: use `killmail_id` as the synthetic `sequence_id` for backfilled killmails (globally unique from ESI)

## Test plan
- [ ] Run killmail backfill again and verify `written` count increases per batch
- [ ] Verify killmails appear in `killmail_events` table after backfill completes
- [ ] Confirm no duplicate writes if backfill is run twice (existing dedup by killmail_id+hash still works)

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf