### PR TITLE
Fix theater ISK/kills bugs and homepage 64MB MySQL overload

### DIFF
--- a/python/orchestrator/jobs/dashboard_summary_sync.py
+++ b/python/orchestrator/jobs/dashboard_summary_sync.py
@@ -61,6 +61,9 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
             **market_kpis,
         },
         "freshness": freshness,
+        # Include priority_queues so PHP doesn't trigger an expensive inline rebuild.
+        # Full queue data is populated by the PHP build path on first bootstrap.
+        "priority_queues": {},
     }
     rows_written = db.upsert_intelligence_snapshot(
         snapshot_key="dashboard_summaries",

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -353,6 +353,8 @@ def _compute_alliance_summary(
     # since rows are expanded per-attacker from the LEFT JOIN.
     seen_loss_km: set[int] = set()
     seen_kill_km: set[tuple[int, int]] = set()  # (killmail_id, alliance_id)
+    km_alliance_damage: dict[int, dict[int, float]] = {}  # km_id -> {alliance_id -> total_damage}
+    km_isk: dict[int, float] = {}  # km_id -> isk value
     for km in killmails:
         km_id = int(km.get("killmail_id") or 0)
         victim_id = int(km.get("victim_character_id") or 0)
@@ -371,6 +373,7 @@ def _compute_alliance_summary(
             entry["total_isk_lost"] += isk
 
         # Record kill for attacker alliance (once per killmail per alliance)
+        # ISK is attributed proportionally by damage dealt, not duplicated.
         if attacker_alliance > 0:
             entry = alliance_stats.setdefault(attacker_alliance, _empty_alliance_stats(attacker_alliance))
             entry["total_damage"] += attacker_damage
@@ -378,7 +381,20 @@ def _compute_alliance_summary(
             if kill_key not in seen_kill_km:
                 seen_kill_km.add(kill_key)
                 entry["total_kills"] += 1
-                entry["total_isk_killed"] += isk
+                # Track per-killmail damage by alliance for proportional ISK later
+                km_alliance_damage.setdefault(km_id, {})[attacker_alliance] = \
+                    km_alliance_damage.get(km_id, {}).get(attacker_alliance, 0.0) + attacker_damage
+                km_isk[km_id] = isk
+
+    # Distribute ISK proportionally by damage dealt per alliance
+    for km_id, alliance_damages in km_alliance_damage.items():
+        total_damage = sum(alliance_damages.values())
+        isk = km_isk.get(km_id, 0.0)
+        for aid, dmg in alliance_damages.items():
+            share = dmg / total_damage if total_damage > 0 else 1.0 / len(alliance_damages)
+            entry = alliance_stats.get(aid)
+            if entry is not None:
+                entry["total_isk_killed"] += isk * share
 
     # Finalize
     result: list[dict[str, Any]] = []

--- a/python/orchestrator/jobs/theater_clustering.py
+++ b/python/orchestrator/jobs/theater_clustering.py
@@ -347,13 +347,29 @@ def _flush_theaters(
     """Write theater data to MariaDB. Returns total rows written."""
     rows_written = 0
 
-    with db.transaction() as (_, cursor):
-        # Truncate and rewrite (full-refresh pattern)
-        cursor.execute("DELETE FROM theater_systems")
-        cursor.execute("DELETE FROM theater_battles")
-        cursor.execute("DELETE FROM theaters")
+    # Collect new theater IDs so we can prune stale rows
+    new_theater_ids = {t["theater_id"] for t in theaters}
 
-        # Insert theaters
+    with db.transaction() as (_, cursor):
+        # Remove theaters/battles/systems that no longer exist, but
+        # preserve analysis-computed fields (total_kills, total_isk,
+        # anomaly_score) for theaters that are being re-clustered.
+        if new_theater_ids:
+            id_placeholders = ",".join(["%s"] * len(new_theater_ids))
+            cursor.execute(f"DELETE FROM theater_systems WHERE theater_id NOT IN ({id_placeholders})", tuple(new_theater_ids))
+            cursor.execute(f"DELETE FROM theater_battles WHERE theater_id NOT IN ({id_placeholders})", tuple(new_theater_ids))
+            cursor.execute(f"DELETE FROM theaters WHERE theater_id NOT IN ({id_placeholders})", tuple(new_theater_ids))
+        else:
+            cursor.execute("DELETE FROM theater_systems")
+            cursor.execute("DELETE FROM theater_battles")
+            cursor.execute("DELETE FROM theaters")
+
+        # Delete existing battle/system rows for theaters we're re-inserting
+        if new_theater_ids:
+            cursor.execute(f"DELETE FROM theater_systems WHERE theater_id IN ({id_placeholders})", tuple(new_theater_ids))
+            cursor.execute(f"DELETE FROM theater_battles WHERE theater_id IN ({id_placeholders})", tuple(new_theater_ids))
+
+        # Upsert theaters — preserve analysis fields (total_kills, total_isk, anomaly_score)
         for t in theaters:
             cursor.execute(
                 """
@@ -363,6 +379,17 @@ def _flush_theaters(
                     battle_count, system_count, total_kills, total_isk,
                     participant_count, anomaly_score, computed_at
                 ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON DUPLICATE KEY UPDATE
+                    label = VALUES(label),
+                    primary_system_id = VALUES(primary_system_id),
+                    region_id = VALUES(region_id),
+                    start_time = VALUES(start_time),
+                    end_time = VALUES(end_time),
+                    duration_seconds = VALUES(duration_seconds),
+                    battle_count = VALUES(battle_count),
+                    system_count = VALUES(system_count),
+                    participant_count = VALUES(participant_count),
+                    computed_at = VALUES(computed_at)
                 """,
                 (
                     t["theater_id"], t["label"], t["primary_system_id"], t["region_id"],

--- a/src/db.php
+++ b/src/db.php
@@ -14504,6 +14504,31 @@ function db_buy_all_summary_latest(string $modeKey, string $sortKey, string $fil
     return $row ?: null;
 }
 
+function db_buy_all_summary_latest_lightweight(string $modeKey, string $sortKey, string $filtersHash, int $maxAgeSeconds = 1800): ?array
+{
+    $safeMode = mb_substr(trim($modeKey), 0, 40);
+    $safeSort = mb_substr(trim($sortKey), 0, 40);
+    $safeHash = mb_substr(trim($filtersHash), 0, 64);
+    if ($safeMode === '' || $safeSort === '' || $safeHash === '') {
+        return null;
+    }
+
+    $safeMaxAge = max(60, min(86400, $maxAgeSeconds));
+    $row = db_select_one(
+        'SELECT id, mode_key, sort_key, filters_hash, summary_json, computed_at
+         FROM buy_all_summary
+         WHERE mode_key = ?
+           AND sort_key = ?
+           AND filters_hash = ?
+           AND computed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL ? SECOND)
+         ORDER BY computed_at DESC, id DESC
+         LIMIT 1',
+        [$safeMode, $safeSort, $safeHash, $safeMaxAge]
+    );
+
+    return $row ?: null;
+}
+
 function db_buy_all_items_by_summary_id(int $summaryId): array
 {
     if ($summaryId <= 0) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -7437,21 +7437,11 @@ function dashboard_intelligence_data_build(): array
 
 function dashboard_snapshot_payload(): array
 {
-    $result = supplycore_materialized_snapshot_read_or_bootstrap(
+    return supplycore_materialized_snapshot_read_or_bootstrap(
         dashboard_snapshot_key(),
         static fn (): array => dashboard_intelligence_data_build(),
         'dashboard-bootstrap'
     );
-
-    if (!isset($result['priority_queues'])) {
-        $payload = dashboard_intelligence_data_build();
-        return supplycore_materialized_snapshot_store(dashboard_snapshot_key(), $payload, [
-            'reason' => 'dashboard-format-recovery',
-            'status' => 'ready',
-        ]);
-    }
-
-    return $result;
 }
 
 function dashboard_refresh_summary(string $reason = 'manual'): array
@@ -23685,21 +23675,15 @@ function supplycore_materialized_snapshot_mark_updating(string $snapshotKey, str
 function supplycore_materialized_snapshot_read_or_bootstrap(string $snapshotKey, callable $builder, string $reason): array
 {
     $snapshot = supplycore_materialized_snapshot_fetch($snapshotKey);
-    $expired = false;
-    if ($snapshot !== null) {
-        $status = trim((string) ($snapshot['meta']['status'] ?? ''));
-        if ($status === 'updating') {
-            $expired = true;
-        }
-        $expiresAt = trim((string) ($snapshot['meta']['expires_at'] ?? ''));
-        if ($expiresAt !== '' && strtotime($expiresAt) !== false && strtotime($expiresAt) < time()) {
-            $expired = true;
-        }
-    }
-    if (!$expired && $snapshot !== null && is_array($snapshot['payload'] ?? null) && $snapshot['payload'] !== []) {
+
+    // Serve existing snapshot even if stale/expired — never rebuild inline on
+    // web requests.  Background Python jobs are responsible for keeping
+    // snapshots fresh.  This prevents 64MB+ inline rebuilds on page load.
+    if ($snapshot !== null && is_array($snapshot['payload'] ?? null) && $snapshot['payload'] !== []) {
         return supplycore_materialized_snapshot_attach_meta($snapshot['payload'], is_array($snapshot['meta'] ?? null) ? $snapshot['meta'] : []);
     }
 
+    // Only rebuild if there is NO snapshot at all (first-time bootstrap)
     $payload = $builder();
     if (!is_array($payload)) {
         $payload = [];
@@ -28866,8 +28850,17 @@ function buy_all_planner_data_uncached(array $query = []): array
 
 function buy_all_dashboard_summary(): array
 {
-    $planner = buy_all_planner_data(['mode' => 'blended', 'page' => 1]);
-    $summary = is_array($planner['summary'] ?? null) ? $planner['summary'] : [];
+    // Lightweight path: only load summary_json, skip the huge payload_json LONGTEXT
+    $request = buy_all_request(['mode' => 'blended', 'page' => 1]);
+    $filtersHash = hash('sha256', json_encode((array) ($request['filters'] ?? []), JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+    $row = db_buy_all_summary_latest_lightweight((string) ($request['mode'] ?? 'blended'), (string) ($request['sort'] ?? 'blended_score'), $filtersHash, 3600);
+    $summary = [];
+    if (is_array($row) && isset($row['summary_json'])) {
+        $decoded = json_decode((string) $row['summary_json'], true);
+        if (is_array($decoded)) {
+            $summary = $decoded;
+        }
+    }
     $recommendedMode = 'blended';
     if ((int) ($summary['doctrine_critical_count'] ?? 0) > 0) {
         $recommendedMode = 'doctrine_critical';


### PR DESCRIPTION
Theater fixes:
- Fix ISK attribution: distribute kill ISK proportionally by damage dealt per alliance instead of crediting full ISK to every participating alliance
- Fix kills=0 in header: clustering now uses upsert (ON DUPLICATE KEY UPDATE) to preserve analysis-computed total_kills/total_isk/anomaly_score instead of truncate-rewrite which reset them to 0

Homepage MySQL fixes:
- Stop loading full buy_all payload_json (10-20MB LONGTEXT) on homepage; new db_buy_all_summary_latest_lightweight() reads only summary_json
- Never rebuild snapshots inline on web requests; serve stale data and let Python background jobs keep snapshots fresh
- Remove priority_queues format-recovery rebuild loop that forced expensive dashboard_intelligence_data_build() on every page load
- Add priority_queues key to Python dashboard_summary_sync payload to prevent PHP from treating the snapshot as invalid

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf