### PR TITLE
Complete UI redesign: notification bell, view tabs, coverage gauge, sortable tables

### DIFF
--- a/database/migrations/20260403_page_cache.sql
+++ b/database/migrations/20260403_page_cache.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS page_cache (
+    cache_key   VARCHAR(120) NOT NULL PRIMARY KEY,
+    cache_value LONGTEXT     NOT NULL,
+    computed_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_page_cache_expires (expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/public/doctrine/index.php
+++ b/public/doctrine/index.php
@@ -97,6 +97,19 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             </div>
                             <span class="badge border-cyan-400/18 bg-cyan-500/10 text-cyan-100"><?= doctrine_format_quantity((int) ($group['fit_count'] ?? 0)) ?> primary fits</span>
                         </div>
+                        <?php
+                        $readyCount = (int) ($group['complete_fits_available'] ?? 0);
+                        $targetCount = max(1, (int) ($group['target_fit_count'] ?? 1));
+                        $readinessPercent = min(100, round(($readyCount / $targetCount) * 100, 1));
+                        $readinessColor = $readinessPercent >= 90 ? 'bg-emerald-400/70' : ($readinessPercent >= 70 ? 'bg-amber-400/70' : 'bg-rose-400/70');
+                        $readinessText = $readinessPercent >= 90 ? 'text-emerald-300' : ($readinessPercent >= 70 ? 'text-amber-300' : 'text-rose-300');
+                        ?>
+                        <div class="mt-3 flex items-center gap-3">
+                            <div class="flex-1 h-2 rounded-full bg-white/8 overflow-hidden">
+                                <div class="h-full rounded-full transition-all <?= $readinessColor ?>" style="width: <?= max(1, $readinessPercent) ?>%"></div>
+                            </div>
+                            <span class="text-sm font-semibold tabular-nums <?= $readinessText ?>"><?= $readinessPercent ?>%</span>
+                        </div>
                         <div class="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
                             <div class="surface-tertiary">
                                 <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Fleet ready</p>

--- a/public/index.php
+++ b/public/index.php
@@ -4,30 +4,26 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../src/bootstrap.php';
 
+// --- Lightweight header data (fast) ---
 $title = 'Command Dashboard';
-$dbStatus = db_connection_status();
-$intel = dashboard_intelligence_data();
-$doctrine = $intel['doctrine'] ?? doctrine_groups_overview_data();
-$pageFreshness = supplycore_page_freshness_view_model((array) ($intel['_freshness'] ?? []));
-$buyAll = buy_all_dashboard_summary();
 $liveRefreshConfig = supplycore_live_refresh_page_config('dashboard');
 $liveRefreshSummary = supplycore_live_refresh_summary($liveRefreshConfig);
 $pageHeaderBadge = 'Alliance logistics intelligence';
 $pageHeaderSummary = 'Focus this page on what changed, what needs action, and where alliance logistics can make or save ISK.';
-$pageHeaderMeta = [
-    [
-        'label' => 'Data freshness',
-        'value' => $pageFreshness['label'] . ' · ' . $pageFreshness['computed_relative'],
-        'caption' => 'Last updated ' . $pageFreshness['computed_at'] . '.',
-    ],
-    [
-        'label' => 'Live updates',
-        'value' => $liveRefreshSummary['mode_label'],
-        'caption' => $liveRefreshSummary['health_message'],
-    ],
-];
+$pageFreshness = [];
 
 include __DIR__ . '/../src/views/partials/header.php';
+
+// Early flush: browser can start rendering the nav shell while we compute
+if (function_exists('ob_flush')) { @ob_flush(); }
+@flush();
+
+// --- Heavy data queries (slow) ---
+$dbStatus = db_connection_status();
+$intel = dashboard_intelligence_data();
+$doctrine = $intel['doctrine'] ?? doctrine_groups_overview_data();
+$dashboardFreshness = supplycore_page_freshness_view_model((array) ($intel['_freshness'] ?? []));
+$buyAll = buy_all_dashboard_summary();
 ?>
 <?php
 $kpiThemes = [
@@ -110,7 +106,22 @@ if ($kpiCards === []) {
         [
             'label' => 'Top Opportunities',
             'value' => '—',
-            'context' => 'No KPI data available yet. Refresh dashboard snapshots to populate intelligence cards.',
+            'context' => 'Computing intelligence... KPI data will appear after the first snapshot completes.',
+        ],
+        [
+            'label' => 'Top Risks',
+            'value' => '—',
+            'context' => 'Awaiting first risk analysis snapshot.',
+        ],
+        [
+            'label' => 'Missing Seed Targets',
+            'value' => '—',
+            'context' => 'Awaiting market coverage data.',
+        ],
+        [
+            'label' => 'Overlap Coverage',
+            'value' => '—',
+            'context' => 'Coverage will show once market orders sync.',
         ],
     ];
 }
@@ -180,6 +191,7 @@ try {
     $dashboardFreshnessCards = [];
 }
 ?>
+<?php ob_start(); // capture KPIs section ?>
 <!-- ui-section:dashboard-kpis:start -->
 <section class="grid gap-4 xl:grid-cols-4" data-ui-section="dashboard-kpis">
     <?php foreach ($kpiCards as $card): ?>
@@ -237,7 +249,9 @@ try {
     <?php endforeach; ?>
 </section>
 <!-- ui-section:dashboard-kpis:end -->
+<?php $sectionKpis = ob_get_clean(); ?>
 
+<?php ob_start(); // capture Buy All section ?>
 <!-- ui-section:dashboard-buyall:start -->
 <section class="mt-8" data-ui-section="dashboard-buyall">
     <article class="surface-primary">
@@ -279,7 +293,7 @@ try {
                     <span class="badge border-orange-400/20 bg-orange-500/10 text-orange-100">Doctrine-critical included</span>
                     <span class="badge border-emerald-400/20 bg-emerald-500/10 text-emerald-100">Positive-margin seed candidates</span>
                 </div>
-                <p class="mt-4 text-sm text-slate-200">The planner keeps doctrine-critical items eligible even when profit data is weak, but otherwise leans toward positive net imports and haul-efficient seeding. Current dashboard summary freshness: <?= htmlspecialchars((string) ($pageFreshness['computed_relative'] ?? 'Unknown'), ENT_QUOTES) ?>.</p>
+                <p class="mt-4 text-sm text-slate-200">The planner keeps doctrine-critical items eligible even when profit data is weak, but otherwise leans toward positive net imports and haul-efficient seeding. Current dashboard summary freshness: <?= htmlspecialchars((string) ($dashboardFreshness['computed_relative'] ?? 'Unknown'), ENT_QUOTES) ?>.</p>
                 <div class="mt-5 flex flex-wrap items-center gap-3">
                     <a href="<?= htmlspecialchars((string) ($buyAll['planner_href'] ?? '/buy-all?mode=blended&page=1'), ENT_QUOTES) ?>" class="btn-primary">Buy All</a>
                     <a href="<?= htmlspecialchars((string) ($buyAll['blended_href'] ?? '/buy-all?mode=blended&page=1'), ENT_QUOTES) ?>" class="btn-secondary">Review blended plan</a>
@@ -289,7 +303,9 @@ try {
     </article>
 </section>
 <!-- ui-section:dashboard-buyall:end -->
+<?php $sectionBuyAll = ob_get_clean(); ?>
 
+<?php ob_start(); // capture Doctrine section ?>
 <!-- ui-section:dashboard-doctrine:start -->
 <section class="mt-8 grid gap-5 xl:grid-cols-[minmax(0,1.3fr)_minmax(320px,0.9fr)]" data-ui-section="dashboard-doctrine">
     <article class="surface-primary">
@@ -442,7 +458,9 @@ try {
     </article>
 </section>
 <!-- ui-section:dashboard-doctrine:end -->
+<?php $sectionDoctrine = ob_get_clean(); ?>
 
+<?php ob_start(); // capture remaining sections (queues, briefings, trends, status) ?>
 <section class="mt-8">
     <article class="surface-secondary">
         <div class="section-header border-b border-white/8 pb-4">
@@ -739,4 +757,13 @@ try {
     <?php endif; ?>
 </section>
 <!-- ui-section:dashboard-queues:end -->
+<?php $sectionRest = ob_get_clean(); ?>
+
+<?php
+// Reordered dashboard: Doctrine first (urgent), then KPIs, then queues/briefings/buy-all/trends
+echo $sectionDoctrine;
+echo $sectionKpis;
+echo $sectionRest;
+echo $sectionBuyAll;
+?>
 <?php include __DIR__ . '/../src/views/partials/footer.php'; ?>

--- a/public/market-status/current-alliance.php
+++ b/public/market-status/current-alliance.php
@@ -25,6 +25,39 @@ $pageFreshness = supplycore_page_freshness_view_model((array) ($data['freshness'
 $liveRefreshConfig = supplycore_live_refresh_page_config('current_alliance');
 $modulePageSectionKey = 'current-alliance-main';
 
+// Coverage gauge data
+$trackedTotal = 0;
+$stockedCount = 0;
+$lowStockCount = 0;
+$criticalCount = 0;
+foreach ($summary as $card) {
+    $label = (string) ($card['label'] ?? '');
+    $val = (int) ($card['value'] ?? 0);
+    if ($label === 'Tracked Modules') { $trackedTotal = $val; }
+    elseif ($label === 'Listings with Stock') { $stockedCount = $val; }
+    elseif ($label === 'Low Stock Count') { $lowStockCount = $val; }
+    elseif ($label === 'Critical Restocks') { $criticalCount = $val; }
+}
+$coveragePercent = $trackedTotal > 0 ? round(($stockedCount / $trackedTotal) * 100, 1) : 0;
+$gapCount = max(0, $trackedTotal - $stockedCount);
+
 include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<!-- Coverage gauge -->
+<section class="surface-secondary mb-6">
+    <div class="flex flex-wrap items-center gap-6">
+        <div class="flex-1">
+            <div class="flex items-center justify-between gap-3">
+                <p class="text-sm font-medium text-slate-200">Coverage</p>
+                <p class="text-2xl font-semibold tabular-nums <?= $coveragePercent >= 80 ? 'text-emerald-300' : ($coveragePercent >= 50 ? 'text-amber-300' : 'text-rose-300') ?>"><?= $coveragePercent ?>%</p>
+            </div>
+            <div class="mt-2 h-2.5 rounded-full bg-white/8 overflow-hidden">
+                <div class="h-full rounded-full transition-all <?= $coveragePercent >= 80 ? 'bg-emerald-400/70' : ($coveragePercent >= 50 ? 'bg-amber-400/70' : 'bg-rose-400/70') ?>" style="width: <?= min(100, max(1, $coveragePercent)) ?>%"></div>
+            </div>
+            <p class="mt-2 text-xs text-slate-500"><?= number_format($trackedTotal) ?> total · <?= number_format($stockedCount) ?> stocked · <?= number_format($gapCount) ?> gaps · <?= number_format($lowStockCount) ?> below minimum<?php if ($criticalCount > 0): ?> · <span class="text-rose-300"><?= number_format($criticalCount) ?> critical</span><?php endif; ?></p>
+        </div>
+    </div>
+</section>
+<?php
 include __DIR__ . '/../../src/views/partials/module-page.php';
 include __DIR__ . '/../../src/views/partials/footer.php';

--- a/public/market-status/missing-items.php
+++ b/public/market-status/missing-items.php
@@ -16,12 +16,61 @@ $tableColumns = [
     'priority' => 'Priority',
 ];
 $highlights = $data['highlights'] ?? [];
-$tableRows = $data['rows'] ?? [];
+$allRows = $data['rows'] ?? [];
 $emptyMessage = 'No missing items detected against ' . market_hub_reference_name() . '.';
 $pageFreshness = supplycore_page_freshness_view_model((array) ($data['freshness'] ?? []));
 $liveRefreshConfig = supplycore_live_refresh_page_config('missing_items');
 $modulePageSectionKey = 'missing-items-main';
 
+// Tier filter
+$tier = trim((string) ($_GET['tier'] ?? 'high'));
+if (!in_array($tier, ['high', 'all', 'high_volume'], true)) {
+    $tier = 'high';
+}
+
+// Classify rows into tiers
+$highPriority = [];
+$highVolume = [];
+$standard = [];
+foreach ($allRows as $row) {
+    $tone = (string) ($row['row_tone'] ?? '');
+    $vol = (int) ($row['daily_volume'] ?? 0);
+    if ($tone === 'opp_high') {
+        $highPriority[] = $row;
+    } elseif ($vol >= 1000) {
+        $highVolume[] = $row;
+    } else {
+        $standard[] = $row;
+    }
+}
+
+$tableRows = match ($tier) {
+    'high' => $highPriority,
+    'high_volume' => $highVolume,
+    default => $allRows,
+};
+
 include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<div class="mb-6 flex items-center gap-2">
+    <?php
+    $tabs = [
+        'high' => 'High Priority ' . count($highPriority),
+        'high_volume' => 'High Volume ' . count($highVolume),
+        'all' => 'All ' . count($allRows),
+    ];
+    foreach ($tabs as $tabKey => $tabLabel):
+        $isActive = $tier === $tabKey;
+        $tabTone = $isActive
+            ? 'border-cyan-400/30 bg-cyan-500/12 text-cyan-100'
+            : 'border-white/8 bg-white/[0.03] text-slate-400 hover:bg-white/[0.06] hover:text-slate-200';
+    ?>
+        <a href="<?= htmlspecialchars(current_path() . '?tier=' . $tabKey, ENT_QUOTES) ?>"
+           class="rounded-full border px-4 py-1.5 text-sm font-medium transition <?= $tabTone ?>">
+            <?= htmlspecialchars($tabLabel, ENT_QUOTES) ?>
+        </a>
+    <?php endforeach; ?>
+</div>
+<?php
 include __DIR__ . '/../../src/views/partials/module-page.php';
 include __DIR__ . '/../../src/views/partials/footer.php';

--- a/public/market-status/price-deviations.php
+++ b/public/market-status/price-deviations.php
@@ -16,12 +16,67 @@ $tableColumns = [
     'severity' => 'Severity',
 ];
 $highlights = $data['highlights'] ?? [];
-$tableRows = $data['rows'] ?? [];
+$allRows = $data['rows'] ?? [];
 $emptyMessage = 'No deviation alerts at this time versus ' . market_hub_reference_name() . '.';
 $pageFreshness = supplycore_page_freshness_view_model((array) ($data['freshness'] ?? []));
 $liveRefreshConfig = supplycore_live_refresh_page_config('price_deviations');
 $modulePageSectionKey = 'price-deviations-main';
 
+// View filter: actionable (default), all, or noise
+$view = trim((string) ($_GET['view'] ?? 'actionable'));
+if (!in_array($view, ['actionable', 'all', 'noise'], true)) {
+    $view = 'actionable';
+}
+
+// Filter rows based on selected view
+$tableRows = [];
+$inActionable = false;
+$inNoise = false;
+foreach ($allRows as $row) {
+    if ((bool) ($row['is_group_header'] ?? false)) {
+        $group = strtolower(trim((string) ($row['module'] ?? '')));
+        $inActionable = $group === 'actionable';
+        $inNoise = $group === 'noise';
+        if ($view === 'all') {
+            $tableRows[] = $row;
+        }
+        continue;
+    }
+    if ($view === 'all') {
+        $tableRows[] = $row;
+    } elseif ($view === 'actionable' && $inActionable) {
+        $tableRows[] = $row;
+    } elseif ($view === 'noise' && $inNoise) {
+        $tableRows[] = $row;
+    }
+}
+
+// Count per group for tab badges
+$actionableCount = (int) (($summary[1] ?? [])['value'] ?? 0);
+$noiseCount = (int) (($summary[2] ?? [])['value'] ?? 0);
+$totalCount = (int) (($summary[0] ?? [])['value'] ?? 0);
+
 include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<div class="mb-6 flex items-center gap-2">
+    <?php
+    $tabs = [
+        'actionable' => 'Actionable ' . $actionableCount,
+        'all' => 'All ' . $totalCount,
+        'noise' => 'Noise ' . $noiseCount,
+    ];
+    foreach ($tabs as $tabKey => $tabLabel):
+        $isActive = $view === $tabKey;
+        $tabTone = $isActive
+            ? 'border-cyan-400/30 bg-cyan-500/12 text-cyan-100'
+            : 'border-white/8 bg-white/[0.03] text-slate-400 hover:bg-white/[0.06] hover:text-slate-200';
+    ?>
+        <a href="<?= htmlspecialchars(current_path() . '?view=' . $tabKey, ENT_QUOTES) ?>"
+           class="rounded-full border px-4 py-1.5 text-sm font-medium transition <?= $tabTone ?>">
+            <?= htmlspecialchars($tabLabel, ENT_QUOTES) ?>
+        </a>
+    <?php endforeach; ?>
+</div>
+<?php
 include __DIR__ . '/../../src/views/partials/module-page.php';
 include __DIR__ . '/../../src/views/partials/footer.php';

--- a/public/market-status/reference-comparison.php
+++ b/public/market-status/reference-comparison.php
@@ -17,12 +17,66 @@ $tableColumns = [
     'severity' => 'Tier',
 ];
 $highlights = $data['highlights'] ?? [];
-$tableRows = $data['rows'] ?? [];
+$allRows = $data['rows'] ?? [];
 $emptyMessage = 'No comparison rows available for ' . $referenceHubName . '.';
 $pageFreshness = supplycore_page_freshness_view_model((array) ($data['freshness'] ?? []));
 $liveRefreshConfig = supplycore_live_refresh_page_config('reference_comparison');
 $modulePageSectionKey = 'reference-comparison-main';
 
+// View filter
+$view = trim((string) ($_GET['view'] ?? 'all'));
+if (!in_array($view, ['all', 'underpriced', 'overpriced'], true)) {
+    $view = 'all';
+}
+
+// Filter rows by view
+$tableRows = [];
+$inUnderpriced = false;
+$inOverpriced = false;
+foreach ($allRows as $row) {
+    if ((bool) ($row['is_group_header'] ?? false)) {
+        $group = strtolower(trim((string) ($row['module'] ?? '')));
+        $inUnderpriced = str_contains($group, 'underpriced');
+        $inOverpriced = str_contains($group, 'overpriced');
+        if ($view === 'all') {
+            $tableRows[] = $row;
+        }
+        continue;
+    }
+    if ($view === 'all') {
+        $tableRows[] = $row;
+    } elseif ($view === 'underpriced' && $inUnderpriced) {
+        $tableRows[] = $row;
+    } elseif ($view === 'overpriced' && $inOverpriced) {
+        $tableRows[] = $row;
+    }
+}
+
+$underpricedCount = (int) (($summary[1] ?? [])['value'] ?? 0);
+$overpricedCount = (int) (($summary[2] ?? [])['value'] ?? 0);
+$totalCount = (int) (($summary[0] ?? [])['value'] ?? 0);
+
 include __DIR__ . '/../../src/views/partials/header.php';
+?>
+<div class="mb-6 flex items-center gap-2">
+    <?php
+    $tabs = [
+        'all' => 'All ' . $totalCount,
+        'underpriced' => 'Underpriced ' . $underpricedCount,
+        'overpriced' => 'Overpriced ' . $overpricedCount,
+    ];
+    foreach ($tabs as $tabKey => $tabLabel):
+        $isActive = $view === $tabKey;
+        $tabTone = $isActive
+            ? 'border-cyan-400/30 bg-cyan-500/12 text-cyan-100'
+            : 'border-white/8 bg-white/[0.03] text-slate-400 hover:bg-white/[0.06] hover:text-slate-200';
+    ?>
+        <a href="<?= htmlspecialchars(current_path() . '?view=' . $tabKey, ENT_QUOTES) ?>"
+           class="rounded-full border px-4 py-1.5 text-sm font-medium transition <?= $tabTone ?>">
+            <?= htmlspecialchars($tabLabel, ENT_QUOTES) ?>
+        </a>
+    <?php endforeach; ?>
+</div>
+<?php
 include __DIR__ . '/../../src/views/partials/module-page.php';
 include __DIR__ . '/../../src/views/partials/footer.php';

--- a/src/functions.php
+++ b/src/functions.php
@@ -203,6 +203,7 @@ function nav_items(): array
             'label' => 'Market Status',
             'path' => '/market-status',
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 6h18"/><path stroke-linecap="round" stroke-linejoin="round" d="M7 12h10"/><path stroke-linecap="round" stroke-linejoin="round" d="M10 18h4"/></svg>',
+            'badge_tooltip' => 'Market analysis views',
             'children' => [
                 ['label' => 'Current Alliance Structure', 'path' => '/market-status/current-alliance'],
                 ['label' => 'Reference Hub Comparison', 'path' => '/market-status/reference-comparison'],
@@ -220,6 +221,7 @@ function nav_items(): array
             'label' => 'History',
             'path' => '/history',
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v5l3 2"/><path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 1 1-3.3-6.95"/></svg>',
+            'badge_tooltip' => 'Trend windows with data',
             'children' => [
                 ['label' => 'Alliance Structure Trends', 'path' => '/history/alliance-trends'],
                 ['label' => 'Module History', 'path' => '/history/module-history'],
@@ -229,6 +231,7 @@ function nav_items(): array
             'label' => 'Killmail Intelligence',
             'path' => '/killmail-intelligence',
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M13 3 4 14h6l-1 7 9-11h-6l1-7Z"/></svg>',
+            'badge_tooltip' => 'Intelligence feeds',
             'children' => [
                 ['label' => 'Recent Killmails', 'path' => '/killmail-intelligence'],
             ],
@@ -237,6 +240,7 @@ function nav_items(): array
             'label' => 'Battle Intelligence',
             'path' => '/battle-intelligence',
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16"/><path stroke-linecap="round" stroke-linejoin="round" d="M4 12h16"/><path stroke-linecap="round" stroke-linejoin="round" d="M4 18h16"/><path stroke-linecap="round" stroke-linejoin="round" d="m9 9 3 3 3-3"/></svg>',
+            'badge_tooltip' => 'Battle analysis tools',
             'children' => [
                 ['label' => 'Pilot Lookup', 'path' => '/battle-intelligence/pilot-lookup.php'],
                 ['label' => 'Suspicion Leaderboard', 'path' => '/battle-intelligence'],
@@ -253,6 +257,7 @@ function nav_items(): array
             'label' => 'Activity Priority',
             'path' => '/activity-priority',
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16"/><path stroke-linecap="round" stroke-linejoin="round" d="M6 12h12"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 17h6"/><path stroke-linecap="round" stroke-linejoin="round" d="m15 5 4 4-4 4"/></svg>',
+            'badge_tooltip' => 'Items needing action',
             'children' => [
                 ['label' => 'Doctrine Activity Board', 'path' => '/activity-priority'],
             ],
@@ -261,6 +266,7 @@ function nav_items(): array
             'label' => 'Doctrine Fits',
             'path' => '/doctrine',
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 5h14v14H5z"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 9h6M9 13h6M9 17h4"/></svg>',
+            'badge_tooltip' => 'Doctrine management views',
             'children' => [
                 ['label' => 'Doctrine Groups', 'path' => '/doctrine'],
                 ['label' => 'Fit Overview', 'path' => '/doctrine/fits'],
@@ -30257,4 +30263,39 @@ function ew_meta_group_label(int $metaGroupId): string
         53 => 'Officer',
         default => 'Meta ' . $metaGroupId,
     };
+}
+
+// ---------------------------------------------------------------------------
+// Page cache helpers (DB-backed, works without Redis)
+// ---------------------------------------------------------------------------
+
+function page_cache_get(string $key): mixed
+{
+    $row = db_select_one(
+        "SELECT cache_value FROM page_cache WHERE cache_key = ? AND expires_at > NOW()",
+        [$key]
+    );
+
+    return $row ? json_decode($row['cache_value'], true) : null;
+}
+
+function page_cache_set(string $key, mixed $data, int $ttl = 300): void
+{
+    db_execute(
+        "REPLACE INTO page_cache (cache_key, cache_value, computed_at, expires_at)
+         VALUES (?, ?, NOW(), DATE_ADD(NOW(), INTERVAL ? SECOND))",
+        [$key, json_encode($data, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE), $ttl]
+    );
+}
+
+function page_cache_clear(string $key): void
+{
+    db_execute("DELETE FROM page_cache WHERE cache_key = ?", [$key]);
+}
+
+function page_cache_flush_expired(): int
+{
+    db_execute("DELETE FROM page_cache WHERE expires_at <= NOW()");
+
+    return 0;
 }

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -62,37 +62,50 @@ $pageFreshnessLine = $pageFreshness !== []
             <div class="mb-6 rounded-2xl border border-emerald-500/30 bg-emerald-500/12 px-4 py-3 text-sm text-emerald-100 shadow-[0_0_24px_rgba(34,197,94,0.08)]"><?= htmlspecialchars($notice, ENT_QUOTES) ?></div>
         <?php endif; ?>
         <?php if ($pageFreshness !== []): ?>
+            <?php
+            $freshnessState = (string) ($pageFreshness['state'] ?? 'stale');
+            $freshnessRelative = (string) ($pageFreshness['computed_relative'] ?? 'Unknown');
+            $freshnessAt = (string) ($pageFreshness['computed_at'] ?? '');
+            ?>
             <!-- ui-section:page-freshness:start -->
-            <div class="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-2xl border px-4 py-2 text-sm shadow-[0_0_24px_rgba(15,23,42,0.14)] <?= htmlspecialchars((string) ($pageFreshness['tone'] ?? 'border-amber-400/20 bg-amber-500/10 text-amber-100'), ENT_QUOTES) ?>" data-ui-section="page-freshness">
-                <div>
-                    <p class="font-medium"><?= htmlspecialchars((string) ($pageFreshness['message'] ?? 'Summary freshness unavailable.'), ENT_QUOTES) ?></p>
-                    <p class="mt-1 text-xs opacity-80" data-ui-freshness-target="page-freshness">Last computed <?= htmlspecialchars((string) ($pageFreshness['computed_relative'] ?? 'Never'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($pageFreshness['computed_at'] ?? 'Unavailable'), ENT_QUOTES) ?></p>
+            <?php if ($freshnessState === 'fresh'): ?>
+                <!-- Fresh data: no banner shown -->
+            <?php elseif ($freshnessState === 'updating'): ?>
+                <p class="mb-4 text-xs text-slate-500" data-ui-section="page-freshness" data-ui-freshness-target="page-freshness">Refreshing data... · Last snapshot <?= htmlspecialchars($freshnessRelative, ENT_QUOTES) ?></p>
+            <?php elseif ($freshnessState === 'stale'): ?>
+                <div class="mb-4 flex items-center gap-2 text-xs text-amber-300/80" data-ui-section="page-freshness">
+                    <svg viewBox="0 0 16 16" fill="currentColor" class="h-3.5 w-3.5 shrink-0 opacity-70"><path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 3a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 7a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"/></svg>
+                    <span data-ui-freshness-target="page-freshness">Data from <?= htmlspecialchars($freshnessRelative, ENT_QUOTES) ?><?= $freshnessAt !== '' ? ' · ' . htmlspecialchars($freshnessAt, ENT_QUOTES) : '' ?></span>
                 </div>
-                <span class="rounded-full border border-current/20 px-3 py-1 text-[11px] uppercase tracking-[0.14em]"><?= htmlspecialchars((string) ($pageFreshness['label'] ?? 'Unknown'), ENT_QUOTES) ?></span>
-            </div>
+            <?php else: ?>
+                <p class="mb-4 text-xs text-slate-500" data-ui-section="page-freshness" data-ui-freshness-target="page-freshness">Data from <?= htmlspecialchars($freshnessRelative, ENT_QUOTES) ?></p>
+            <?php endif; ?>
             <!-- ui-section:page-freshness:end -->
         <?php endif; ?>
         <?php if ($dealAlertPopupRows !== []): ?>
-            <?php
-            $dealAlertPopupSignature = sha1(json_encode(array_values(array_map(static fn (array $row): string => (string) ($row['alert_key'] ?? ''), $dealAlertPopupRows)), JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE) ?: '');
-            ?>
-            <div class="fixed inset-x-4 top-4 z-50 ml-auto max-w-xl" data-deal-alert-popup data-deal-alert-signature="<?= htmlspecialchars($dealAlertPopupSignature, ENT_QUOTES) ?>" data-deal-alert-dismiss-minutes="<?= max(5, $dealAlertDismissMinutes) ?>">
-                <section class="rounded-[1.6rem] border border-rose-400/35 bg-gradient-to-br from-[#2a0911]/96 via-[#1a0c14]/96 to-[#120811]/96 px-5 py-4 text-rose-50 shadow-[0_28px_90px_rgba(244,63,94,0.28)] backdrop-blur-xl">
-                    <div class="flex items-start justify-between gap-4">
+            <!-- Notification bell trigger (fixed top-right) -->
+            <button type="button" class="fixed right-5 top-5 z-50 flex h-10 w-10 items-center justify-center rounded-full border border-rose-400/30 bg-[#1a0c14]/90 text-rose-100 shadow-[0_4px_24px_rgba(244,63,94,0.25)] backdrop-blur-xl transition hover:bg-rose-500/20" data-alert-bell-toggle aria-label="Open anomaly alerts">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="h-5 w-5"><path stroke-linecap="round" stroke-linejoin="round" d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path stroke-linecap="round" stroke-linejoin="round" d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+                <span class="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-bold text-white" data-alert-bell-count><?= count($dealAlertPopupRows) ?></span>
+            </button>
+
+            <!-- Slide-out alert drawer -->
+            <div class="fixed inset-0 z-[60] hidden" data-alert-drawer>
+                <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" data-alert-drawer-backdrop></div>
+                <aside class="absolute bottom-0 right-0 top-0 flex w-full max-w-md flex-col border-l border-rose-400/20 bg-gradient-to-b from-[#1a0c14] via-[#120811] to-[#0b0610] shadow-[0_0_60px_rgba(244,63,94,0.15)]">
+                    <div class="flex items-center justify-between border-b border-white/8 px-5 py-4">
                         <div>
-                            <p class="text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-rose-200/80">Immediate market anomaly</p>
-                            <h2 class="mt-2 text-lg font-semibold text-white">Critical / high-confidence deal alerts are active</h2>
-                            <p class="mt-1 text-sm text-rose-100/90">SupplyCore detected listings far below their local historical baseline in the alliance market or reference hub.</p>
+                            <p class="text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-rose-200/80">Market anomalies</p>
+                            <p class="mt-1 text-sm text-rose-100/70"><span data-alert-drawer-count><?= count($dealAlertPopupRows) ?></span> active alerts</p>
                         </div>
                         <div class="flex items-center gap-2">
-                            <a href="/deal-alerts" class="rounded-full border border-rose-200/20 bg-white/8 px-3 py-1 text-xs font-medium text-white hover:bg-white/12">Open deals page</a>
-                            <button type="button" class="rounded-full border border-white/20 bg-black/20 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-white hover:bg-black/35" data-deal-alert-close>Close</button>
+                            <a href="/deal-alerts" class="rounded-full border border-rose-200/20 bg-white/8 px-3 py-1 text-xs font-medium text-white hover:bg-white/12">View all</a>
+                            <button type="button" class="rounded-full border border-white/20 bg-black/20 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-white hover:bg-black/35" data-alert-drawer-close>Close</button>
                         </div>
                     </div>
-
-                    <div class="mt-4 space-y-3">
+                    <div class="flex-1 overflow-y-auto px-5 py-4 space-y-3" data-alert-drawer-list>
                         <?php foreach ($dealAlertPopupRows as $popupRow): ?>
-                            <article class="rounded-2xl border border-white/10 bg-black/20 p-4">
+                            <article class="rounded-2xl border border-white/10 bg-black/20 p-4" data-alert-item data-alert-id="<?= htmlspecialchars((string) ($popupRow['alert_key'] ?? ''), ENT_QUOTES) ?>">
                                 <div class="flex flex-wrap items-start justify-between gap-3">
                                     <div class="min-w-0 flex-1">
                                         <div class="flex flex-wrap items-center gap-2">
@@ -111,54 +124,67 @@ $pageFreshnessLine = $pageFreshness !== []
                                             <?= htmlspecialchars((string) ($popupRow['source_name'] ?? ''), ENT_QUOTES) ?> · Fresh <?= htmlspecialchars((string) ($popupRow['freshness_relative'] ?? 'Unknown'), ENT_QUOTES) ?>
                                         </p>
                                     </div>
-                                    <form method="post" action="/deal-alerts" class="shrink-0">
-                                        <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
-                                        <input type="hidden" name="alert_action" value="dismiss">
-                                        <input type="hidden" name="alert_key" value="<?= htmlspecialchars((string) ($popupRow['alert_key'] ?? ''), ENT_QUOTES) ?>">
-                                        <input type="hidden" name="severity_rank" value="<?= (int) ($popupRow['severity_rank'] ?? 1) ?>">
-                                        <input type="hidden" name="return_to" value="<?= htmlspecialchars((string) ($_SERVER['REQUEST_URI'] ?? '/deal-alerts'), ENT_QUOTES) ?>">
-                                        <button type="submit" class="rounded-full border border-white/12 bg-white/6 px-3 py-1.5 text-xs font-medium text-white hover:bg-white/12">
-                                            Dismiss <?= $dealAlertDismissMinutes ?>m
-                                        </button>
-                                    </form>
+                                    <button type="button" class="shrink-0 rounded-full border border-white/12 bg-white/6 px-3 py-1.5 text-xs font-medium text-white hover:bg-white/12" data-alert-dismiss="<?= htmlspecialchars((string) ($popupRow['alert_key'] ?? ''), ENT_QUOTES) ?>">
+                                        Dismiss
+                                    </button>
                                 </div>
                             </article>
                         <?php endforeach; ?>
                     </div>
-                </section>
+                </aside>
             </div>
             <script>
                 (() => {
-                    const popup = document.querySelector('[data-deal-alert-popup]');
-                    if (!popup) return;
-                    const signature = popup.getAttribute('data-deal-alert-signature') || '';
-                    const ttlMinutes = Number.parseInt(popup.getAttribute('data-deal-alert-dismiss-minutes') || '120', 10);
-                    const key = `deal-alert-popup:${signature}`;
-                    try {
-                        const raw = window.sessionStorage.getItem(key);
-                        if (raw) {
-                            const expiresAt = Number.parseInt(raw, 10);
-                            if (Number.isFinite(expiresAt) && Date.now() < expiresAt) {
-                                popup.remove();
-                                return;
-                            }
-                            window.sessionStorage.removeItem(key);
-                        }
-                    } catch (error) {
-                        // ignore storage access failures and still allow close interaction
+                    const bell = document.querySelector('[data-alert-bell-toggle]');
+                    const drawer = document.querySelector('[data-alert-drawer]');
+                    if (!bell || !drawer) return;
+                    const backdrop = drawer.querySelector('[data-alert-drawer-backdrop]');
+                    const closeBtn = drawer.querySelector('[data-alert-drawer-close]');
+                    const bellCount = bell.querySelector('[data-alert-bell-count]');
+                    const drawerCount = drawer.querySelector('[data-alert-drawer-count]');
+
+                    function filterDismissed() {
+                        let visible = 0;
+                        drawer.querySelectorAll('[data-alert-item]').forEach(item => {
+                            const id = item.getAttribute('data-alert-id');
+                            try {
+                                const ts = localStorage.getItem('dismissed_alert_' + id);
+                                if (ts && Date.now() < Number(ts)) { item.remove(); return; }
+                                if (ts) localStorage.removeItem('dismissed_alert_' + id);
+                            } catch (e) {}
+                            visible++;
+                        });
+                        updateCount(visible);
+                        if (visible === 0) { bell.classList.add('hidden'); }
                     }
-                    const closeButton = popup.querySelector('[data-deal-alert-close]');
-                    if (!closeButton) return;
-                    closeButton.addEventListener('click', () => {
-                        try {
-                            const minutes = Number.isFinite(ttlMinutes) ? Math.max(5, ttlMinutes) : 120;
-                            const expiresAt = Date.now() + (minutes * 60 * 1000);
-                            window.sessionStorage.setItem(key, String(expiresAt));
-                        } catch (error) {
-                            // no-op
-                        }
-                        popup.remove();
+
+                    function updateCount(n) {
+                        if (bellCount) bellCount.textContent = n;
+                        if (drawerCount) drawerCount.textContent = n;
+                    }
+
+                    function openDrawer() { drawer.classList.remove('hidden'); document.body.style.overflow = 'hidden'; }
+                    function closeDrawer() { drawer.classList.add('hidden'); document.body.style.overflow = ''; }
+
+                    bell.addEventListener('click', openDrawer);
+                    if (backdrop) backdrop.addEventListener('click', closeDrawer);
+                    if (closeBtn) closeBtn.addEventListener('click', closeDrawer);
+                    document.addEventListener('keydown', e => { if (e.key === 'Escape') closeDrawer(); });
+
+                    drawer.querySelectorAll('[data-alert-dismiss]').forEach(btn => {
+                        btn.addEventListener('click', () => {
+                            const id = btn.getAttribute('data-alert-dismiss');
+                            const ttl = 2 * 60 * 60 * 1000; // 2 hours
+                            try { localStorage.setItem('dismissed_alert_' + id, String(Date.now() + ttl)); } catch (e) {}
+                            const item = btn.closest('[data-alert-item]');
+                            if (item) item.remove();
+                            const remaining = drawer.querySelectorAll('[data-alert-item]').length;
+                            updateCount(remaining);
+                            if (remaining === 0) { closeDrawer(); bell.classList.add('hidden'); }
+                        });
                     });
+
+                    filterDismissed();
                 })();
             </script>
         <?php endif; ?>

--- a/src/views/partials/module-page.php
+++ b/src/views/partials/module-page.php
@@ -156,7 +156,7 @@ $buildPageUrl = static function (int $targetPage) use ($queryParams): string {
                     $alignRight = in_array((string) $column, ['Stock', 'Daily Volume'], true);
                     $thClass = $alignRight ? 'text-right' : '';
                     ?>
-                    <th class="<?= $thClass ?>"><?= htmlspecialchars((string) $column, ENT_QUOTES) ?></th>
+                    <th class="<?= $thClass ?> select-none"><?= htmlspecialchars((string) $column, ENT_QUOTES) ?><span class="ml-1 text-[10px] text-slate-500" data-sort-arrow></span></th>
                 <?php endforeach; ?>
             </tr>
             </thead>
@@ -232,6 +232,73 @@ $buildPageUrl = static function (int $targetPage) use ($queryParams): string {
         </table>
     </div>
 </section>
+
+<?php if (!$hasTableControls): ?>
+    <div class="mt-3 flex items-center gap-3">
+        <label class="block flex-1 max-w-xs">
+            <input type="search" placeholder="Quick filter by name..." class="field-input text-sm" data-table-quick-filter>
+        </label>
+        <span class="text-xs text-slate-500" data-table-filter-count></span>
+    </div>
+<?php endif; ?>
+
+<script>
+(() => {
+    // Client-side column sort on th click
+    document.querySelectorAll('.table-ui').forEach(table => {
+        const headers = table.querySelectorAll('thead th');
+        const tbody = table.querySelector('tbody');
+        if (!tbody || !headers.length) return;
+
+        let sortCol = -1, sortAsc = true;
+
+        headers.forEach((th, idx) => {
+            th.style.cursor = 'pointer';
+            th.title = 'Click to sort';
+            th.addEventListener('click', () => {
+                if (sortCol === idx) { sortAsc = !sortAsc; } else { sortCol = idx; sortAsc = true; }
+
+                // Update header indicators
+                headers.forEach(h => { const a = h.querySelector('[data-sort-arrow]'); if (a) a.textContent = ''; });
+                const arrow = th.querySelector('[data-sort-arrow]');
+                if (arrow) arrow.textContent = sortAsc ? '\u25B2' : '\u25BC';
+
+                const rows = Array.from(tbody.querySelectorAll('tr:not([class*="bg-white"])'));
+                rows.sort((a, b) => {
+                    const aCell = a.cells[idx]?.textContent?.trim() ?? '';
+                    const bCell = b.cells[idx]?.textContent?.trim() ?? '';
+                    const aNum = parseFloat(aCell.replace(/[^0-9.\-+]/g, ''));
+                    const bNum = parseFloat(bCell.replace(/[^0-9.\-+]/g, ''));
+                    if (!isNaN(aNum) && !isNaN(bNum)) return sortAsc ? aNum - bNum : bNum - aNum;
+                    return sortAsc ? aCell.localeCompare(bCell) : bCell.localeCompare(aCell);
+                });
+                rows.forEach(r => tbody.appendChild(r));
+            });
+        });
+    });
+
+    // Quick filter for non-paginated tables
+    const filterInput = document.querySelector('[data-table-quick-filter]');
+    const countEl = document.querySelector('[data-table-filter-count]');
+    if (filterInput) {
+        const tbody = document.querySelector('.table-ui tbody');
+        if (tbody) {
+            filterInput.addEventListener('input', () => {
+                const q = filterInput.value.toLowerCase();
+                let shown = 0;
+                tbody.querySelectorAll('tr').forEach(row => {
+                    if (row.classList.contains('bg-white/[0.05]')) return; // group headers
+                    const text = row.textContent.toLowerCase();
+                    const match = q === '' || text.includes(q);
+                    row.style.display = match ? '' : 'none';
+                    if (match) shown++;
+                });
+                if (countEl) countEl.textContent = q ? shown + ' shown' : '';
+            });
+        }
+    }
+})();
+</script>
 
 <?php if ($modulePageSectionKey !== ''): ?>
     </div>

--- a/src/views/partials/sidebar.php
+++ b/src/views/partials/sidebar.php
@@ -60,7 +60,7 @@
                     <span class="flex h-8 w-8 items-center justify-center rounded-xl border border-white/8 bg-slate-950/70 text-base shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"><?= $item['icon'] ?></span>
                     <span class="flex-1"><?= htmlspecialchars($item['label'], ENT_QUOTES) ?></span>
                     <?php if ($item['children'] !== []): ?>
-                        <span class="text-xs text-slate-500"><?= count($item['children']) ?></span>
+                        <span class="text-xs text-slate-500" <?php if (!empty($item['badge_tooltip'])): ?>title="<?= htmlspecialchars(count($item['children']) . ' ' . $item['badge_tooltip'], ENT_QUOTES) ?>"<?php endif; ?>><?= count($item['children']) ?></span>
                     <?php endif; ?>
                 </a>
                 <?php if ($item['children'] !== []): ?>


### PR DESCRIPTION
## Summary

Phase 1 of the complete SupplyCore UI redesign — global fixes and highest-impact page improvements.

### Global fixes (every page)
- **Anomaly popup → notification bell**: Fixed bell icon top-right with red badge count. Click opens slide-out drawer from right. Per-alert dismiss stored in localStorage (2hr TTL). Backdrop click + ESC to close.
- **Stale data banner → subtle timestamp**: Fresh data = no banner. Updating = grey note. Stale = small amber inline with icon. No more full-width warning bars.
- **Navigation badge tooltips**: Each nav section badge now has a `title` tooltip explaining what the count represents.
- **Page cache table**: New `page_cache` DB table with `page_cache_get()`, `page_cache_set()`, `page_cache_clear()` helper functions for DB-backed caching (works without Redis).
- **Early flush**: Dashboard sends header HTML shell before heavy DB queries, reducing perceived TTFB.

### Dashboard
- **Section reordering**: Doctrine supply risk (urgent) now renders first, followed by KPI cards, then intelligence queues, then Buy All planner.
- **Empty state**: All 4 KPI skeleton cards shown with "Computing..." / "Awaiting..." messages instead of single "No data" card.

### Market Status pages
- **Price Deviations**: Tabbed view filter — Actionable (default) / All / Noise — shows only the 32 actionable items by default instead of all 1335.
- **Current Alliance**: Coverage gauge with progress bar showing X% coverage, total/stocked/gap/critical counts.
- **Missing Items**: Tier filter tabs — High Priority / High Volume / All — groups the 924 items into manageable tiers.
- **Reference Comparison**: View tabs — All / Underpriced / Overpriced — to focus on specific market positions.

### Doctrine
- **Readiness bars**: Each doctrine group card now has a visual progress bar showing fleet readiness %. Color-coded: green ≥90%, amber ≥70%, red <70%.

### All tables (module-page template)
- **Client-side column sort**: Click any column header to sort ascending/descending. Handles both text and numeric values. Arrow indicators (▲/▼) on active column.
- **Quick filter**: Non-paginated tables get a "Quick filter by name..." search input with live filtering and match count.

## Test plan

- [ ] Run migration: `CREATE TABLE page_cache ...` (see `database/migrations/20260403_page_cache.sql`)
- [ ] Load dashboard — verify Doctrine section renders first, KPIs second
- [ ] Trigger deal alerts — verify bell icon appears instead of popup overlay
- [ ] Click bell → drawer opens, dismiss an alert → verify localStorage persistence
- [ ] Load price deviations — verify Actionable tab is default, click All/Noise tabs
- [ ] Load current alliance — verify coverage gauge with progress bar at top
- [ ] Load missing items — verify High Priority tab is default
- [ ] Load reference comparison — verify view tabs work
- [ ] Load doctrine groups — verify readiness progress bar per group
- [ ] Click table column headers — verify sort toggles with arrow indicators
- [ ] Type in quick filter input on non-paginated tables — verify live filtering

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf