### PR TITLE
Refine theater overview side labeling and alignment

### DIFF
--- a/public/theater-intelligence/partials/_alliance_summary.php
+++ b/public/theater-intelligence/partials/_alliance_summary.php
@@ -19,7 +19,7 @@
             <tbody>
                 <?php foreach ($allianceSummary as $a): ?>
                     <?php
-                        $aSide = (string) ($a['side'] ?? '');
+                        $aSide = $displaySideForAlliance((int) ($a['alliance_id'] ?? 0), (string) ($a['side'] ?? ''));
                         $eff = (float) ($a['efficiency'] ?? 0);
                         $effClass = $eff >= 0.6 ? 'text-green-400' : ($eff >= 0.4 ? 'text-yellow-400' : 'text-red-400');
                         $aSideColor = $sideColorClass[$aSide] ?? 'text-slate-300';

--- a/public/theater-intelligence/partials/_battle_report.php
+++ b/public/theater-intelligence/partials/_battle_report.php
@@ -35,6 +35,9 @@
                         <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Tracked</span>
                     <?php endif; ?>
                 </h3>
+                <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted">
+                    <?= $side === ($ourSide ?? 'side_a') ? 'Friendly coalition overview' : 'Opposition coalition overview' ?>
+                </p>
 
                 <div class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
                     <div>

--- a/public/theater-intelligence/partials/_header.php
+++ b/public/theater-intelligence/partials/_header.php
@@ -18,6 +18,9 @@
                 <span class="text-slate-500 mx-2">vs</span>
                 <span class="<?= $sideColorClass[$enemySide] ?? 'text-red-300' ?> font-semibold"><?= htmlspecialchars($sideLabels[$enemySide] ?? 'Side B', ENT_QUOTES) ?></span>
             </p>
+            <p class="mt-1 text-xs text-muted">
+                Tracked coalition on this theater: <?= number_format((int) ($trackedAllianceCountsBySide[$ourSide ?? 'side_a'] ?? 0)) ?> alliance<?= ((int) ($trackedAllianceCountsBySide[$ourSide ?? 'side_a'] ?? 0) === 1) ? '' : 's' ?>.
+            </p>
             <p class="mt-1 text-sm text-slate-300">
                 <?= htmlspecialchars((string) ($theater['region_name'] ?? ''), ENT_QUOTES) ?>
                 &middot; <?= htmlspecialchars($theaterStartActual, ENT_QUOTES) ?>

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -125,14 +125,29 @@ $sideLabels = [];
 foreach (['side_a', 'side_b'] as $side) {
     $alliances = $displaySideAlliancesByPilots[$side];
     if ($alliances === []) {
-        $sideLabels[$side] = $side === $ourSide ? 'Our Side' : 'Enemy';
+        $sideLabels[$side] = $side === $ourSide ? 'Tracked Coalition' : 'Opposition';
         continue;
     }
     arsort($alliances);
-    $topAllianceId = array_key_first($alliances);
-    $topName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $topAllianceId, '', 'Alliance');
+    $preferredAllianceId = 0;
+    if ($side === $ourSide) {
+        foreach ($alliances as $allianceId => $_pilotCount) {
+            if (in_array((int) $allianceId, $trackedAllianceIds, true)) {
+                $preferredAllianceId = (int) $allianceId;
+                break;
+            }
+        }
+    }
+    if ($preferredAllianceId <= 0) {
+        $preferredAllianceId = (int) array_key_first($alliances);
+    }
+    $preferredName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $preferredAllianceId, '', 'Alliance');
     $otherCount = count($alliances) - 1;
-    $sideLabels[$side] = $topName . ($otherCount > 0 ? " +{$otherCount}" : '');
+    if ($side === $ourSide) {
+        $sideLabels[$side] = $preferredName . ($otherCount > 0 ? " +{$otherCount}" : '');
+    } else {
+        $sideLabels[$side] = $preferredName . ($otherCount > 0 ? " +{$otherCount}" : '');
+    }
 }
 
 $sideColorClass = [
@@ -197,7 +212,7 @@ $participantKillTotal = 0;
 $participantKillTotalsBySide = ['side_a' => 0, 'side_b' => 0];
 foreach ($participantsAll as $row) {
     $kills = (int) ($row['kills'] ?? 0);
-    $side = (string) ($row['side'] ?? 'side_b');
+    $side = $displaySideForAlliance((int) ($row['alliance_id'] ?? 0), (string) ($row['side'] ?? 'side_b'));
     $participantKillTotal += $kills;
     if (isset($participantKillTotalsBySide[$side])) {
         $participantKillTotalsBySide[$side] += $kills;


### PR DESCRIPTION
### Motivation
- The theater overview presented inconsistent side labels and totals when tracked alliances were remapped to the friendly side, making the UI confusing.
- Alliance rows in the summary table used raw source-side values rather than the same tracked-aware display mapping used across the view.
- The header lacked immediate context about how many tracked alliances are represented on the detected friendly side, which reduced quick readability.

### Description
- Update side-label resolution in `public/theater-intelligence/view.php` to prefer tracked alliances when choosing a representative name and to fallback to `Tracked Coalition` / `Opposition` when appropriate, using the existing `displaySideForAlliance` mapping.
- Align participant kill-involvement rollups to the display-side mapping by using `displaySideForAlliance` when aggregating `participantKillTotalsBySide` in `public/theater-intelligence/view.php`.
- Show an explicit tracked-coalition count in the theater header by adding a small info line in `public/theater-intelligence/partials/_header.php`.
- Add a short descriptive label (`Friendly coalition overview` / `Opposition coalition overview`) to the side comparison cards in `public/theater-intelligence/partials/_battle_report.php` to clarify panel context.
- Normalize alliance table side badges to use the tracked-aware mapped sides by switching to `displaySideForAlliance` in `public/theater-intelligence/partials/_alliance_summary.php` so table badges and overview panels match.

### Testing
- Ran `php -l public/theater-intelligence/view.php` and it returned no syntax errors.
- Ran `php -l public/theater-intelligence/partials/_header.php` and it returned no syntax errors.
- Ran `php -l public/theater-intelligence/partials/_battle_report.php` and it returned no syntax errors.
- Ran `php -l public/theater-intelligence/partials/_alliance_summary.php` and it returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8017a95a4832f9081ebd158879f17)