### PR TITLE
Fix ref_alliances crash and register missing graph_model_audit job

### DIFF
--- a/python/orchestrator/processor_registry.py
+++ b/python/orchestrator/processor_registry.py
@@ -55,7 +55,7 @@ from .jobs.theater_graph_integration import run_theater_graph_integration
 from .jobs.theater_suspicion import run_theater_suspicion
 from .jobs.compute_economic_warfare import run_compute_economic_warfare
 from .jobs.graph_universe_sync import run_graph_universe_sync
-from .jobs.graph_pipeline import run_compute_graph_sync_killmail_entities
+from .jobs.graph_pipeline import run_compute_graph_sync_killmail_entities, run_graph_model_audit
 from .jobs.compute_alliance_dossiers import run_compute_alliance_dossiers
 from .jobs.compute_threat_corridors import run_compute_threat_corridors
 
@@ -94,6 +94,7 @@ PYTHON_COMPUTE_PROCESSOR_JOB_KEYS: set[str] = {
     "compute_graph_sync_killmail_entities",
     "compute_alliance_dossiers",
     "compute_threat_corridors",
+    "graph_model_audit",
 }
 
 PYTHON_SYNC_PROCESSOR_JOB_KEYS: set[str] = {
@@ -181,6 +182,8 @@ _PROCESSOR_DISPATCH: dict[str, tuple] = {
     # Intelligence expansion — dossiers & threat corridors
     "compute_alliance_dossiers": (run_compute_alliance_dossiers, lambda db, cfg: (db, neo4j_runtime(cfg))),
     "compute_threat_corridors": (run_compute_threat_corridors, lambda db, cfg: (db, neo4j_runtime(cfg))),
+    # Graph audit
+    "graph_model_audit": (run_graph_model_audit, lambda db, cfg: (db, neo4j_runtime(cfg))),
 }
 
 

--- a/src/db.php
+++ b/src/db.php
@@ -15665,11 +15665,12 @@ function db_alliance_dossier(int $allianceId): ?array
 {
     $rows = db_select(
         'SELECT ad.*,
-                ra.alliance_name AS ref_alliance_name,
+                emc.entity_name AS ref_alliance_name,
                 rr.region_name AS primary_region_name,
                 rs.system_name AS primary_system_name
          FROM alliance_dossiers ad
-         LEFT JOIN ref_alliances ra ON ra.alliance_id = ad.alliance_id
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = \'alliance\' AND emc.entity_id = ad.alliance_id
          LEFT JOIN ref_regions rr ON rr.region_id = ad.primary_region_id
          LEFT JOIN ref_systems rs ON rs.system_id = ad.primary_system_id
          WHERE ad.alliance_id = ?


### PR DESCRIPTION
- Fix alliance dossier view crash: ref_alliances table doesn't exist, use entity_metadata_cache instead for alliance name lookup
- Register run_graph_model_audit in processor_registry (was the only standalone schedulable job missing from dispatch)

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf