### PR TITLE
Fix economic warfare migration: remove nonexistent workload_class column

### DIFF
--- a/database/migrations/20260331_economic_warfare.sql
+++ b/database/migrations/20260331_economic_warfare.sql
@@ -84,6 +84,6 @@ CREATE TABLE IF NOT EXISTS economic_warfare_scores (
 
 -- ─── Schedule ─────────────────────────────────────────────────────────────────
 
-INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode, workload_class)
-VALUES ('compute_economic_warfare', 1, 3600, 'python', 'compute')
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode)
+VALUES ('compute_economic_warfare', 1, 3600, 'python')
 ON DUPLICATE KEY UPDATE enabled = enabled;


### PR DESCRIPTION
## Summary

- Fixes migration error in `20260331_economic_warfare.sql` where the `INSERT INTO sync_schedules` referenced a `workload_class` column that doesn't exist on the table
- Removes the nonexistent column from the INSERT statement so the migration completes cleanly

## Test plan

- [ ] Re-run migration and confirm it completes without errors
- [ ] Verify `compute_economic_warfare` row exists in `sync_schedules`

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf