### PR TITLE
Fix theater data model and modularize view

### DIFF
--- a/public/theater-intelligence/partials/_header.php
+++ b/public/theater-intelligence/partials/_header.php
@@ -26,7 +26,7 @@
         </div>
     </div>
 
-    <div class="mt-3 grid gap-3 md:grid-cols-6">
+    <div class="mt-3 grid grid-cols-6 gap-3">
         <div class="surface-tertiary">
             <p class="text-xs text-muted">Battles</p>
             <p class="text-lg text-slate-50 font-semibold"><?= (int) ($theater['battle_count'] ?? 0) ?></p>

--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -1,6 +1,30 @@
 <?php
+/**
+ * Participants partial — side-by-side layout.
+ * Tracked friendlies on left, enemies on right.
+ * Falls back to single-column when a specific side/suspicious filter is active.
+ */
+
+// Split participants by side for the two-column layout
+$friendlyParticipants = [];
+$enemyParticipants = [];
+foreach ($participantsAll as $p) {
+    $pSide = (string) ($p['side'] ?? '');
+    if ($pSide === ($ourSide ?? 'side_a')) {
+        $friendlyParticipants[] = $p;
+    } else {
+        $enemyParticipants[] = $p;
+    }
+}
+
+// When a specific filter is active, show single filtered list
+$showSideBySide = ($sideFilter === null && !$suspiciousOnly);
+$filteredList = $showSideBySide ? [] : $participants;
+
+// Compute max damage across ALL participants for consistent bar scaling
 $maxDamageDone = 0;
-foreach ($participants as $p) {
+$allForMax = $showSideBySide ? $participantsAll : $participants;
+foreach ($allForMax as $p) {
     $dmg = (float) ($p['damage_done'] ?? 0);
     if ($dmg > $maxDamageDone) $maxDamageDone = $dmg;
 }
@@ -16,6 +40,108 @@ foreach ($participants as $p) {
         </div>
     </div>
     <p class="text-xs text-muted mt-1">Kill Involvements = killmails where pilot was an attacker. Damage Done/Taken = HP damage. ISK Lost = value of ships destroyed.</p>
+
+<?php if ($showSideBySide): ?>
+    <div class="mt-3 grid grid-cols-2 gap-4">
+        <?php
+        $panelSets = [
+            ['label' => $sideLabels[$ourSide ?? 'side_a'] ?? 'Friendlies', 'side' => $ourSide ?? 'side_a', 'rows' => $friendlyParticipants, 'colorClass' => 'text-blue-300', 'borderClass' => 'border-blue-500/30'],
+            ['label' => $sideLabels[$enemySide] ?? 'Enemies', 'side' => $enemySide, 'rows' => $enemyParticipants, 'colorClass' => 'text-red-300', 'borderClass' => 'border-red-500/30'],
+        ];
+        foreach ($panelSets as $panel):
+        ?>
+        <div>
+            <h3 class="text-sm font-semibold <?= $panel['colorClass'] ?> mb-2"><?= htmlspecialchars($panel['label'], ENT_QUOTES) ?> <span class="text-muted font-normal">(<?= count($panel['rows']) ?>)</span></h3>
+            <div class="table-shell border-t <?= $panel['borderClass'] ?>">
+                <table class="table-ui w-full">
+                    <thead>
+                        <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                            <th class="px-2 py-2 text-left">Pilot</th>
+                            <th class="px-2 py-2 text-left">Ship</th>
+                            <th class="px-2 py-2 text-left">Role</th>
+                            <th class="px-2 py-2 text-right">K/D</th>
+                            <th class="px-2 py-2 text-right">Damage Done</th>
+                            <th class="px-2 py-2 text-right">ISK Lost</th>
+                            <th class="px-2 py-2 text-right"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if ($panel['rows'] === []): ?>
+                            <tr><td colspan="7" class="px-2 py-4 text-sm text-muted">No participants.</td></tr>
+                        <?php else: ?>
+                            <?php foreach ($panel['rows'] as $p): ?>
+                                <?php
+                                    $pSusp = (float) ($p['suspicion_score'] ?? 0);
+                                    $isSusp = (int) ($p['is_suspicious'] ?? 0);
+                                    $charName = killmail_entity_preferred_name($resolvedEntities, 'character', (int) ($p['character_id'] ?? 0), (string) ($p['character_name'] ?? ''), 'Character');
+                                    $fleetRole = (string) ($p['role_proxy'] ?? 'mainline_dps');
+                                    $kills = (int) ($p['kills'] ?? 0);
+                                    $deaths = (int) ($p['deaths'] ?? 0);
+                                    $dmgDone = (float) ($p['damage_done'] ?? 0);
+                                    $iskLost = (float) ($p['isk_lost'] ?? 0);
+                                    $dmgPct = $maxDamageDone > 0 ? ($dmgDone / $maxDamageDone) * 100 : 0;
+
+                                    $shipIds = [];
+                                    $shipJson = $p['ship_type_ids'] ?? null;
+                                    if (is_string($shipJson)) {
+                                        $decoded = json_decode($shipJson, true);
+                                        if (is_array($decoded)) $shipIds = $decoded;
+                                    }
+                                ?>
+                                <tr class="border-b border-border/50 <?= $isSusp ? 'bg-red-900/10' : '' ?>">
+                                    <td class="px-2 py-1.5">
+                                        <a class="text-accent text-sm" href="/battle-intelligence/character.php?character_id=<?= (int) ($p['character_id'] ?? 0) ?>">
+                                            <?= htmlspecialchars($charName, ENT_QUOTES) ?>
+                                        </a>
+                                        <?php if ($isSusp): ?>
+                                            <span class="inline-block w-1.5 h-1.5 rounded-full bg-red-400 ml-1" title="Suspicious"></span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td class="px-2 py-1.5">
+                                        <?php if ($shipIds): ?>
+                                            <div class="flex items-center gap-1">
+                                                <img src="https://images.evetech.net/types/<?= (int) ($shipIds[0]) ?>/icon?size=32" alt="" class="w-4 h-4" loading="lazy">
+                                                <span class="text-[11px] text-slate-300 truncate max-w-[6rem]"><?= htmlspecialchars((string) ($shipTypeNames[(int) ($shipIds[0] ?? 0)] ?? ''), ENT_QUOTES) ?></span>
+                                                <?php if (count($shipIds) > 1): ?>
+                                                    <span class="text-[10px] text-muted">+<?= count($shipIds) - 1 ?></span>
+                                                <?php endif; ?>
+                                            </div>
+                                        <?php else: ?>
+                                            <span class="text-slate-500 text-xs">-</span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td class="px-2 py-1.5">
+                                        <span class="inline-block rounded-full px-1.5 py-0.5 text-[9px] uppercase tracking-wider <?= fleet_function_color_class($fleetRole) ?>">
+                                            <?= htmlspecialchars(fleet_function_label($fleetRole), ENT_QUOTES) ?>
+                                        </span>
+                                    </td>
+                                    <td class="px-2 py-1.5 text-right text-sm">
+                                        <span class="text-green-400"><?= $kills ?></span><span class="text-slate-500">/</span><span class="text-red-400"><?= $deaths ?></span>
+                                    </td>
+                                    <td class="px-2 py-1.5 text-right">
+                                        <div class="flex items-center justify-end gap-1">
+                                            <div class="w-12 h-1.5 rounded-full bg-slate-800 overflow-hidden">
+                                                <div class="h-full bg-blue-500/70 rounded-full" style="width: <?= number_format($dmgPct, 1) ?>%"></div>
+                                            </div>
+                                            <span class="text-[11px] text-slate-300"><?= number_format($dmgDone, 0) ?></span>
+                                        </div>
+                                    </td>
+                                    <td class="px-2 py-1.5 text-right text-xs <?= $iskLost > 0 ? 'text-red-300' : 'text-slate-500' ?>"><?= $iskLost > 0 ? supplycore_format_isk($iskLost) : '-' ?></td>
+                                    <td class="px-2 py-1.5 text-right">
+                                        <a class="text-accent text-[11px]" href="/battle-intelligence/character.php?character_id=<?= (int) ($p['character_id'] ?? 0) ?>">Intel</a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <?php endforeach; ?>
+    </div>
+
+<?php else: ?>
+    <!-- Single-column filtered view -->
     <div class="mt-3 table-shell">
         <table class="table-ui">
             <thead>
@@ -33,10 +159,10 @@ foreach ($participants as $p) {
                 </tr>
             </thead>
             <tbody>
-                <?php if ($participants === []): ?>
+                <?php if ($filteredList === []): ?>
                     <tr><td colspan="10" class="px-3 py-6 text-sm text-muted">No participants found.</td></tr>
                 <?php else: ?>
-                    <?php foreach ($participants as $p): ?>
+                    <?php foreach ($filteredList as $p): ?>
                         <?php
                             $pSide = (string) ($p['side'] ?? '');
                             $pSideClass = $sideColorClass[$pSide] ?? 'text-slate-300';
@@ -130,4 +256,5 @@ foreach ($participants as $p) {
             </tbody>
         </table>
     </div>
+<?php endif; ?>
 </section>

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -46,7 +46,7 @@ foreach ($allianceSummary as $row) {
         $entityRequests['alliance'][$id] = $id;
     }
 }
-foreach ($participants as $row) {
+foreach ($participantsAll as $row) {
     if (($id = (int) ($row['character_id'] ?? 0)) > 0) {
         $entityRequests['character'][$id] = $id;
     }
@@ -214,7 +214,7 @@ foreach ($sidePanels as $side => $data) {
 
 // ── Resolve ship type names for participant table ──────────────────────
 $allShipTypeIds = [];
-foreach ($participants as $p) {
+foreach ($participantsAll as $p) {
     $shipJson = $p['ship_type_ids'] ?? null;
     if (is_string($shipJson)) {
         $ids = json_decode($shipJson, true);


### PR DESCRIPTION
## Summary

- **Fix `damage_taken` bug**: Was storing ISK value instead of HP damage. Now `damage_taken` = sum of attacker HP damage, new `isk_lost` column tracks ISK separately
- **Modularize view.php**: Split 845-line monolithic file into 9 focused partials
- **KPI cards horizontal**: 6-column grid layout instead of stacked rows
- **Participants side-by-side**: Default view shows tracked friendlies on left, enemies on right in two-column layout
- **Clarify metrics**: Renamed to "Unique Pilots", "Distinct Killmails", "Kill Involvements", "Final Blows"
- **Enhanced participant table**: Ship icons, damage bars, K/D column, ISK Lost, suspicion dots
- **Theater time window**: Recomputed from actual battle start/end times
- **`supplycore_format_isk()`**: Consistent short ISK formatting (1.5t, 2.3b, 15.0m)

## Migration

- `20260401_theater_participant_isk_lost.sql` — adds `isk_lost DECIMAL(20,2)` to `theater_participants`

## Test plan

- [ ] Run migration on dev database
- [ ] Re-run theater analysis job — verify `damage_taken` has HP values, `isk_lost` has ISK values
- [ ] Load theater view — verify KPI cards render horizontally in one row
- [ ] Verify participants show side-by-side (friendlies left, enemies right)
- [ ] Click side filter links — verify single-column fallback works
- [ ] Check ship icons, damage bars, ISK formatting

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf