### PR TITLE
Fix participant ship display, ISK attribution, add FC role and portraits

### DIFF
--- a/database/migrations/20260402_theater_participant_ships_lost_detail.sql
+++ b/database/migrations/20260402_theater_participant_ships_lost_detail.sql
@@ -1,0 +1,6 @@
+-- Add per-ship-type loss breakdown for theater participants.
+-- Stores an array of {ship_type_id, count, isk_lost} objects so the UI can
+-- display individual hull types lost (instead of a generic +N counter).
+
+ALTER TABLE theater_participants
+    ADD COLUMN ships_lost_detail JSON DEFAULT NULL AFTER ship_type_ids;

--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -98,23 +98,54 @@ foreach ($allForMax as $p) {
                                         if (is_array($decoded)) $shipIds = $decoded;
                                     }
                                 ?>
-                                <tr class="border-b border-border/50 <?= $isSusp ? 'bg-red-900/10' : '' ?>">
+                                <?php
+                                    // Parse ships_lost_detail for display
+                                    $lostDetail = [];
+                                    $lostJson = $p['ships_lost_detail'] ?? null;
+                                    if (is_string($lostJson)) {
+                                        $decoded = json_decode($lostJson, true);
+                                        if (is_array($decoded)) $lostDetail = $decoded;
+                                    }
+                                    // Filter out pods (670=Capsule, 33328=Golden Capsule) for display
+                                    $lostDisplay = array_values(array_filter($lostDetail, static fn(array $e): bool => !in_array((int) ($e['ship_type_id'] ?? 0), [670, 33328], true)));
+                                    // Build ship display string from lost ships (or fall back to ship_type_ids)
+                                    $shipDisplayParts = [];
+                                    $primaryShipIcon = 0;
+                                    if ($lostDisplay !== []) {
+                                        // Sort by ISK lost desc so most expensive ship is primary
+                                        usort($lostDisplay, static fn(array $a, array $b): int => (float) ($b['isk_lost'] ?? 0) <=> (float) ($a['isk_lost'] ?? 0));
+                                        $primaryShipIcon = (int) ($lostDisplay[0]['ship_type_id'] ?? 0);
+                                        foreach ($lostDisplay as $entry) {
+                                            $stid = (int) ($entry['ship_type_id'] ?? 0);
+                                            $cnt = (int) ($entry['count'] ?? 1);
+                                            $name = (string) ($shipTypeNames[$stid] ?? '');
+                                            $shipDisplayParts[] = $cnt > 1 ? ($name . '+' . ($cnt - 1)) : $name;
+                                        }
+                                    } elseif ($shipIds) {
+                                        $primaryShipIcon = (int) $shipIds[0];
+                                        $shipDisplayParts[] = (string) ($shipTypeNames[$primaryShipIcon] ?? '');
+                                        if (count($shipIds) > 1) {
+                                            $shipDisplayParts[0] .= '+' . (count($shipIds) - 1);
+                                        }
+                                    }
+                                ?>
+                                <tr class="border-b border-border/50 <?= $isSusp ? 'bg-red-900/10' : '' ?> <?= $fleetRole === 'fc' ? 'border-l-2 border-l-yellow-400/60' : '' ?>">
                                     <td class="px-2 py-1.5">
-                                        <a class="text-accent text-sm" href="/battle-intelligence/character.php?character_id=<?= (int) ($p['character_id'] ?? 0) ?>">
-                                            <?= htmlspecialchars($charName, ENT_QUOTES) ?>
-                                        </a>
-                                        <?php if ($isSusp): ?>
-                                            <span class="inline-block w-1.5 h-1.5 rounded-full bg-red-400 ml-1" title="Suspicious"></span>
-                                        <?php endif; ?>
+                                        <div class="flex items-center gap-1.5">
+                                            <img src="https://images.evetech.net/characters/<?= (int) ($p['character_id'] ?? 0) ?>/portrait?size=32" alt="" class="w-5 h-5 rounded-full" loading="lazy">
+                                            <a class="text-accent text-sm" href="/battle-intelligence/character.php?character_id=<?= (int) ($p['character_id'] ?? 0) ?>">
+                                                <?= htmlspecialchars($charName, ENT_QUOTES) ?>
+                                            </a>
+                                            <?php if ($isSusp): ?>
+                                                <span class="inline-block w-1.5 h-1.5 rounded-full bg-red-400 ml-1" title="Suspicious"></span>
+                                            <?php endif; ?>
+                                        </div>
                                     </td>
                                     <td class="px-2 py-1.5">
-                                        <?php if ($shipIds): ?>
+                                        <?php if ($primaryShipIcon > 0): ?>
                                             <div class="flex items-center gap-1">
-                                                <img src="https://images.evetech.net/types/<?= (int) ($shipIds[0]) ?>/icon?size=32" alt="" class="w-4 h-4" loading="lazy">
-                                                <span class="text-[11px] text-slate-300 truncate max-w-[6rem]"><?= htmlspecialchars((string) ($shipTypeNames[(int) ($shipIds[0] ?? 0)] ?? ''), ENT_QUOTES) ?></span>
-                                                <?php if (count($shipIds) > 1): ?>
-                                                    <span class="text-[10px] text-muted">+<?= count($shipIds) - 1 ?></span>
-                                                <?php endif; ?>
+                                                <img src="https://images.evetech.net/types/<?= $primaryShipIcon ?>/icon?size=32" alt="" class="w-4 h-4" loading="lazy">
+                                                <span class="text-[11px] text-slate-300 truncate max-w-[8rem]"><?= htmlspecialchars(implode(', ', $shipDisplayParts), ENT_QUOTES) ?></span>
                                             </div>
                                         <?php else: ?>
                                             <span class="text-slate-500 text-xs">-</span>
@@ -195,38 +226,71 @@ foreach ($allForMax as $p) {
                                 $decoded = json_decode($shipJson, true);
                                 if (is_array($decoded)) $shipIds = $decoded;
                             }
+
+                            // Parse ships_lost_detail for display
+                            $lostDetail2 = [];
+                            $lostJson2 = $p['ships_lost_detail'] ?? null;
+                            if (is_string($lostJson2)) {
+                                $decoded2 = json_decode($lostJson2, true);
+                                if (is_array($decoded2)) $lostDetail2 = $decoded2;
+                            }
+                            $lostDisplay2 = array_values(array_filter($lostDetail2, static fn(array $e): bool => !in_array((int) ($e['ship_type_id'] ?? 0), [670, 33328], true)));
+                            $shipDisplayParts2 = [];
+                            $primaryShipIcon2 = 0;
+                            if ($lostDisplay2 !== []) {
+                                usort($lostDisplay2, static fn(array $a, array $b): int => (float) ($b['isk_lost'] ?? 0) <=> (float) ($a['isk_lost'] ?? 0));
+                                $primaryShipIcon2 = (int) ($lostDisplay2[0]['ship_type_id'] ?? 0);
+                                foreach ($lostDisplay2 as $entry2) {
+                                    $stid2 = (int) ($entry2['ship_type_id'] ?? 0);
+                                    $cnt2 = (int) ($entry2['count'] ?? 1);
+                                    $name2 = (string) ($shipTypeNames[$stid2] ?? '');
+                                    $shipDisplayParts2[] = $cnt2 > 1 ? ($name2 . '+' . ($cnt2 - 1)) : $name2;
+                                }
+                            } elseif ($shipIds) {
+                                $primaryShipIcon2 = (int) $shipIds[0];
+                                $shipDisplayParts2[] = (string) ($shipTypeNames[$primaryShipIcon2] ?? '');
+                                if (count($shipIds) > 1) {
+                                    $shipDisplayParts2[0] .= '+' . (count($shipIds) - 1);
+                                }
+                            }
                         ?>
-                        <tr class="border-b border-border/50 <?= $isSusp ? 'bg-red-900/10' : '' ?>">
+                        <tr class="border-b border-border/50 <?= $isSusp ? 'bg-red-900/10' : '' ?> <?= $fleetRole === 'fc' ? 'border-l-2 border-l-yellow-400/60' : '' ?>">
                             <td class="px-3 py-2">
-                                <a class="text-accent text-sm" href="/battle-intelligence/character.php?character_id=<?= (int) ($p['character_id'] ?? 0) ?>">
-                                    <?= htmlspecialchars($charName, ENT_QUOTES) ?>
-                                </a>
-                                <?php if ($isSusp): ?>
-                                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-red-400 ml-1" title="Suspicious"></span>
-                                <?php endif; ?>
-                                <span class="inline-block rounded-full px-1.5 py-0.5 text-[9px] uppercase tracking-wider ml-1 <?= $sideBgClass[$pSide] ?? 'bg-slate-700' ?> <?= $pSideClass ?>">
-                                    <?= htmlspecialchars($sideLabels[$pSide] ?? $pSide, ENT_QUOTES) ?>
-                                </span>
+                                <div class="flex items-center gap-1.5">
+                                    <img src="https://images.evetech.net/characters/<?= (int) ($p['character_id'] ?? 0) ?>/portrait?size=32" alt="" class="w-5 h-5 rounded-full" loading="lazy">
+                                    <a class="text-accent text-sm" href="/battle-intelligence/character.php?character_id=<?= (int) ($p['character_id'] ?? 0) ?>">
+                                        <?= htmlspecialchars($charName, ENT_QUOTES) ?>
+                                    </a>
+                                    <?php if ($isSusp): ?>
+                                        <span class="inline-block w-1.5 h-1.5 rounded-full bg-red-400 ml-1" title="Suspicious"></span>
+                                    <?php endif; ?>
+                                    <span class="inline-block rounded-full px-1.5 py-0.5 text-[9px] uppercase tracking-wider ml-1 <?= $sideBgClass[$pSide] ?? 'bg-slate-700' ?> <?= $pSideClass ?>">
+                                        <?= htmlspecialchars($sideLabels[$pSide] ?? $pSide, ENT_QUOTES) ?>
+                                    </span>
+                                </div>
                             </td>
                             <td class="px-3 py-2 text-slate-300 text-xs">
-                                <?php if (!str_starts_with($resolvedAlliance, 'Alliance #') && !str_starts_with($resolvedAlliance, 'Alliance 0')): ?>
-                                    <span class="text-slate-100"><?= htmlspecialchars($resolvedAlliance, ENT_QUOTES) ?></span>
-                                <?php elseif (!str_starts_with($resolvedCorp, 'Corp #') && !str_starts_with($resolvedCorp, 'Corp 0')): ?>
-                                    <span class="text-slate-300"><?= htmlspecialchars($resolvedCorp, ENT_QUOTES) ?></span>
-                                <?php else: ?>
-                                    <span class="text-slate-500">-</span>
-                                <?php endif; ?>
+                                <div class="flex items-center gap-1.5">
+                                    <?php $allianceId = (int) ($p['alliance_id'] ?? 0); $corpId = (int) ($p['corporation_id'] ?? 0); ?>
+                                    <?php if ($allianceId > 0): ?>
+                                        <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=32" alt="" class="w-4 h-4" loading="lazy">
+                                    <?php elseif ($corpId > 0): ?>
+                                        <img src="https://images.evetech.net/corporations/<?= $corpId ?>/logo?size=32" alt="" class="w-4 h-4" loading="lazy">
+                                    <?php endif; ?>
+                                    <?php if (!str_starts_with($resolvedAlliance, 'Alliance #') && !str_starts_with($resolvedAlliance, 'Alliance 0')): ?>
+                                        <span class="text-slate-100"><?= htmlspecialchars($resolvedAlliance, ENT_QUOTES) ?></span>
+                                    <?php elseif (!str_starts_with($resolvedCorp, 'Corp #') && !str_starts_with($resolvedCorp, 'Corp 0')): ?>
+                                        <span class="text-slate-300"><?= htmlspecialchars($resolvedCorp, ENT_QUOTES) ?></span>
+                                    <?php else: ?>
+                                        <span class="text-slate-500">-</span>
+                                    <?php endif; ?>
+                                </div>
                             </td>
                             <td class="px-3 py-2">
-                                <?php if ($shipIds): ?>
+                                <?php if ($primaryShipIcon2 > 0): ?>
                                     <div class="flex items-center gap-1">
-                                        <?php foreach (array_slice($shipIds, 0, 2) as $stid): ?>
-                                            <img src="https://images.evetech.net/types/<?= (int) $stid ?>/icon?size=32" alt="" class="w-5 h-5" loading="lazy" title="<?= htmlspecialchars((string) ($shipTypeNames[(int) $stid] ?? ''), ENT_QUOTES) ?>">
-                                        <?php endforeach; ?>
-                                        <span class="text-[11px] text-slate-300"><?= htmlspecialchars((string) ($shipTypeNames[(int) ($shipIds[0] ?? 0)] ?? ''), ENT_QUOTES) ?></span>
-                                        <?php if (count($shipIds) > 1): ?>
-                                            <span class="text-[10px] text-muted">+<?= count($shipIds) - 1 ?></span>
-                                        <?php endif; ?>
+                                        <img src="https://images.evetech.net/types/<?= $primaryShipIcon2 ?>/icon?size=32" alt="" class="w-5 h-5" loading="lazy">
+                                        <span class="text-[11px] text-slate-300 truncate max-w-[10rem]"><?= htmlspecialchars(implode(', ', $shipDisplayParts2), ENT_QUOTES) ?></span>
                                     </div>
                                 <?php else: ?>
                                     <span class="text-slate-500 text-xs">-</span>

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -258,6 +258,17 @@ foreach ($participantsAll as $p) {
             foreach ($ids as $stid) $allShipTypeIds[(int) $stid] = true;
         }
     }
+    // Also collect type IDs from ships_lost_detail for name resolution
+    $lostJson = $p['ships_lost_detail'] ?? null;
+    if (is_string($lostJson)) {
+        $lostArr = json_decode($lostJson, true);
+        if (is_array($lostArr)) {
+            foreach ($lostArr as $entry) {
+                $stid = (int) ($entry['ship_type_id'] ?? 0);
+                if ($stid > 0) $allShipTypeIds[$stid] = true;
+            }
+        }
+    }
 }
 $shipTypeNames = !empty($allShipTypeIds) ? db_market_orders_current_compact_type_names(array_keys($allShipTypeIds)) : [];
 

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -148,6 +148,9 @@ def _load_ship_group_map(db: SupplyCoreDb) -> dict[int, int]:
 
 def _resolve_fleet_function(ship_type_id: int, ship_group_map: dict[int, int]) -> str:
     """Resolve a ship type ID to its fleet function string."""
+    # Monitor (Flag Cruiser) is exclusively used as an FC ship
+    if ship_type_id == 45534:
+        return "fc"
     group_id = ship_group_map.get(ship_type_id, 0)
     return FLEET_FUNCTION_BY_GROUP.get(group_id, "mainline_dps")
 
@@ -406,8 +409,7 @@ def _compute_alliance_summary(
     # since rows are expanded per-attacker from the LEFT JOIN.
     seen_loss_km: set[int] = set()
     seen_kill_km: set[tuple[int, int]] = set()  # (killmail_id, alliance_id)
-    km_alliance_damage: dict[int, dict[int, float]] = {}  # km_id -> {alliance_id -> total_damage}
-    km_isk: dict[int, float] = {}  # km_id -> isk value
+    seen_final_blow_km: set[int] = set()  # killmail_ids where final blow ISK was credited
     for km in killmails:
         km_id = int(km.get("killmail_id") or 0)
         victim_id = int(km.get("victim_character_id") or 0)
@@ -417,6 +419,7 @@ def _compute_alliance_summary(
         attacker_id = int(km.get("attacker_character_id") or 0)
         attacker_alliance = int(km.get("attacker_alliance_id") or 0)
         attacker_damage = float(km.get("attacker_damage_done") or 0)
+        final_blow = int(km.get("attacker_final_blow") or 0)
 
         # Record loss for victim alliance (once per killmail)
         if victim_alliance > 0 and km_id not in seen_loss_km:
@@ -425,8 +428,7 @@ def _compute_alliance_summary(
             entry["total_losses"] += 1
             entry["total_isk_lost"] += isk
 
-        # Record kill for attacker alliance (once per killmail per alliance)
-        # ISK is attributed proportionally by damage dealt, not duplicated.
+        # Record kill involvement for attacker alliance (once per killmail per alliance)
         if attacker_alliance > 0:
             entry = alliance_stats.setdefault(attacker_alliance, _empty_alliance_stats(attacker_alliance))
             entry["total_damage"] += attacker_damage
@@ -434,20 +436,12 @@ def _compute_alliance_summary(
             if kill_key not in seen_kill_km:
                 seen_kill_km.add(kill_key)
                 entry["total_kills"] += 1
-                # Track per-killmail damage by alliance for proportional ISK later
-                km_alliance_damage.setdefault(km_id, {})[attacker_alliance] = \
-                    km_alliance_damage.get(km_id, {}).get(attacker_alliance, 0.0) + attacker_damage
-                km_isk[km_id] = isk
 
-    # Distribute ISK proportionally by damage dealt per alliance
-    for km_id, alliance_damages in km_alliance_damage.items():
-        total_damage = sum(alliance_damages.values())
-        isk = km_isk.get(km_id, 0.0)
-        for aid, dmg in alliance_damages.items():
-            share = dmg / total_damage if total_damage > 0 else 1.0 / len(alliance_damages)
-            entry = alliance_stats.get(aid)
-            if entry is not None:
-                entry["total_isk_killed"] += isk * share
+        # ISK killed credited to the final-blow alliance only (no double-counting)
+        if final_blow and attacker_alliance > 0 and km_id not in seen_final_blow_km:
+            seen_final_blow_km.add(km_id)
+            entry = alliance_stats.setdefault(attacker_alliance, _empty_alliance_stats(attacker_alliance))
+            entry["total_isk_killed"] += isk
 
     # Finalize
     result: list[dict[str, Any]] = []
@@ -528,6 +522,7 @@ def _compute_participants(
                 "corporation_id": corp_id if corp_id > 0 else None,
                 "side": char_sides.get(cid, "third_party"),
                 "ship_type_ids": [],
+                "ships_lost_detail": defaultdict(lambda: {"count": 0, "isk_lost": 0.0}),
                 "kills": 0,
                 "deaths": 0,
                 "damage_done": 0.0,
@@ -569,6 +564,15 @@ def _compute_participants(
             char_stats[victim_id]["isk_lost"] += isk
             char_times[victim_id].append(km_time)
 
+            # Track per-ship-type loss breakdown
+            victim_ship = int(km.get("victim_ship_type_id") or 0)
+            if victim_ship > 0:
+                loss = char_stats[victim_id]["ships_lost_detail"][victim_ship]
+                loss["count"] += 1
+                loss["isk_lost"] += isk
+                if victim_ship not in char_stats[victim_id]["ship_type_ids"]:
+                    char_stats[victim_id]["ship_type_ids"].append(victim_ship)
+
         attacker_id = int(km.get("attacker_character_id") or 0)
         attacker_damage = float(km.get("attacker_damage_done") or 0)
 
@@ -590,6 +594,12 @@ def _compute_participants(
 
         ship_json = json_dumps_safe(stats["ship_type_ids"]) if stats["ship_type_ids"] else None
 
+        lost_detail = dict(stats.get("ships_lost_detail", {}))
+        ships_lost_json = json_dumps_safe([
+            {"ship_type_id": stid, "count": d["count"], "isk_lost": d["isk_lost"]}
+            for stid, d in lost_detail.items()
+        ]) if lost_detail else None
+
         result.append({
             "theater_id": theater_id,
             "character_id": cid,
@@ -598,6 +608,7 @@ def _compute_participants(
             "corporation_id": stats["corporation_id"],
             "side": stats["side"],
             "ship_type_ids": ship_json,
+            "ships_lost_detail": ships_lost_json,
             "kills": stats["kills"],
             "deaths": stats["deaths"],
             "damage_done": stats["damage_done"],
@@ -861,17 +872,17 @@ def _flush_analysis(
                 """
                 INSERT INTO theater_participants (
                     theater_id, character_id, character_name, alliance_id,
-                    corporation_id, side, ship_type_ids, kills, deaths,
+                    corporation_id, side, ship_type_ids, ships_lost_detail, kills, deaths,
                     damage_done, damage_taken, isk_lost, role_proxy,
                     entry_time, exit_time, battles_present,
                     suspicion_score, is_suspicious
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 [
                     (
                         p["theater_id"], p["character_id"], p["character_name"],
                         p["alliance_id"], p["corporation_id"], p["side"],
-                        p["ship_type_ids"], p["kills"], p["deaths"],
+                        p["ship_type_ids"], p["ships_lost_detail"], p["kills"], p["deaths"],
                         p["damage_done"], p["damage_taken"], p["isk_lost"], p["role_proxy"],
                         p["entry_time"], p["exit_time"], p["battles_present"],
                         p["suspicion_score"], p["is_suspicious"],

--- a/src/functions.php
+++ b/src/functions.php
@@ -10929,6 +10929,7 @@ function killmail_ship_class_label(?int $groupId): string
 function fleet_function_label(string $role): string
 {
     return match ($role) {
+        'fc' => 'FC',
         'mainline_dps' => 'Mainline DPS',
         'capital_dps' => 'Capital DPS',
         'logistics' => 'Logistics',
@@ -10953,6 +10954,7 @@ function fleet_function_label(string $role): string
 function fleet_function_color_class(string $role): string
 {
     return match ($role) {
+        'fc' => 'bg-yellow-900/60 text-yellow-200 ring-1 ring-yellow-400/40',
         'logistics', 'logi' => 'bg-emerald-900/60 text-emerald-300',
         'capital_logistics' => 'bg-emerald-900/60 text-emerald-300',
         'command' => 'bg-amber-900/60 text-amber-300',


### PR DESCRIPTION
- Collect victim ship types from killmails into ships_lost_detail JSON column with per-ship-type breakdown (type_id, count, isk_lost)
- Ship display: same hull type uses +N counter, different types shown comma-separated, pods (670/33328) excluded from display
- Alliance ISK killed now credited to final-blow alliance only instead of proportional damage distribution (no double-counting)
- Monitor (type 45534) always resolves to FC role with yellow highlight
- Add character portraits, alliance/corp logos to participant rows
- New migration: theater_participants.ships_lost_detail JSON column

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf