### PR TITLE
Fix SVG 1487px expansion and killmail page performance

### DIFF
--- a/public/api/search-alliances.php
+++ b/public/api/search-alliances.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: private, max-age=60');
+
+$q = trim((string) ($_GET['q'] ?? ''));
+
+if (mb_strlen($q) < 1) {
+    echo json_encode(['results' => []]);
+    exit;
+}
+
+$latestSequencesSql = db_killmail_latest_sequences_sql();
+$rows = db_select(
+    "SELECT DISTINCT
+        e.victim_alliance_id AS entity_id,
+        COALESCE(NULLIF(ta.label, ''), CONCAT('Alliance #', e.victim_alliance_id)) AS entity_label
+     FROM {$latestSequencesSql} latest
+     INNER JOIN killmail_events e ON e.sequence_id = latest.sequence_id
+     LEFT JOIN killmail_tracked_alliances ta
+       ON ta.alliance_id = e.victim_alliance_id
+      AND ta.is_active = 1
+     WHERE e.victim_alliance_id IS NOT NULL
+       AND e.victim_alliance_id > 0
+       AND (
+           ta.label LIKE CONCAT('%', ?, '%')
+           OR CAST(e.victim_alliance_id AS CHAR) LIKE CONCAT(?, '%')
+       )
+     ORDER BY entity_label ASC
+     LIMIT 25",
+    [$q, $q]
+);
+
+$results = [];
+foreach ($rows as $row) {
+    $id = (int) ($row['entity_id'] ?? 0);
+    if ($id > 0) {
+        $results[] = ['id' => $id, 'label' => (string) ($row['entity_label'] ?? 'Alliance #' . $id)];
+    }
+}
+
+echo json_encode(['results' => $results]);

--- a/public/api/search-corporations.php
+++ b/public/api/search-corporations.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: private, max-age=60');
+
+$q = trim((string) ($_GET['q'] ?? ''));
+
+if (mb_strlen($q) < 1) {
+    echo json_encode(['results' => []]);
+    exit;
+}
+
+$latestSequencesSql = db_killmail_latest_sequences_sql();
+$rows = db_select(
+    "SELECT DISTINCT
+        e.victim_corporation_id AS entity_id,
+        COALESCE(NULLIF(tc.label, ''), CONCAT('Corporation #', e.victim_corporation_id)) AS entity_label
+     FROM {$latestSequencesSql} latest
+     INNER JOIN killmail_events e ON e.sequence_id = latest.sequence_id
+     LEFT JOIN killmail_tracked_corporations tc
+       ON tc.corporation_id = e.victim_corporation_id
+      AND tc.is_active = 1
+     WHERE e.victim_corporation_id IS NOT NULL
+       AND e.victim_corporation_id > 0
+       AND (
+           tc.label LIKE CONCAT('%', ?, '%')
+           OR CAST(e.victim_corporation_id AS CHAR) LIKE CONCAT(?, '%')
+       )
+     ORDER BY entity_label ASC
+     LIMIT 25",
+    [$q, $q]
+);
+
+$results = [];
+foreach ($rows as $row) {
+    $id = (int) ($row['entity_id'] ?? 0);
+    if ($id > 0) {
+        $results[] = ['id' => $id, 'label' => (string) ($row['entity_label'] ?? 'Corporation #' . $id)];
+    }
+}
+
+echo json_encode(['results' => $results]);

--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -60,6 +60,8 @@ $buildPageUrl = static function (int $targetPage) use ($queryParams): string {
 };
 
 include __DIR__ . '/../../src/views/partials/header.php';
+if (function_exists('ob_flush')) { @ob_flush(); }
+@flush();
 ?>
 <?php if (is_string($error) && trim($error) !== ''): ?>
     <section class="mb-6 rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
@@ -167,22 +169,34 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Search losses</span>
                 <input type="search" name="q" value="<?= htmlspecialchars((string) ($filters['search'] ?? ''), ENT_QUOTES) ?>" placeholder="Search ship, system, region, corporation, alliance, sequence, or killmail..." class="w-full field-input">
             </label>
-            <label class="block text-sm text-muted">
+            <?php
+                $selectedAllianceId = (int) ($filters['alliance_id'] ?? 0);
+                $selectedAllianceLabel = '';
+                if ($selectedAllianceId > 0) {
+                    $selectedAllianceLabel = (string) (($filters['alliance_options'] ?? [])[(string) $selectedAllianceId] ?? 'Alliance #' . $selectedAllianceId);
+                }
+                $selectedCorpId = (int) ($filters['corporation_id'] ?? 0);
+                $selectedCorpLabel = '';
+                if ($selectedCorpId > 0) {
+                    $selectedCorpLabel = (string) (($filters['corporation_options'] ?? [])[(string) $selectedCorpId] ?? 'Corporation #' . $selectedCorpId);
+                }
+            ?>
+            <div class="block text-sm text-muted">
                 <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Victim alliance</span>
-                <select name="alliance_id" class="w-full field-select">
-                    <?php foreach ((array) ($filters['alliance_options'] ?? []) as $optionValue => $optionLabel): ?>
-                        <option value="<?= htmlspecialchars((string) $optionValue, ENT_QUOTES) ?>" <?= (string) $optionValue === (string) ($filters['alliance_id'] ?? 0) ? 'selected' : '' ?>><?= htmlspecialchars((string) $optionLabel, ENT_QUOTES) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </label>
-            <label class="block text-sm text-muted">
+                <div class="relative" data-autocomplete data-autocomplete-url="/api/search-alliances.php">
+                    <input type="hidden" name="alliance_id" value="<?= $selectedAllianceId ?>" data-autocomplete-value>
+                    <input type="search" class="w-full field-input" placeholder="Search alliances..." value="<?= htmlspecialchars($selectedAllianceLabel, ENT_QUOTES) ?>" data-autocomplete-input autocomplete="off">
+                    <ul class="absolute left-0 right-0 top-full z-30 mt-1 hidden max-h-48 overflow-y-auto rounded-xl border border-white/10 bg-[#0d1422] shadow-lg" data-autocomplete-list></ul>
+                </div>
+            </div>
+            <div class="block text-sm text-muted">
                 <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Victim corporation</span>
-                <select name="corporation_id" class="w-full field-select">
-                    <?php foreach ((array) ($filters['corporation_options'] ?? []) as $optionValue => $optionLabel): ?>
-                        <option value="<?= htmlspecialchars((string) $optionValue, ENT_QUOTES) ?>" <?= (string) $optionValue === (string) ($filters['corporation_id'] ?? 0) ? 'selected' : '' ?>><?= htmlspecialchars((string) $optionLabel, ENT_QUOTES) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </label>
+                <div class="relative" data-autocomplete data-autocomplete-url="/api/search-corporations.php">
+                    <input type="hidden" name="corporation_id" value="<?= $selectedCorpId ?>" data-autocomplete-value>
+                    <input type="search" class="w-full field-input" placeholder="Search corporations..." value="<?= htmlspecialchars($selectedCorpLabel, ENT_QUOTES) ?>" data-autocomplete-input autocomplete="off">
+                    <ul class="absolute left-0 right-0 top-full z-30 mt-1 hidden max-h-48 overflow-y-auto rounded-xl border border-white/10 bg-[#0d1422] shadow-lg" data-autocomplete-list></ul>
+                </div>
+            </div>
             <label class="block text-sm text-muted">
                 <span class="mb-1 block text-xs uppercase tracking-[0.18em]">Page size</span>
                 <select name="page_size" class="w-full field-select">
@@ -239,7 +253,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <td class="px-3 py-3 align-top">
                             <div class="flex items-start gap-3">
                                 <?php if ((string) ($row['victim_portrait_url'] ?? '') !== ''): ?>
-                                    <img src="<?= htmlspecialchars((string) $row['victim_portrait_url'], ENT_QUOTES) ?>" alt="" class="h-10 w-10 rounded-xl object-cover">
+                                    <img src="<?= htmlspecialchars((string) $row['victim_portrait_url'], ENT_QUOTES) ?>" alt="" width="40" height="40" loading="lazy" class="h-10 w-10 rounded-xl object-cover">
                                 <?php endif; ?>
                                 <div>
                                     <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['victim_character'] ?? '—'), ENT_QUOTES) ?></p>
@@ -257,7 +271,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <td class="px-3 py-3 align-top">
                             <div class="flex items-start gap-3">
                                 <?php if ((string) ($row['final_blow_portrait_url'] ?? '') !== ''): ?>
-                                    <img src="<?= htmlspecialchars((string) $row['final_blow_portrait_url'], ENT_QUOTES) ?>" alt="" class="h-10 w-10 rounded-xl object-cover">
+                                    <img src="<?= htmlspecialchars((string) $row['final_blow_portrait_url'], ENT_QUOTES) ?>" alt="" width="40" height="40" loading="lazy" class="h-10 w-10 rounded-xl object-cover">
                                 <?php endif; ?>
                                 <div>
                                     <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['final_blow_character'] ?? 'Unknown character'), ENT_QUOTES) ?></p>
@@ -269,7 +283,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <td class="px-3 py-3 align-top">
                             <div class="flex items-start gap-3">
                                 <?php if ((string) ($row['ship_icon_url'] ?? '') !== ''): ?>
-                                    <img src="<?= htmlspecialchars((string) $row['ship_icon_url'], ENT_QUOTES) ?>" alt="" class="h-10 w-10 rounded-lg bg-black/30 object-contain p-1">
+                                    <img src="<?= htmlspecialchars((string) $row['ship_icon_url'], ENT_QUOTES) ?>" alt="" width="40" height="40" loading="lazy" class="h-10 w-10 rounded-lg bg-black/30 object-contain p-1">
                                 <?php endif; ?>
                                 <div>
                                     <p class="font-medium text-slate-50"><?= htmlspecialchars((string) ($row['ship_type'] ?? '—'), ENT_QUOTES) ?></p>
@@ -327,4 +341,75 @@ include __DIR__ . '/../../src/views/partials/header.php';
 </section>
 <!-- ui-section:killmail-overview-table:end -->
 
+<script>
+(() => {
+    document.querySelectorAll('[data-autocomplete]').forEach(container => {
+        const url = container.getAttribute('data-autocomplete-url');
+        const input = container.querySelector('[data-autocomplete-input]');
+        const hidden = container.querySelector('[data-autocomplete-value]');
+        const list = container.querySelector('[data-autocomplete-list]');
+        if (!url || !input || !hidden || !list) return;
+
+        let debounce = null;
+        let abortCtrl = null;
+
+        function show(results) {
+            list.innerHTML = '';
+            if (results.length === 0) {
+                list.classList.add('hidden');
+                return;
+            }
+            results.forEach(r => {
+                const li = document.createElement('li');
+                li.textContent = r.label;
+                li.className = 'cursor-pointer px-3 py-2 text-sm text-slate-200 hover:bg-sky-500/16';
+                li.addEventListener('mousedown', e => {
+                    e.preventDefault();
+                    hidden.value = r.id;
+                    input.value = r.label;
+                    list.classList.add('hidden');
+                });
+                list.appendChild(li);
+            });
+            list.classList.remove('hidden');
+        }
+
+        input.addEventListener('input', () => {
+            clearTimeout(debounce);
+            const q = input.value.trim();
+            if (q === '') {
+                hidden.value = '0';
+                list.classList.add('hidden');
+                return;
+            }
+            debounce = setTimeout(() => {
+                if (abortCtrl) abortCtrl.abort();
+                abortCtrl = new AbortController();
+                fetch(url + '?q=' + encodeURIComponent(q), { signal: abortCtrl.signal })
+                    .then(r => r.json())
+                    .then(data => show(data.results || []))
+                    .catch(() => {});
+            }, 200);
+        });
+
+        input.addEventListener('blur', () => {
+            setTimeout(() => list.classList.add('hidden'), 150);
+        });
+
+        input.addEventListener('focus', () => {
+            if (input.value.trim() !== '' && list.children.length > 0) {
+                list.classList.remove('hidden');
+            }
+        });
+
+        // Allow clearing
+        input.addEventListener('search', () => {
+            if (input.value === '') {
+                hidden.value = '0';
+                list.classList.add('hidden');
+            }
+        });
+    });
+})();
+</script>
 <?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/market-status/current-alliance.php
+++ b/public/market-status/current-alliance.php
@@ -41,10 +41,11 @@ foreach ($summary as $card) {
 $coveragePercent = $trackedTotal > 0 ? round(($stockedCount / $trackedTotal) * 100, 1) : 0;
 $gapCount = max(0, $trackedTotal - $stockedCount);
 
+$suppressPageFreshness = true;
 include __DIR__ . '/../../src/views/partials/header.php';
 ?>
-<!-- Coverage gauge -->
-<section class="surface-secondary mb-6">
+<!-- Coverage gauge (above freshness — most important summary) -->
+<section class="surface-secondary mb-4">
     <div class="flex flex-wrap items-center gap-6">
         <div class="flex-1">
             <div class="flex items-center justify-between gap-3">
@@ -58,6 +59,14 @@ include __DIR__ . '/../../src/views/partials/header.php';
         </div>
     </div>
 </section>
+<?php if ($pageFreshness !== [] && ($pageFreshness['state'] ?? '') === 'stale'): ?>
+    <div class="mb-4 flex items-center gap-2 text-xs text-amber-300/80">
+        <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14" class="h-3.5 w-3.5 shrink-0 opacity-70"><path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 3a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 7a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"/></svg>
+        <span>Data from <?= htmlspecialchars((string) ($pageFreshness['computed_relative'] ?? 'Unknown'), ENT_QUOTES) ?></span>
+    </div>
+<?php elseif ($pageFreshness !== [] && ($pageFreshness['state'] ?? '') !== 'fresh'): ?>
+    <p class="mb-4 text-xs text-slate-500">Data from <?= htmlspecialchars((string) ($pageFreshness['computed_relative'] ?? 'Unknown'), ENT_QUOTES) ?></p>
+<?php endif; ?>
 <?php
 include __DIR__ . '/../../src/views/partials/module-page.php';
 include __DIR__ . '/../../src/views/partials/footer.php';

--- a/resources/styles/app.css
+++ b/resources/styles/app.css
@@ -308,3 +308,13 @@
         @apply bg-white/[0.01];
     }
 }
+
+/* Safety net: prevent SVG icons without explicit dimensions from expanding in flex containers */
+@layer base {
+    svg:not([width]):not([height]) {
+        width: 1em;
+        height: 1em;
+        min-width: 0;
+        min-height: 0;
+    }
+}

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -61,7 +61,7 @@ $pageFreshnessLine = $pageFreshness !== []
         <?php if ($notice): ?>
             <div class="mb-6 rounded-2xl border border-emerald-500/30 bg-emerald-500/12 px-4 py-3 text-sm text-emerald-100 shadow-[0_0_24px_rgba(34,197,94,0.08)]"><?= htmlspecialchars($notice, ENT_QUOTES) ?></div>
         <?php endif; ?>
-        <?php if ($pageFreshness !== []): ?>
+        <?php if ($pageFreshness !== [] && empty($suppressPageFreshness)): ?>
             <?php
             $freshnessState = (string) ($pageFreshness['state'] ?? 'stale');
             $freshnessRelative = (string) ($pageFreshness['computed_relative'] ?? 'Unknown');
@@ -74,7 +74,7 @@ $pageFreshnessLine = $pageFreshness !== []
                 <p class="mb-4 text-xs text-slate-500" data-ui-section="page-freshness" data-ui-freshness-target="page-freshness">Refreshing data... · Last snapshot <?= htmlspecialchars($freshnessRelative, ENT_QUOTES) ?></p>
             <?php elseif ($freshnessState === 'stale'): ?>
                 <div class="mb-4 flex items-center gap-2 text-xs text-amber-300/80" data-ui-section="page-freshness">
-                    <svg viewBox="0 0 16 16" fill="currentColor" class="h-3.5 w-3.5 shrink-0 opacity-70"><path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 3a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 7a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"/></svg>
+                    <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14" class="h-3.5 w-3.5 shrink-0 opacity-70"><path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 3a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 7a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"/></svg>
                     <span data-ui-freshness-target="page-freshness">Data from <?= htmlspecialchars($freshnessRelative, ENT_QUOTES) ?><?= $freshnessAt !== '' ? ' · ' . htmlspecialchars($freshnessAt, ENT_QUOTES) : '' ?></span>
                 </div>
             <?php else: ?>


### PR DESCRIPTION
## Summary

- **SVG fix**: Freshness indicator SVGs expanded to 1487×1487px in flex containers due to missing `width`/`height` HTML attributes. Added explicit dimensions and a CSS safety net rule for all unsized SVGs. Reordered coverage gauge above freshness timestamp on current-alliance page.
- **Killmail page performance**: Page was 252KB with a 903-option corporation dropdown (85KB HTML) and 72 simultaneous ESI image requests causing browser freeze. Replaced alliance/corporation `<select>` dropdowns with AJAX autocomplete text inputs backed by new `/api/search-alliances.php` and `/api/search-corporations.php` endpoints. Added `loading="lazy"` and explicit `width="40" height="40"` to all ESI images (victim portrait, final blow portrait, ship icon). Added output buffering for early page shell flush.

## Test plan

- [ ] Verify SVG icons in freshness indicators render at correct size (~14px), not expanding to fill container
- [ ] Verify coverage gauge appears above freshness timestamp on Current Alliance page
- [ ] Verify killmail page loads without browser freeze — no 903-option dropdown in HTML source
- [ ] Type in alliance/corporation autocomplete fields and confirm dropdown results appear from API
- [ ] Verify selecting an autocomplete result and clicking "Apply filters" correctly filters killmails
- [ ] Verify clearing the autocomplete field resets the filter to "all"
- [ ] Verify ESI images lazy-load (check network tab — images below fold should not load immediately)
- [ ] Verify `/api/search-corporations.php?q=test` and `/api/search-alliances.php?q=test` return valid JSON

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf