### PR TITLE
Fix economic warfare job: opponent detection and fitted item filtering

### DIFF
--- a/python/orchestrator/jobs/compute_economic_warfare.py
+++ b/python/orchestrator/jobs/compute_economic_warfare.py
@@ -81,7 +81,7 @@ def _extract_opponent_fits(db: Any, window_days: int) -> dict[int, dict]:
         INNER JOIN killmail_opponent_alliances koa
             ON koa.alliance_id = ke.victim_alliance_id AND koa.is_active = 1
         WHERE ke.killmail_time >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL %s DAY)
-          AND ki.item_role = 'fitted'
+          AND (ki.item_flag BETWEEN 11 AND 34 OR ki.item_flag BETWEEN 92 AND 94 OR ki.item_flag BETWEEN 125 AND 132)
         ORDER BY ke.sequence_id
     """
     kills: dict[int, dict] = {}
@@ -253,7 +253,7 @@ def _score_modules(
                     ON koa.alliance_id = ke.victim_alliance_id AND koa.is_active = 1
                 WHERE ki.item_type_id IN ({lp})
                   AND ke.killmail_time >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 30 DAY)
-                  AND ki.item_role = 'fitted'
+                  AND (ki.item_flag BETWEEN 11 AND 34 OR ki.item_flag BETWEEN 92 AND 94 OR ki.item_flag BETWEEN 125 AND 132)
                 GROUP BY ki.item_type_id""",
             tuple(type_id_list),
         )


### PR DESCRIPTION
## Summary

- **Replace `mail_type IN ('kill','opponent_loss')` with JOIN on `killmail_opponent_alliances`** — the `opponent_loss` enum value was never added to the DB, so the query matched zero opponent kills
- **Replace `item_role = 'fitted'` with `item_flag` ranges** — `item_role` defaults to `'other'` and is never populated during killmail ingestion, so zero fitted items matched
- Uses ESI item_flag values directly: 11-34 (high/mid/low slots), 92-94 (rigs), 125-132 (T3 subsystems) — matching the `ITEM_FLAG_CATEGORY` constant

## Test plan

- [ ] Verify `python -m orchestrator run-job --job-key compute_economic_warfare` now finds opponent kills and scores modules
- [ ] Check `economic_warfare_scores` table is populated after run
- [ ] Check `hostile_fit_families` table has clustered fits

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf