### PR TITLE
Fix three failing compute jobs crashing every run

### DIFF
--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import math
 import time
 from pathlib import Path
 from typing import Any
@@ -1559,6 +1560,13 @@ def _compute_composite_scores(item_data: dict[int, dict[str, Any]]) -> None:
         )
 
 
+def _sanitize_for_mysql(value: Any) -> Any:
+    """Replace float NaN/Inf with None so MySQL doesn't reject them."""
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        return None
+    return value
+
+
 def _persist_criticality_index(db: SupplyCoreDb, item_data: dict[int, dict[str, Any]], computed_at: str) -> int:
     """Write item_criticality_index table and assign priority_rank."""
     if not item_data:
@@ -1571,7 +1579,7 @@ def _persist_criticality_index(db: SupplyCoreDb, item_data: dict[int, dict[str, 
 
     rows = []
     for tid, d in sorted_items:
-        rows.append((
+        rows.append(tuple(_sanitize_for_mysql(v) for v in (
             tid,
             d.get("doctrine_count", 0),
             d.get("fit_count", 0),
@@ -1602,7 +1610,7 @@ def _persist_criticality_index(db: SupplyCoreDb, item_data: dict[int, dict[str, 
             d.get("priority_index", 0),
             d.get("priority_rank"),
             computed_at,
-        ))
+        )))
 
     with db.transaction() as (_, cursor):
         cursor.execute("DELETE FROM item_criticality_index")

--- a/python/orchestrator/jobs/intelligence_pipeline.py
+++ b/python/orchestrator/jobs/intelligence_pipeline.py
@@ -637,10 +637,8 @@ def _compute_shared_alliance_history(client: Neo4jClient) -> None:
                rel.overlap_start = overlap_start,
                rel.overlap_end = overlap_end,
                rel.overlap_days = duration.between(
-                   date(CASE WHEN date(h1.started_at) > date(h2.started_at)
-                             THEN h1.started_at ELSE h2.started_at END),
-                   CASE WHEN COALESCE(date(h1.ended_at), date()) < COALESCE(date(h2.ended_at), date())
-                        THEN COALESCE(date(h1.ended_at), date()) ELSE COALESCE(date(h2.ended_at), date()) END
+                   date(overlap_start),
+                   COALESCE(date(overlap_end), date())
                ).days""",
         {"lookback_days": OVERLAP_LOOKBACK_DAYS},
     )

--- a/python/orchestrator/jobs/theater_suspicion.py
+++ b/python/orchestrator/jobs/theater_suspicion.py
@@ -92,7 +92,7 @@ def _load_suspicion_scores(db: SupplyCoreDb, character_ids: list[int]) -> dict[i
             if cid > 0:
                 result[cid] = score
 
-    # For characters not in suspicion_signals, try battle_actor_features
+    # For characters not in suspicion_signals, derive a score from battle_actor_features
     missing = [cid for cid in character_ids if cid not in result]
     if missing:
         for offset in range(0, len(missing), BATCH_SIZE):
@@ -100,7 +100,8 @@ def _load_suspicion_scores(db: SupplyCoreDb, character_ids: list[int]) -> dict[i
             placeholders = ",".join(["%s"] * len(chunk))
             rows = db.fetch_all(
                 f"""
-                SELECT character_id, MAX(suspicion_score) AS suspicion_score
+                SELECT character_id,
+                       MAX(0.5 * COALESCE(centrality_score, 0) + 0.5 * COALESCE(visibility_score, 0)) AS derived_score
                 FROM battle_actor_features
                 WHERE character_id IN ({placeholders})
                 GROUP BY character_id
@@ -109,7 +110,7 @@ def _load_suspicion_scores(db: SupplyCoreDb, character_ids: list[int]) -> dict[i
             )
             for r in rows:
                 cid = int(r.get("character_id") or 0)
-                score = float(r.get("suspicion_score") or 0)
+                score = float(r.get("derived_score") or 0)
                 if cid > 0:
                     result[cid] = score
 


### PR DESCRIPTION
## Summary

- **intelligence_pipeline**: `h2` variable not defined in Neo4j Cypher — the `WITH` clause dropped `h1`/`h2` relationship variables, then `SET` tried to re-derive overlap from them. Fixed by using the already-computed `overlap_start`/`overlap_end` aliases.
- **theater_suspicion**: Fallback query on `battle_actor_features` referenced nonexistent `suspicion_score` column. Fixed by deriving from available `centrality_score` + `visibility_score`.
- **compute_graph_insights**: InfluxDB `stddev()` returns NaN for single-point series, which MySQL rejects with "nan can not be used with MySQL". Fixed by adding `_sanitize_for_mysql()` that replaces NaN/Inf with None before INSERT.

All three jobs have been failing every scheduled run since deployment.

## Test plan

- [ ] Deploy and verify `intelligence_pipeline` completes without Neo4j syntax error
- [ ] Verify `theater_suspicion` completes without "Unknown column" error
- [ ] Verify `compute_graph_insights` completes without NaN rejection
- [ ] Check logs after next scheduled cycle for clean runs

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf