### PR TITLE
Improve pilot lookup quick stats layout responsiveness

### DIFF
--- a/public/battle-intelligence/pilot-lookup.php
+++ b/public/battle-intelligence/pilot-lookup.php
@@ -114,7 +114,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
             </div>
 
             <!-- Quick stats -->
-            <div class="mt-4 grid gap-3 md:grid-cols-6">
+            <div class="mt-4 grid gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-6">
                 <div class="surface-tertiary">
                     <p class="text-xs text-muted">Theaters</p>
                     <p class="text-lg text-slate-50 font-semibold"><?= (int) ($stats['theater_count'] ?? 0) ?></p>


### PR DESCRIPTION
### Motivation
- Make the Pilot Lookup "Quick stats" metrics readable side-by-side on typical viewports instead of collapsing into a single vertical stack by using compiled utility classes that exist in the stylesheet.

### Description
- Replace the one-line grid class in `public/battle-intelligence/pilot-lookup.php` from `md:grid-cols-6` to `sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-6` so the six stat cards flow responsively across breakpoints.

### Testing
- Ran `php -l public/battle-intelligence/pilot-lookup.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c753dc5bb0832fa1776c8e0990ecb3)