### PR TITLE
Refactor alliance classification to settings-based friendly/opponent/third_party

### DIFF
--- a/public/theater-intelligence/partials/_alliance_summary.php
+++ b/public/theater-intelligence/partials/_alliance_summary.php
@@ -19,18 +19,21 @@
             <tbody>
                 <?php foreach ($allianceSummary as $a): ?>
                     <?php
-                        $aSide = $displaySideForAlliance((int) ($a['alliance_id'] ?? 0), (string) ($a['side'] ?? ''));
+                        $aSide = $classifyAlliance((int) ($a['alliance_id'] ?? 0));
                         $eff = (float) ($a['efficiency'] ?? 0);
                         $effClass = $eff >= 0.6 ? 'text-green-400' : ($eff >= 0.4 ? 'text-yellow-400' : 'text-red-400');
                         $aSideColor = $sideColorClass[$aSide] ?? 'text-slate-300';
                         $aSideBg = $sideBgClass[$aSide] ?? 'bg-slate-700';
-                        $isTracked = in_array((int) ($a['alliance_id'] ?? 0), $trackedAllianceIds, true);
+                        $isTracked = $aSide === 'friendly';
+                        $isOpponent = $aSide === 'opponent';
                     ?>
                     <tr class="border-b border-border/50">
                         <td class="px-3 py-2 text-slate-100">
                             <?= htmlspecialchars(killmail_entity_preferred_name($resolvedEntities, 'alliance', (int) ($a['alliance_id'] ?? 0), (string) ($a['alliance_name'] ?? ''), 'Alliance'), ENT_QUOTES) ?>
                             <?php if ($isTracked): ?>
-                                <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Tracked</span>
+                                <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Friendly</span>
+                            <?php elseif ($isOpponent): ?>
+                                <span class="text-[10px] uppercase tracking-wider bg-red-900/60 text-red-300 rounded-full px-1.5 py-0.5 ml-1">Opponent</span>
                             <?php endif; ?>
                         </td>
                         <td class="px-3 py-2 <?= $aSideColor ?>">

--- a/public/theater-intelligence/partials/_battle_report.php
+++ b/public/theater-intelligence/partials/_battle_report.php
@@ -1,105 +1,185 @@
 <?php if ($allianceSummary !== []): ?>
 <?php
-    $ourPanel = $sidePanels[$ourSide ?? 'side_a'] ?? $sidePanels['side_a'];
-    $enemyPanel = $sidePanels[$enemySide] ?? $sidePanels['side_b'];
-    $totalIskBothSides = $ourPanel['isk_lost'] + $enemyPanel['isk_lost'];
-    $ourBarPct = $totalIskBothSides > 0 ? ($enemyPanel['isk_lost'] / $totalIskBothSides) * 100 : 50;
+    $ourPanel = $sidePanels['friendly'] ?? [];
+    $enemyPanel = $sidePanels['opponent'] ?? [];
+    $thirdPartyPanel = $sidePanels['third_party'] ?? [];
+
+    // Merge third party into enemy side for the overview
+    $enemyCombinedIskLost = ($enemyPanel['isk_lost'] ?? 0) + ($thirdPartyPanel['isk_lost'] ?? 0);
+    $enemyCombinedIskKilled = ($enemyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_killed'] ?? 0);
+    $enemyCombinedPilots = ($enemyPanel['pilots'] ?? 0) + ($thirdPartyPanel['pilots'] ?? 0);
+    $enemyCombinedLosses = ($enemyPanel['losses'] ?? 0) + ($thirdPartyPanel['losses'] ?? 0);
+    $enemyCombinedTotalIsk = $enemyCombinedIskKilled + $enemyCombinedIskLost;
+    $enemyCombinedEfficiency = $enemyCombinedTotalIsk > 0 ? $enemyCombinedIskKilled / $enemyCombinedTotalIsk : 0.0;
+
+    $totalIskBothSides = ($ourPanel['isk_lost'] ?? 0) + $enemyCombinedIskLost;
+    $ourBarPct = $totalIskBothSides > 0 ? ($enemyCombinedIskLost / $totalIskBothSides) * 100 : 50;
     $enemyBarPct = 100 - $ourBarPct;
 ?>
 <section class="surface-primary mt-4">
     <!-- Efficiency Bar -->
     <div class="flex items-center gap-3 mb-3">
-        <span class="text-xs font-semibold <?= $sideColorClass[$ourSide ?? 'side_a'] ?? 'text-blue-300' ?>"><?= number_format(($ourPanel['efficiency'] ?? 0) * 100, 1) ?>%</span>
+        <span class="text-xs font-semibold text-blue-300"><?= number_format(($ourPanel['efficiency'] ?? 0) * 100, 1) ?>%</span>
         <div class="flex-1 h-2.5 rounded-full overflow-hidden bg-slate-800 flex">
             <div class="bg-blue-500 h-full transition-all" style="width: <?= number_format($ourBarPct, 1) ?>%"></div>
             <div class="bg-red-500 h-full transition-all" style="width: <?= number_format($enemyBarPct, 1) ?>%"></div>
         </div>
-        <span class="text-xs font-semibold <?= $sideColorClass[$enemySide] ?? 'text-red-300' ?>"><?= number_format(($enemyPanel['efficiency'] ?? 0) * 100, 1) ?>%</span>
+        <span class="text-xs font-semibold text-red-300"><?= number_format($enemyCombinedEfficiency * 100, 1) ?>%</span>
     </div>
 
     <!-- Two-column side comparison -->
     <div class="grid gap-4 md:grid-cols-2">
-        <?php foreach ([$ourSide ?? 'side_a', $enemySide] as $side): ?>
-            <?php
-                $panel = $sidePanels[$side] ?? [];
-                $colorClass = $sideColorClass[$side] ?? 'text-slate-300';
-                $bgClass = $sideBgClass[$side] ?? 'bg-slate-700';
-                $panelFinalBlows = (int) ($panel['final_blows'] ?? 0);
-                $panelLosses = (int) ($panel['losses'] ?? 0);
-                $panelInvolvements = (int) ($panel['kill_involvements'] ?? 0);
-            ?>
-            <div class="<?= $bgClass ?> rounded-lg p-4">
-                <h3 class="text-sm font-semibold <?= $colorClass ?> mb-3">
-                    <?= htmlspecialchars($sideLabels[$side] ?? $side, ENT_QUOTES) ?>
-                    <?php if ($side === ($ourSide ?? 'side_a')): ?>
-                        <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Tracked</span>
-                    <?php endif; ?>
-                </h3>
-                <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted">
-                    <?= $side === ($ourSide ?? 'side_a') ? 'Friendly coalition overview' : 'Opposition coalition overview' ?>
-                </p>
+        <!-- Friendly panel -->
+        <div class="bg-blue-900/60 rounded-lg p-4">
+            <h3 class="text-sm font-semibold text-blue-300 mb-3">
+                <?= htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES) ?>
+                <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Friendly</span>
+            </h3>
+            <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted">Friendly coalition overview</p>
 
-                <div class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-                    <div>
-                        <p class="text-xs text-muted">Unique Pilots</p>
-                        <p class="text-slate-100 font-semibold"><?= number_format((int) ($panel['pilots'] ?? 0)) ?></p>
-                    </div>
-                    <div>
-                        <p class="text-xs text-muted">ISK Efficiency</p>
-                        <p class="text-slate-100 font-semibold"><?= number_format(($panel['efficiency'] ?? 0) * 100, 1) ?>%</p>
-                    </div>
-                    <div>
-                        <p class="text-xs text-muted">Final Blows / Losses</p>
-                        <p class="text-slate-100 font-semibold"><?= number_format($panelFinalBlows) ?> / <?= number_format($panelLosses) ?></p>
-                        <p class="text-[10px] text-muted">Kill involvements: <?= number_format($panelInvolvements) ?></p>
-                    </div>
-                    <div>
-                        <p class="text-xs text-muted">ISK Killed / Lost</p>
-                        <p class="text-slate-100 font-semibold"><?= supplycore_format_isk((float) ($panel['isk_killed'] ?? 0)) ?> / <?= supplycore_format_isk((float) ($panel['isk_lost'] ?? 0)) ?></p>
+            <div class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                <div>
+                    <p class="text-xs text-muted">Unique Pilots</p>
+                    <p class="text-slate-100 font-semibold"><?= number_format((int) ($ourPanel['pilots'] ?? 0)) ?></p>
+                </div>
+                <div>
+                    <p class="text-xs text-muted">ISK Efficiency</p>
+                    <p class="text-slate-100 font-semibold"><?= number_format(($ourPanel['efficiency'] ?? 0) * 100, 1) ?>%</p>
+                </div>
+                <div>
+                    <p class="text-xs text-muted">Final Blows / Losses</p>
+                    <p class="text-slate-100 font-semibold"><?= number_format((int) ($ourPanel['final_blows'] ?? 0)) ?> / <?= number_format((int) ($ourPanel['losses'] ?? 0)) ?></p>
+                    <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($ourPanel['kill_involvements'] ?? 0)) ?></p>
+                </div>
+                <div>
+                    <p class="text-xs text-muted">ISK Killed / Lost</p>
+                    <p class="text-slate-100 font-semibold"><?= supplycore_format_isk((float) ($ourPanel['isk_killed'] ?? 0)) ?> / <?= supplycore_format_isk((float) ($ourPanel['isk_lost'] ?? 0)) ?></p>
+                </div>
+            </div>
+
+            <?php $panelAlliances = $ourPanel['alliances'] ?? []; ?>
+            <?php if ($panelAlliances): ?>
+                <div class="mt-3 border-t border-slate-700/50 pt-2">
+                    <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Alliances</p>
+                    <?php foreach ($panelAlliances as $allianceRow): ?>
+                        <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                        <div class="flex items-center gap-2 py-0.5">
+                            <?php if ($allianceId > 0): ?>
+                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=32" alt="" class="w-4 h-4 rounded-sm" loading="lazy">
+                            <?php endif; ?>
+                            <span class="text-xs text-slate-200 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
+                            <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+
+            <?php $panelShips = $ourPanel['ships'] ?? []; ?>
+            <?php if ($panelShips): ?>
+                <div class="mt-3 border-t border-slate-700/50 pt-2">
+                    <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
+                    <div class="flex flex-wrap gap-1.5">
+                        <?php foreach (array_slice($panelShips, 0, 12) as $ship): ?>
+                            <div class="flex items-center gap-1 bg-slate-800/60 rounded px-1.5 py-0.5">
+                                <?php if (($ship['type_id'] ?? 0) > 0): ?>
+                                    <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/icon?size=32" alt="" class="w-4 h-4" loading="lazy">
+                                <?php endif; ?>
+                                <span class="text-[11px] text-slate-300"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
+                                <span class="text-[10px] text-muted">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
+                            </div>
+                        <?php endforeach; ?>
+                        <?php if (count($panelShips) > 12): ?>
+                            <span class="text-[10px] text-muted self-center">+<?= count($panelShips) - 12 ?> more</span>
+                        <?php endif; ?>
                     </div>
                 </div>
+            <?php endif; ?>
+        </div>
 
-                <!-- Alliance breakdown -->
-                <?php $panelAlliances = $panel['alliances'] ?? []; ?>
-                <?php if ($panelAlliances): ?>
-                    <div class="mt-3 border-t border-slate-700/50 pt-2">
-                        <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Alliances</p>
-                        <?php foreach ($panelAlliances as $allianceRow): ?>
-                            <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
-                            <div class="flex items-center gap-2 py-0.5">
-                                <?php if ($allianceId > 0): ?>
-                                    <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=32" alt="" class="w-4 h-4 rounded-sm" loading="lazy">
+        <!-- Opposition + Third Party panel -->
+        <div class="bg-red-900/60 rounded-lg p-4">
+            <h3 class="text-sm font-semibold text-red-300 mb-3">
+                <?= htmlspecialchars($sideLabels['opponent'] ?? 'Opposition', ENT_QUOTES) ?>
+                <?php if (($thirdPartyPanel['pilots'] ?? 0) > 0): ?>
+                    <span class="text-slate-400 text-xs font-normal ml-1">+ Third Party</span>
+                <?php endif; ?>
+            </h3>
+            <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted">Opposition coalition overview</p>
+
+            <div class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                <div>
+                    <p class="text-xs text-muted">Unique Pilots</p>
+                    <p class="text-slate-100 font-semibold"><?= number_format($enemyCombinedPilots) ?></p>
+                </div>
+                <div>
+                    <p class="text-xs text-muted">ISK Efficiency</p>
+                    <p class="text-slate-100 font-semibold"><?= number_format($enemyCombinedEfficiency * 100, 1) ?>%</p>
+                </div>
+                <div>
+                    <p class="text-xs text-muted">Final Blows / Losses</p>
+                    <p class="text-slate-100 font-semibold"><?= number_format((int) ($enemyPanel['final_blows'] ?? 0) + (int) ($thirdPartyPanel['final_blows'] ?? 0)) ?> / <?= number_format($enemyCombinedLosses) ?></p>
+                    <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($enemyPanel['kill_involvements'] ?? 0) + (int) ($thirdPartyPanel['kill_involvements'] ?? 0)) ?></p>
+                </div>
+                <div>
+                    <p class="text-xs text-muted">ISK Killed / Lost</p>
+                    <p class="text-slate-100 font-semibold"><?= supplycore_format_isk($enemyCombinedIskKilled) ?> / <?= supplycore_format_isk($enemyCombinedIskLost) ?></p>
+                </div>
+            </div>
+
+            <?php $opponentAlliances = $enemyPanel['alliances'] ?? []; ?>
+            <?php if ($opponentAlliances): ?>
+                <div class="mt-3 border-t border-slate-700/50 pt-2">
+                    <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Opponent Alliances</p>
+                    <?php foreach ($opponentAlliances as $allianceRow): ?>
+                        <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                        <div class="flex items-center gap-2 py-0.5">
+                            <?php if ($allianceId > 0): ?>
+                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=32" alt="" class="w-4 h-4 rounded-sm" loading="lazy">
+                            <?php endif; ?>
+                            <span class="text-xs text-slate-200 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
+                            <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+
+            <?php $tpAlliances = $thirdPartyPanel['alliances'] ?? []; ?>
+            <?php if ($tpAlliances): ?>
+                <div class="mt-3 border-t border-slate-700/50 pt-2">
+                    <p class="text-[10px] uppercase tracking-wider text-slate-400 mb-1">Third Party</p>
+                    <?php foreach ($tpAlliances as $allianceRow): ?>
+                        <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                        <div class="flex items-center gap-2 py-0.5">
+                            <?php if ($allianceId > 0): ?>
+                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=32" alt="" class="w-4 h-4 rounded-sm" loading="lazy">
+                            <?php endif; ?>
+                            <span class="text-xs text-slate-400 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
+                            <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+
+            <?php $panelShips = array_merge($enemyPanel['ships'] ?? [], $thirdPartyPanel['ships'] ?? []); ?>
+            <?php usort($panelShips, static fn(array $l, array $r): int => ($r['pilots'] ?? 0) <=> ($l['pilots'] ?? 0)); ?>
+            <?php $panelShips = array_slice($panelShips, 0, 12); ?>
+            <?php if ($panelShips): ?>
+                <div class="mt-3 border-t border-slate-700/50 pt-2">
+                    <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
+                    <div class="flex flex-wrap gap-1.5">
+                        <?php foreach ($panelShips as $ship): ?>
+                            <div class="flex items-center gap-1 bg-slate-800/60 rounded px-1.5 py-0.5">
+                                <?php if (($ship['type_id'] ?? 0) > 0): ?>
+                                    <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/icon?size=32" alt="" class="w-4 h-4" loading="lazy">
                                 <?php endif; ?>
-                                <span class="text-xs text-slate-200 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
-                                <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
+                                <span class="text-[11px] text-slate-300"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
+                                <span class="text-[10px] text-muted">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
                             </div>
                         <?php endforeach; ?>
                     </div>
-                <?php endif; ?>
-
-                <!-- Ship composition (from fleet composition query, grouped by ship_type_id) -->
-                <?php $panelShips = $panel['ships'] ?? []; ?>
-                <?php if ($panelShips): ?>
-                    <div class="mt-3 border-t border-slate-700/50 pt-2">
-                        <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
-                        <div class="flex flex-wrap gap-1.5">
-                            <?php foreach (array_slice($panelShips, 0, 12) as $ship): ?>
-                                <div class="flex items-center gap-1 bg-slate-800/60 rounded px-1.5 py-0.5">
-                                    <?php if (($ship['type_id'] ?? 0) > 0): ?>
-                                        <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/icon?size=32" alt="" class="w-4 h-4" loading="lazy">
-                                    <?php endif; ?>
-                                    <span class="text-[11px] text-slate-300"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
-                                    <span class="text-[10px] text-muted">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
-                                </div>
-                            <?php endforeach; ?>
-                            <?php if (count($panelShips) > 12): ?>
-                                <span class="text-[10px] text-muted self-center">+<?= count($panelShips) - 12 ?> more</span>
-                            <?php endif; ?>
-                        </div>
-                    </div>
-                <?php endif; ?>
-            </div>
-        <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        </div>
     </div>
 </section>
 <?php endif; ?>

--- a/public/theater-intelligence/partials/_header.php
+++ b/public/theater-intelligence/partials/_header.php
@@ -11,15 +11,18 @@
                 <?php endif; ?>
             </h1>
             <p class="mt-1 text-base text-slate-200">
-                <span class="<?= $sideColorClass[$ourSide ?? 'side_a'] ?? 'text-blue-300' ?> font-semibold"><?= htmlspecialchars($sideLabels[$ourSide ?? 'side_a'] ?? 'Side A', ENT_QUOTES) ?></span>
-                <?php if ($ourSide !== null): ?>
-                    <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Tracked</span>
-                <?php endif; ?>
+                <span class="text-blue-300 font-semibold"><?= htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES) ?></span>
+                <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Friendly</span>
                 <span class="text-slate-500 mx-2">vs</span>
-                <span class="<?= $sideColorClass[$enemySide] ?? 'text-red-300' ?> font-semibold"><?= htmlspecialchars($sideLabels[$enemySide] ?? 'Side B', ENT_QUOTES) ?></span>
+                <span class="text-red-300 font-semibold"><?= htmlspecialchars($sideLabels['opponent'] ?? 'Opposition', ENT_QUOTES) ?></span>
+                <?php $thirdPartyCount = count($sideAlliancesByPilots['third_party'] ?? []); ?>
+                <?php if ($thirdPartyCount > 0): ?>
+                    <span class="text-slate-400 ml-2 text-sm">(+<?= $thirdPartyCount ?> third party)</span>
+                <?php endif; ?>
             </p>
             <p class="mt-1 text-xs text-muted">
-                Tracked coalition on this theater: <?= number_format((int) ($trackedAllianceCountsBySide[$ourSide ?? 'side_a'] ?? 0)) ?> alliance<?= ((int) ($trackedAllianceCountsBySide[$ourSide ?? 'side_a'] ?? 0) === 1) ? '' : 's' ?>.
+                Friendly alliances: <?= number_format(count($sideAlliancesByPilots['friendly'] ?? [])) ?> &middot;
+                Opponent alliances: <?= number_format(count($sideAlliancesByPilots['opponent'] ?? [])) ?>
             </p>
             <p class="mt-1 text-sm text-slate-300">
                 <?= htmlspecialchars((string) ($theater['region_name'] ?? ''), ENT_QUOTES) ?>

--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -5,15 +5,18 @@
  * Falls back to single-column when a specific side/suspicious filter is active.
  */
 
-// Split participants by side for the two-column layout
+// Split participants by classification for the multi-column layout
 $friendlyParticipants = [];
 $enemyParticipants = [];
+$thirdPartyParticipants = [];
 foreach ($participantsAll as $p) {
-    $pSide = $displaySideForAlliance((int) ($p['alliance_id'] ?? 0), (string) ($p['side'] ?? ''));
-    if ($pSide === ($ourSide ?? 'side_a')) {
+    $pSide = $classifyAlliance((int) ($p['alliance_id'] ?? 0));
+    if ($pSide === 'friendly') {
         $friendlyParticipants[] = $p;
-    } else {
+    } elseif ($pSide === 'opponent') {
         $enemyParticipants[] = $p;
+    } else {
+        $thirdPartyParticipants[] = $p;
     }
 }
 
@@ -34,8 +37,9 @@ foreach ($allForMax as $p) {
         <h2 class="text-lg font-semibold text-slate-50">Participants</h2>
         <div class="flex gap-2 text-sm">
             <a href="?theater_id=<?= urlencode($theaterId) ?>" class="<?= $sideFilter === null && !$suspiciousOnly ? 'text-slate-50 font-semibold' : 'text-accent' ?>">All</a>
-            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=<?= urlencode($ourSide ?? 'side_a') ?>" class="<?= $sideFilter === ($ourSide ?? 'side_a') ? ($sideColorClass[$ourSide ?? 'side_a'] ?? 'text-blue-300') . ' font-semibold' : 'text-accent' ?>"><?= htmlspecialchars($sideLabels[$ourSide ?? 'side_a'] ?? 'Side A', ENT_QUOTES) ?></a>
-            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=<?= urlencode($enemySide) ?>" class="<?= $sideFilter === $enemySide ? ($sideColorClass[$enemySide] ?? 'text-red-300') . ' font-semibold' : 'text-accent' ?>"><?= htmlspecialchars($sideLabels[$enemySide] ?? 'Side B', ENT_QUOTES) ?></a>
+            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=friendly" class="<?= $sideFilter === 'friendly' ? 'text-blue-300 font-semibold' : 'text-accent' ?>"><?= htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES) ?></a>
+            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=opponent" class="<?= $sideFilter === 'opponent' ? 'text-red-300 font-semibold' : 'text-accent' ?>"><?= htmlspecialchars($sideLabels['opponent'] ?? 'Opposition', ENT_QUOTES) ?></a>
+            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=third_party" class="<?= $sideFilter === 'third_party' ? 'text-slate-400 font-semibold' : 'text-accent' ?>">Third Party</a>
             <a href="?theater_id=<?= urlencode($theaterId) ?>&suspicious=1" class="<?= $suspiciousOnly ? 'text-yellow-300 font-semibold' : 'text-accent' ?>">Suspicious</a>
         </div>
     </div>
@@ -44,9 +48,15 @@ foreach ($allForMax as $p) {
 <?php if ($showSideBySide): ?>
     <div class="mt-3 grid gap-4 md:grid-cols-2">
         <?php
+        // Merge third party into enemy column for side-by-side display
+        $enemyCombinedParticipants = array_merge($enemyParticipants, $thirdPartyParticipants);
+        $enemyLabel = ($sideLabels['opponent'] ?? 'Opposition');
+        if ($thirdPartyParticipants !== []) {
+            $enemyLabel .= ' + Third Party';
+        }
         $panelSets = [
-            ['label' => $sideLabels[$ourSide ?? 'side_a'] ?? 'Friendlies', 'side' => $ourSide ?? 'side_a', 'rows' => $friendlyParticipants, 'colorClass' => 'text-blue-300', 'borderClass' => 'border-blue-500/30'],
-            ['label' => $sideLabels[$enemySide] ?? 'Enemies', 'side' => $enemySide, 'rows' => $enemyParticipants, 'colorClass' => 'text-red-300', 'borderClass' => 'border-red-500/30'],
+            ['label' => $sideLabels['friendly'] ?? 'Friendlies', 'side' => 'friendly', 'rows' => $friendlyParticipants, 'colorClass' => 'text-blue-300', 'borderClass' => 'border-blue-500/30'],
+            ['label' => $enemyLabel, 'side' => 'opponent', 'rows' => $enemyCombinedParticipants, 'colorClass' => 'text-red-300', 'borderClass' => 'border-red-500/30'],
         ];
         foreach ($panelSets as $panel):
         ?>
@@ -164,7 +174,7 @@ foreach ($allForMax as $p) {
                 <?php else: ?>
                     <?php foreach ($filteredList as $p): ?>
                         <?php
-                            $pSide = $displaySideForAlliance((int) ($p['alliance_id'] ?? 0), (string) ($p['side'] ?? ''));
+                            $pSide = $classifyAlliance((int) ($p['alliance_id'] ?? 0));
                             $pSideClass = $sideColorClass[$pSide] ?? 'text-slate-300';
                             $pSusp = (float) ($p['suspicion_score'] ?? 0);
                             $isSusp = (int) ($p['is_suspicious'] ?? 0);

--- a/public/theater-intelligence/partials/_timeline.php
+++ b/public/theater-intelligence/partials/_timeline.php
@@ -1,7 +1,7 @@
 <?php if ($timeline !== []): ?>
 <section class="surface-primary mt-4">
     <h2 class="text-lg font-semibold text-slate-50">Timeline</h2>
-    <p class="text-xs text-muted mt-1"><?= count($timeline) ?> buckets (1-minute intervals). Momentum: positive = <span class="<?= $sideColorClass[$ourSide ?? 'side_a'] ?? '' ?>"><?= htmlspecialchars($sideLabels[$ourSide ?? 'side_a'] ?? 'Side A', ENT_QUOTES) ?></span> winning, negative = <span class="<?= $sideColorClass[$enemySide] ?? '' ?>"><?= htmlspecialchars($sideLabels[$enemySide] ?? 'Side B', ENT_QUOTES) ?></span> winning.</p>
+    <p class="text-xs text-muted mt-1"><?= count($timeline) ?> buckets (1-minute intervals). Momentum: positive = <span class="text-blue-300"><?= htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES) ?></span> winning, negative = <span class="text-red-300"><?= htmlspecialchars($sideLabels['opponent'] ?? 'Opposition', ENT_QUOTES) ?></span> winning.</p>
 
     <?php if ($turningPoints !== []): ?>
         <div class="mt-2">
@@ -9,7 +9,7 @@
             <?php foreach ($turningPoints as $tp): ?>
                 <?php
                     $tpDir = (string) ($tp['direction'] ?? '');
-                    $tpSide = str_contains($tpDir, 'side_a') ? 'side_a' : 'side_b';
+                    $tpSide = str_contains($tpDir, 'friendly') ? 'friendly' : 'opponent';
                     $tpColor = $sideColorClass[$tpSide] ?? 'text-slate-300';
                     $tpSideLabel = $sideLabels[$tpSide] ?? $tpSide;
                 ?>
@@ -31,8 +31,8 @@
                         <th class="px-3 py-2 text-left">Time</th>
                         <th class="px-3 py-2 text-right">Killmails</th>
                         <th class="px-3 py-2 text-right">ISK</th>
-                        <th class="px-3 py-2 text-right <?= $sideColorClass[$ourSide ?? 'side_a'] ?? '' ?>"><?= htmlspecialchars($sideLabels[$ourSide ?? 'side_a'] ?? 'Side A', ENT_QUOTES) ?></th>
-                        <th class="px-3 py-2 text-right <?= $sideColorClass[$enemySide] ?? '' ?>"><?= htmlspecialchars($sideLabels[$enemySide] ?? 'Side B', ENT_QUOTES) ?></th>
+                        <th class="px-3 py-2 text-right text-blue-300"><?= htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES) ?></th>
+                        <th class="px-3 py-2 text-right text-red-300"><?= htmlspecialchars($sideLabels['opponent'] ?? 'Opposition', ENT_QUOTES) ?></th>
                         <th class="px-3 py-2 text-right">Momentum</th>
                     </tr>
                 </thead>
@@ -43,8 +43,8 @@
                             <td class="px-3 py-2 text-xs text-slate-300"><?= htmlspecialchars((string) ($t['bucket_time'] ?? ''), ENT_QUOTES) ?></td>
                             <td class="px-3 py-2 text-right"><?= (int) ($t['kills'] ?? 0) ?></td>
                             <td class="px-3 py-2 text-right"><?= supplycore_format_isk((float) ($t['isk_destroyed'] ?? 0)) ?></td>
-                            <td class="px-3 py-2 text-right <?= $sideColorClass[$ourSide ?? 'side_a'] ?? 'text-blue-300' ?>"><?= (int) ($t['side_a_kills'] ?? 0) ?></td>
-                            <td class="px-3 py-2 text-right <?= $sideColorClass[$enemySide] ?? 'text-red-300' ?>"><?= (int) ($t['side_b_kills'] ?? 0) ?></td>
+                            <td class="px-3 py-2 text-right text-blue-300"><?= (int) ($t['side_a_kills'] ?? 0) ?></td>
+                            <td class="px-3 py-2 text-right text-red-300"><?= (int) ($t['side_b_kills'] ?? 0) ?></td>
                             <td class="px-3 py-2 text-right <?= $mom > 0 ? 'text-blue-400' : ($mom < 0 ? 'text-red-400' : 'text-slate-300') ?>">
                                 <?= number_format($mom, 3) ?>
                             </td>

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -67,105 +67,72 @@ foreach ($entityRequests as $type => $ids) {
 }
 $resolvedEntities = killmail_entity_resolve_batch($entityRequests, true);
 
-// ── Determine meaningful side labels from tracked alliances ──────────
+// ── Classify alliances from user settings (friendly/opponent/third_party) ──
 $trackedAlliances = db_killmail_tracked_alliances_active();
-$trackedAllianceIds = array_column($trackedAlliances, 'alliance_id');
-$trackedAllianceIds = array_map('intval', $trackedAllianceIds);
+$trackedAllianceIds = array_map('intval', array_column($trackedAlliances, 'alliance_id'));
 $trackedAllianceIds = array_values(array_unique($trackedAllianceIds));
 
-$ourSide = null;
-$trackedPilotsBySide = ['side_a' => 0, 'side_b' => 0];
-$trackedAllianceCountsBySide = ['side_a' => 0, 'side_b' => 0];
-foreach ($allianceSummary as $a) {
-    $side = (string) ($a['side'] ?? '');
-    $aid = (int) ($a['alliance_id'] ?? 0);
-    $pilots = (int) ($a['participant_count'] ?? 0);
-    if (isset($trackedPilotsBySide[$side]) && in_array($aid, $trackedAllianceIds, true)) {
-        $trackedPilotsBySide[$side] += $pilots;
-        $trackedAllianceCountsBySide[$side]++;
-    }
-}
+$opponentAlliances = db_killmail_opponent_alliances_active();
+$opponentAllianceIds = array_map('intval', array_column($opponentAlliances, 'alliance_id'));
+$opponentAllianceIds = array_values(array_unique($opponentAllianceIds));
 
-if ($trackedPilotsBySide['side_a'] > $trackedPilotsBySide['side_b']) {
-    $ourSide = 'side_a';
-} elseif ($trackedPilotsBySide['side_b'] > $trackedPilotsBySide['side_a']) {
-    $ourSide = 'side_b';
-} elseif ($trackedAllianceCountsBySide['side_a'] > $trackedAllianceCountsBySide['side_b']) {
-    $ourSide = 'side_a';
-} elseif ($trackedAllianceCountsBySide['side_b'] > $trackedAllianceCountsBySide['side_a']) {
-    $ourSide = 'side_b';
-}
-
-if ($ourSide === null) {
-    $ourSide = 'side_a';
-}
-$enemySide = ($ourSide === 'side_a') ? 'side_b' : 'side_a';
-
-$displaySideForAlliance = static function (int $allianceId, string $fallbackSide) use ($trackedAllianceIds, $ourSide, $enemySide): string {
+$classifyAlliance = static function (int $allianceId) use ($trackedAllianceIds, $opponentAllianceIds): string {
     if ($allianceId > 0 && in_array($allianceId, $trackedAllianceIds, true)) {
-        return $ourSide;
+        return 'friendly';
     }
-
-    return $fallbackSide === $ourSide ? $ourSide : $enemySide;
+    if ($allianceId > 0 && in_array($allianceId, $opponentAllianceIds, true)) {
+        return 'opponent';
+    }
+    return 'third_party';
 };
 
-// Ensure tracked alliances always appear on the tracked/friendly side in UI panels.
-$displaySideAlliancesByPilots = ['side_a' => [], 'side_b' => []];
+$ourSide = 'friendly';
+$enemySide = 'opponent';
+
+$sideLabels = [
+    'friendly' => 'Friendlies',
+    'opponent' => 'Opposition',
+    'third_party' => 'Third Party',
+];
+
+// Build friendly/opponent labels from actual alliance names
+$sideAlliancesByPilots = ['friendly' => [], 'opponent' => [], 'third_party' => []];
 foreach ($allianceSummary as $a) {
-    $sourceSide = (string) ($a['side'] ?? '');
     $aid = (int) ($a['alliance_id'] ?? 0);
     $pilots = (int) ($a['participant_count'] ?? 0);
-    $displaySide = $displaySideForAlliance($aid, $sourceSide);
-    if (isset($displaySideAlliancesByPilots[$displaySide])) {
-        $displaySideAlliancesByPilots[$displaySide][$aid] = ($displaySideAlliancesByPilots[$displaySide][$aid] ?? 0) + $pilots;
-    }
+    $classification = $classifyAlliance($aid);
+    $sideAlliancesByPilots[$classification][$aid] = ($sideAlliancesByPilots[$classification][$aid] ?? 0) + $pilots;
 }
 
-$sideLabels = [];
-foreach (['side_a', 'side_b'] as $side) {
-    $alliances = $displaySideAlliancesByPilots[$side];
+foreach (['friendly', 'opponent'] as $side) {
+    $alliances = $sideAlliancesByPilots[$side];
     if ($alliances === []) {
-        $sideLabels[$side] = $side === $ourSide ? 'Tracked Coalition' : 'Opposition';
         continue;
     }
     arsort($alliances);
-    $preferredAllianceId = 0;
-    if ($side === $ourSide) {
-        foreach ($alliances as $allianceId => $_pilotCount) {
-            if (in_array((int) $allianceId, $trackedAllianceIds, true)) {
-                $preferredAllianceId = (int) $allianceId;
-                break;
-            }
-        }
-    }
-    if ($preferredAllianceId <= 0) {
-        $preferredAllianceId = (int) array_key_first($alliances);
-    }
+    $preferredAllianceId = (int) array_key_first($alliances);
     $preferredName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $preferredAllianceId, '', 'Alliance');
     $otherCount = count($alliances) - 1;
-    if ($side === $ourSide) {
-        $sideLabels[$side] = $preferredName . ($otherCount > 0 ? " +{$otherCount}" : '');
-    } else {
-        $sideLabels[$side] = $preferredName . ($otherCount > 0 ? " +{$otherCount}" : '');
-    }
+    $sideLabels[$side] = $preferredName . ($otherCount > 0 ? " +{$otherCount}" : '');
 }
 
 $sideColorClass = [
-    $ourSide ?? 'side_a' => 'text-blue-300',
-    $enemySide => 'text-red-300',
+    'friendly' => 'text-blue-300',
+    'opponent' => 'text-red-300',
+    'third_party' => 'text-slate-400',
 ];
 $sideBgClass = [
-    $ourSide ?? 'side_a' => 'bg-blue-900/60',
-    $enemySide => 'bg-red-900/60',
+    'friendly' => 'bg-blue-900/60',
+    'opponent' => 'bg-red-900/60',
+    'third_party' => 'bg-slate-700/60',
 ];
 
 if ($sideFilter !== null || $suspiciousOnly) {
     $participants = array_values(array_filter(
         $participantsAll,
-        static function (array $participant) use ($sideFilter, $suspiciousOnly, $displaySideForAlliance): bool {
+        static function (array $participant) use ($sideFilter, $suspiciousOnly, $classifyAlliance): bool {
             $allianceId = (int) ($participant['alliance_id'] ?? 0);
-            $sourceSide = (string) ($participant['side'] ?? '');
-            $displaySide = $displaySideForAlliance($allianceId, $sourceSide);
+            $displaySide = $classifyAlliance($allianceId);
             if ($sideFilter !== null && $displaySide !== $sideFilter) {
                 return false;
             }
@@ -196,11 +163,11 @@ if ($battles !== []) {
 
 // ── Derived aggregates / data-quality guards ───────────────────────────
 $timelineKillTotal = 0;
-$timelineSideKills = ['side_a' => 0, 'side_b' => 0];
+$timelineSideKills = ['friendly' => 0, 'opponent' => 0];
 foreach ($timeline as $row) {
     $timelineKillTotal += (int) ($row['kills'] ?? 0);
-    $timelineSideKills['side_a'] += (int) ($row['side_a_kills'] ?? 0);
-    $timelineSideKills['side_b'] += (int) ($row['side_b_kills'] ?? 0);
+    $timelineSideKills['friendly'] += (int) ($row['side_a_kills'] ?? 0);
+    $timelineSideKills['opponent'] += (int) ($row['side_b_kills'] ?? 0);
 }
 $allianceKillTotal = 0;
 $allianceLossTotal = 0;
@@ -209,10 +176,10 @@ foreach ($allianceSummary as $row) {
     $allianceLossTotal += (int) ($row['total_losses'] ?? 0);
 }
 $participantKillTotal = 0;
-$participantKillTotalsBySide = ['side_a' => 0, 'side_b' => 0];
+$participantKillTotalsBySide = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
 foreach ($participantsAll as $row) {
     $kills = (int) ($row['kills'] ?? 0);
-    $side = $displaySideForAlliance((int) ($row['alliance_id'] ?? 0), (string) ($row['side'] ?? 'side_b'));
+    $side = $classifyAlliance((int) ($row['alliance_id'] ?? 0));
     $participantKillTotal += $kills;
     if (isset($participantKillTotalsBySide[$side])) {
         $participantKillTotalsBySide[$side] += $kills;
@@ -235,11 +202,12 @@ if ($allianceKillTotal > 0 && $allianceLossTotal > 0 && abs($allianceKillTotal -
 
 // ── Build side panels from alliance + participant + composition data ──
 $sidePanels = [
-    'side_a' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => []],
-    'side_b' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => []],
+    'friendly' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => []],
+    'opponent' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => []],
+    'third_party' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => []],
 ];
 foreach ($allianceSummary as $a) {
-    $side = $displaySideForAlliance((int) ($a['alliance_id'] ?? 0), (string) ($a['side'] ?? ''));
+    $side = $classifyAlliance((int) ($a['alliance_id'] ?? 0));
     if (!isset($sidePanels[$side])) continue;
     $sidePanels[$side]['pilots'] += (int) ($a['participant_count'] ?? 0);
     $sidePanels[$side]['kills'] += (int) ($a['total_kills'] ?? 0);
@@ -261,8 +229,11 @@ foreach ($sidePanels as $side => $data) {
     $sidePanels[$side]['alliances'] = array_slice($data['alliances'], 0, 4);
 }
 
+// Fleet composition uses side_a/side_b from DB — map to friendly/opponent
+$fleetSideMap = ['side_a' => 'friendly', 'side_b' => 'opponent', 'friendly' => 'friendly', 'opponent' => 'opponent', 'third_party' => 'third_party'];
 foreach ($fleetComposition as $row) {
-    $side = (string) ($row['side'] ?? '');
+    $rawSide = (string) ($row['side'] ?? '');
+    $side = $fleetSideMap[$rawSide] ?? 'third_party';
     if (!isset($sidePanels[$side])) continue;
     $pilots = (int) ($row['pilot_count'] ?? 0);
     $sidePanels[$side]['ship_pilots'] += $pilots;

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -212,112 +212,61 @@ def _load_side_configuration_ids(db: SupplyCoreDb) -> dict[str, set[int]]:
 
 # ── Side determination ──────────────────────────────────────────────────────
 
-def _determine_sides(
-    participants: list[dict[str, Any]],
+def _classify_alliance(
+    alliance_id: int,
+    corporation_id: int,
     side_configuration: dict[str, set[int]],
-) -> tuple[dict[str, str], dict[int, str], dict[str, Any]]:
-    """Determine the two largest sides and assign characters.
-
-    Returns:
-        side_labels: mapping side_key → "side_a" or "side_b"
-        char_sides:  mapping character_id → "side_a" or "side_b"
-        side_meta:   scoring/debug metadata
-    """
-    side_counts: dict[str, int] = defaultdict(int)
-    char_side_keys: dict[int, str] = {}
-    side_scores: dict[str, dict[str, int]] = {}
-
+) -> str:
+    """Classify an entity as friendly/opponent/third_party from user settings only."""
     friendly_alliance_ids = side_configuration.get("friendly_alliance_ids", set())
     friendly_corporation_ids = side_configuration.get("friendly_corporation_ids", set())
     opponent_alliance_ids = side_configuration.get("opponent_alliance_ids", set())
     opponent_corporation_ids = side_configuration.get("opponent_corporation_ids", set())
 
+    if (alliance_id > 0 and alliance_id in friendly_alliance_ids) or \
+       (corporation_id > 0 and corporation_id in friendly_corporation_ids):
+        return "friendly"
+    if (alliance_id > 0 and alliance_id in opponent_alliance_ids) or \
+       (corporation_id > 0 and corporation_id in opponent_corporation_ids):
+        return "opponent"
+    return "third_party"
+
+
+def _determine_sides(
+    participants: list[dict[str, Any]],
+    side_configuration: dict[str, set[int]],
+) -> tuple[dict[str, str], dict[int, str], dict[str, Any]]:
+    """Classify each character as friendly/opponent/third_party from user settings.
+
+    Side is determined ONLY from configured tracked alliances (friendly),
+    tracked opponents (opponent), with everything else as third_party.
+    No inference from battle participation or side_key grouping.
+
+    Returns:
+        side_labels: empty dict (kept for API compatibility)
+        char_sides:  mapping character_id → "friendly" | "opponent" | "third_party"
+        side_meta:   classification counts for debug/logging
+    """
+    char_sides: dict[int, str] = {}
+    counts = {"friendly": 0, "opponent": 0, "third_party": 0}
+
     for p in participants:
-        side_key = str(p.get("side_key") or "unknown")
         char_id = int(p.get("character_id") or 0)
-        alliance_id = int(p.get("alliance_id") or 0)
-        corporation_id = int(p.get("corporation_id") or 0)
         if char_id <= 0:
             continue
-        side_counts[side_key] += 1
-        char_side_keys[char_id] = side_key
-        score_entry = side_scores.setdefault(
-            side_key,
-            {"friendly_score": 0, "opponent_score": 0, "participant_count": 0},
-        )
-        score_entry["participant_count"] += 1
-        if alliance_id > 0 and alliance_id in friendly_alliance_ids:
-            score_entry["friendly_score"] += 1
-        if corporation_id > 0 and corporation_id in friendly_corporation_ids:
-            score_entry["friendly_score"] += 1
-        if alliance_id > 0 and alliance_id in opponent_alliance_ids:
-            score_entry["opponent_score"] += 1
-        if corporation_id > 0 and corporation_id in opponent_corporation_ids:
-            score_entry["opponent_score"] += 1
+        alliance_id = int(p.get("alliance_id") or 0)
+        corporation_id = int(p.get("corporation_id") or 0)
+        classification = _classify_alliance(alliance_id, corporation_id, side_configuration)
+        char_sides[char_id] = classification
+        counts[classification] += 1
 
-    # Rank sides by participant count
-    ranked = sorted(side_counts.items(), key=lambda x: -x[1])
-
-    side_labels: dict[str, str] = {}
-    total_friendly_matches = sum(entry["friendly_score"] for entry in side_scores.values())
-    total_opponent_matches = sum(entry["opponent_score"] for entry in side_scores.values())
-    used_fallback = total_friendly_matches == 0 and total_opponent_matches == 0
-
-    if used_fallback:
-        if len(ranked) >= 1:
-            side_labels[ranked[0][0]] = "side_a"
-        if len(ranked) >= 2:
-            side_labels[ranked[1][0]] = "side_b"
-        # All others are "side_b" (smaller coalition)
-        for sk in side_counts:
-            if sk not in side_labels:
-                side_labels[sk] = "side_b"
-    else:
-        scored_side_keys = list(side_scores.keys())
-        friendly_ranked = sorted(
-            scored_side_keys,
-            key=lambda sk: (
-                -side_scores[sk]["friendly_score"],
-                side_scores[sk]["opponent_score"],
-                sk,
-            ),
-        )
-        opponent_ranked = sorted(
-            scored_side_keys,
-            key=lambda sk: (
-                -side_scores[sk]["opponent_score"],
-                side_scores[sk]["friendly_score"],
-                sk,
-            ),
-        )
-
-        if friendly_ranked:
-            side_labels[friendly_ranked[0]] = "side_a"
-        for sk in opponent_ranked:
-            if sk not in side_labels:
-                side_labels[sk] = "side_b"
-                break
-
-        if "side_b" not in side_labels.values():
-            for sk, _ in ranked:
-                if sk not in side_labels:
-                    side_labels[sk] = "side_b"
-                    break
-
-        for sk in side_counts:
-            if sk not in side_labels:
-                side_labels[sk] = "side_b"
-
-    char_sides: dict[int, str] = {}
-    for char_id, sk in char_side_keys.items():
-        char_sides[char_id] = side_labels.get(sk, "side_b")
-
-    return side_labels, char_sides, {
-        "used_fallback": used_fallback,
-        "total_friendly_matches": total_friendly_matches,
-        "total_opponent_matches": total_opponent_matches,
-        "side_scores": side_scores,
-        "side_labels": side_labels,
+    return {}, char_sides, {
+        "used_fallback": False,
+        "total_friendly_matches": counts["friendly"],
+        "total_opponent_matches": counts["opponent"],
+        "total_third_party": counts["third_party"],
+        "side_scores": {},
+        "side_labels": {},
     }
 
 
@@ -361,18 +310,19 @@ def _compute_timeline(
 
         victim_id = int(km.get("victim_character_id") or 0)
         isk = float(km.get("total_value") or 0)
-        victim_side = char_sides.get(victim_id, "side_b")
+        victim_side = char_sides.get(victim_id, "third_party")
 
         # A kill counts against the victim's side
         bucket["kills"] += 1
         bucket["isk_destroyed"] += isk
 
-        if victim_side == "side_a":
-            bucket["side_b_kills"] += 1  # side_b scored a kill
+        if victim_side == "friendly":
+            bucket["side_b_kills"] += 1  # opponent scored a kill against friendly
             bucket["side_b_isk"] += isk
-        else:
-            bucket["side_a_kills"] += 1  # side_a scored a kill
+        elif victim_side == "opponent":
+            bucket["side_a_kills"] += 1  # friendly scored a kill against opponent
             bucket["side_a_isk"] += isk
+        # third_party victims don't count toward either side's momentum
 
     # Sort by time and compute momentum
     sorted_buckets = sorted(bucket_data.values(), key=lambda b: b["bucket_time"])
@@ -406,9 +356,9 @@ def _detect_turning_points(
         delta = curr - prev
 
         if abs(delta) >= TURNING_POINT_MAGNITUDE_THRESHOLD:
-            direction = "side_a_surge" if delta > 0 else "side_b_surge"
+            direction = "friendly_surge" if delta > 0 else "opponent_surge"
             description = (
-                f"Momentum shifted {'toward side A' if delta > 0 else 'toward side B'} "
+                f"Momentum shifted {'toward friendlies' if delta > 0 else 'toward opponents'} "
                 f"({prev:.2f} → {curr:.2f}, Δ={delta:+.2f})"
             )
             turning_points.append({
@@ -426,7 +376,7 @@ def _detect_turning_points(
 def _compute_alliance_summary(
     killmails: list[dict[str, Any]],
     bp_rows: list[dict[str, Any]],
-    side_labels: dict[str, str],
+    side_configuration: dict[str, set[int]],
     char_sides: dict[int, str],
 ) -> list[dict[str, Any]]:
     """Compute per-alliance summary across the theater."""
@@ -503,11 +453,8 @@ def _compute_alliance_summary(
     result: list[dict[str, Any]] = []
     for aid, stats in alliance_stats.items():
         stats["participant_count"] = len(alliance_participants.get(aid, set()))
-        # Determine side from majority of characters
-        side_votes: dict[str, int] = defaultdict(int)
-        for cid in alliance_participants.get(aid, set()):
-            side_votes[char_sides.get(cid, "side_b")] += 1
-        stats["side"] = max(side_votes, key=side_votes.get) if side_votes else "side_b"
+        # Classify alliance directly from user settings
+        stats["side"] = _classify_alliance(aid, 0, side_configuration)
         # Efficiency
         total_isk = stats["total_isk_killed"] + stats["total_isk_lost"]
         stats["efficiency"] = round(_safe_div(stats["total_isk_killed"], total_isk, 0.0), 4)
@@ -520,7 +467,7 @@ def _empty_alliance_stats(alliance_id: int) -> dict[str, Any]:
     return {
         "alliance_id": alliance_id,
         "alliance_name": None,
-        "side": "side_b",
+        "side": "third_party",
         "participant_count": 0,
         "total_kills": 0,
         "total_losses": 0,
@@ -579,7 +526,7 @@ def _compute_participants(
                 "character_name": None,
                 "alliance_id": aid if aid > 0 else None,
                 "corporation_id": corp_id if corp_id > 0 else None,
-                "side": char_sides.get(cid, "side_b"),
+                "side": char_sides.get(cid, "third_party"),
                 "ship_type_ids": [],
                 "kills": 0,
                 "deaths": 0,
@@ -687,7 +634,7 @@ def _compute_side_composition(
         cid = int(p.get("character_id") or 0)
         if cid <= 0:
             continue
-        side = char_sides.get(cid, "side_b")
+        side = char_sides.get(cid, "third_party")
         ship_type_id = int(p.get("ship_type_id") or 0)
         group_id = ship_group_map.get(ship_type_id, 0)
         fleet_fn = FLEET_FUNCTION_BY_GROUP.get(group_id, "mainline_dps")
@@ -818,10 +765,10 @@ def _compute_anomaly_score(
     score += min(0.3, tp_density * 0.5)
 
     # Efficiency imbalance
-    side_a_eff = [a["efficiency"] for a in alliance_summary if a["side"] == "side_a"]
-    side_b_eff = [a["efficiency"] for a in alliance_summary if a["side"] == "side_b"]
-    avg_a = sum(side_a_eff) / len(side_a_eff) if side_a_eff else 0.5
-    avg_b = sum(side_b_eff) / len(side_b_eff) if side_b_eff else 0.5
+    friendly_eff = [a["efficiency"] for a in alliance_summary if a["side"] == "friendly"]
+    opponent_eff = [a["efficiency"] for a in alliance_summary if a["side"] == "opponent"]
+    avg_a = sum(friendly_eff) / len(friendly_eff) if friendly_eff else 0.5
+    avg_b = sum(opponent_eff) / len(opponent_eff) if opponent_eff else 0.5
     eff_imbalance = abs(avg_a - avg_b)
     score += min(0.3, eff_imbalance * 0.5)
 
@@ -1075,7 +1022,7 @@ def run_theater_analysis(
             turning_points = _detect_turning_points(timeline)
 
             # Compute alliance summary
-            alliance_summary = _compute_alliance_summary(killmails, bp_rows, side_labels, char_sides)
+            alliance_summary = _compute_alliance_summary(killmails, bp_rows, side_configuration, char_sides)
 
             # Compute participant stats
             participant_stats = _compute_participants(killmails, bp_rows, char_sides, theater_id, ship_group_map)
@@ -1108,11 +1055,10 @@ def run_theater_analysis(
                 "timeline_buckets": len(timeline),
                 "turning_points": len(turning_points),
                 "anomaly_score": anomaly_score,
-                "side_resolution": "unresolved_fallback_size_based" if side_resolution["used_fallback"] else "configured_entity_match",
-                "friendly_matches": side_resolution["total_friendly_matches"],
-                "opponent_matches": side_resolution["total_opponent_matches"],
-                "side_labels": side_resolution["side_labels"],
-                "side_scores": side_resolution["side_scores"],
+                "side_resolution": "settings_based_classification",
+                "friendly_count": side_resolution["total_friendly_matches"],
+                "opponent_count": side_resolution["total_opponent_matches"],
+                "third_party_count": side_resolution.get("total_third_party", 0),
             })
 
         finish_job_run(

--- a/python/tests/test_theater_side_determination.py
+++ b/python/tests/test_theater_side_determination.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import unittest
 
-from orchestrator.jobs.theater_analysis import _determine_sides
+from orchestrator.jobs.theater_analysis import _determine_sides, _classify_alliance
 
 
 class TheaterSideDeterminationTests(unittest.TestCase):
-    def test_friendly_side_wins_even_when_enemy_side_has_more_pilots(self) -> None:
+    def test_friendly_alliance_classified_as_friendly(self) -> None:
         participants = [
             {"character_id": 1, "side_key": "LEFT", "alliance_id": 9001, "corporation_id": 0},
             {"character_id": 2, "side_key": "RIGHT", "alliance_id": 0, "corporation_id": 0},
@@ -20,10 +20,11 @@ class TheaterSideDeterminationTests(unittest.TestCase):
             "opponent_corporation_ids": set(),
         }
 
-        side_labels, _char_sides, side_meta = _determine_sides(participants, side_configuration)
+        _side_labels, char_sides, side_meta = _determine_sides(participants, side_configuration)
 
-        self.assertEqual(side_labels["LEFT"], "side_a")
-        self.assertFalse(side_meta["used_fallback"])
+        self.assertEqual(char_sides[1], "friendly")
+        self.assertEqual(char_sides[2], "third_party")
+        self.assertEqual(side_meta["total_friendly_matches"], 1)
 
     def test_friendly_corporation_match_without_alliance_match_is_still_friendly(self) -> None:
         participants = [
@@ -39,12 +40,12 @@ class TheaterSideDeterminationTests(unittest.TestCase):
             "opponent_corporation_ids": set(),
         }
 
-        side_labels, _char_sides, side_meta = _determine_sides(participants, side_configuration)
+        _side_labels, char_sides, side_meta = _determine_sides(participants, side_configuration)
 
-        self.assertEqual(side_labels["LEFT"], "side_a")
-        self.assertFalse(side_meta["used_fallback"])
+        self.assertEqual(char_sides[10], "friendly")
+        self.assertEqual(side_meta["total_friendly_matches"], 1)
 
-    def test_friendly_and_opponent_entities_map_to_left_and_right(self) -> None:
+    def test_friendly_and_opponent_entities_classified_correctly(self) -> None:
         participants = [
             {"character_id": 20, "side_key": "LEFT", "alliance_id": 111, "corporation_id": 0},
             {"character_id": 21, "side_key": "LEFT", "alliance_id": 0, "corporation_id": 2222},
@@ -58,13 +59,16 @@ class TheaterSideDeterminationTests(unittest.TestCase):
             "opponent_corporation_ids": {4444},
         }
 
-        side_labels, _char_sides, side_meta = _determine_sides(participants, side_configuration)
+        _side_labels, char_sides, side_meta = _determine_sides(participants, side_configuration)
 
-        self.assertEqual(side_labels["LEFT"], "side_a")
-        self.assertEqual(side_labels["RIGHT"], "side_b")
-        self.assertFalse(side_meta["used_fallback"])
+        self.assertEqual(char_sides[20], "friendly")
+        self.assertEqual(char_sides[21], "friendly")
+        self.assertEqual(char_sides[22], "opponent")
+        self.assertEqual(char_sides[23], "opponent")
+        self.assertEqual(side_meta["total_friendly_matches"], 2)
+        self.assertEqual(side_meta["total_opponent_matches"], 2)
 
-    def test_fallback_only_when_no_configured_entities_match(self) -> None:
+    def test_unmatched_entities_classified_as_third_party(self) -> None:
         participants = [
             {"character_id": 30, "side_key": "LEFT", "alliance_id": 0, "corporation_id": 0},
             {"character_id": 31, "side_key": "RIGHT", "alliance_id": 0, "corporation_id": 0},
@@ -77,11 +81,26 @@ class TheaterSideDeterminationTests(unittest.TestCase):
             "opponent_corporation_ids": {6666},
         }
 
-        side_labels, _char_sides, side_meta = _determine_sides(participants, side_configuration)
+        _side_labels, char_sides, side_meta = _determine_sides(participants, side_configuration)
 
-        self.assertTrue(side_meta["used_fallback"])
-        self.assertEqual(side_labels["RIGHT"], "side_a")
-        self.assertEqual(side_labels["LEFT"], "side_b")
+        self.assertEqual(char_sides[30], "third_party")
+        self.assertEqual(char_sides[31], "third_party")
+        self.assertEqual(char_sides[32], "third_party")
+        self.assertEqual(side_meta["total_third_party"], 3)
+
+    def test_classify_alliance_helper(self) -> None:
+        config = {
+            "friendly_alliance_ids": {100},
+            "friendly_corporation_ids": {200},
+            "opponent_alliance_ids": {300},
+            "opponent_corporation_ids": {400},
+        }
+        self.assertEqual(_classify_alliance(100, 0, config), "friendly")
+        self.assertEqual(_classify_alliance(0, 200, config), "friendly")
+        self.assertEqual(_classify_alliance(300, 0, config), "opponent")
+        self.assertEqual(_classify_alliance(0, 400, config), "opponent")
+        self.assertEqual(_classify_alliance(999, 999, config), "third_party")
+        self.assertEqual(_classify_alliance(0, 0, config), "third_party")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Replace inference-based side assignment** (side_key grouping + majority vote) with direct three-way classification (`friendly` / `opponent` / `third_party`) driven entirely by user settings (`killmail_tracked_alliances` → friendly, `killmail_opponent_alliances` → opponent, everything else → third_party)
- **Third parties display on the opponent side** of the battle report overview but are labeled distinctly as "Third Party" with separate alliance listings
- **Timeline momentum** only counts friendly vs opponent kills; third_party victims don't affect momentum scoring

### Files changed

| File | Change |
|---|---|
| `python/orchestrator/jobs/theater_analysis.py` | New `_classify_alliance()` helper; rewrite `_determine_sides()`, `_compute_alliance_summary()`, timeline, anomaly scoring |
| `python/tests/test_theater_side_determination.py` | Updated tests for three-way classification + new `_classify_alliance` test |
| `public/theater-intelligence/view.php` | New `$classifyAlliance` closure from tracked/opponent lists; remove all inference logic |
| `public/theater-intelligence/partials/_battle_report.php` | Friendly panel + merged opponent/third_party panel with distinct sections |
| `public/theater-intelligence/partials/_participants.php` | Three-way split; third_party merged into enemy column in side-by-side view |
| `public/theater-intelligence/partials/_alliance_summary.php` | Friendly/Opponent badges via `$classifyAlliance()` |
| `public/theater-intelligence/partials/_header.php` | Show friendly/opponent/third_party counts |
| `public/theater-intelligence/partials/_timeline.php` | Friendly/opponent labels for columns and turning points |

## Test plan

- [ ] Run `python -m pytest python/tests/test_theater_side_determination.py` — all 5 tests pass
- [ ] Verify theater view loads correctly with tracked + opponent alliances configured
- [ ] Confirm third_party alliances appear in opponent panel but labeled as "Third Party"
- [ ] Check timeline momentum only reflects friendly vs opponent kills
- [ ] Verify alliance summary badges show correct Friendly/Opponent tags

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf