### PR TITLE
Fix CAST(? AS JSON) for MariaDB compatibility

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -11157,9 +11157,9 @@ function db_economic_warfare_scores(array $filters = [], int $limit = 100, int $
         $where[] = 'ew.type_id IN (
             SELECT hfm.item_type_id FROM hostile_fit_family_modules hfm
             INNER JOIN hostile_fit_families hff ON hff.id = hfm.family_id
-            WHERE JSON_CONTAINS(hff.alliance_ids_json, CAST(? AS JSON))
+            WHERE JSON_CONTAINS(hff.alliance_ids_json, ?)
         )';
-        $params[] = (int) $filters['hostile_alliance_id'];
+        $params[] = json_encode((int) $filters['hostile_alliance_id']);
     }
 
     $whereSql = implode(' AND ', $where);
@@ -11201,8 +11201,8 @@ function db_hostile_fit_families(array $filters = [], int $limit = 100, int $off
         $params[] = (int) $filters['hull_type_id'];
     }
     if (isset($filters['hostile_alliance_id']) && (int) $filters['hostile_alliance_id'] > 0) {
-        $where[] = 'JSON_CONTAINS(hff.alliance_ids_json, CAST(? AS JSON))';
-        $params[] = (int) $filters['hostile_alliance_id'];
+        $where[] = 'JSON_CONTAINS(hff.alliance_ids_json, ?)';
+        $params[] = json_encode((int) $filters['hostile_alliance_id']);
     }
     if (isset($filters['min_confidence']) && (float) $filters['min_confidence'] > 0) {
         $where[] = 'hff.confidence >= ?';


### PR DESCRIPTION
## Summary

- MariaDB doesn't support `CAST(? AS JSON)` syntax, causing SQL errors on the economic warfare and hostile fit families pages
- Fixed by passing the value as a JSON-encoded string directly to `JSON_CONTAINS()` — e.g. `json_encode((int) $id)` produces `"1354830081"` which MariaDB accepts as a valid JSON scalar
- Fixed in both `db_economic_warfare_scores()` and `db_hostile_fit_families()`

## Test plan

- [ ] Load `/economic-warfare/?hostile_alliance_id=1354830081` — should no longer throw PDOException

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf