### PR TITLE
Fix theater viewer friendly-side mapping and compact intelligence layout

### DIFF
--- a/public/theater-intelligence/partials/_header.php
+++ b/public/theater-intelligence/partials/_header.php
@@ -26,7 +26,7 @@
         </div>
     </div>
 
-    <div class="mt-3 grid grid-cols-6 gap-3">
+    <div class="mt-3 grid gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-6">
         <div class="surface-tertiary">
             <p class="text-xs text-muted">Battles</p>
             <p class="text-lg text-slate-50 font-semibold"><?= (int) ($theater['battle_count'] ?? 0) ?></p>

--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -9,7 +9,7 @@
 $friendlyParticipants = [];
 $enemyParticipants = [];
 foreach ($participantsAll as $p) {
-    $pSide = (string) ($p['side'] ?? '');
+    $pSide = $displaySideForAlliance((int) ($p['alliance_id'] ?? 0), (string) ($p['side'] ?? ''));
     if ($pSide === ($ourSide ?? 'side_a')) {
         $friendlyParticipants[] = $p;
     } else {
@@ -42,7 +42,7 @@ foreach ($allForMax as $p) {
     <p class="text-xs text-muted mt-1">Kill Involvements = killmails where pilot was an attacker. Damage Done/Taken = HP damage. ISK Lost = value of ships destroyed.</p>
 
 <?php if ($showSideBySide): ?>
-    <div class="mt-3 grid grid-cols-2 gap-4">
+    <div class="mt-3 grid gap-4 md:grid-cols-2">
         <?php
         $panelSets = [
             ['label' => $sideLabels[$ourSide ?? 'side_a'] ?? 'Friendlies', 'side' => $ourSide ?? 'side_a', 'rows' => $friendlyParticipants, 'colorClass' => 'text-blue-300', 'borderClass' => 'border-blue-500/30'],
@@ -164,7 +164,7 @@ foreach ($allForMax as $p) {
                 <?php else: ?>
                     <?php foreach ($filteredList as $p): ?>
                         <?php
-                            $pSide = (string) ($p['side'] ?? '');
+                            $pSide = $displaySideForAlliance((int) ($p['alliance_id'] ?? 0), (string) ($p['side'] ?? ''));
                             $pSideClass = $sideColorClass[$pSide] ?? 'text-slate-300';
                             $pSusp = (float) ($p['suspicion_score'] ?? 0);
                             $isSusp = (int) ($p['is_suspicious'] ?? 0);

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -32,7 +32,7 @@ $turningPoints = db_theater_turning_points($theaterId);
 $sideFilter = isset($_GET['side']) ? (string) $_GET['side'] : null;
 $suspiciousOnly = isset($_GET['suspicious']) && $_GET['suspicious'] === '1';
 $participantsAll = db_theater_participants($theaterId, null, false, 1000);
-$participants = db_theater_participants($theaterId, $sideFilter, $suspiciousOnly);
+$participants = $participantsAll;
 $graphParticipants = db_theater_graph_participants($theaterId);
 
 // ── Batch-resolve entity names via ESI (cache + network fallback) ──
@@ -71,28 +71,59 @@ $resolvedEntities = killmail_entity_resolve_batch($entityRequests, true);
 $trackedAlliances = db_killmail_tracked_alliances_active();
 $trackedAllianceIds = array_column($trackedAlliances, 'alliance_id');
 $trackedAllianceIds = array_map('intval', $trackedAllianceIds);
+$trackedAllianceIds = array_values(array_unique($trackedAllianceIds));
 
 $ourSide = null;
-$sideAlliancesByPilots = ['side_a' => [], 'side_b' => []];
+$trackedPilotsBySide = ['side_a' => 0, 'side_b' => 0];
+$trackedAllianceCountsBySide = ['side_a' => 0, 'side_b' => 0];
 foreach ($allianceSummary as $a) {
     $side = (string) ($a['side'] ?? '');
     $aid = (int) ($a['alliance_id'] ?? 0);
     $pilots = (int) ($a['participant_count'] ?? 0);
-    if (isset($sideAlliancesByPilots[$side])) {
-        $sideAlliancesByPilots[$side][$aid] = $pilots;
-    }
-    if ($ourSide === null && in_array($aid, $trackedAllianceIds, true)) {
-        $ourSide = $side;
+    if (isset($trackedPilotsBySide[$side]) && in_array($aid, $trackedAllianceIds, true)) {
+        $trackedPilotsBySide[$side] += $pilots;
+        $trackedAllianceCountsBySide[$side]++;
     }
 }
+
+if ($trackedPilotsBySide['side_a'] > $trackedPilotsBySide['side_b']) {
+    $ourSide = 'side_a';
+} elseif ($trackedPilotsBySide['side_b'] > $trackedPilotsBySide['side_a']) {
+    $ourSide = 'side_b';
+} elseif ($trackedAllianceCountsBySide['side_a'] > $trackedAllianceCountsBySide['side_b']) {
+    $ourSide = 'side_a';
+} elseif ($trackedAllianceCountsBySide['side_b'] > $trackedAllianceCountsBySide['side_a']) {
+    $ourSide = 'side_b';
+}
+
 if ($ourSide === null) {
     $ourSide = 'side_a';
 }
 $enemySide = ($ourSide === 'side_a') ? 'side_b' : 'side_a';
 
+$displaySideForAlliance = static function (int $allianceId, string $fallbackSide) use ($trackedAllianceIds, $ourSide, $enemySide): string {
+    if ($allianceId > 0 && in_array($allianceId, $trackedAllianceIds, true)) {
+        return $ourSide;
+    }
+
+    return $fallbackSide === $ourSide ? $ourSide : $enemySide;
+};
+
+// Ensure tracked alliances always appear on the tracked/friendly side in UI panels.
+$displaySideAlliancesByPilots = ['side_a' => [], 'side_b' => []];
+foreach ($allianceSummary as $a) {
+    $sourceSide = (string) ($a['side'] ?? '');
+    $aid = (int) ($a['alliance_id'] ?? 0);
+    $pilots = (int) ($a['participant_count'] ?? 0);
+    $displaySide = $displaySideForAlliance($aid, $sourceSide);
+    if (isset($displaySideAlliancesByPilots[$displaySide])) {
+        $displaySideAlliancesByPilots[$displaySide][$aid] = ($displaySideAlliancesByPilots[$displaySide][$aid] ?? 0) + $pilots;
+    }
+}
+
 $sideLabels = [];
 foreach (['side_a', 'side_b'] as $side) {
-    $alliances = $sideAlliancesByPilots[$side];
+    $alliances = $displaySideAlliancesByPilots[$side];
     if ($alliances === []) {
         $sideLabels[$side] = $side === $ourSide ? 'Our Side' : 'Enemy';
         continue;
@@ -112,6 +143,25 @@ $sideBgClass = [
     $ourSide ?? 'side_a' => 'bg-blue-900/60',
     $enemySide => 'bg-red-900/60',
 ];
+
+if ($sideFilter !== null || $suspiciousOnly) {
+    $participants = array_values(array_filter(
+        $participantsAll,
+        static function (array $participant) use ($sideFilter, $suspiciousOnly, $displaySideForAlliance): bool {
+            $allianceId = (int) ($participant['alliance_id'] ?? 0);
+            $sourceSide = (string) ($participant['side'] ?? '');
+            $displaySide = $displaySideForAlliance($allianceId, $sourceSide);
+            if ($sideFilter !== null && $displaySide !== $sideFilter) {
+                return false;
+            }
+            if ($suspiciousOnly && (int) ($participant['is_suspicious'] ?? 0) !== 1) {
+                return false;
+            }
+
+            return true;
+        }
+    ));
+}
 
 $title = htmlspecialchars((string) ($theater['primary_system_name'] ?? 'Theater'), ENT_QUOTES) . ' Theater';
 $durationSec = max(1, (int) ($theater['duration_seconds'] ?? 0));
@@ -174,7 +224,7 @@ $sidePanels = [
     'side_b' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => []],
 ];
 foreach ($allianceSummary as $a) {
-    $side = (string) ($a['side'] ?? '');
+    $side = $displaySideForAlliance((int) ($a['alliance_id'] ?? 0), (string) ($a['side'] ?? ''));
     if (!isset($sidePanels[$side])) continue;
     $sidePanels[$side]['pilots'] += (int) ($a['participant_count'] ?? 0);
     $sidePanels[$side]['kills'] += (int) ($a['total_kills'] ?? 0);


### PR DESCRIPTION
### Motivation
- Tracked alliances were sometimes shown on the enemy side in theater/battle views because side selection used first-match logic, causing friendly/allies to appear under enemies in the UI.
- Participant placement and panel aggregates could disagree with tracked alliance settings, producing confusing left/right grouping in the theater view.
- The Theater Intelligence stat cards used a non-existent grid class and stacked vertically on larger screens, wasting space.

### Description
- Determine the friendly/tracked side by summing tracked pilots per side with a tracked-alliance-count tiebreaker and derive `ourSide`/`enemySide` from that logic in `public/theater-intelligence/view.php`.
- Add `displaySideForAlliance(...)` to override source side for tracked alliances so tracked alliances are always rendered on the friendly side, and use that mapping to build side labels and side panels in `public/theater-intelligence/view.php`.
- Use the unified display-side mapping for participant splitting and for filtered/single-list views so participants appear in the expected friendly/enemy columns in `public/theater-intelligence/partials/_participants.php`.
- Make the stat/cards header layout responsive by switching to compiled CSS grid classes (`sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-6`) and change the participants two-column layout to `md:grid-cols-2` to avoid stacking on desktop in `public/theater-intelligence/partials/_header.php` and `_participants.php`.
- Keep original data sources unchanged and only modify control-plane presentation and filtering logic; no schema or background job changes were made.

### Testing
- Ran syntax checks: `php -l public/theater-intelligence/view.php` and it succeeded.
- Ran syntax checks: `php -l public/theater-intelligence/partials/_participants.php` and it succeeded.
- Ran syntax checks: `php -l public/theater-intelligence/partials/_header.php` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f9636ddc832f86058b24244195b3)