### PR TITLE
Add fleet composition normalization to suspicion scoring

### DIFF
--- a/database/migrations/20260330_theater_side_composition.sql
+++ b/database/migrations/20260330_theater_side_composition.sql
@@ -1,0 +1,45 @@
+-- Theater side composition features for force-composition normalization.
+-- Stores per-side metrics so suspicion scoring can distinguish between
+-- "outperformed because composition was stronger" vs "genuinely anomalous".
+
+CREATE TABLE IF NOT EXISTS theater_side_composition (
+    theater_id              CHAR(64)        NOT NULL,
+    side                    VARCHAR(80)     NOT NULL,
+    pilot_count             INT UNSIGNED    NOT NULL DEFAULT 0,
+    -- Hull class distribution
+    hull_small_count        INT UNSIGNED    NOT NULL DEFAULT 0,
+    hull_medium_count       INT UNSIGNED    NOT NULL DEFAULT 0,
+    hull_large_count        INT UNSIGNED    NOT NULL DEFAULT 0,
+    hull_capital_count      INT UNSIGNED    NOT NULL DEFAULT 0,
+    -- Role distribution
+    role_mainline_dps       INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_capital_dps        INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_logistics          INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_capital_logistics  INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_tackle             INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_heavy_tackle       INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_bubble_control     INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_command            INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_ewar               INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_bomber             INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_scout              INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_supercapital       INT UNSIGNED    NOT NULL DEFAULT 0,
+    role_non_combat         INT UNSIGNED    NOT NULL DEFAULT 0,
+    -- Composite scores
+    side_hull_weight_score          DECIMAL(10,4) NOT NULL DEFAULT 0,
+    side_role_balance_score         DECIMAL(10,4) NOT NULL DEFAULT 0,
+    side_logi_strength_score        DECIMAL(10,4) NOT NULL DEFAULT 0,
+    side_command_strength_score     DECIMAL(10,4) NOT NULL DEFAULT 0,
+    side_capital_ratio              DECIMAL(10,4) NOT NULL DEFAULT 0,
+    side_expected_performance_score DECIMAL(10,4) NOT NULL DEFAULT 0,
+    PRIMARY KEY (theater_id, side),
+    KEY idx_theater_side_expected (theater_id, side_expected_performance_score)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Per-character composition-adjusted performance delta, computed by the
+-- intelligence pipeline after side composition is available.
+ALTER TABLE character_suspicion_signals
+    ADD COLUMN IF NOT EXISTS composition_adjusted_delta DECIMAL(10,6) DEFAULT NULL
+        AFTER peer_normalized_damage_delta,
+    ADD COLUMN IF NOT EXISTS side_expected_performance DECIMAL(10,4) DEFAULT NULL
+        AFTER composition_adjusted_delta;

--- a/python/orchestrator/eve_constants.py
+++ b/python/orchestrator/eve_constants.py
@@ -115,3 +115,40 @@ SHIP_SIZE_BY_GROUP: dict[int, str] = {
     30: "capital",      # Titan
     1973: "capital",    # Force Auxiliary
 }
+
+# ── Hull weight scores for composition normalization ────────────────────────
+# Reflects combat power multiplier per hull size class.
+# A side bringing battleships vs cruisers should be *expected* to outperform.
+HULL_WEIGHT: dict[str, float] = {
+    "small": 1.0,
+    "medium": 2.0,
+    "large": 3.5,
+    "capital": 6.0,
+}
+
+# Fleet function combat power multiplier for composition normalization.
+# Reflects how much a role contributes to raw kill/damage output.
+ROLE_COMBAT_WEIGHT: dict[str, float] = {
+    "mainline_dps": 1.0,
+    "capital_dps": 2.5,
+    "logistics": 0.1,       # Doesn't contribute kills but multiplies fleet survival
+    "capital_logistics": 0.1,
+    "tackle": 0.3,
+    "heavy_tackle": 0.4,
+    "bubble_control": 0.3,
+    "command": 0.2,
+    "ewar": 0.3,
+    "bomber": 0.9,
+    "scout": 0.1,
+    "supercapital": 4.0,
+    "non_combat": 0.0,
+}
+
+# Fleet function force-multiplier contribution (logistics, command, ewar
+# amplify the whole fleet rather than producing kills directly).
+ROLE_MULTIPLIER_WEIGHT: dict[str, float] = {
+    "logistics": 1.5,
+    "capital_logistics": 2.5,
+    "command": 1.3,
+    "ewar": 0.8,
+}

--- a/python/orchestrator/jobs/intelligence_pipeline.py
+++ b/python/orchestrator/jobs/intelligence_pipeline.py
@@ -463,6 +463,65 @@ def _compute_co_presence_clusters(client: Neo4jClient) -> None:
     )
 
 
+def _compute_composition_adjusted_performance(client: Neo4jClient, db: SupplyCoreDb) -> None:
+    """Compute composition-adjusted performance ratio per character.
+
+    Loads side composition from MariaDB (theater_side_composition +
+    theater_participants) and computes the ratio of the character's
+    side expected_performance vs the opposing side's.
+
+    comp_ratio > 1 → character's side was stronger (outperformance expected)
+    comp_ratio < 1 → character's side was weaker (underperformance expected)
+    comp_ratio = 1 → no composition data or balanced sides
+    """
+    # Load per-character side assignment and expected performance from MariaDB.
+    # For characters in multiple theaters, average across all.
+    rows = db.fetch_all(
+        """SELECT
+               tp.character_id,
+               tp.side AS my_side,
+               my_comp.side_expected_performance_score AS my_expected,
+               opp_comp.side_expected_performance_score AS opp_expected
+           FROM theater_participants tp
+           INNER JOIN theater_side_composition my_comp
+               ON my_comp.theater_id = tp.theater_id AND my_comp.side = tp.side
+           INNER JOIN theater_side_composition opp_comp
+               ON opp_comp.theater_id = tp.theater_id AND opp_comp.side <> tp.side
+           WHERE my_comp.side_expected_performance_score > 0
+             AND opp_comp.side_expected_performance_score > 0"""
+    )
+    if not rows:
+        return
+
+    # Aggregate: average composition advantage ratio per character
+    char_ratios: dict[int, list[float]] = {}
+    for r in rows:
+        cid = int(r.get("character_id") or 0)
+        my_exp = float(r.get("my_expected") or 1.0)
+        opp_exp = float(r.get("opp_expected") or 1.0)
+        if cid > 0 and opp_exp > 0:
+            char_ratios.setdefault(cid, []).append(my_exp / opp_exp)
+
+    # Set on Neo4j Character nodes in batches
+    batch_data = [
+        {"character_id": cid, "comp_ratio": sum(ratios) / len(ratios)}
+        for cid, ratios in char_ratios.items()
+        if ratios
+    ]
+
+    for offset in range(0, len(batch_data), BATCH_SIZE):
+        batch = batch_data[offset:offset + BATCH_SIZE]
+        client.query(
+            """UNWIND $batch AS row
+               CALL {
+                   WITH row
+                   MATCH (c:Character {character_id: row.character_id})
+                   SET c.composition_advantage_ratio = row.comp_ratio
+               } IN TRANSACTIONS OF 500 ROWS""",
+            {"batch": batch},
+        )
+
+
 def _compute_score_assembly(client: Neo4jClient, weights: dict[str, float] | None = None) -> None:
     """Step 5.9: Assemble final suspicion score and flags.
 
@@ -482,29 +541,50 @@ def _compute_score_assembly(client: Neo4jClient, weights: dict[str, float] | Non
            WITH c,
                COALESCE(c.primary_fleet_function, 'mainline_dps') AS ff,
                COALESCE(c.selective_non_engagement_score, 0) AS sne,
-               COALESCE(c.peer_norm_kills_delta, 0) AS pnk,
-               COALESCE(c.peer_norm_damage_delta, 0) AS pnd,
+               COALESCE(c.peer_norm_kills_delta, 0) AS raw_pnk,
+               COALESCE(c.peer_norm_damage_delta, 0) AS raw_pnd,
                COALESCE(c.high_presence_low_output_score, 0) AS hplo,
                COALESCE(c.token_participation_score, 0) AS tp,
-               COALESCE(c.loss_without_attack_ratio, 0) AS lwa
-           // Role-aware weight adjustments
-           WITH c, ff, sne, pnk, pnd, hplo, tp, lwa,
+               COALESCE(c.loss_without_attack_ratio, 0) AS lwa,
+               COALESCE(c.composition_advantage_ratio, 1.0) AS comp_ratio
+
+           // ── Composition-adjusted peer deltas ──
+           // comp_ratio > 1 → stronger side → discount positive outperformance
+           // comp_ratio < 1 → weaker side → discount underperformance
+           WITH c, ff, sne, hplo, tp, lwa, comp_ratio,
+               CASE WHEN comp_ratio < 0.1 THEN 1.0 ELSE comp_ratio END AS safe_ratio,
+               raw_pnk, raw_pnd
+
+           WITH c, ff, sne, hplo, tp, lwa, safe_ratio AS comp_ratio,
+               CASE WHEN raw_pnk >= 0 THEN raw_pnk / safe_ratio
+                    ELSE raw_pnk * safe_ratio END AS pnk,
+               CASE WHEN raw_pnd >= 0 THEN raw_pnd / safe_ratio
+                    ELSE raw_pnd * safe_ratio END AS pnd,
+               // Dampen high_presence_low_output when on weaker side
+               CASE WHEN safe_ratio < 0.7 THEN hplo * safe_ratio
+                    ELSE hplo END AS adj_hplo
+
+           // ── Role-aware weight adjustments ──
+           WITH c, ff, sne, pnk, pnd, adj_hplo, tp, lwa, comp_ratio,
                CASE WHEN ff IN $high_loss_roles THEN 0.0 ELSE $w_lwa END AS eff_w_lwa,
                CASE WHEN ff IN $high_loss_roles THEN $w_tp * 0.3 ELSE $w_tp END AS eff_w_tp,
                CASE WHEN ff IN $low_kill_roles THEN $w_pnk * 0.3 ELSE $w_pnk END AS eff_w_pnk,
                CASE WHEN ff IN $low_kill_roles THEN $w_hplo * 0.3 ELSE $w_hplo END AS eff_w_hplo
-           WITH c, ff,
+
+           // ── Final score assembly ──
+           WITH c, ff, comp_ratio, sne, pnk, pnd, adj_hplo, tp, lwa,
+               eff_w_lwa, eff_w_tp, eff_w_pnk, eff_w_hplo,
                (sne * $w_sne) +
                (pnk * eff_w_pnk) +
                (pnd * $w_pnd) +
-               (hplo * eff_w_hplo) +
+               (adj_hplo * eff_w_hplo) +
                (tp * eff_w_tp) +
                (lwa * eff_w_lwa)
                AS raw_score,
                [
                    CASE WHEN sne > 0.7
                         THEN 'selective_non_engagement' END,
-                   CASE WHEN hplo > 0.6 AND NOT ff IN $low_kill_roles
+                   CASE WHEN adj_hplo > 0.6 AND NOT ff IN $low_kill_roles
                         THEN 'high_presence_low_output' END,
                    CASE WHEN tp > 0.5 AND NOT ff IN $high_loss_roles
                         THEN 'token_participation' END,
@@ -517,10 +597,11 @@ def _compute_score_assembly(client: Neo4jClient, weights: dict[str, float] | Non
                    CASE WHEN lwa > 0.7 AND NOT ff IN $high_loss_roles
                         THEN 'loss_without_attack' END
                ] AS all_flags
-           WITH c, raw_score,
+           WITH c, raw_score, comp_ratio,
                 [f IN all_flags WHERE f IS NOT NULL] AS flags
            SET c.suspicion_score = raw_score,
                c.suspicion_flags = flags,
+               c.composition_advantage_ratio = comp_ratio,
                c.computed_at = toString(datetime())""",
         {
             "w_sne": w.get("selective_non_engagement", 0.35),
@@ -656,6 +737,7 @@ def _export_suspicion_signals(client: Neo4jClient, db: SupplyCoreDb, computed_at
                toFloat(COALESCE(c.loss_without_attack_ratio, 0)) AS loss_without_attack_ratio,
                toFloat(COALESCE(c.peer_norm_kills_delta, 0)) AS peer_norm_kills_delta,
                toFloat(COALESCE(c.peer_norm_damage_delta, 0)) AS peer_norm_damage_delta,
+               toFloat(COALESCE(c.composition_advantage_ratio, 1.0)) AS composition_advantage_ratio,
                toFloat(COALESCE(c.suspicion_score, 0)) AS suspicion_score,
                c.suspicion_flags AS suspicion_flags,
                engagement_rates"""
@@ -677,8 +759,9 @@ def _export_suspicion_signals(client: Neo4jClient, db: SupplyCoreDb, computed_at
                     selective_non_engagement_score, high_presence_low_output_score,
                     token_participation_score, loss_without_attack_ratio,
                     peer_normalized_kills_delta, peer_normalized_damage_delta,
+                    composition_adjusted_delta, side_expected_performance,
                     suspicion_score, suspicion_flags, engagement_rate_by_alliance, computed_at)
-                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
                 (
                     cid,
                     int(r.get("alliance_id") or 0),
@@ -693,6 +776,8 @@ def _export_suspicion_signals(client: Neo4jClient, db: SupplyCoreDb, computed_at
                     float(r.get("loss_without_attack_ratio") or 0),
                     float(r.get("peer_norm_kills_delta") or 0),
                     float(r.get("peer_norm_damage_delta") or 0),
+                    float(r.get("composition_advantage_ratio") or 1.0) - 1.0,  # delta from neutral
+                    float(r.get("composition_advantage_ratio") or 1.0),
                     float(r.get("suspicion_score") or 0),
                     json_dumps_safe(r.get("suspicion_flags") or []),
                     json_dumps_safe(r.get("engagement_rates") or []),
@@ -859,7 +944,8 @@ def run_intelligence_pipeline(
         skipped_stages.extend([
             "battle_presence", "fleet_function", "encounter_vs_engagement", "peer_normalisation",
             "selective_non_engagement", "high_presence_low_output", "token_participation",
-            "loss_pattern", "co_presence_clusters", "score_assembly",
+            "loss_pattern", "co_presence_clusters",
+            "composition_adjusted_performance", "score_assembly",
             "shared_alliance_history", "former_allies_attacking", "repeat_targeting",
             "overlap_score", "cross_system_correlation",
         ])
@@ -874,6 +960,11 @@ def run_intelligence_pipeline(
         _timed("token_participation", _compute_token_participation, client)
         _timed("loss_pattern", _compute_loss_pattern, client)
         _timed("co_presence_clusters", _compute_co_presence_clusters, client)
+
+        # 4b. Composition normalization — compute per-character advantage ratios
+        # from MariaDB side composition data (theater_side_composition).
+        _timed("composition_adjusted_performance", _compute_composition_adjusted_performance, client, db)
+
         _timed("score_assembly", _compute_score_assembly, client, recalibrated_weights)
 
         # 5. Historical alliance overlap.

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -27,13 +27,25 @@ if __package__ in (None, ""):
     if package_root not in sys.path:
         sys.path.insert(0, package_root)
     from orchestrator.db import SupplyCoreDb
-    from orchestrator.eve_constants import FLEET_FUNCTION_BY_GROUP
+    from orchestrator.eve_constants import (
+        FLEET_FUNCTION_BY_GROUP,
+        HULL_WEIGHT,
+        ROLE_COMBAT_WEIGHT,
+        ROLE_MULTIPLIER_WEIGHT,
+        SHIP_SIZE_BY_GROUP,
+    )
     from orchestrator.job_result import JobResult
     from orchestrator.json_utils import json_dumps_safe
     from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
 else:
     from ..db import SupplyCoreDb
-    from ..eve_constants import FLEET_FUNCTION_BY_GROUP
+    from ..eve_constants import (
+        FLEET_FUNCTION_BY_GROUP,
+        HULL_WEIGHT,
+        ROLE_COMBAT_WEIGHT,
+        ROLE_MULTIPLIER_WEIGHT,
+        SHIP_SIZE_BY_GROUP,
+    )
     from ..job_result import JobResult
     from ..json_utils import json_dumps_safe
     from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
@@ -525,6 +537,133 @@ def _compute_participants(
     return result
 
 
+# ── Side composition computation ──────────────────────────────────────────
+
+def _compute_side_composition(
+    bp_rows: list[dict[str, Any]],
+    char_sides: dict[int, str],
+    ship_group_map: dict[int, int],
+    theater_id: str,
+) -> list[dict[str, Any]]:
+    """Compute per-side composition features for force-composition normalization.
+
+    Returns one row per side with hull distribution, role distribution,
+    and composite scores (hull_weight, role_balance, logi_strength, etc.).
+    """
+    # Per-side accumulators
+    sides: dict[str, dict[str, Any]] = {}
+
+    for p in bp_rows:
+        cid = int(p.get("character_id") or 0)
+        if cid <= 0:
+            continue
+        side = char_sides.get(cid, "side_b")
+        ship_type_id = int(p.get("ship_type_id") or 0)
+        group_id = ship_group_map.get(ship_type_id, 0)
+        fleet_fn = FLEET_FUNCTION_BY_GROUP.get(group_id, "mainline_dps")
+        ship_size = SHIP_SIZE_BY_GROUP.get(group_id, "medium")
+
+        if side not in sides:
+            sides[side] = {
+                "theater_id": theater_id,
+                "side": side,
+                "pilots": set(),
+                "hull_counts": {"small": 0, "medium": 0, "large": 0, "capital": 0},
+                "role_counts": {},
+            }
+
+        acc = sides[side]
+        acc["pilots"].add(cid)
+        acc["hull_counts"][ship_size] = acc["hull_counts"].get(ship_size, 0) + 1
+        acc["role_counts"][fleet_fn] = acc["role_counts"].get(fleet_fn, 0) + 1
+
+    result: list[dict[str, Any]] = []
+    for side, acc in sides.items():
+        pilot_count = len(acc["pilots"])
+        hulls = acc["hull_counts"]
+        roles = acc["role_counts"]
+        total_ships = sum(hulls.values()) or 1
+
+        # Hull weight: weighted average hull class power
+        hull_weight_score = sum(
+            count * HULL_WEIGHT.get(sz, 1.0)
+            for sz, count in hulls.items()
+        ) / total_ships
+
+        # Role balance: Shannon entropy of role distribution normalized to [0,1]
+        # Higher = more diverse fleet composition
+        role_total = sum(roles.values()) or 1
+        role_entropy = 0.0
+        for count in roles.values():
+            if count > 0:
+                p = count / role_total
+                role_entropy -= p * math.log2(p)
+        # Normalize: max entropy = log2(num_roles) ≈ 3.7 for 13 combat roles
+        max_entropy = math.log2(13) if len(roles) > 1 else 1.0
+        role_balance_score = min(1.0, role_entropy / max_entropy)
+
+        # Logistics strength: ratio of logi pilots to total
+        logi_count = roles.get("logistics", 0) + roles.get("capital_logistics", 0)
+        logi_strength = logi_count / pilot_count if pilot_count > 0 else 0.0
+
+        # Command strength
+        command_count = roles.get("command", 0)
+        command_strength = command_count / pilot_count if pilot_count > 0 else 0.0
+
+        # Capital ratio
+        capital_count = hulls.get("capital", 0)
+        capital_ratio = capital_count / total_ships
+
+        # Expected performance composite:
+        # Base = hull_weight (bigger ships hit harder)
+        # × (1 + logi_multiplier + command_multiplier + ewar_multiplier) for force multipliers
+        # × sqrt(pilot_count) for Lanchester's square law
+        force_multiplier = 1.0
+        for role, mult in ROLE_MULTIPLIER_WEIGHT.items():
+            role_count = roles.get(role, 0)
+            if role_count > 0 and pilot_count > 0:
+                # Each multiplier role adds its weight proportional to its presence
+                force_multiplier += mult * (role_count / pilot_count)
+
+        # Combat power: sum of role-weighted combat contributions
+        combat_power = sum(
+            count * ROLE_COMBAT_WEIGHT.get(role, 0.5)
+            for role, count in roles.items()
+        ) / total_ships
+
+        # Expected performance = combat_power × hull_weight × force_multiplier × sqrt(N)
+        expected_perf = combat_power * hull_weight_score * force_multiplier * math.sqrt(max(1, pilot_count))
+
+        # Build all role count columns
+        all_roles = [
+            "mainline_dps", "capital_dps", "logistics", "capital_logistics",
+            "tackle", "heavy_tackle", "bubble_control", "command", "ewar",
+            "bomber", "scout", "supercapital", "non_combat",
+        ]
+
+        row = {
+            "theater_id": theater_id,
+            "side": side,
+            "pilot_count": pilot_count,
+            "hull_small_count": hulls.get("small", 0),
+            "hull_medium_count": hulls.get("medium", 0),
+            "hull_large_count": hulls.get("large", 0),
+            "hull_capital_count": hulls.get("capital", 0),
+            "side_hull_weight_score": round(hull_weight_score, 4),
+            "side_role_balance_score": round(role_balance_score, 4),
+            "side_logi_strength_score": round(logi_strength, 4),
+            "side_command_strength_score": round(command_strength, 4),
+            "side_capital_ratio": round(capital_ratio, 4),
+            "side_expected_performance_score": round(expected_perf, 4),
+        }
+        for role in all_roles:
+            row[f"role_{role}"] = roles.get(role, 0)
+
+        result.append(row)
+
+    return result
+
+
 # ── Anomaly scoring ────────────────────────────────────────────────────────
 
 def _compute_anomaly_score(
@@ -585,6 +724,7 @@ def _flush_analysis(
     anomaly_score: float,
     computed_at: str,
     battle_ids: list[str],
+    side_composition_rows: list[dict[str, Any]] | None = None,
 ) -> int:
     """Write analysis results for one theater. Returns rows written."""
     rows_written = 0
@@ -678,6 +818,40 @@ def _flush_analysis(
             )
             rows_written += 1
 
+        # Side composition
+        if side_composition_rows:
+            cursor.execute("DELETE FROM theater_side_composition WHERE theater_id = %s", (theater_id,))
+            for sc in side_composition_rows:
+                cursor.execute(
+                    """
+                    INSERT INTO theater_side_composition (
+                        theater_id, side, pilot_count,
+                        hull_small_count, hull_medium_count, hull_large_count, hull_capital_count,
+                        role_mainline_dps, role_capital_dps, role_logistics, role_capital_logistics,
+                        role_tackle, role_heavy_tackle, role_bubble_control, role_command, role_ewar,
+                        role_bomber, role_scout, role_supercapital, role_non_combat,
+                        side_hull_weight_score, side_role_balance_score,
+                        side_logi_strength_score, side_command_strength_score,
+                        side_capital_ratio, side_expected_performance_score
+                    ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                    """,
+                    (
+                        sc["theater_id"], sc["side"], sc["pilot_count"],
+                        sc["hull_small_count"], sc["hull_medium_count"],
+                        sc["hull_large_count"], sc["hull_capital_count"],
+                        sc["role_mainline_dps"], sc["role_capital_dps"],
+                        sc["role_logistics"], sc["role_capital_logistics"],
+                        sc["role_tackle"], sc["role_heavy_tackle"],
+                        sc["role_bubble_control"], sc["role_command"], sc["role_ewar"],
+                        sc["role_bomber"], sc["role_scout"],
+                        sc["role_supercapital"], sc["role_non_combat"],
+                        sc["side_hull_weight_score"], sc["side_role_balance_score"],
+                        sc["side_logi_strength_score"], sc["side_command_strength_score"],
+                        sc["side_capital_ratio"], sc["side_expected_performance_score"],
+                    ),
+                )
+                rows_written += 1
+
         # Update theater aggregates
         cursor.execute(
             """
@@ -765,6 +939,9 @@ def run_theater_analysis(
             # Compute participant stats
             participant_stats = _compute_participants(killmails, bp_rows, char_sides, theater_id, ship_group_map)
 
+            # Compute side composition features for force-normalization
+            side_composition = _compute_side_composition(bp_rows, char_sides, ship_group_map, theater_id)
+
             # Compute totals
             total_kills = sum(t["kills"] for t in timeline)
             total_isk = sum(t["isk_destroyed"] for t in timeline)
@@ -777,7 +954,7 @@ def run_theater_analysis(
                 written = _flush_analysis(
                     db, theater_id, timeline, alliance_summary, participant_stats,
                     turning_points, total_kills, total_isk, anomaly_score, computed_at,
-                    battle_ids,
+                    battle_ids, side_composition,
                 )
                 rows_written += written
 

--- a/src/db.php
+++ b/src/db.php
@@ -14298,6 +14298,14 @@ function db_signals_recent(int $limit = 200): array
     );
 }
 
+function db_theater_side_composition(string $theaterId): array
+{
+    return db_select_all(
+        'SELECT * FROM theater_side_composition WHERE theater_id = ? ORDER BY side ASC',
+        [$theaterId]
+    );
+}
+
 function db_pilot_search(string $query, int $limit = 30): array
 {
     $q = trim($query);


### PR DESCRIPTION
## Summary
- **Raw side outperformance is no longer treated as suspicious.** The system now normalizes for fleet composition differences before scoring.
- Computes per-side composition features at theater analysis time: hull class distribution, role mix, logistics/command/capital strength, and a composite `side_expected_performance_score`
- Intelligence pipeline computes a `composition_advantage_ratio` per character (my_side_expected / opp_side_expected), then adjusts peer norm deltas and high_presence_low_output accordingly
- Stronger side outperforming → discounted (expected). Weaker side underperforming → discounted (expected). Only *composition-adjusted* anomalies trigger suspicion flags.

### Normalization factors
| Feature | What it captures |
|---------|-----------------|
| `side_hull_weight_score` | Hull class power (BS=3.5, capital=6, frig=1) |
| `side_role_balance_score` | Fleet role diversity (Shannon entropy) |
| `side_logi_strength_score` | Logistics pilot ratio |
| `side_command_strength_score` | Command/boost pilot ratio |
| `side_capital_ratio` | Capital ship ratio |
| `side_expected_performance_score` | Composite: combat_power × hull_weight × force_mult × √N |

### Files changed
- `eve_constants.py` — New constants: HULL_WEIGHT, ROLE_COMBAT_WEIGHT, ROLE_MULTIPLIER_WEIGHT
- `theater_analysis.py` — New `_compute_side_composition()`, writes `theater_side_composition` table
- `intelligence_pipeline.py` — New `_compute_composition_adjusted_performance()` stage, composition-adjusted score assembly
- `src/db.php` — `db_theater_side_composition()` reader
- Migration: `theater_side_composition` table + new columns on `character_suspicion_signals`

## Test plan
- [ ] Run migration `20260330_theater_side_composition.sql`
- [ ] Run theater_analysis job → verify `theater_side_composition` populated with per-side features
- [ ] Verify side_expected_performance_score differs between sides with different compositions
- [ ] Run intelligence pipeline → verify `composition_advantage_ratio` set on Character nodes
- [ ] Verify suspicion scores change: BS-heavy side pilots should see reduced suspicion vs before
- [ ] Verify weaker-side pilots with low output get dampened `high_presence_low_output` scores

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf