### PR TITLE
Add EVE Intelligence Platform: Item Criticality + Economic Warfare

### DIFF
--- a/database/migrations/20260331_economic_warfare.sql
+++ b/database/migrations/20260331_economic_warfare.sql
@@ -1,0 +1,89 @@
+-- Economic Warfare: Opponent tracking, hostile fit families, and module scoring
+
+-- ─── Tracked Opponent Entities ────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS killmail_opponent_alliances (
+    alliance_id     BIGINT UNSIGNED PRIMARY KEY,
+    label           VARCHAR(190)    DEFAULT NULL,
+    is_active       TINYINT(1)      NOT NULL DEFAULT 1,
+    created_at      TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP       DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_active (is_active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS killmail_opponent_corporations (
+    corporation_id  BIGINT UNSIGNED PRIMARY KEY,
+    label           VARCHAR(190)    DEFAULT NULL,
+    is_active       TINYINT(1)      NOT NULL DEFAULT 1,
+    created_at      TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP       DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_active (is_active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ─── Extend mail_type to support opponent kill/loss classification ────────────
+
+ALTER TABLE killmail_events
+    MODIFY COLUMN mail_type ENUM('kill','loss','opponent_loss','opponent_kill') NOT NULL DEFAULT 'loss';
+
+-- ─── Hostile Fit Families ─────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS hostile_fit_families (
+    id                  INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+    hull_type_id        INT UNSIGNED    NOT NULL,
+    family_fingerprint  VARCHAR(64)     NOT NULL,
+    module_set_json     JSON            NOT NULL,
+    observation_count   INT UNSIGNED    NOT NULL DEFAULT 0,
+    confidence          DECIMAL(6,4)    NOT NULL DEFAULT 0,
+    first_seen          DATETIME        NOT NULL,
+    last_seen           DATETIME        NOT NULL,
+    alliance_ids_json   JSON            DEFAULT NULL,
+    computed_at         DATETIME        NOT NULL,
+    UNIQUE KEY uniq_hull_fingerprint (hull_type_id, family_fingerprint),
+    KEY idx_hull (hull_type_id),
+    KEY idx_last_seen (last_seen),
+    KEY idx_confidence (confidence DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS hostile_fit_family_modules (
+    id              BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    family_id       INT UNSIGNED    NOT NULL,
+    item_type_id    INT UNSIGNED    NOT NULL,
+    flag_category   ENUM('high','medium','low','rig','drone','subsystem','other') NOT NULL DEFAULT 'other',
+    frequency       DECIMAL(6,4)    NOT NULL DEFAULT 1.0000,
+    is_core         TINYINT(1)      NOT NULL DEFAULT 0,
+    KEY idx_family (family_id),
+    KEY idx_item (item_type_id),
+    KEY idx_core (is_core, item_type_id),
+    UNIQUE KEY uniq_family_item_flag (family_id, item_type_id, flag_category)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ─── Economic Warfare Scores ──────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS economic_warfare_scores (
+    type_id                     INT UNSIGNED    PRIMARY KEY,
+    type_name                   VARCHAR(255)    DEFAULT NULL,
+    group_id                    INT UNSIGNED    DEFAULT NULL,
+    meta_group_id               INT UNSIGNED    DEFAULT NULL,
+    doctrine_penetration_score  DECIMAL(8,4)    NOT NULL DEFAULT 0,
+    fit_constraint_score        DECIMAL(8,4)    NOT NULL DEFAULT 0,
+    substitution_penalty_score  DECIMAL(8,4)    NOT NULL DEFAULT 0,
+    replacement_friction_score  DECIMAL(8,4)    NOT NULL DEFAULT 0,
+    loss_pressure_score         DECIMAL(8,4)    NOT NULL DEFAULT 0,
+    economic_warfare_score      DECIMAL(8,4)    NOT NULL DEFAULT 0,
+    hostile_family_count        INT UNSIGNED    NOT NULL DEFAULT 0,
+    hostile_alliance_count      INT UNSIGNED    NOT NULL DEFAULT 0,
+    total_destroyed_30d         INT UNSIGNED    NOT NULL DEFAULT 0,
+    cross_fit_persistence       DECIMAL(6,4)    DEFAULT NULL,
+    is_fitting_variant          TINYINT(1)      NOT NULL DEFAULT 0,
+    substitute_count            INT UNSIGNED    NOT NULL DEFAULT 0,
+    computed_at                 DATETIME        NOT NULL,
+    KEY idx_ew_score (economic_warfare_score DESC),
+    KEY idx_group (group_id),
+    KEY idx_meta (meta_group_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ─── Schedule ─────────────────────────────────────────────────────────────────
+
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode, workload_class)
+VALUES ('compute_economic_warfare', 1, 3600, 'python', 'compute')
+ON DUPLICATE KEY UPDATE enabled = enabled;

--- a/public/economic-warfare/family-modules.php
+++ b/public/economic-warfare/family-modules.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$familyId = (int) ($_GET['family_id'] ?? 0);
+
+if ($familyId <= 0) {
+    http_response_code(422);
+    echo json_encode(['error' => 'Invalid family_id.', 'modules' => []], JSON_THROW_ON_ERROR);
+    exit;
+}
+
+try {
+    $modules = db_hostile_fit_family_modules($familyId);
+    echo json_encode(['modules' => $modules], JSON_THROW_ON_ERROR);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to load modules.', 'modules' => []], JSON_THROW_ON_ERROR);
+}

--- a/public/economic-warfare/index.php
+++ b/public/economic-warfare/index.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Economic Warfare';
+$filters = [
+    'hostile_alliance_id' => (int) ($_GET['hostile_alliance_id'] ?? 0),
+    'min_score' => (float) ($_GET['min_score'] ?? 0),
+    'meta_group_id' => (int) ($_GET['meta_group_id'] ?? 0),
+    'limit' => (int) ($_GET['limit'] ?? 100),
+    'offset' => (int) ($_GET['offset'] ?? 0),
+];
+
+$data = economic_warfare_page_data($filters);
+$summary = (array) ($data['summary'] ?? []);
+$scores = (array) ($data['scores'] ?? []);
+$families = (array) ($data['families'] ?? []);
+$hostileAlliances = (array) ($data['hostile_alliances'] ?? []);
+$computedAt = (string) ($summary['computed_at'] ?? '');
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<section class="surface-primary">
+    <div class="flex items-center justify-between gap-4">
+        <div>
+            <p class="text-xs uppercase tracking-[0.16em] text-muted">Supply intelligence</p>
+            <h1 class="mt-1 text-2xl font-semibold text-slate-50">Economic Warfare</h1>
+            <p class="mt-2 text-sm text-muted">Identifies fitting-constrained modules in hostile doctrines where supply pressure has maximum impact.</p>
+        </div>
+    </div>
+    <p class="mt-4 text-xs text-muted">Computed at <?= htmlspecialchars($computedAt !== '' ? $computedAt : 'not yet computed', ENT_QUOTES) ?></p>
+
+    <!-- Summary Cards -->
+    <div class="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+            <p class="text-xs text-muted">Kills Analyzed</p>
+            <p class="mt-1 text-lg font-semibold text-slate-100"><?= number_format((int) ($summary['total_observations'] ?? 0)) ?></p>
+        </div>
+        <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+            <p class="text-xs text-muted">Fit Families</p>
+            <p class="mt-1 text-lg font-semibold text-slate-100"><?= number_format((int) ($summary['fit_families'] ?? 0)) ?></p>
+        </div>
+        <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+            <p class="text-xs text-muted">Hostile Alliances</p>
+            <p class="mt-1 text-lg font-semibold text-slate-100"><?= number_format((int) ($summary['hostile_alliances'] ?? 0)) ?></p>
+        </div>
+        <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+            <p class="text-xs text-muted">Top Pressure Target</p>
+            <p class="mt-1 text-sm font-semibold text-slate-100 truncate"><?= htmlspecialchars((string) ($summary['top_target'] ?? 'N/A'), ENT_QUOTES) ?></p>
+        </div>
+        <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+            <p class="text-xs text-muted">Avg Replacement Friction</p>
+            <p class="mt-1 text-lg font-semibold text-slate-100"><?= number_format((float) ($summary['avg_replacement_friction'] ?? 0), 3) ?></p>
+        </div>
+    </div>
+
+    <!-- Filters -->
+    <form class="mt-5 flex flex-wrap items-end gap-3" method="get">
+        <label class="block space-y-1">
+            <span class="text-xs text-muted">Hostile Alliance</span>
+            <select name="hostile_alliance_id" class="field-input text-sm">
+                <option value="0">All alliances</option>
+                <?php foreach ($hostileAlliances as $ha): ?>
+                    <option value="<?= (int) ($ha['alliance_id'] ?? 0) ?>" <?= (int) ($filters['hostile_alliance_id'] ?? 0) === (int) ($ha['alliance_id'] ?? 0) ? 'selected' : '' ?>>
+                        <?= htmlspecialchars((string) ($ha['label'] ?? ('Alliance #' . ($ha['alliance_id'] ?? '?'))), ENT_QUOTES) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label class="block space-y-1">
+            <span class="text-xs text-muted">Min EW Score</span>
+            <input type="number" name="min_score" step="0.01" min="0" max="1" value="<?= htmlspecialchars((string) ($filters['min_score'] ?? ''), ENT_QUOTES) ?>" placeholder="0.00" class="field-input text-sm w-24" />
+        </label>
+        <label class="block space-y-1">
+            <span class="text-xs text-muted">Meta Group</span>
+            <select name="meta_group_id" class="field-input text-sm">
+                <option value="0">All</option>
+                <option value="1" <?= (int) ($filters['meta_group_id'] ?? 0) === 1 ? 'selected' : '' ?>>T1</option>
+                <option value="2" <?= (int) ($filters['meta_group_id'] ?? 0) === 2 ? 'selected' : '' ?>>T2</option>
+                <option value="4" <?= (int) ($filters['meta_group_id'] ?? 0) === 4 ? 'selected' : '' ?>>Faction</option>
+                <option value="6" <?= (int) ($filters['meta_group_id'] ?? 0) === 6 ? 'selected' : '' ?>>Deadspace</option>
+                <option value="14" <?= (int) ($filters['meta_group_id'] ?? 0) === 14 ? 'selected' : '' ?>>T3</option>
+            </select>
+        </label>
+        <button type="submit" class="btn-primary text-sm">Filter</button>
+        <a href="/economic-warfare/" class="btn-secondary text-sm">Reset</a>
+    </form>
+
+    <!-- Main Table: Economic Warfare Targets -->
+    <div class="mt-5 table-shell">
+        <table class="table-ui">
+            <thead>
+            <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                <th class="px-3 py-2 text-left">#</th>
+                <th class="px-3 py-2 text-left">Module</th>
+                <th class="px-3 py-2 text-center">Meta</th>
+                <th class="px-3 py-2 text-right">EW Score</th>
+                <th class="px-3 py-2 text-right">Fit Constraint</th>
+                <th class="px-3 py-2 text-right">Substitution</th>
+                <th class="px-3 py-2 text-right">Replacement</th>
+                <th class="px-3 py-2 text-right">Doctrine Pen.</th>
+                <th class="px-3 py-2 text-right">Loss Pressure</th>
+                <th class="px-3 py-2 text-right">Families</th>
+                <th class="px-3 py-2 text-right">Alliances</th>
+                <th class="px-3 py-2 text-right">Destroyed (30d)</th>
+                <th class="px-3 py-2 text-center">Fitting?</th>
+                <th class="px-3 py-2 text-right">Detail</th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php if ($scores === []): ?>
+                <tr><td colspan="14" class="px-3 py-6 text-sm text-muted">No economic warfare data yet. Run compute_economic_warfare to analyze opponent fits.</td></tr>
+            <?php else: ?>
+                <?php $rank = ((int) ($filters['offset'] ?? 0)) + 1; ?>
+                <?php foreach ($scores as $row): ?>
+                    <?php
+                        $ewScore = (float) ($row['economic_warfare_score'] ?? 0);
+                        $fitScore = (float) ($row['fit_constraint_score'] ?? 0);
+                        $constraintClass = ew_constraint_color_class($fitScore);
+                    ?>
+                    <tr class="border-b border-border/30 hover:bg-white/[0.02]">
+                        <td class="px-3 py-2 text-sm text-muted"><?= $rank++ ?></td>
+                        <td class="px-3 py-2 text-sm text-slate-100"><?= htmlspecialchars((string) ($row['type_name'] ?? ('Type #' . ($row['type_id'] ?? '?'))), ENT_QUOTES) ?></td>
+                        <td class="px-3 py-2 text-center text-xs text-muted"><?= htmlspecialchars(ew_meta_group_label((int) ($row['meta_group_id'] ?? 0)), ENT_QUOTES) ?></td>
+                        <td class="px-3 py-2 text-right text-sm font-semibold <?= $ewScore >= 0.5 ? 'text-red-400' : ($ewScore >= 0.3 ? 'text-amber-300' : 'text-zinc-400') ?>"><?= number_format($ewScore, 3) ?></td>
+                        <td class="px-3 py-2 text-right text-sm <?= $constraintClass ?>"><?= number_format($fitScore, 3) ?></td>
+                        <td class="px-3 py-2 text-right text-sm text-slate-300"><?= number_format((float) ($row['substitution_penalty_score'] ?? 0), 3) ?></td>
+                        <td class="px-3 py-2 text-right text-sm text-slate-300"><?= number_format((float) ($row['replacement_friction_score'] ?? 0), 3) ?></td>
+                        <td class="px-3 py-2 text-right text-sm text-slate-300"><?= number_format((float) ($row['doctrine_penetration_score'] ?? 0), 3) ?></td>
+                        <td class="px-3 py-2 text-right text-sm text-slate-300"><?= number_format((float) ($row['loss_pressure_score'] ?? 0), 3) ?></td>
+                        <td class="px-3 py-2 text-right text-sm text-muted"><?= number_format((int) ($row['hostile_family_count'] ?? 0)) ?></td>
+                        <td class="px-3 py-2 text-right text-sm text-muted"><?= number_format((int) ($row['hostile_alliance_count'] ?? 0)) ?></td>
+                        <td class="px-3 py-2 text-right text-sm text-muted"><?= number_format((int) ($row['total_destroyed_30d'] ?? 0)) ?></td>
+                        <td class="px-3 py-2 text-center text-xs"><?= (int) ($row['is_fitting_variant'] ?? 0) ? '<span class="text-amber-300">FIT</span>' : '<span class="text-zinc-500">-</span>' ?></td>
+                        <td class="px-3 py-2 text-right">
+                            <a href="/economic-warfare/module.php?type_id=<?= (int) ($row['type_id'] ?? 0) ?>" class="text-xs text-blue-400 hover:text-blue-300">Drilldown</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+
+    <!-- Fit Family Browser -->
+    <?php if ($families !== []): ?>
+    <div class="mt-8">
+        <h2 class="text-lg font-semibold text-slate-100">Hostile Fit Families</h2>
+        <p class="mt-1 text-sm text-muted">Reconstructed doctrine archetypes from observed opponent losses, grouped by hull.</p>
+
+        <div class="mt-4 space-y-3">
+            <?php foreach ($families as $fam): ?>
+                <?php
+                    $familyId = (int) ($fam['id'] ?? 0);
+                    $hullName = (string) ($fam['hull_name'] ?? ('Hull #' . ($fam['hull_type_id'] ?? '?')));
+                    $obs = (int) ($fam['observation_count'] ?? 0);
+                    $conf = (float) ($fam['confidence'] ?? 0);
+                    $allianceIds = json_decode((string) ($fam['alliance_ids_json'] ?? '[]'), true) ?: [];
+                ?>
+                <details class="rounded-xl border border-border bg-black/20">
+                    <summary class="cursor-pointer list-none px-4 py-3 hover:bg-white/[0.02]">
+                        <div class="flex items-center justify-between gap-4">
+                            <div class="flex items-center gap-3">
+                                <span class="text-sm font-medium text-slate-100"><?= htmlspecialchars($hullName, ENT_QUOTES) ?></span>
+                                <span class="text-xs text-muted"><?= $obs ?> observations</span>
+                                <span class="text-xs <?= $conf >= 0.9 ? 'text-green-400' : ($conf >= 0.7 ? 'text-amber-300' : 'text-zinc-500') ?>">
+                                    <?= number_format($conf * 100, 0) ?>% confidence
+                                </span>
+                            </div>
+                            <span class="text-xs text-muted"><?= count($allianceIds) ?> alliance<?= count($allianceIds) !== 1 ? 's' : '' ?></span>
+                        </div>
+                    </summary>
+                    <div class="border-t border-border px-4 py-3" id="family-<?= $familyId ?>">
+                        <p class="text-xs text-muted mb-2">Loading modules...</p>
+                        <script>
+                            (function() {
+                                const container = document.getElementById('family-<?= $familyId ?>');
+                                fetch('/economic-warfare/family-modules.php?family_id=<?= $familyId ?>')
+                                    .then(r => r.json())
+                                    .then(data => {
+                                        if (!Array.isArray(data.modules) || data.modules.length === 0) {
+                                            container.innerHTML = '<p class="text-xs text-muted">No module data available.</p>';
+                                            return;
+                                        }
+                                        let html = '<div class="grid gap-1">';
+                                        data.modules.forEach(m => {
+                                            const freq = (parseFloat(m.frequency) * 100).toFixed(0);
+                                            const coreClass = parseInt(m.is_core) ? 'text-amber-300' : 'text-zinc-400';
+                                            const barWidth = Math.max(4, freq);
+                                            html += '<div class="flex items-center gap-3 text-sm">' +
+                                                '<span class="w-5 text-right text-xs ' + coreClass + '">' + (parseInt(m.is_core) ? 'C' : '') + '</span>' +
+                                                '<span class="w-48 truncate text-slate-200">' + (m.type_name || ('Type #' + m.item_type_id)) + '</span>' +
+                                                '<span class="text-xs text-muted w-14">' + m.flag_category + '</span>' +
+                                                '<div class="flex-1 h-2 rounded bg-black/30">' +
+                                                    '<div class="h-2 rounded bg-blue-500/60" style="width:' + barWidth + '%"></div>' +
+                                                '</div>' +
+                                                '<span class="text-xs text-muted w-10 text-right">' + freq + '%</span>' +
+                                            '</div>';
+                                        });
+                                        html += '</div>';
+                                        container.innerHTML = html;
+                                    })
+                                    .catch(() => {
+                                        container.innerHTML = '<p class="text-xs text-red-400">Failed to load modules.</p>';
+                                    });
+                            })();
+                        </script>
+                    </div>
+                </details>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <?php endif; ?>
+
+    <!-- Scoring Methodology -->
+    <details class="mt-8 rounded-xl border border-border bg-black/20 p-4">
+        <summary class="cursor-pointer list-none text-sm font-medium text-slate-100">Scoring Methodology</summary>
+        <div class="mt-4 space-y-3 text-sm text-muted">
+            <p>Each module is scored on five dimensions, weighted to prioritize <span class="text-slate-100">fitting constraint</span> over raw price:</p>
+            <ul class="space-y-1 ml-4 list-disc">
+                <li><span class="text-slate-100">Fit Constraint (30%)</span> - Is this a compact/faction/deadspace module chosen because standard T2 doesn't fit? High cross-fit persistence means mandatory.</li>
+                <li><span class="text-slate-100">Substitution Penalty (25%)</span> - How many viable alternatives exist in the same item group? Fewer = harder to replace.</li>
+                <li><span class="text-slate-100">Replacement Friction (20%)</span> - Market thinness and price. Low volume = supply pressure works faster.</li>
+                <li><span class="text-slate-100">Doctrine Penetration (15%)</span> - How broadly is this module used across hostile fit families and alliances?</li>
+                <li><span class="text-slate-100">Loss Pressure (10%)</span> - Recent attrition velocity. Higher burn rate = more demand for replacements.</li>
+            </ul>
+            <p class="mt-2">The <span class="text-amber-300">FIT</span> flag indicates modules with faction/deadspace/compact meta groups or fitting-variant type names, which are strong indicators of fitting constraint.</p>
+        </div>
+    </details>
+</section>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/economic-warfare/module.php
+++ b/public/economic-warfare/module.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$typeId = (int) ($_GET['type_id'] ?? 0);
+
+if ($typeId <= 0) {
+    header('Location: /economic-warfare/');
+    exit;
+}
+
+$title = 'Module Drilldown';
+$drilldown = db_economic_warfare_module_drilldown($typeId);
+$score = is_array($drilldown['score'] ?? null) ? $drilldown['score'] : [];
+$families = (array) ($drilldown['families'] ?? []);
+$substitutes = (array) ($drilldown['substitutes'] ?? []);
+$moduleName = (string) ($score['type_name'] ?? ('Type #' . $typeId));
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<section class="surface-primary">
+    <div class="flex items-center justify-between gap-4">
+        <div>
+            <p class="text-xs uppercase tracking-[0.16em] text-muted">Economic warfare &middot; Module drilldown</p>
+            <h1 class="mt-1 text-2xl font-semibold text-slate-50"><?= htmlspecialchars($moduleName, ENT_QUOTES) ?></h1>
+        </div>
+        <a href="/economic-warfare/" class="btn-secondary text-sm">Back to overview</a>
+    </div>
+
+    <?php if ($score === []): ?>
+        <div class="mt-6 rounded-xl border border-border bg-black/20 px-4 py-6 text-center text-sm text-muted">
+            No economic warfare data for this module. It may not appear in any observed hostile fits.
+        </div>
+    <?php else: ?>
+        <!-- Score Breakdown -->
+        <div class="mt-5 grid gap-3 sm:grid-cols-3 lg:grid-cols-6">
+            <?php
+                $scoreFields = [
+                    ['EW Score', 'economic_warfare_score', true],
+                    ['Fit Constraint', 'fit_constraint_score', false],
+                    ['Substitution', 'substitution_penalty_score', false],
+                    ['Replacement', 'replacement_friction_score', false],
+                    ['Doctrine Pen.', 'doctrine_penetration_score', false],
+                    ['Loss Pressure', 'loss_pressure_score', false],
+                ];
+            ?>
+            <?php foreach ($scoreFields as [$label, $key, $isPrimary]): ?>
+                <?php $val = (float) ($score[$key] ?? 0); ?>
+                <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+                    <p class="text-xs text-muted"><?= $label ?></p>
+                    <p class="mt-1 text-lg font-semibold <?= $isPrimary ? ($val >= 0.5 ? 'text-red-400' : ($val >= 0.3 ? 'text-amber-300' : 'text-zinc-400')) : 'text-slate-100' ?>">
+                        <?= number_format($val, 3) ?>
+                    </p>
+                </div>
+            <?php endforeach; ?>
+        </div>
+
+        <div class="mt-4 grid gap-3 sm:grid-cols-4">
+            <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+                <p class="text-xs text-muted">Meta Group</p>
+                <p class="mt-1 text-sm font-medium text-slate-100"><?= htmlspecialchars(ew_meta_group_label((int) ($score['meta_group_id'] ?? 0)), ENT_QUOTES) ?></p>
+            </div>
+            <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+                <p class="text-xs text-muted">Fitting Variant</p>
+                <p class="mt-1 text-sm font-medium <?= (int) ($score['is_fitting_variant'] ?? 0) ? 'text-amber-300' : 'text-zinc-400' ?>"><?= (int) ($score['is_fitting_variant'] ?? 0) ? 'Yes' : 'No' ?></p>
+            </div>
+            <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+                <p class="text-xs text-muted">Cross-Fit Persistence</p>
+                <p class="mt-1 text-sm font-medium text-slate-100"><?= number_format((float) ($score['cross_fit_persistence'] ?? 0) * 100, 1) ?>%</p>
+            </div>
+            <div class="rounded-xl border border-border bg-black/20 px-4 py-3">
+                <p class="text-xs text-muted">Substitutes Available</p>
+                <p class="mt-1 text-sm font-medium text-slate-100"><?= number_format((int) ($score['substitute_count'] ?? 0)) ?></p>
+            </div>
+        </div>
+
+        <!-- Hostile Families Using This Module -->
+        <?php if ($families !== []): ?>
+        <div class="mt-8">
+            <h2 class="text-lg font-semibold text-slate-100">Used in <?= count($families) ?> hostile fit families</h2>
+            <div class="mt-3 table-shell">
+                <table class="table-ui">
+                    <thead>
+                    <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                        <th class="px-3 py-2 text-left">Hull</th>
+                        <th class="px-3 py-2 text-center">Slot</th>
+                        <th class="px-3 py-2 text-right">Frequency</th>
+                        <th class="px-3 py-2 text-center">Core?</th>
+                        <th class="px-3 py-2 text-right">Observations</th>
+                        <th class="px-3 py-2 text-right">Confidence</th>
+                        <th class="px-3 py-2 text-right">Alliances</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($families as $fam): ?>
+                        <?php $allianceIds = json_decode((string) ($fam['alliance_ids_json'] ?? '[]'), true) ?: []; ?>
+                        <tr class="border-b border-border/30 hover:bg-white/[0.02]">
+                            <td class="px-3 py-2 text-sm text-slate-100"><?= htmlspecialchars((string) ($fam['hull_name'] ?? ('Hull #' . ($fam['hull_type_id'] ?? '?'))), ENT_QUOTES) ?></td>
+                            <td class="px-3 py-2 text-center text-xs text-muted"><?= htmlspecialchars((string) ($fam['flag_category'] ?? '-'), ENT_QUOTES) ?></td>
+                            <td class="px-3 py-2 text-right text-sm text-slate-300"><?= number_format((float) ($fam['frequency'] ?? 0) * 100, 0) ?>%</td>
+                            <td class="px-3 py-2 text-center text-xs"><?= (int) ($fam['is_core'] ?? 0) ? '<span class="text-amber-300">Core</span>' : '<span class="text-zinc-500">-</span>' ?></td>
+                            <td class="px-3 py-2 text-right text-sm text-muted"><?= number_format((int) ($fam['observation_count'] ?? 0)) ?></td>
+                            <td class="px-3 py-2 text-right text-sm <?= (float) ($fam['confidence'] ?? 0) >= 0.9 ? 'text-green-400' : 'text-slate-300' ?>"><?= number_format((float) ($fam['confidence'] ?? 0) * 100, 0) ?>%</td>
+                            <td class="px-3 py-2 text-right text-sm text-muted"><?= count($allianceIds) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <?php endif; ?>
+
+        <!-- Substitutes -->
+        <?php if ($substitutes !== []): ?>
+        <div class="mt-8">
+            <h2 class="text-lg font-semibold text-slate-100">Substitutes (same group)</h2>
+            <p class="mt-1 text-sm text-muted">Other modules in the same item group that could replace this module. Fewer viable substitutes = higher pressure.</p>
+            <div class="mt-3 table-shell">
+                <table class="table-ui">
+                    <thead>
+                    <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                        <th class="px-3 py-2 text-left">Module</th>
+                        <th class="px-3 py-2 text-center">Meta</th>
+                        <th class="px-3 py-2 text-right">EW Score</th>
+                        <th class="px-3 py-2 text-right">Fit Constraint</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($substitutes as $sub): ?>
+                        <tr class="border-b border-border/30 hover:bg-white/[0.02]">
+                            <td class="px-3 py-2 text-sm text-slate-100">
+                                <a href="/economic-warfare/module.php?type_id=<?= (int) ($sub['type_id'] ?? 0) ?>" class="hover:text-blue-400"><?= htmlspecialchars((string) ($sub['type_name'] ?? ('Type #' . ($sub['type_id'] ?? '?'))), ENT_QUOTES) ?></a>
+                            </td>
+                            <td class="px-3 py-2 text-center text-xs text-muted"><?= htmlspecialchars(ew_meta_group_label((int) ($sub['meta_group_id'] ?? 0)), ENT_QUOTES) ?></td>
+                            <td class="px-3 py-2 text-right text-sm text-slate-300"><?= $sub['economic_warfare_score'] !== null ? number_format((float) $sub['economic_warfare_score'], 3) : '-' ?></td>
+                            <td class="px-3 py-2 text-right text-sm text-slate-300"><?= $sub['fit_constraint_score'] !== null ? number_format((float) $sub['fit_constraint_score'], 3) : '-' ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <?php endif; ?>
+    <?php endif; ?>
+</section>
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -415,6 +415,8 @@ if ($dbStatus['ok']) {
 
 $trackedAlliances = [];
 $trackedCorporations = [];
+$opponentAlliances = [];
+$opponentCorporations = [];
 $killmailStatus = null;
 $killmailWorkerStatus = [];
 $killmailStatusSummary = [];
@@ -425,11 +427,15 @@ if ($dbStatus['ok']) {
     try {
         $trackedAlliances = db_killmail_tracked_alliances_active();
         $trackedCorporations = db_killmail_tracked_corporations_active();
+        $opponentAlliances = db_killmail_opponent_alliances_active();
+        $opponentCorporations = db_killmail_opponent_corporations_active();
         $killmailStatus = db_killmail_ingestion_status();
         $killmailWorkerStatus = zkill_worker_runtime_status();
     } catch (Throwable) {
         $trackedAlliances = [];
         $trackedCorporations = [];
+        $opponentAlliances = [];
+        $opponentCorporations = [];
         $killmailStatus = null;
         $killmailWorkerStatus = [];
     }
@@ -1298,6 +1304,22 @@ include __DIR__ . '/../../src/views/partials/header.php';
 ", array_map(static fn (array $row): string => (string) $row['id'] . ' | ' . (string) $row['name'], $trackedAllianceSelections));
                 $corporationsText = implode("
 ", array_map(static fn (array $row): string => (string) $row['id'] . ' | ' . (string) $row['name'], $trackedCorporationSelections));
+
+                $opponentAllianceSelections = array_values(array_map(static fn (array $row): array => [
+                    'id' => (int) ($row['alliance_id'] ?? 0),
+                    'name' => (string) ($row['label'] ?? ('Alliance #' . (int) ($row['alliance_id'] ?? 0))),
+                    'type' => 'Alliance',
+                ], array_filter($opponentAlliances, static fn (array $row): bool => (int) ($row['alliance_id'] ?? 0) > 0)));
+                $opponentCorporationSelections = array_values(array_map(static fn (array $row): array => [
+                    'id' => (int) ($row['corporation_id'] ?? 0),
+                    'name' => (string) ($row['label'] ?? ('Corporation #' . (int) ($row['corporation_id'] ?? 0))),
+                    'type' => 'Corporation',
+                ], array_filter($opponentCorporations, static fn (array $row): bool => (int) ($row['corporation_id'] ?? 0) > 0)));
+                $opponentAlliancesText = implode("
+", array_map(static fn (array $row): string => (string) $row['id'] . ' | ' . (string) $row['name'], $opponentAllianceSelections));
+                $opponentCorporationsText = implode("
+", array_map(static fn (array $row): string => (string) $row['id'] . ' | ' . (string) $row['name'], $opponentCorporationSelections));
+
                 $statusState = is_array($killmailStatus['state'] ?? null) ? $killmailStatus['state'] : [];
                 $killmailHealth = is_array($killmailStatusSummary['health'] ?? null) ? $killmailStatusSummary['health'] : [];
             ?>
@@ -1401,6 +1423,59 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <p>Add alliances and corporations from the lookup, or enter exact numeric IDs when you already know them.</p>
                     <p>The continuous zKill worker keeps a killmail only when the victim belongs to one of these tracked entities. Attacker-only matches are ignored for the tracked loss board.</p>
                     <p>Each saved entry is stored locally as <span class="text-slate-100">ID + name</span>, and you can remove anything here before saving if an alliance or corporation leaves the group you care about.</p>
+                </div>
+
+                <h3 class="text-base font-semibold text-slate-100 mt-6">Tracked Opponents (Economic Warfare)</h3>
+
+                <div class="grid gap-4 lg:grid-cols-2">
+                    <label class="block space-y-2" id="killmail-opponent-alliance-search-field">
+                        <span class="text-sm text-muted">Opponent Alliances</span>
+                        <textarea name="opponent_alliance_names" id="opponent_alliance_names" rows="4" class="hidden"><?= htmlspecialchars($opponentAlliancesText, ENT_QUOTES) ?></textarea>
+                        <div class="flex gap-2">
+                            <input
+                                type="text"
+                                id="opponent_alliance_search"
+                                autocomplete="off"
+                                placeholder="Search alliances by name or add an exact alliance ID"
+                                class="w-full field-input"
+                            />
+                            <button type="button" id="opponent_alliance_add" class="rounded-lg border border-border bg-black/30 px-3 py-2 text-sm text-slate-100 transition hover:bg-white/5">Add</button>
+                        </div>
+                        <p id="opponent_alliance_status" class="text-xs text-muted">
+                            <?= htmlspecialchars($opponentAllianceSelections === []
+                                ? 'Search by name, or add an exact numeric alliance ID.'
+                                : ('Tracking ' . count($opponentAllianceSelections) . ' opponent alliance' . (count($opponentAllianceSelections) === 1 ? '' : 's') . '.'), ENT_QUOTES) ?>
+                        </p>
+                        <ul id="opponent_alliance_results" class="hidden max-h-60 overflow-y-auto surface-tertiary"></ul>
+                        <div id="opponent_alliance_selected" class="space-y-2 rounded-lg border border-border bg-black/10 p-3"></div>
+                    </label>
+
+                    <label class="block space-y-2" id="killmail-opponent-corporation-search-field">
+                        <span class="text-sm text-muted">Opponent Corporations</span>
+                        <textarea name="opponent_corporation_names" id="opponent_corporation_names" rows="4" class="hidden"><?= htmlspecialchars($opponentCorporationsText, ENT_QUOTES) ?></textarea>
+                        <div class="flex gap-2">
+                            <input
+                                type="text"
+                                id="opponent_corporation_search"
+                                autocomplete="off"
+                                placeholder="Search corporations by name or add an exact corporation ID"
+                                class="w-full field-input"
+                            />
+                            <button type="button" id="opponent_corporation_add" class="rounded-lg border border-border bg-black/30 px-3 py-2 text-sm text-slate-100 transition hover:bg-white/5">Add</button>
+                        </div>
+                        <p id="opponent_corporation_status" class="text-xs text-muted">
+                            <?= htmlspecialchars($opponentCorporationSelections === []
+                                ? 'Search by name, or add an exact numeric corporation ID.'
+                                : ('Tracking ' . count($opponentCorporationSelections) . ' opponent corporation' . (count($opponentCorporationSelections) === 1 ? '' : 's') . '.'), ENT_QUOTES) ?>
+                        </p>
+                        <ul id="opponent_corporation_results" class="hidden max-h-60 overflow-y-auto surface-tertiary"></ul>
+                        <div id="opponent_corporation_selected" class="space-y-2 rounded-lg border border-border bg-black/10 p-3"></div>
+                    </label>
+                </div>
+
+                <div class="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-muted space-y-2">
+                    <p>Opponent entities are tracked separately from your own alliances/corporations. The system fetches <span class="text-slate-100">all kills and losses</span> for these entities — not just fights involving you.</p>
+                    <p>This powers the <span class="text-slate-100">Economic Warfare</span> page: hostile fit family reconstruction, module scoring, and supply pressure analysis across their full engagement history.</p>
                 </div>
 
                 <script>
@@ -1732,6 +1807,28 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             selectedId: 'tracked_corporation_selected',
                             allowedType: 'Corporation',
                             initialItems: <?= json_encode($trackedCorporationSelections, JSON_THROW_ON_ERROR) ?>,
+                        });
+
+                        createTrackedEntityPicker({
+                            inputId: 'opponent_alliance_search',
+                            addButtonId: 'opponent_alliance_add',
+                            hiddenId: 'opponent_alliance_names',
+                            resultsId: 'opponent_alliance_results',
+                            statusId: 'opponent_alliance_status',
+                            selectedId: 'opponent_alliance_selected',
+                            allowedType: 'Alliance',
+                            initialItems: <?= json_encode($opponentAllianceSelections, JSON_THROW_ON_ERROR) ?>,
+                        });
+
+                        createTrackedEntityPicker({
+                            inputId: 'opponent_corporation_search',
+                            addButtonId: 'opponent_corporation_add',
+                            hiddenId: 'opponent_corporation_names',
+                            resultsId: 'opponent_corporation_results',
+                            statusId: 'opponent_corporation_status',
+                            selectedId: 'opponent_corporation_selected',
+                            allowedType: 'Corporation',
+                            initialItems: <?= json_encode($opponentCorporationSelections, JSON_THROW_ON_ERROR) ?>,
                         });
                     })();
                 </script>

--- a/python/orchestrator/eve_constants.py
+++ b/python/orchestrator/eve_constants.py
@@ -152,3 +152,24 @@ ROLE_MULTIPLIER_WEIGHT: dict[str, float] = {
     "command": 1.3,
     "ewar": 0.8,
 }
+
+# ── Economic Warfare: item flag → slot category mapping (ESI standard) ────────
+
+ITEM_FLAG_CATEGORY: dict[int, str] = {
+    **{f: "high" for f in range(11, 19)},       # high slots (11-18)
+    **{f: "medium" for f in range(19, 27)},      # mid slots (19-26)
+    **{f: "low" for f in range(27, 35)},         # low slots (27-34)
+    **{f: "rig" for f in range(92, 95)},         # rig slots (92-94)
+    87: "drone",                                  # drone bay
+    **{f: "subsystem" for f in range(125, 133)},  # T3 subsystems (125-132)
+}
+
+# Meta group IDs that indicate fitting-optimized module choices.
+# 4=Faction, 6=Deadspace, 14=Tech III — pilots choose these because
+# standard T2 variants don't fit or perform worse in tight fits.
+FITTING_CONSTRAINED_META_GROUPS: frozenset[int] = frozenset({4, 6, 14})
+
+# Type name keywords that indicate a fitting variant module (CPU/PG optimized).
+FITTING_VARIANT_KEYWORDS: tuple[str, ...] = (
+    "Compact", "Restrained", "Scoped", "Enduring", "Ample", "Copious",
+)

--- a/python/orchestrator/jobs/__init__.py
+++ b/python/orchestrator/jobs/__init__.py
@@ -52,3 +52,4 @@ from .theater_clustering import run_theater_clustering
 from .theater_analysis import run_theater_analysis
 from .theater_graph_integration import run_theater_graph_integration
 from .theater_suspicion import run_theater_suspicion
+from .compute_economic_warfare import run_compute_economic_warfare

--- a/python/orchestrator/jobs/compute_economic_warfare.py
+++ b/python/orchestrator/jobs/compute_economic_warfare.py
@@ -1,0 +1,516 @@
+"""Compute Economic Warfare scores from opponent killmail data.
+
+Phase 1: Extract fitted modules from opponent losses (mail_type IN ('kill','opponent_loss'))
+Phase 2: Cluster into fit families per hull type (exact fingerprint + Jaccard merge)
+Phase 3: Score modules on 5 dimensions (doctrine penetration, fit constraint,
+         substitution penalty, replacement friction, loss pressure)
+Phase 4: Write composite economic_warfare_score for each module
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import time
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import Any
+
+from ..eve_constants import (
+    FITTING_CONSTRAINED_META_GROUPS,
+    FITTING_VARIANT_KEYWORDS,
+    ITEM_FLAG_CATEGORY,
+)
+
+logger = logging.getLogger("supplycore.economic_warfare")
+
+# ── Scoring weights ──────────────────────────────────────────────────────────
+# Fit constraint (0.30) is the dominant signal per design:
+# fitting constraint matters more than price.
+_W_DOCTRINE_PENETRATION = 0.15
+_W_FIT_CONSTRAINT = 0.30
+_W_SUBSTITUTION_PENALTY = 0.25
+_W_REPLACEMENT_FRICTION = 0.20
+_W_LOSS_PRESSURE = 0.10
+
+_JACCARD_MERGE_THRESHOLD = 0.80
+_CORE_FREQUENCY_THRESHOLD = 0.80
+_DEFAULT_WINDOW_DAYS = 90
+_CONFIDENCE_DECAY = 5.0  # 1 - exp(-count/5)
+
+
+def _fingerprint(modules: list[tuple[int, str]]) -> str:
+    """MD5 of sorted (type_id, flag_category) multiset — preserves duplicates for guns."""
+    canon = sorted(modules)
+    return hashlib.md5(json.dumps(canon, separators=(",", ":")).encode()).hexdigest()
+
+
+def _jaccard(a: set, b: set) -> float:
+    if not a and not b:
+        return 1.0
+    intersection = len(a & b)
+    union = len(a | b)
+    return intersection / union if union > 0 else 0.0
+
+
+def _confidence(observation_count: int) -> float:
+    return 1.0 - math.exp(-observation_count / _CONFIDENCE_DECAY)
+
+
+def _flag_category(item_flag: int) -> str:
+    return ITEM_FLAG_CATEGORY.get(item_flag, "other")
+
+
+def _is_fitting_variant(type_name: str, meta_group_id: int) -> bool:
+    if meta_group_id in FITTING_CONSTRAINED_META_GROUPS:
+        return True
+    return any(kw in type_name for kw in FITTING_VARIANT_KEYWORDS)
+
+
+# ── Phase 1: Extract fitted modules from opponent losses ─────────────────────
+
+def _extract_opponent_fits(db: Any, window_days: int) -> dict[int, dict]:
+    """Return {sequence_id: {hull_type_id, alliance_id, modules: [(type_id, flag_cat)]}}."""
+    sql = """
+        SELECT ke.sequence_id, ke.victim_ship_type_id, ke.victim_alliance_id,
+               ki.item_type_id, ki.item_flag
+        FROM killmail_events ke
+        INNER JOIN killmail_items ki ON ki.sequence_id = ke.sequence_id
+        WHERE ke.mail_type IN ('kill', 'opponent_loss')
+          AND ke.killmail_time >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL %s DAY)
+          AND ki.item_role = 'fitted'
+        ORDER BY ke.sequence_id
+    """
+    kills: dict[int, dict] = {}
+    for batch in db.iterate_batches(sql, (window_days,), batch_size=5000):
+        for row in batch:
+            seq_id = int(row["sequence_id"])
+            if seq_id not in kills:
+                kills[seq_id] = {
+                    "hull_type_id": int(row["victim_ship_type_id"] or 0),
+                    "alliance_id": int(row["victim_alliance_id"] or 0),
+                    "modules": [],
+                }
+            flag_cat = _flag_category(int(row["item_flag"] or 0))
+            kills[seq_id]["modules"].append((int(row["item_type_id"]), flag_cat))
+
+    logger.info("Phase 1: extracted %d opponent kills with fitted modules", len(kills))
+    return kills
+
+
+# ── Phase 2: Cluster into fit families ───────────────────────────────────────
+
+def _cluster_fit_families(kills: dict[int, dict]) -> list[dict]:
+    """Group kills by hull then fingerprint, with Jaccard fuzzy merge."""
+    # Group by hull
+    by_hull: dict[int, list[dict]] = defaultdict(list)
+    for seq_id, kill in kills.items():
+        if kill["hull_type_id"] <= 0:
+            continue
+        by_hull[kill["hull_type_id"]].append({
+            "sequence_id": seq_id,
+            "alliance_id": kill["alliance_id"],
+            "modules": kill["modules"],
+            "fingerprint": _fingerprint(kill["modules"]),
+            "module_set": set(kill["modules"]),
+        })
+
+    families: list[dict] = []
+
+    for hull_type_id, hull_kills in by_hull.items():
+        # Fast path: exact fingerprint grouping
+        fp_groups: dict[str, list[dict]] = defaultdict(list)
+        for kill in hull_kills:
+            fp_groups[kill["fingerprint"]].append(kill)
+
+        hull_families: list[dict] = []
+        for fp, group in fp_groups.items():
+            alliance_ids = {k["alliance_id"] for k in group if k["alliance_id"] > 0}
+            # Count module frequencies
+            module_counts: dict[tuple[int, str], int] = defaultdict(int)
+            for kill in group:
+                for mod in kill["modules"]:
+                    module_counts[mod] += 1
+            obs = len(group)
+            hull_families.append({
+                "hull_type_id": hull_type_id,
+                "fingerprint": fp,
+                "observation_count": obs,
+                "alliance_ids": alliance_ids,
+                "module_counts": module_counts,
+                "module_set": group[0]["module_set"],
+                "first_seen": None,
+                "last_seen": None,
+            })
+
+        # Fuzzy merge: try to merge small families into larger ones via Jaccard
+        merged = True
+        while merged:
+            merged = False
+            hull_families.sort(key=lambda f: f["observation_count"], reverse=True)
+            i = 0
+            while i < len(hull_families):
+                j = i + 1
+                while j < len(hull_families):
+                    sim = _jaccard(hull_families[i]["module_set"], hull_families[j]["module_set"])
+                    if sim >= _JACCARD_MERGE_THRESHOLD:
+                        # Merge j into i
+                        target = hull_families[i]
+                        source = hull_families[j]
+                        target["observation_count"] += source["observation_count"]
+                        target["alliance_ids"] |= source["alliance_ids"]
+                        for mod, cnt in source["module_counts"].items():
+                            target["module_counts"][mod] += cnt
+                        target["module_set"] |= source["module_set"]
+                        # Recompute fingerprint based on dominant family
+                        hull_families.pop(j)
+                        merged = True
+                    else:
+                        j += 1
+                i += 1
+
+        families.extend(hull_families)
+
+    logger.info("Phase 2: clustered into %d fit families across %d hulls",
+                len(families), len(by_hull))
+    return families
+
+
+# ── Phase 3: Score modules ───────────────────────────────────────────────────
+
+def _score_modules(
+    db: Any,
+    families: list[dict],
+    window_days: int,
+) -> list[dict]:
+    """Compute 5 sub-scores + composite for each module appearing in hostile families."""
+    if not families:
+        return []
+
+    # Collect all unique type_ids from families
+    all_type_ids: set[int] = set()
+    for fam in families:
+        for (type_id, _flag_cat) in fam["module_counts"]:
+            all_type_ids.add(type_id)
+
+    if not all_type_ids:
+        return []
+
+    # Load item reference data
+    type_id_list = list(all_type_ids)
+    placeholders = ",".join(["%s"] * len(type_id_list))
+    ref_rows = db.fetch_all(
+        f"SELECT type_id, type_name, group_id, meta_group_id FROM ref_item_types WHERE type_id IN ({placeholders})",
+        tuple(type_id_list),
+    )
+    ref_map: dict[int, dict] = {int(r["type_id"]): r for r in ref_rows}
+
+    # Count substitutes per group_id (viable alternatives at same/lower meta_group)
+    group_ids = {int(r.get("group_id") or 0) for r in ref_rows if int(r.get("group_id") or 0) > 0}
+    group_substitute_count: dict[int, int] = {}
+    if group_ids:
+        gp = ",".join(["%s"] * len(group_ids))
+        sub_rows = db.fetch_all(
+            f"SELECT group_id, COUNT(*) AS cnt FROM ref_item_types WHERE group_id IN ({gp}) AND published = 1 GROUP BY group_id",
+            tuple(group_ids),
+        )
+        for sr in sub_rows:
+            group_substitute_count[int(sr["group_id"])] = int(sr["cnt"])
+
+    # Load market data for replacement friction
+    market_data: dict[int, dict] = {}
+    if type_id_list:
+        mp = ",".join(["%s"] * len(type_id_list))
+        market_rows = db.fetch_all(
+            f"""SELECT type_id, sell_price_min, sell_volume_total
+                FROM market_order_snapshots_summary
+                WHERE type_id IN ({mp})
+                  AND source_type = 'sell'
+                  AND observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 7 DAY)
+                ORDER BY observed_at DESC""",
+            tuple(type_id_list),
+        )
+        for mr in market_rows:
+            tid = int(mr["type_id"])
+            if tid not in market_data:
+                market_data[tid] = {
+                    "sell_price": float(mr.get("sell_price_min") or 0),
+                    "sell_volume": int(mr.get("sell_volume_total") or 0),
+                }
+
+    # Load loss pressure (30d destroyed count from killmail_items)
+    loss_counts: dict[int, int] = {}
+    if type_id_list:
+        lp = ",".join(["%s"] * len(type_id_list))
+        loss_rows = db.fetch_all(
+            f"""SELECT ki.item_type_id, COUNT(*) AS cnt
+                FROM killmail_items ki
+                INNER JOIN killmail_events ke ON ke.sequence_id = ki.sequence_id
+                WHERE ki.item_type_id IN ({lp})
+                  AND ke.mail_type IN ('kill', 'opponent_loss')
+                  AND ke.killmail_time >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 30 DAY)
+                  AND ki.item_role = 'fitted'
+                GROUP BY ki.item_type_id""",
+            tuple(type_id_list),
+        )
+        for lr in loss_rows:
+            loss_counts[int(lr["item_type_id"])] = int(lr["cnt"])
+
+    # Pre-compute per-module family membership
+    total_families = len(families)
+    total_alliances = len({aid for fam in families for aid in fam["alliance_ids"]})
+
+    # Per hull: how many families exist, and which modules appear in how many
+    hull_family_count: dict[int, int] = defaultdict(int)
+    for fam in families:
+        hull_family_count[fam["hull_type_id"]] += 1
+
+    # Per module: which families use it, which alliances use it
+    module_family_ids: dict[int, set[int]] = defaultdict(set)
+    module_alliance_ids: dict[int, set[int]] = defaultdict(set)
+    # Per (module, hull): family count for cross-fit persistence
+    module_hull_families: dict[tuple[int, int], int] = defaultdict(int)
+
+    for fam_idx, fam in enumerate(families):
+        hull = fam["hull_type_id"]
+        for (type_id, _flag_cat) in fam["module_counts"]:
+            module_family_ids[type_id].add(fam_idx)
+            module_alliance_ids[type_id] |= fam["alliance_ids"]
+            module_hull_families[(type_id, hull)] += 1
+
+    # Score each module
+    scored: list[dict] = []
+    now_str = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+
+    for type_id in all_type_ids:
+        ref = ref_map.get(type_id, {})
+        type_name = str(ref.get("type_name") or "")
+        group_id = int(ref.get("group_id") or 0)
+        meta_group_id = int(ref.get("meta_group_id") or 0)
+
+        # (a) Doctrine penetration
+        fam_count = len(module_family_ids.get(type_id, set()))
+        alliance_count = len(module_alliance_ids.get(type_id, set()))
+        family_ratio = fam_count / total_families if total_families > 0 else 0
+        alliance_ratio = alliance_count / total_alliances if total_alliances > 0 else 0
+        doctrine_penetration = 0.6 * family_ratio + 0.4 * alliance_ratio
+
+        # (b) Fit constraint
+        is_fv = _is_fitting_variant(type_name, meta_group_id)
+        # Cross-fit persistence: across all hulls this module appears in,
+        # what fraction of families for that hull include it?
+        cross_fit_values = []
+        for (tid, hull), hfc in module_hull_families.items():
+            if tid == type_id:
+                total_for_hull = hull_family_count.get(hull, 1)
+                cross_fit_values.append(hfc / total_for_hull)
+        cross_fit_persistence = max(cross_fit_values) if cross_fit_values else 0.0
+        fit_constraint = 0.4 * (1.0 if is_fv else 0.0) + 0.6 * cross_fit_persistence
+
+        # (c) Substitution penalty
+        subs = group_substitute_count.get(group_id, 0)
+        substitution_penalty = 1.0 - min(1.0, subs / 8.0)
+
+        # (d) Replacement friction
+        mkt = market_data.get(type_id)
+        if mkt is not None:
+            vol = mkt["sell_volume"]
+            price = mkt["sell_price"]
+            volume_thinness = 1.0 - min(1.0, vol / 1000.0)
+            price_factor = min(1.0, math.log10(max(price, 1.0)) / 10.0)
+            replacement_friction = 0.7 * volume_thinness + 0.3 * price_factor
+        else:
+            replacement_friction = 0.8  # absence = scarcity signal
+
+        # (e) Loss pressure
+        destroyed_30d = loss_counts.get(type_id, 0)
+        attrition_per_day = destroyed_30d / 30.0
+        loss_pressure = min(1.0, attrition_per_day / 10.0)
+
+        # (f) Composite
+        ew_score = (
+            _W_DOCTRINE_PENETRATION * doctrine_penetration
+            + _W_FIT_CONSTRAINT * fit_constraint
+            + _W_SUBSTITUTION_PENALTY * substitution_penalty
+            + _W_REPLACEMENT_FRICTION * replacement_friction
+            + _W_LOSS_PRESSURE * loss_pressure
+        )
+
+        scored.append({
+            "type_id": type_id,
+            "type_name": type_name,
+            "group_id": group_id,
+            "meta_group_id": meta_group_id,
+            "doctrine_penetration_score": round(doctrine_penetration, 4),
+            "fit_constraint_score": round(fit_constraint, 4),
+            "substitution_penalty_score": round(substitution_penalty, 4),
+            "replacement_friction_score": round(replacement_friction, 4),
+            "loss_pressure_score": round(loss_pressure, 4),
+            "economic_warfare_score": round(ew_score, 4),
+            "hostile_family_count": fam_count,
+            "hostile_alliance_count": alliance_count,
+            "total_destroyed_30d": destroyed_30d,
+            "cross_fit_persistence": round(cross_fit_persistence, 4),
+            "is_fitting_variant": 1 if is_fv else 0,
+            "substitute_count": subs,
+            "computed_at": now_str,
+        })
+
+    scored.sort(key=lambda s: s["economic_warfare_score"], reverse=True)
+    logger.info("Phase 3: scored %d unique modules", len(scored))
+    return scored
+
+
+# ── Phase 4: Write results ───────────────────────────────────────────────────
+
+def _write_families(db: Any, families: list[dict]) -> int:
+    """UPSERT hostile_fit_families and hostile_fit_family_modules."""
+    now_str = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    rows_written = 0
+
+    with db.transaction() as (_, cursor):
+        for fam in families:
+            hull = fam["hull_type_id"]
+            fp = fam["fingerprint"]
+            obs = fam["observation_count"]
+            conf = round(_confidence(obs), 4)
+            alliance_json = json.dumps(sorted(fam["alliance_ids"]))
+            module_set_json = json.dumps([
+                {"type_id": tid, "flag_category": fc, "count": cnt}
+                for (tid, fc), cnt in sorted(fam["module_counts"].items())
+            ])
+
+            cursor.execute(
+                """INSERT INTO hostile_fit_families
+                   (hull_type_id, family_fingerprint, module_set_json, observation_count,
+                    confidence, first_seen, last_seen, alliance_ids_json, computed_at)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                   ON DUPLICATE KEY UPDATE
+                       module_set_json = VALUES(module_set_json),
+                       observation_count = VALUES(observation_count),
+                       confidence = VALUES(confidence),
+                       last_seen = VALUES(last_seen),
+                       alliance_ids_json = VALUES(alliance_ids_json),
+                       computed_at = VALUES(computed_at)""",
+                (hull, fp, module_set_json, obs, conf, now_str, now_str, alliance_json, now_str),
+            )
+            rows_written += 1
+
+            # Get family ID for module rows
+            cursor.execute(
+                "SELECT id FROM hostile_fit_families WHERE hull_type_id = %s AND family_fingerprint = %s LIMIT 1",
+                (hull, fp),
+            )
+            fam_row = cursor.fetchone()
+            if not fam_row:
+                continue
+            family_id = int(fam_row["id"])
+
+            # Write per-module membership
+            for (type_id, flag_cat), cnt in fam["module_counts"].items():
+                freq = round(cnt / obs, 4) if obs > 0 else 1.0
+                is_core = 1 if freq >= _CORE_FREQUENCY_THRESHOLD else 0
+                cursor.execute(
+                    """INSERT INTO hostile_fit_family_modules
+                       (family_id, item_type_id, flag_category, frequency, is_core)
+                       VALUES (%s, %s, %s, %s, %s)
+                       ON DUPLICATE KEY UPDATE
+                           frequency = VALUES(frequency),
+                           is_core = VALUES(is_core)""",
+                    (family_id, type_id, flag_cat, freq, is_core),
+                )
+                rows_written += 1
+
+    return rows_written
+
+
+def _write_scores(db: Any, scored: list[dict]) -> int:
+    """REPLACE INTO economic_warfare_scores."""
+    if not scored:
+        return 0
+
+    rows_written = 0
+    with db.transaction() as (_, cursor):
+        for s in scored:
+            cursor.execute(
+                """REPLACE INTO economic_warfare_scores
+                   (type_id, type_name, group_id, meta_group_id,
+                    doctrine_penetration_score, fit_constraint_score,
+                    substitution_penalty_score, replacement_friction_score,
+                    loss_pressure_score, economic_warfare_score,
+                    hostile_family_count, hostile_alliance_count,
+                    total_destroyed_30d, cross_fit_persistence,
+                    is_fitting_variant, substitute_count, computed_at)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                (
+                    s["type_id"], s["type_name"], s["group_id"], s["meta_group_id"],
+                    s["doctrine_penetration_score"], s["fit_constraint_score"],
+                    s["substitution_penalty_score"], s["replacement_friction_score"],
+                    s["loss_pressure_score"], s["economic_warfare_score"],
+                    s["hostile_family_count"], s["hostile_alliance_count"],
+                    s["total_destroyed_30d"], s["cross_fit_persistence"],
+                    s["is_fitting_variant"], s["substitute_count"], s["computed_at"],
+                ),
+            )
+            rows_written += 1
+
+    return rows_written
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+def run_compute_economic_warfare(db: Any, influx_raw: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Main entry point for the economic warfare compute job."""
+    started_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    t0 = time.monotonic()
+
+    window_days = _DEFAULT_WINDOW_DAYS
+
+    # Phase 1: Extract
+    kills = _extract_opponent_fits(db, window_days)
+    if not kills:
+        return {
+            "status": "success",
+            "summary": "No opponent kills found — nothing to score.",
+            "started_at": started_at,
+            "rows_seen": 0,
+            "rows_processed": 0,
+            "rows_written": 0,
+        }
+
+    # Phase 2: Cluster
+    families = _cluster_fit_families(kills)
+
+    # Phase 3: Score
+    scored = _score_modules(db, families, window_days)
+
+    # Phase 4: Write
+    family_rows = _write_families(db, families)
+    score_rows = _write_scores(db, scored)
+
+    elapsed_ms = int((time.monotonic() - t0) * 1000)
+
+    return {
+        "status": "success",
+        "summary": f"Economic warfare: {len(families)} fit families, {len(scored)} modules scored.",
+        "started_at": started_at,
+        "finished_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "duration_ms": elapsed_ms,
+        "rows_seen": len(kills),
+        "rows_processed": len(kills),
+        "rows_written": family_rows + score_rows,
+        "meta": {
+            "window_days": window_days,
+            "kills_analyzed": len(kills),
+            "fit_families": len(families),
+            "modules_scored": len(scored),
+            "family_rows_written": family_rows,
+            "score_rows_written": score_rows,
+            "top_5": [
+                {"type_id": s["type_id"], "type_name": s["type_name"], "score": s["economic_warfare_score"]}
+                for s in scored[:5]
+            ],
+        },
+    }

--- a/python/orchestrator/jobs/killmail_history_backfill.py
+++ b/python/orchestrator/jobs/killmail_history_backfill.py
@@ -59,12 +59,12 @@ def _http_get(url: str, user_agent: str, timeout: int = 30, accept_encoding: boo
         return 0, ""
 
 
-def _fetch_zkb_page(entity_type: str, entity_id: int, year: int, month: int, page: int, user_agent: str) -> list[dict[str, Any]]:
-    """Fetch one page of losses from zKillboard API for an entity+month.
+def _fetch_zkb_page(entity_type: str, entity_id: int, year: int, month: int, page: int, user_agent: str, endpoint: str = "losses") -> list[dict[str, Any]]:
+    """Fetch one page of losses or kills from zKillboard API for an entity+month.
 
     Returns list of {killmail_id, zkb: {hash, ...}} dicts.
     """
-    url = f"{_ZKB_API_BASE}/losses/{entity_type}/{entity_id}/year/{year}/month/{month}/page/{page}/"
+    url = f"{_ZKB_API_BASE}/{endpoint}/{entity_type}/{entity_id}/year/{year}/month/{month}/page/{page}/"
     status, body = _http_get(url, user_agent)
     logger.info("zKB response: status=%d body_len=%d url=%s", status, len(body), url)
     if status == 404 or status == 429:
@@ -116,18 +116,21 @@ def _collect_entity_kills(
     year: int,
     months: list[int],
     user_agent: str,
+    endpoint: str = "losses",
 ) -> dict[int, str]:
     """Collect all {killmail_id: hash} pairs for an entity across months.
 
-    Paginates through all pages for each month.
+    Paginates through all pages for each month. ``endpoint`` can be
+    ``"losses"`` (default — fetches entity deaths) or ``"kills"``
+    (fetches entity kills of others).
     """
     collected: dict[int, str] = {}
 
     for month in months:
         page = 1
         while True:
-            logger.info("zKB fetch: %s/%d year=%d month=%02d page=%d", entity_type, entity_id, year, month, page)
-            results = _fetch_zkb_page(entity_type, entity_id, year, month, page, user_agent)
+            logger.info("zKB fetch: %s/%d year=%d month=%02d page=%d endpoint=%s", entity_type, entity_id, year, month, page, endpoint)
+            results = _fetch_zkb_page(entity_type, entity_id, year, month, page, user_agent, endpoint)
             if not results:
                 logger.info("zKB fetch: no results, moving on")
                 break
@@ -167,6 +170,8 @@ def run_killmail_history_backfill(context: Any) -> dict[str, Any]:
     user_agent = str(job_context.get("user_agent") or "SupplyCore killmail-backfill/1.0")
     tracked_alliances: list[int] = [int(x) for x in (job_context.get("tracked_alliance_ids") or []) if int(x) > 0]
     tracked_corporations: list[int] = [int(x) for x in (job_context.get("tracked_corporation_ids") or []) if int(x) > 0]
+    opponent_alliances: list[int] = [int(x) for x in (job_context.get("opponent_alliance_ids") or []) if int(x) > 0]
+    opponent_corporations: list[int] = [int(x) for x in (job_context.get("opponent_corporation_ids") or []) if int(x) > 0]
 
     if not start_date_str or not end_date_str:
         return {
@@ -174,17 +179,19 @@ def run_killmail_history_backfill(context: Any) -> dict[str, Any]:
             "error": "Missing start_date or end_date in backfill context.",
         }
 
-    if not tracked_alliances and not tracked_corporations:
+    has_tracked = bool(tracked_alliances or tracked_corporations)
+    has_opponents = bool(opponent_alliances or opponent_corporations)
+    if not has_tracked and not has_opponents:
         return {
             "status": "failed",
-            "error": "No tracked alliances or corporations configured.",
+            "error": "No tracked alliances/corporations or opponent entities configured.",
         }
 
     start_date = datetime.strptime(start_date_str, "%Y-%m-%d").replace(tzinfo=UTC)
     end_date = datetime.strptime(end_date_str, "%Y-%m-%d").replace(tzinfo=UTC)
 
-    logger.info("Backfill starting: %s to %s, alliances=%s, corporations=%s",
-                start_date_str, end_date_str, tracked_alliances, tracked_corporations)
+    logger.info("Backfill starting: %s to %s, tracked_alliances=%s, tracked_corps=%s, opponent_alliances=%s, opponent_corps=%s",
+                start_date_str, end_date_str, tracked_alliances, tracked_corporations, opponent_alliances, opponent_corporations)
 
     # Build list of months to query
     year = start_date.year
@@ -202,19 +209,36 @@ def run_killmail_history_backfill(context: Any) -> dict[str, Any]:
     total_skipped_existing = 0
     batch_size = 25
     entities_processed = 0
-    total_entities = len(tracked_alliances) + len(tracked_corporations)
 
-    # Collect killmail IDs from all tracked entities via zKB API
+    # Build entity work items: (entity_type_param, entity_id, endpoint_type)
+    # For tracked entities: fetch /losses/ (their losses = our kills or our losses)
+    # For opponent entities: fetch both /losses/ AND /kills/ for full coverage
+    entity_work: list[tuple[str, int, str]] = []
+    for alliance_id in tracked_alliances:
+        entity_work.append(("allianceID", alliance_id, "losses"))
+    for corp_id in tracked_corporations:
+        entity_work.append(("corporationID", corp_id, "losses"))
+    for alliance_id in opponent_alliances:
+        entity_work.append(("allianceID", alliance_id, "losses"))
+        entity_work.append(("allianceID", alliance_id, "kills"))
+    for corp_id in opponent_corporations:
+        entity_work.append(("corporationID", corp_id, "losses"))
+        entity_work.append(("corporationID", corp_id, "kills"))
+
+    total_entities = len(entity_work)
+
+    # Collect killmail IDs from all entities via zKB API
     all_kills: dict[int, str] = {}
 
-    for alliance_id in tracked_alliances:
+    for entity_type_param, entity_id, endpoint_type in entity_work:
         entities_processed += 1
+        entity_label = f"{entity_type_param.replace('ID', '')} {entity_id} ({endpoint_type})"
         try:
             bridge.call("update-setting", payload={
                 "key": "killmail_backfill_progress",
                 "value": json.dumps({
                     "phase": "collecting",
-                    "entity": f"alliance {alliance_id}",
+                    "entity": entity_label,
                     "entities_done": entities_processed,
                     "entities_total": total_entities,
                     "killmails_found": len(all_kills),
@@ -224,29 +248,7 @@ def run_killmail_history_backfill(context: Any) -> dict[str, Any]:
         except Exception:
             pass
 
-        entity_kills = _collect_entity_kills("allianceID", alliance_id, year, months, user_agent)
-        all_kills.update(entity_kills)
-        # Pause between entities
-        time.sleep(2)
-
-    for corp_id in tracked_corporations:
-        entities_processed += 1
-        try:
-            bridge.call("update-setting", payload={
-                "key": "killmail_backfill_progress",
-                "value": json.dumps({
-                    "phase": "collecting",
-                    "entity": f"corporation {corp_id}",
-                    "entities_done": entities_processed,
-                    "entities_total": total_entities,
-                    "killmails_found": len(all_kills),
-                    "updated_at": utc_now_iso(),
-                }),
-            })
-        except Exception:
-            pass
-
-        entity_kills = _collect_entity_kills("corporationID", corp_id, year, months, user_agent)
+        entity_kills = _collect_entity_kills(entity_type_param, entity_id, year, months, user_agent, endpoint_type)
         all_kills.update(entity_kills)
         time.sleep(2)
 
@@ -343,6 +345,9 @@ def run_killmail_history_backfill(context: Any) -> dict[str, Any]:
         "finished_at": utc_now_iso(),
         "tracked_alliances": len(tracked_alliances),
         "tracked_corporations": len(tracked_corporations),
+        "opponent_alliances": len(opponent_alliances),
+        "opponent_corporations": len(opponent_corporations),
+        "entity_work_items": total_entities,
         "killmails_seen": total_killmails_seen,
         "skipped_existing": total_skipped_existing,
         "esi_fetched": total_esi_fetched,

--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -95,6 +95,8 @@ def parse_args() -> argparse.Namespace:
 
     compute_signals = subparsers.add_parser("compute-signals", help="Generate precomputed intelligence signals into MariaDB")
     compute_signals.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
+    compute_ew = subparsers.add_parser("compute-economic-warfare", help="Compute economic warfare scores from opponent killmail data")
+    compute_ew.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
     compute_graph_sync = subparsers.add_parser("compute-graph-sync", help="Incrementally sync doctrine-fit-item graph into Neo4j")
     compute_graph_sync.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
     compute_graph_insights = subparsers.add_parser("compute-graph-insights", help="Compute graph-derived metrics and persist into MariaDB")
@@ -211,6 +213,15 @@ def main() -> int:
         from .db import SupplyCoreDb
         db = SupplyCoreDb(config.raw.get("db", {}))
         result = run_compute_signals(db, influx_runtime(config.raw))
+        print(result)
+        return 0
+    if command == "compute-economic-warfare":
+        app_root = Path(args.app_root).resolve()
+        config = load_php_runtime_config(app_root)
+        from .db import SupplyCoreDb
+        db = SupplyCoreDb(config.raw.get("db", {}))
+        from .jobs.compute_economic_warfare import run_compute_economic_warfare
+        result = run_compute_economic_warfare(db, influx_runtime(config.raw))
         print(result)
         return 0
     if command == "compute-graph-sync":

--- a/python/orchestrator/processor_registry.py
+++ b/python/orchestrator/processor_registry.py
@@ -53,6 +53,7 @@ from .jobs.theater_clustering import run_theater_clustering
 from .jobs.theater_analysis import run_theater_analysis
 from .jobs.theater_graph_integration import run_theater_graph_integration
 from .jobs.theater_suspicion import run_theater_suspicion
+from .jobs.compute_economic_warfare import run_compute_economic_warfare
 
 PYTHON_COMPUTE_PROCESSOR_JOB_KEYS: set[str] = {
     "compute_graph_sync",
@@ -84,6 +85,7 @@ PYTHON_COMPUTE_PROCESSOR_JOB_KEYS: set[str] = {
     "theater_analysis",
     "theater_graph_integration",
     "theater_suspicion",
+    "compute_economic_warfare",
 }
 
 PYTHON_SYNC_PROCESSOR_JOB_KEYS: set[str] = {
@@ -130,6 +132,7 @@ _PROCESSOR_DISPATCH: dict[str, tuple] = {
     # Market / supply intelligence jobs
     "compute_buy_all": (run_compute_buy_all, lambda db, cfg: (db,)),
     "compute_signals": (run_compute_signals, lambda db, cfg: (db, influx_runtime(cfg))),
+    "compute_economic_warfare": (run_compute_economic_warfare, lambda db, cfg: (db, influx_runtime(cfg))),
     # Sync phase jobs
     "market_hub_current_sync": (run_market_hub_current_sync, lambda db, cfg: (db,)),
     "alliance_current_sync": (run_alliance_current_sync, lambda db, cfg: (db,)),

--- a/src/db.php
+++ b/src/db.php
@@ -11069,6 +11069,239 @@ function db_killmail_tracked_corporations_active(): array
     return db_select('SELECT corporation_id, label FROM killmail_tracked_corporations WHERE is_active = 1 ORDER BY corporation_id ASC');
 }
 
+function db_killmail_opponent_alliances_active(): array
+{
+    return db_select('SELECT alliance_id, label FROM killmail_opponent_alliances WHERE is_active = 1 ORDER BY alliance_id ASC');
+}
+
+function db_killmail_opponent_corporations_active(): array
+{
+    return db_select('SELECT corporation_id, label FROM killmail_opponent_corporations WHERE is_active = 1 ORDER BY corporation_id ASC');
+}
+
+function db_killmail_opponent_alliances_replace(array $rows): bool
+{
+    db_execute('CREATE TABLE IF NOT EXISTS killmail_opponent_alliances (
+        alliance_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+        label VARCHAR(255) DEFAULT NULL,
+        is_active TINYINT(1) NOT NULL DEFAULT 1,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
+
+    return db_transaction(static function () use ($rows): bool {
+        db_execute('DELETE FROM killmail_opponent_alliances');
+
+        foreach ($rows as $row) {
+            db_execute(
+                'INSERT INTO killmail_opponent_alliances (alliance_id, label, is_active) VALUES (?, ?, 1)
+                 ON DUPLICATE KEY UPDATE label = VALUES(label), is_active = 1, updated_at = CURRENT_TIMESTAMP',
+                [(int) ($row['alliance_id'] ?? 0), $row['label'] ?? null]
+            );
+        }
+
+        return true;
+    });
+}
+
+function db_killmail_opponent_corporations_replace(array $rows): bool
+{
+    db_execute('CREATE TABLE IF NOT EXISTS killmail_opponent_corporations (
+        corporation_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+        label VARCHAR(255) DEFAULT NULL,
+        is_active TINYINT(1) NOT NULL DEFAULT 1,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
+
+    return db_transaction(static function () use ($rows): bool {
+        db_execute('DELETE FROM killmail_opponent_corporations');
+
+        foreach ($rows as $row) {
+            db_execute(
+                'INSERT INTO killmail_opponent_corporations (corporation_id, label, is_active) VALUES (?, ?, 1)
+                 ON DUPLICATE KEY UPDATE label = VALUES(label), is_active = 1, updated_at = CURRENT_TIMESTAMP',
+                [(int) ($row['corporation_id'] ?? 0), $row['label'] ?? null]
+            );
+        }
+
+        return true;
+    });
+}
+
+// ── Economic Warfare queries ─────────────────────────────────────────────────
+
+function db_economic_warfare_scores(array $filters = [], int $limit = 100, int $offset = 0): array
+{
+    $where = ['1 = 1'];
+    $params = [];
+
+    if (isset($filters['min_score']) && (float) $filters['min_score'] > 0) {
+        $where[] = 'ew.economic_warfare_score >= ?';
+        $params[] = (float) $filters['min_score'];
+    }
+    if (isset($filters['group_id']) && (int) $filters['group_id'] > 0) {
+        $where[] = 'ew.group_id = ?';
+        $params[] = (int) $filters['group_id'];
+    }
+    if (isset($filters['meta_group_id']) && (int) $filters['meta_group_id'] > 0) {
+        $where[] = 'ew.meta_group_id = ?';
+        $params[] = (int) $filters['meta_group_id'];
+    }
+    if (isset($filters['hostile_alliance_id']) && (int) $filters['hostile_alliance_id'] > 0) {
+        $where[] = 'ew.type_id IN (
+            SELECT hfm.item_type_id FROM hostile_fit_family_modules hfm
+            INNER JOIN hostile_fit_families hff ON hff.id = hfm.family_id
+            WHERE JSON_CONTAINS(hff.alliance_ids_json, CAST(? AS JSON))
+        )';
+        $params[] = (int) $filters['hostile_alliance_id'];
+    }
+
+    $whereSql = implode(' AND ', $where);
+    $params[] = max(1, min(500, $limit));
+    $params[] = max(0, $offset);
+
+    return db_select(
+        "SELECT ew.* FROM economic_warfare_scores ew
+         WHERE {$whereSql}
+         ORDER BY ew.economic_warfare_score DESC
+         LIMIT ? OFFSET ?",
+        $params
+    );
+}
+
+function db_economic_warfare_summary(): array
+{
+    $row = db_select_one(
+        "SELECT
+            COUNT(*) AS modules_scored,
+            SUM(hostile_family_count) AS total_family_refs,
+            MAX(economic_warfare_score) AS max_score,
+            AVG(economic_warfare_score) AS avg_score,
+            AVG(replacement_friction_score) AS avg_replacement_friction,
+            MAX(computed_at) AS computed_at
+         FROM economic_warfare_scores
+         WHERE economic_warfare_score > 0"
+    );
+    return is_array($row) ? $row : [];
+}
+
+function db_hostile_fit_families(array $filters = [], int $limit = 100, int $offset = 0): array
+{
+    $where = ['1 = 1'];
+    $params = [];
+
+    if (isset($filters['hull_type_id']) && (int) $filters['hull_type_id'] > 0) {
+        $where[] = 'hff.hull_type_id = ?';
+        $params[] = (int) $filters['hull_type_id'];
+    }
+    if (isset($filters['hostile_alliance_id']) && (int) $filters['hostile_alliance_id'] > 0) {
+        $where[] = 'JSON_CONTAINS(hff.alliance_ids_json, CAST(? AS JSON))';
+        $params[] = (int) $filters['hostile_alliance_id'];
+    }
+    if (isset($filters['min_confidence']) && (float) $filters['min_confidence'] > 0) {
+        $where[] = 'hff.confidence >= ?';
+        $params[] = (float) $filters['min_confidence'];
+    }
+
+    $whereSql = implode(' AND ', $where);
+    $params[] = max(1, min(500, $limit));
+    $params[] = max(0, $offset);
+
+    return db_select(
+        "SELECT hff.*, rit.type_name AS hull_name
+         FROM hostile_fit_families hff
+         LEFT JOIN ref_item_types rit ON rit.type_id = hff.hull_type_id
+         WHERE {$whereSql}
+         ORDER BY hff.observation_count DESC
+         LIMIT ? OFFSET ?",
+        $params
+    );
+}
+
+function db_hostile_fit_family_modules(int $familyId): array
+{
+    return db_select(
+        "SELECT hfm.*, rit.type_name
+         FROM hostile_fit_family_modules hfm
+         LEFT JOIN ref_item_types rit ON rit.type_id = hfm.item_type_id
+         WHERE hfm.family_id = ?
+         ORDER BY hfm.is_core DESC, hfm.frequency DESC",
+        [$familyId]
+    );
+}
+
+function db_economic_warfare_module_drilldown(int $typeId): array
+{
+    $families = db_select(
+        "SELECT hff.id, hff.hull_type_id, hff.observation_count, hff.confidence,
+                hff.alliance_ids_json, rit.type_name AS hull_name,
+                hfm.frequency, hfm.is_core, hfm.flag_category
+         FROM hostile_fit_family_modules hfm
+         INNER JOIN hostile_fit_families hff ON hff.id = hfm.family_id
+         LEFT JOIN ref_item_types rit ON rit.type_id = hff.hull_type_id
+         WHERE hfm.item_type_id = ?
+         ORDER BY hff.observation_count DESC
+         LIMIT 50",
+        [$typeId]
+    );
+
+    $score = db_select_one(
+        "SELECT * FROM economic_warfare_scores WHERE type_id = ? LIMIT 1",
+        [$typeId]
+    );
+
+    $substitutes = [];
+    if (is_array($score) && (int) ($score['group_id'] ?? 0) > 0) {
+        $substitutes = db_select(
+            "SELECT rit.type_id, rit.type_name, rit.meta_group_id,
+                    ew.economic_warfare_score, ew.fit_constraint_score
+             FROM ref_item_types rit
+             LEFT JOIN economic_warfare_scores ew ON ew.type_id = rit.type_id
+             WHERE rit.group_id = ? AND rit.type_id != ? AND rit.published = 1
+             ORDER BY ew.economic_warfare_score DESC
+             LIMIT 20",
+            [(int) $score['group_id'], $typeId]
+        );
+    }
+
+    return [
+        'score' => $score,
+        'families' => $families,
+        'substitutes' => $substitutes,
+    ];
+}
+
+function db_economic_warfare_hostile_alliances(): array
+{
+    $rows = db_select(
+        "SELECT DISTINCT jt.alliance_id
+         FROM hostile_fit_families hff,
+              JSON_TABLE(hff.alliance_ids_json, '\$[*]' COLUMNS (alliance_id BIGINT PATH '\$')) jt
+         WHERE jt.alliance_id > 0
+         ORDER BY jt.alliance_id ASC
+         LIMIT 200"
+    );
+
+    $allianceIds = array_map(static fn (array $row): int => (int) ($row['alliance_id'] ?? 0), $rows);
+    $result = [];
+    foreach ($allianceIds as $aid) {
+        if ($aid <= 0) {
+            continue;
+        }
+        $label = db_select_one(
+            "SELECT label FROM killmail_opponent_alliances WHERE alliance_id = ? LIMIT 1",
+            [$aid]
+        );
+        $result[] = [
+            'alliance_id' => $aid,
+            'label' => ($label['label'] ?? null) ?: ('Alliance #' . $aid),
+        ];
+    }
+
+    return $result;
+}
+
 function db_sync_schedule_delete_by_job_keys(array $jobKeys): int
 {
     $safeJobKeys = array_values(array_filter(array_map(static fn (mixed $jobKey): string => trim((string) $jobKey), $jobKeys), static fn (string $jobKey): bool => $jobKey !== ''));

--- a/src/functions.php
+++ b/src/functions.php
@@ -15091,6 +15091,14 @@ function python_bridge_killmail_backfill_context(): array
         static fn (array $row): int => (int) ($row['corporation_id'] ?? 0),
         db_killmail_tracked_corporations_active()
     ));
+    $opponentAllianceIds = array_values(array_map(
+        static fn (array $row): int => (int) ($row['alliance_id'] ?? 0),
+        db_killmail_opponent_alliances_active()
+    ));
+    $opponentCorporationIds = array_values(array_map(
+        static fn (array $row): int => (int) ($row['corporation_id'] ?? 0),
+        db_killmail_opponent_corporations_active()
+    ));
 
     return [
         'start_date' => $startDate !== '' ? $startDate : date('Y') . '-01-01',
@@ -15098,6 +15106,8 @@ function python_bridge_killmail_backfill_context(): array
         'user_agent' => $userAgent . ' killmail-backfill/1.0 (+https://github.com/cvweiss/supplycore)',
         'tracked_alliance_ids' => $trackedAllianceIds,
         'tracked_corporation_ids' => $trackedCorporationIds,
+        'opponent_alliance_ids' => $opponentAllianceIds,
+        'opponent_corporation_ids' => $opponentCorporationIds,
     ];
 }
 
@@ -15316,6 +15326,7 @@ function python_bridge_process_killmail_batch(array $payloads): array
 
     db_killmail_payload_schema_ensure();
     ['alliance_ids' => $trackedAllianceIds, 'corporation_ids' => $trackedCorporationIds] = killmail_active_tracked_entity_ids();
+    ['alliance_ids' => $opponentAllianceIds, 'corporation_ids' => $opponentCorporationIds] = killmail_active_opponent_entity_ids();
 
     $rowsSeen = 0;
     $rowsMatched = 0;
@@ -15334,7 +15345,7 @@ function python_bridge_process_killmail_batch(array $payloads): array
         $rowsSeen++;
         $requestedSequenceId = (int) ($payload['requested_sequence_id'] ?? $payload['sequence_id'] ?? 0);
         try {
-            $result = killmail_persist_r2z2_payload($payload, $trackedAllianceIds, $trackedCorporationIds, false, $requestedSequenceId > 0 ? $requestedSequenceId : null);
+            $result = killmail_persist_r2z2_payload($payload, $trackedAllianceIds, $trackedCorporationIds, false, $requestedSequenceId > 0 ? $requestedSequenceId : null, $opponentAllianceIds, $opponentCorporationIds);
         } catch (Throwable $exception) {
             $rowsFailed++;
             $failureReason = trim($exception->getMessage()) !== '' ? scheduler_normalize_error_message($exception->getMessage()) : 'Killmail write failed.';
@@ -18748,6 +18759,11 @@ function killmail_settings_from_request(array $request): array
         (string) ($request['tracked_corporation_names'] ?? '')
     );
 
+    $resolvedOpponents = killmail_resolve_tracked_entities(
+        (string) ($request['opponent_alliance_names'] ?? ''),
+        (string) ($request['opponent_corporation_names'] ?? '')
+    );
+
     // Note: killmail_ingestion_enabled is NOT included here — it is controlled
     // exclusively from the Automation Control section to avoid accidentally
     // disabling ingestion when saving killmail intelligence settings.
@@ -18765,7 +18781,18 @@ function killmail_settings_from_request(array $request): array
             static fn (array $row): array => ['corporation_id' => (int) ($row['id'] ?? 0), 'label' => $row['label'] ?? null],
             (array) ($resolvedEntities['corporations'] ?? [])
         ),
-        'unresolved' => array_values((array) ($resolvedEntities['unresolved'] ?? [])),
+        'opponent_alliances' => array_map(
+            static fn (array $row): array => ['alliance_id' => (int) ($row['id'] ?? 0), 'label' => $row['label'] ?? null],
+            (array) ($resolvedOpponents['alliances'] ?? [])
+        ),
+        'opponent_corporations' => array_map(
+            static fn (array $row): array => ['corporation_id' => (int) ($row['id'] ?? 0), 'label' => $row['label'] ?? null],
+            (array) ($resolvedOpponents['corporations'] ?? [])
+        ),
+        'unresolved' => array_values(array_merge(
+            (array) ($resolvedEntities['unresolved'] ?? []),
+            (array) ($resolvedOpponents['unresolved'] ?? [])
+        )),
     ];
 }
 
@@ -18782,6 +18809,8 @@ function save_killmail_intelligence_settings(array $request): array
         db_app_settings_upsert_many((array) ($payload['settings'] ?? []));
         db_killmail_tracked_alliances_replace((array) ($payload['alliances'] ?? []));
         db_killmail_tracked_corporations_replace((array) ($payload['corporations'] ?? []));
+        db_killmail_opponent_alliances_replace((array) ($payload['opponent_alliances'] ?? []));
+        db_killmail_opponent_corporations_replace((array) ($payload['opponent_corporations'] ?? []));
 
         $reloadedSettings = get_settings(array_keys((array) ($payload['settings'] ?? [])));
         foreach ((array) ($payload['settings'] ?? []) as $key => $value) {
@@ -18801,6 +18830,18 @@ function save_killmail_intelligence_settings(array $request): array
         if ($reloadedAllianceIds !== $expectedAllianceIds || $reloadedCorporationIds !== $expectedCorporationIds) {
             throw new RuntimeException('Killmail tracked entity readback mismatch after save.');
         }
+
+        $reloadedOpponentAllianceIds = array_values(array_map(static fn (array $row): int => (int) ($row['alliance_id'] ?? 0), db_killmail_opponent_alliances_active()));
+        $reloadedOpponentCorporationIds = array_values(array_map(static fn (array $row): int => (int) ($row['corporation_id'] ?? 0), db_killmail_opponent_corporations_active()));
+        $expectedOpponentAllianceIds = array_values(array_map(static fn (array $row): int => (int) ($row['alliance_id'] ?? 0), (array) ($payload['opponent_alliances'] ?? [])));
+        $expectedOpponentCorporationIds = array_values(array_map(static fn (array $row): int => (int) ($row['corporation_id'] ?? 0), (array) ($payload['opponent_corporations'] ?? [])));
+        sort($reloadedOpponentAllianceIds);
+        sort($reloadedOpponentCorporationIds);
+        sort($expectedOpponentAllianceIds);
+        sort($expectedOpponentCorporationIds);
+        if ($reloadedOpponentAllianceIds !== $expectedOpponentAllianceIds || $reloadedOpponentCorporationIds !== $expectedOpponentCorporationIds) {
+            throw new RuntimeException('Killmail opponent entity readback mismatch after save.');
+        }
         $saved = true;
     } catch (Throwable $e) {
         error_log('[killmail-settings] Save failed: ' . $e->getMessage());
@@ -18816,6 +18857,8 @@ function save_killmail_intelligence_settings(array $request): array
         'settings' => (array) ($payload['settings'] ?? []),
         'alliances' => (array) ($payload['alliances'] ?? []),
         'corporations' => (array) ($payload['corporations'] ?? []),
+        'opponent_alliances' => (array) ($payload['opponent_alliances'] ?? []),
+        'opponent_corporations' => (array) ($payload['opponent_corporations'] ?? []),
         'unresolved' => array_slice((array) ($payload['unresolved'] ?? []), 0, 8),
     ];
 }
@@ -18899,24 +18942,40 @@ function killmail_region_id_from_system(?int $systemId): ?int
 }
 
 
-function killmail_event_matches_tracked_entities(array $event, array $attackers, array $trackedAllianceIds, array $trackedCorporationIds): bool
-{
-    if ($trackedAllianceIds === [] && $trackedCorporationIds === []) {
+function killmail_event_matches_tracked_entities(
+    array $event,
+    array $attackers,
+    array $trackedAllianceIds,
+    array $trackedCorporationIds,
+    array $opponentAllianceIds = [],
+    array $opponentCorporationIds = [],
+): bool {
+    $hasTracked = $trackedAllianceIds !== [] || $trackedCorporationIds !== [];
+    $hasOpponents = $opponentAllianceIds !== [] || $opponentCorporationIds !== [];
+    if (!$hasTracked && !$hasOpponents) {
         return true;
     }
 
-    // Check victim (loss side)
     $victimAllianceId = (int) ($event['victim_alliance_id'] ?? 0);
+    $victimCorporationId = (int) ($event['victim_corporation_id'] ?? 0);
+
+    // Check victim against tracked (loss side)
     if ($victimAllianceId > 0 && isset($trackedAllianceIds[$victimAllianceId])) {
         return true;
     }
-
-    $victimCorporationId = (int) ($event['victim_corporation_id'] ?? 0);
     if ($victimCorporationId > 0 && isset($trackedCorporationIds[$victimCorporationId])) {
         return true;
     }
 
-    // Check attackers (kill side)
+    // Check victim against opponents (opponent_loss)
+    if ($victimAllianceId > 0 && isset($opponentAllianceIds[$victimAllianceId])) {
+        return true;
+    }
+    if ($victimCorporationId > 0 && isset($opponentCorporationIds[$victimCorporationId])) {
+        return true;
+    }
+
+    // Check attackers against tracked (kill side)
     foreach ($attackers as $attacker) {
         if (!is_array($attacker)) {
             continue;
@@ -18927,6 +18986,13 @@ function killmail_event_matches_tracked_entities(array $event, array $attackers,
         }
         $attackerCorporationId = (int) ($attacker['corporation_id'] ?? 0);
         if ($attackerCorporationId > 0 && isset($trackedCorporationIds[$attackerCorporationId])) {
+            return true;
+        }
+        // Check attackers against opponents (opponent_kill)
+        if ($attackerAllianceId > 0 && isset($opponentAllianceIds[$attackerAllianceId])) {
+            return true;
+        }
+        if ($attackerCorporationId > 0 && isset($opponentCorporationIds[$attackerCorporationId])) {
             return true;
         }
     }
@@ -18958,12 +19024,38 @@ function killmail_active_tracked_entity_ids(): array
     ];
 }
 
+function killmail_active_opponent_entity_ids(): array
+{
+    $opponentAllianceIds = [];
+    foreach (db_killmail_opponent_alliances_active() as $row) {
+        $id = (int) ($row['alliance_id'] ?? 0);
+        if ($id > 0) {
+            $opponentAllianceIds[$id] = true;
+        }
+    }
+
+    $opponentCorporationIds = [];
+    foreach (db_killmail_opponent_corporations_active() as $row) {
+        $id = (int) ($row['corporation_id'] ?? 0);
+        if ($id > 0) {
+            $opponentCorporationIds[$id] = true;
+        }
+    }
+
+    return [
+        'alliance_ids' => $opponentAllianceIds,
+        'corporation_ids' => $opponentCorporationIds,
+    ];
+}
+
 function killmail_persist_r2z2_payload(
     array $payload,
     array $trackedAllianceIds,
     array $trackedCorporationIds,
     bool $strictSequenceId = false,
-    ?int $requestedSequenceId = null
+    ?int $requestedSequenceId = null,
+    array $opponentAllianceIds = [],
+    array $opponentCorporationIds = [],
 ): array {
     $transformed = killmail_transform_r2z2_payload($payload);
     $event = (array) ($transformed['event'] ?? []);
@@ -18990,20 +19082,48 @@ function killmail_persist_r2z2_payload(
         ];
     }
 
-    if (!killmail_event_matches_tracked_entities($event, (array) ($transformed['attackers'] ?? []), $trackedAllianceIds, $trackedCorporationIds)) {
+    $attackers = (array) ($transformed['attackers'] ?? []);
+    if (!killmail_event_matches_tracked_entities($event, $attackers, $trackedAllianceIds, $trackedCorporationIds, $opponentAllianceIds, $opponentCorporationIds)) {
         return [
             'status' => 'filtered',
             'sequence_id' => $sequenceId,
         ];
     }
 
-    // Determine mail_type: 'loss' if victim is tracked, 'kill' if attacker is tracked.
-    $mailType = 'kill';
+    // Determine mail_type with priority: own loss/kill > opponent loss/kill.
     $victimAllianceId = (int) ($event['victim_alliance_id'] ?? 0);
     $victimCorporationId = (int) ($event['victim_corporation_id'] ?? 0);
-    if (($victimAllianceId > 0 && isset($trackedAllianceIds[$victimAllianceId]))
-        || ($victimCorporationId > 0 && isset($trackedCorporationIds[$victimCorporationId]))) {
+    $victimIsTracked = ($victimAllianceId > 0 && isset($trackedAllianceIds[$victimAllianceId]))
+        || ($victimCorporationId > 0 && isset($trackedCorporationIds[$victimCorporationId]));
+    $victimIsOpponent = ($victimAllianceId > 0 && isset($opponentAllianceIds[$victimAllianceId]))
+        || ($victimCorporationId > 0 && isset($opponentCorporationIds[$victimCorporationId]));
+
+    $attackerIsTracked = false;
+    $attackerIsOpponent = false;
+    foreach ($attackers as $attacker) {
+        if (!is_array($attacker)) {
+            continue;
+        }
+        $aAlly = (int) ($attacker['alliance_id'] ?? 0);
+        $aCorp = (int) ($attacker['corporation_id'] ?? 0);
+        if (!$attackerIsTracked && (($aAlly > 0 && isset($trackedAllianceIds[$aAlly])) || ($aCorp > 0 && isset($trackedCorporationIds[$aCorp])))) {
+            $attackerIsTracked = true;
+        }
+        if (!$attackerIsOpponent && (($aAlly > 0 && isset($opponentAllianceIds[$aAlly])) || ($aCorp > 0 && isset($opponentCorporationIds[$aCorp])))) {
+            $attackerIsOpponent = true;
+        }
+    }
+
+    if ($victimIsTracked) {
         $mailType = 'loss';
+    } elseif ($attackerIsTracked) {
+        $mailType = 'kill';
+    } elseif ($victimIsOpponent) {
+        $mailType = 'opponent_loss';
+    } elseif ($attackerIsOpponent) {
+        $mailType = 'opponent_kill';
+    } else {
+        $mailType = 'kill';
     }
     $transformed['event']['mail_type'] = $mailType;
 
@@ -19104,6 +19224,7 @@ function sync_killmail_r2z2_stream(string $runMode = 'incremental'): array
         // Ensure any one-time killmail schema migrations run before per-row write transactions begin.
         db_killmail_payload_schema_ensure();
         ['alliance_ids' => $trackedAllianceIds, 'corporation_ids' => $trackedCorporationIds] = killmail_active_tracked_entity_ids();
+        ['alliance_ids' => $opponentAllianceIds, 'corporation_ids' => $opponentCorporationIds] = killmail_active_opponent_entity_ids();
 
         $sequenceProbe = killmail_r2z2_fetch_json(killmail_r2z2_sequence_url());
         $sequenceProbeStatus = (int) ($sequenceProbe['status'] ?? 0);
@@ -19199,7 +19320,9 @@ function sync_killmail_r2z2_stream(string $runMode = 'incremental'): array
                 $trackedAllianceIds,
                 $trackedCorporationIds,
                 true,
-                $nextSequence
+                $nextSequence,
+                $opponentAllianceIds,
+                $opponentCorporationIds,
             );
             $sequenceId = (int) ($result['sequence_id'] ?? 0);
             $statusKey = (string) ($result['status'] ?? 'invalid');
@@ -29889,5 +30012,92 @@ function criticality_tier_color_class(string $tier): string
         'medium'   => 'text-amber-300',
         'low'      => 'text-zinc-400',
         default    => 'text-zinc-400',
+    };
+}
+
+// ── Economic Warfare ─────────────────────────────────────────────────────────
+
+function economic_warfare_page_data(array $filters = []): array
+{
+    $safeFilters = [];
+    if (isset($filters['hostile_alliance_id']) && (int) $filters['hostile_alliance_id'] > 0) {
+        $safeFilters['hostile_alliance_id'] = (int) $filters['hostile_alliance_id'];
+    }
+    if (isset($filters['min_score'])) {
+        $safeFilters['min_score'] = max(0, min(1, (float) $filters['min_score']));
+    }
+    if (isset($filters['meta_group_id']) && (int) $filters['meta_group_id'] > 0) {
+        $safeFilters['meta_group_id'] = (int) $filters['meta_group_id'];
+    }
+
+    $limit = max(1, min(200, (int) ($filters['limit'] ?? 100)));
+    $offset = max(0, (int) ($filters['offset'] ?? 0));
+
+    $summary = db_economic_warfare_summary();
+    $scores = db_economic_warfare_scores($safeFilters, $limit, $offset);
+    $families = db_hostile_fit_families($safeFilters, 50, 0);
+    $hostileAlliances = db_economic_warfare_hostile_alliances();
+
+    $totalFamilies = 0;
+    $totalObservations = 0;
+    foreach ($families as $fam) {
+        $totalFamilies++;
+        $totalObservations += (int) ($fam['observation_count'] ?? 0);
+    }
+
+    $topTarget = null;
+    if ($scores !== []) {
+        $topTarget = $scores[0]['type_name'] ?? ('Type #' . ($scores[0]['type_id'] ?? '?'));
+    }
+
+    return [
+        'summary' => [
+            'modules_scored' => (int) ($summary['modules_scored'] ?? 0),
+            'fit_families' => $totalFamilies,
+            'total_observations' => $totalObservations,
+            'hostile_alliances' => count($hostileAlliances),
+            'top_target' => $topTarget,
+            'avg_replacement_friction' => round((float) ($summary['avg_replacement_friction'] ?? 0), 3),
+            'computed_at' => $summary['computed_at'] ?? null,
+        ],
+        'scores' => $scores,
+        'families' => $families,
+        'hostile_alliances' => $hostileAlliances,
+        'filters' => $safeFilters,
+    ];
+}
+
+function ew_constraint_label(float $score): string
+{
+    if ($score >= 0.7) {
+        return 'high_constraint';
+    }
+    if ($score >= 0.4) {
+        return 'medium_constraint';
+    }
+    return 'low_constraint';
+}
+
+function ew_constraint_color_class(float $score): string
+{
+    if ($score >= 0.7) {
+        return 'text-red-400';
+    }
+    if ($score >= 0.4) {
+        return 'text-amber-300';
+    }
+    return 'text-zinc-400';
+}
+
+function ew_meta_group_label(int $metaGroupId): string
+{
+    return match ($metaGroupId) {
+        1  => 'T1',
+        2  => 'T2',
+        4  => 'Faction',
+        6  => 'Deadspace',
+        14 => 'T3',
+        53 => 'Officer',
+        default => 'Meta ' . $metaGroupId,
     };
 }


### PR DESCRIPTION
## Summary

- **Item Criticality Index**: Graph-based scoring of items by supply chain risk — trend urgency, single-point-of-failure detection, substitutability, and priority scoring integrated into the Buy All planner
- **Economic Warfare**: Full-stack system that reconstructs hostile doctrine fit families from opponent killmails, scores modules on 5 dimensions (fit constraint, substitution penalty, replacement friction, doctrine penetration, loss pressure), and surfaces fitting-constrained modules where market/supply pressure has maximum impact
- **Opponent Tracking**: Separate tracked opponents infrastructure (settings UI, DB tables, mail_type ENUM extension) that ingests all kills AND losses for enemy alliances/corporations — not just fights involving us — giving full doctrine coverage and accurate loss velocity

### Key design decisions

- **Fitting constraint > price**: Fit constraint weighted highest (0.30) because a compact/faction module chosen for fitting reasons has no viable T2 substitute regardless of cost
- **Fit family clustering**: MD5 fingerprint of sorted (type_id, flag_category) multiset with Jaccard >= 0.80 fuzzy merge to handle minor variations
- **Mail type priority**: loss > kill > opponent_loss > opponent_kill ensures our own engagement data always takes precedence

### Files changed (17 files, +2281 lines)

- 2 migrations (item_criticality_index, economic_warfare tables)
- Python compute job with 4-phase pipeline (extract → cluster → score → write)
- Job registered in processor_registry, main.py CLI, __init__.py
- PHP page at `/economic-warfare/` with module drilldown, fit family browser, filters
- Settings page extended with Tracked Opponents section
- Backfill extended to fetch opponent kills + losses from zKillboard

## Test plan

- [ ] Run migration `20260330_item_criticality_index.sql` and `20260331_economic_warfare.sql`
- [ ] Add opponent alliances/corporations via Settings > Killmail Intelligence > Tracked Opponents
- [ ] Trigger backfill to ingest opponent killmail data
- [ ] Run `compute_economic_warfare` job and verify scores populate
- [ ] Verify `/economic-warfare/` page loads with summary cards, scored module table, and fit family browser
- [ ] Test module drilldown page shows score breakdown, family membership, and substitutes
- [ ] Verify filters (alliance, min score, meta group) work correctly
- [ ] Confirm existing killmail ingestion still works (mail_type priority doesn't break tracked entity matching)

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf