### PR TITLE
Fix graph_universe_sync crash: remove nonexistent columns

### DIFF
--- a/python/orchestrator/jobs/graph_universe_sync.py
+++ b/python/orchestrator/jobs/graph_universe_sync.py
@@ -133,11 +133,11 @@ def run_graph_universe_sync(
     now_sql = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
     db.execute(
         """
-        INSERT INTO graph_sync_state (sync_key, last_synced_at, rows_synced, meta_json)
-        VALUES (%s, %s, %s, NULL)
-        ON DUPLICATE KEY UPDATE last_synced_at = VALUES(last_synced_at), rows_synced = VALUES(rows_synced)
+        INSERT INTO graph_sync_state (sync_key, last_synced_at)
+        VALUES (%s, %s)
+        ON DUPLICATE KEY UPDATE last_synced_at = VALUES(last_synced_at)
         """,
-        ("graph_universe_sync", now_sql, rows_written),
+        ("graph_universe_sync", now_sql),
     )
 
     duration_ms = int((time.perf_counter() - started) * 1000)


### PR DESCRIPTION
## Summary

- `graph_universe_sync` INSERT referenced `rows_synced` and `meta_json` columns that don't exist on `graph_sync_state` table
- Table only has `sync_key`, `last_synced_at`, `updated_at`
- Simplified the upsert to match actual schema

## Test plan

- [ ] Run `python -m orchestrator run-job --job-key graph_universe_sync` — should complete without error

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf