### PR TITLE
Sanitize non-finite floats before persisting graph insights

### DIFF
--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import math
 import time
 from pathlib import Path
 from typing import Any
@@ -55,6 +56,19 @@ def _coerce_batch_size(value: Any, *, fallback: int = DEFAULT_BATCH_SIZE) -> int
         return max(100, min(5000, int(value)))
     except (TypeError, ValueError):
         return fallback
+
+
+def _safe_float(value: Any, *, default: float | None = None) -> float | None:
+    """Convert to float and guard against NaN/Infinity for MariaDB writes."""
+    if value is None:
+        return default
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(numeric):
+        return default
+    return numeric
 
 
 def _sync_state_get(db: SupplyCoreDb, dataset_key: str) -> dict[str, Any] | None:
@@ -1575,31 +1589,31 @@ def _persist_criticality_index(db: SupplyCoreDb, item_data: dict[int, dict[str, 
             tid,
             d.get("doctrine_count", 0),
             d.get("fit_count", 0),
-            d.get("dependency_score", 0),
-            d.get("critical_edge_ratio", 0),
+            _safe_float(d.get("dependency_score"), default=0.0),
+            _safe_float(d.get("critical_edge_ratio"), default=0.0),
             d.get("substitute_count", 0),
-            d.get("substitutability", 1.0),
+            _safe_float(d.get("substitutability"), default=1.0),
             d.get("dependency_depth", 0),
             d.get("spof_flag", 0),
-            d.get("spof_impact_score", 0),
-            d.get("criticality_score", 0),
-            d.get("price_avg_7d"),
-            d.get("price_avg_30d"),
-            d.get("volume_avg_7d"),
-            d.get("volume_avg_30d"),
-            d.get("price_velocity"),
-            d.get("volume_velocity"),
-            d.get("price_volatility"),
+            _safe_float(d.get("spof_impact_score"), default=0.0),
+            _safe_float(d.get("criticality_score"), default=0.0),
+            _safe_float(d.get("price_avg_7d")),
+            _safe_float(d.get("price_avg_30d")),
+            _safe_float(d.get("volume_avg_7d")),
+            _safe_float(d.get("volume_avg_30d")),
+            _safe_float(d.get("price_velocity")),
+            _safe_float(d.get("volume_velocity")),
+            _safe_float(d.get("price_volatility")),
             d.get("trend_regime", "stable"),
-            d.get("trend_score", 0),
-            d.get("market_spread_pct"),
-            d.get("liquidity_score"),
-            d.get("stock_days_remaining"),
-            d.get("market_stress_score", 0),
-            d.get("data_freshness_hrs"),
-            d.get("coverage_ratio"),
-            d.get("confidence_score", 0.5),
-            d.get("priority_index", 0),
+            _safe_float(d.get("trend_score"), default=0.0),
+            _safe_float(d.get("market_spread_pct")),
+            _safe_float(d.get("liquidity_score")),
+            _safe_float(d.get("stock_days_remaining")),
+            _safe_float(d.get("market_stress_score"), default=0.0),
+            _safe_float(d.get("data_freshness_hrs")),
+            _safe_float(d.get("coverage_ratio")),
+            _safe_float(d.get("confidence_score"), default=0.5),
+            _safe_float(d.get("priority_index"), default=0.0),
             d.get("priority_rank"),
             computed_at,
         ))


### PR DESCRIPTION
### Motivation
- `compute_graph_insights` intermittently failed with `ProgrammingError: nan can not be used with MySQL` because NaN/Infinity values from trend/market metrics were being written directly to MariaDB. 
- Persisting non-finite numbers is a runtime failure (not just a UI artifact) and must be guarded at the execution plane before SQL writes. 

### Description
- Added a `_safe_float(...)` helper in `python/orchestrator/jobs/graph_pipeline.py` to coerce values to `float` and reject `NaN`/`Infinity`, returning a provided safe default or `None` for nullable columns. 
- Replaced direct float-field accesses in `_persist_criticality_index(...)` with `_safe_float(...)` for every numeric column that is inserted into `item_criticality_index`, preserving existing schema defaults for non-nullable scores. 
- Imported `math` and kept behavior that valid finite values are persisted unchanged while non-finite values degrade to safe defaults or `NULL` to avoid SQL driver errors. 

### Testing
- Ran `python -m compileall python/orchestrator/jobs/graph_pipeline.py` and the file compiled successfully. 
- No additional automated unit tests were present for this job; the change is limited to numeric sanitization before `executemany(...)` writes and is covered by the compile check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c79f9099fc832f84be78c7aaa517c7)