### PR TITLE
Redesign logo and favicon with intelligence network motif

### DIFF
--- a/public/assets/branding/supplycore-favicon.svg
+++ b/public/assets/branding/supplycore-favicon.svg
@@ -1,5 +1,40 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="16" fill="#0f172a"/>
-  <path d="M14 32c0-9.941 8.059-18 18-18h10v8H32c-5.523 0-10 4.477-10 10s4.477 10 10 10h10v8H32c-9.941 0-18-8.059-18-18Z" fill="#e2e8f0"/>
-  <circle cx="46" cy="32" r="6" fill="#38bdf8"/>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e3a5f"/>
+      <stop offset="100%" stop-color="#0b1628"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#34d6ff"/>
+      <stop offset="60%" stop-color="#2f9bff"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#67e8f9"/>
+      <stop offset="100%" stop-color="#2f9bff"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect x="2" y="2" width="60" height="60" rx="16" fill="url(#bg)" stroke="url(#ring)" stroke-width="1.5" opacity="0.95"/>
+
+  <!-- Network edges -->
+  <line x1="22" y1="22" x2="42" y2="16" stroke="#2f9bff" stroke-width="1.3" opacity="0.5"/>
+  <line x1="42" y1="16" x2="46" y2="38" stroke="#2f9bff" stroke-width="1.3" opacity="0.5"/>
+  <line x1="46" y1="38" x2="22" y2="22" stroke="#2f9bff" stroke-width="1.3" opacity="0.4"/>
+  <line x1="22" y1="22" x2="18" y2="44" stroke="#2f9bff" stroke-width="1.3" opacity="0.4"/>
+  <line x1="18" y1="44" x2="46" y2="38" stroke="#2f9bff" stroke-width="1.3" opacity="0.35"/>
+  <line x1="18" y1="44" x2="38" y2="52" stroke="#2f9bff" stroke-width="1.3" opacity="0.4"/>
+  <line x1="46" y1="38" x2="38" y2="52" stroke="#2f9bff" stroke-width="1.3" opacity="0.35"/>
+
+  <!-- Core node -->
+  <circle cx="32" cy="32" r="7.5" fill="url(#bg)" stroke="url(#ring)" stroke-width="2"/>
+  <circle cx="32" cy="32" r="4" fill="url(#glow)" opacity="0.9"/>
+
+  <!-- Satellite nodes -->
+  <circle cx="22" cy="22" r="4" fill="url(#glow)" opacity="0.7"/>
+  <circle cx="42" cy="16" r="3.5" fill="url(#glow)" opacity="0.55"/>
+  <circle cx="46" cy="38" r="3.5" fill="url(#glow)" opacity="0.55"/>
+  <circle cx="18" cy="44" r="3.5" fill="url(#glow)" opacity="0.5"/>
+  <circle cx="38" cy="52" r="3" fill="url(#glow)" opacity="0.4"/>
 </svg>

--- a/public/assets/branding/supplycore-logo.svg
+++ b/public/assets/branding/supplycore-logo.svg
@@ -1,18 +1,57 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
-  <title id="title">SupplyCore logo placeholder</title>
-  <desc id="desc">Placeholder logo for the SupplyCore alliance logistics platform.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 64" role="img" aria-labelledby="title desc">
+  <title id="title">SupplyCore</title>
+  <desc id="desc">SupplyCore alliance logistics intelligence platform logo.</desc>
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1d4ed8" />
-      <stop offset="100%" stop-color="#0f172a" />
+    <linearGradient id="mark-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e3a5f"/>
+      <stop offset="100%" stop-color="#0b1628"/>
     </linearGradient>
-    <linearGradient id="core" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#e2e8f0" />
-      <stop offset="100%" stop-color="#93c5fd" />
+    <linearGradient id="ring-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#34d6ff"/>
+      <stop offset="60%" stop-color="#2f9bff"/>
+      <stop offset="100%" stop-color="#6366f1"/>
     </linearGradient>
+    <linearGradient id="node-glow" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#67e8f9"/>
+      <stop offset="100%" stop-color="#2f9bff"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
   </defs>
-  <rect width="128" height="128" rx="28" fill="url(#bg)" />
-  <path d="M26 64c0-21 17-38 38-38h20v16H64c-12.15 0-22 9.85-22 22s9.85 22 22 22h20v16H64c-21 0-38-17-38-38Z" fill="url(#core)" />
-  <path d="M74 34h12c9.941 0 18 8.059 18 18v24c0 9.941-8.059 18-18 18H74V78h10c1.105 0 2-.895 2-2V52c0-1.105-.895-2-2-2H74V34Z" fill="#38bdf8" />
-  <circle cx="96" cy="64" r="6" fill="#f8fafc" />
+
+  <!-- Mark background -->
+  <rect x="2" y="2" width="60" height="60" rx="16" fill="url(#mark-bg)" stroke="url(#ring-grad)" stroke-width="1.5" opacity="0.95"/>
+
+  <!-- Hexagonal supply network — 3 connected nodes -->
+  <g filter="url(#glow)">
+    <!-- Edges -->
+    <line x1="22" y1="22" x2="42" y2="16" stroke="#2f9bff" stroke-width="1.2" opacity="0.5"/>
+    <line x1="42" y1="16" x2="46" y2="38" stroke="#2f9bff" stroke-width="1.2" opacity="0.5"/>
+    <line x1="46" y1="38" x2="22" y2="22" stroke="#2f9bff" stroke-width="1.2" opacity="0.4"/>
+    <line x1="22" y1="22" x2="18" y2="44" stroke="#2f9bff" stroke-width="1.2" opacity="0.4"/>
+    <line x1="18" y1="44" x2="46" y2="38" stroke="#2f9bff" stroke-width="1.2" opacity="0.35"/>
+    <line x1="18" y1="44" x2="38" y2="52" stroke="#2f9bff" stroke-width="1.2" opacity="0.4"/>
+    <line x1="46" y1="38" x2="38" y2="52" stroke="#2f9bff" stroke-width="1.2" opacity="0.35"/>
+  </g>
+
+  <!-- Core node (center of gravity) -->
+  <circle cx="32" cy="32" r="7" fill="url(#mark-bg)" stroke="url(#ring-grad)" stroke-width="1.8"/>
+  <circle cx="32" cy="32" r="3.5" fill="url(#node-glow)" opacity="0.9"/>
+
+  <!-- Satellite nodes -->
+  <circle cx="22" cy="22" r="3.5" fill="url(#node-glow)" opacity="0.7"/>
+  <circle cx="42" cy="16" r="3" fill="url(#node-glow)" opacity="0.55"/>
+  <circle cx="46" cy="38" r="3" fill="url(#node-glow)" opacity="0.55"/>
+  <circle cx="18" cy="44" r="3" fill="url(#node-glow)" opacity="0.5"/>
+  <circle cx="38" cy="52" r="2.5" fill="url(#node-glow)" opacity="0.4"/>
+
+  <!-- Wordmark -->
+  <text x="76" y="30" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-weight="700" font-size="18" fill="#eef5ff" letter-spacing="0.03em">Supply</text>
+  <text x="149" y="30" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-weight="700" font-size="18" fill="#34d6ff" letter-spacing="0.03em">Core</text>
+  <text x="76" y="48" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-weight="400" font-size="9.5" fill="#8fa2bd" letter-spacing="0.18em" text-transform="uppercase">INTELLIGENCE PLATFORM</text>
 </svg>


### PR DESCRIPTION
## Summary

- Replaces placeholder logo/favicon with a network graph motif matching the dark intelligence platform aesthetic
- Five interconnected glowing cyan nodes on dark navy background with gradient border
- Logo wordmark: "Supply" in near-white (`#eef5ff`), "Core" in cyan (`#34d6ff`), "INTELLIGENCE PLATFORM" subtitle
- Favicon: same network mark with larger nodes and thicker strokes for small-size legibility

## Test plan

- [ ] Verify logo renders correctly in the header/nav
- [ ] Verify favicon appears in browser tab at 16x16 and 32x32
- [ ] Check both SVGs render in light and dark browser contexts

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf