### PR TITLE
Full dossier consistency audit + service-safe pipeline rebuild

### DIFF
--- a/scripts/reset_and_rebuild.sh
+++ b/scripts/reset_and_rebuild.sh
@@ -2,13 +2,18 @@
 # =============================================================================
 # SupplyCore Intelligence Pipeline — Full Reset & Rebuild
 # =============================================================================
-# Clears all computed/derived data and sync cursors, then runs all compute jobs
-# in dependency order until fully rebuilt.
+# Stops all workers, clears all computed/derived data and sync cursors, then
+# runs all compute jobs in dependency order until fully rebuilt, then restarts
+# the workers.
 #
 # KEEPS: ref_* tables, killmail data, market data, doctrine definitions,
 #        entity_metadata_cache, settings, ESI tokens, tracked alliances/corps
 #
-# Usage: bash scripts/reset_and_rebuild.sh
+# Usage: sudo bash scripts/reset_and_rebuild.sh
+#        (requires root for systemctl stop/start)
+#
+# Options:
+#   --no-service-control   Skip stopping/starting workers (for dev/testing)
 # =============================================================================
 
 set -euo pipefail
@@ -16,6 +21,13 @@ set -euo pipefail
 PYTHON="${PYTHON:-/var/www/SupplyCore/.venv-orchestrator/bin/python}"
 PROJECT_DIR="${PROJECT_DIR:-/var/www/SupplyCore}"
 DB_NAME="${DB_NAME:-supplycore}"
+SERVICE_CONTROL=true
+
+for arg in "$@"; do
+    case "$arg" in
+        --no-service-control) SERVICE_CONTROL=false ;;
+    esac
+done
 
 cd "$PROJECT_DIR"
 
@@ -24,8 +36,79 @@ echo " SupplyCore Intelligence Pipeline Reset"
 echo "============================================="
 echo ""
 
+# ── Step 0: Stop all workers ──────────────────────────────────────────────
+# Prevents race conditions: workers writing to tables mid-truncate,
+# re-seeding stale cursors, or failing on missing data.
+STOPPED_SERVICES=()
+
+stop_services() {
+    if [ "$SERVICE_CONTROL" != "true" ]; then
+        echo "[0/5] Skipping service control (--no-service-control)"
+        echo ""
+        return
+    fi
+
+    echo "[0/5] Stopping orchestrator workers and sync services..."
+
+    # Discover all active supplycore worker services
+    local services
+    services=$(systemctl list-units --type=service --state=running --no-legend \
+               | awk '{print $1}' \
+               | grep -E '^supplycore-(sync-worker|compute-worker|zkill)' || true)
+
+    # Also stop the influx timer to prevent it firing mid-rebuild
+    local timers
+    timers=$(systemctl list-units --type=timer --state=active --no-legend \
+             | awk '{print $1}' \
+             | grep -E '^supplycore-' || true)
+
+    if [ -z "$services" ] && [ -z "$timers" ]; then
+        echo "  No running supplycore services found — skipping"
+        echo ""
+        return
+    fi
+
+    for svc in $services $timers; do
+        echo -n "  Stopping $svc... "
+        if systemctl stop "$svc" 2>/dev/null; then
+            STOPPED_SERVICES+=("$svc")
+            echo "✓"
+        else
+            echo "✗ (may need sudo)"
+        fi
+    done
+
+    # Wait for workers to finish any in-flight jobs (graceful SIGTERM → 90s timeout)
+    echo -n "  Waiting for workers to drain... "
+    sleep 3
+    echo "✓"
+    echo ""
+}
+
+restart_services() {
+    if [ "$SERVICE_CONTROL" != "true" ] || [ ${#STOPPED_SERVICES[@]} -eq 0 ]; then
+        return
+    fi
+
+    echo ""
+    echo "[5/5] Restarting stopped services..."
+    for svc in "${STOPPED_SERVICES[@]}"; do
+        echo -n "  Starting $svc... "
+        if systemctl start "$svc" 2>/dev/null; then
+            echo "✓"
+        else
+            echo "✗ (may need sudo)"
+        fi
+    done
+}
+
+# Ensure services are restarted even if the script fails partway through
+trap restart_services EXIT
+
+stop_services
+
 # ── Step 1: Clear sync cursors & job state ──────────────────────────────────
-echo "[1/4] Clearing sync cursors and job state..."
+echo "[1/5] Clearing sync cursors and job state..."
 mysql "$DB_NAME" -e "
 TRUNCATE TABLE sync_state;
 TRUNCATE TABLE graph_sync_state;
@@ -36,7 +119,7 @@ DELETE FROM sync_runs WHERE 1=1;
 echo "  ✓ Sync cursors and job state cleared"
 
 # ── Step 2: Clear all computed/derived tables ───────────────────────────────
-echo "[2/4] Clearing computed/derived tables..."
+echo "[2/5] Clearing computed/derived tables..."
 mysql "$DB_NAME" -e "
 -- Battle intelligence
 TRUNCATE TABLE battle_rollups;
@@ -120,7 +203,7 @@ TRUNCATE TABLE item_priority_snapshots;
 echo "  ✓ All computed tables cleared"
 
 # ── Step 3: Run all compute jobs in order ───────────────────────────────────
-echo "[3/4] Running compute pipeline..."
+echo "[3/5] Running compute pipeline..."
 echo ""
 
 run_job() {
@@ -223,12 +306,20 @@ run_job "compute_economic_warfare" "Economic Warfare"
 
 # ── Step 4: Summary ─────────────────────────────────────────────────────────
 echo ""
+echo "[4/5] Verifying results..."
+mysql "$DB_NAME" -e "
+SELECT 'battle_rollups' AS \`table\`, COUNT(*) AS rows FROM battle_rollups
+UNION ALL SELECT 'theaters', COUNT(*) FROM theaters
+UNION ALL SELECT 'alliance_dossiers', COUNT(*) FROM alliance_dossiers
+UNION ALL SELECT 'threat_corridors', COUNT(*) FROM threat_corridors
+UNION ALL SELECT 'character_suspicion_signals', COUNT(*) FROM character_suspicion_signals;
+"
+
+# Step 5 (restart_services) runs automatically via the EXIT trap
+
+echo ""
 echo "============================================="
 echo " Pipeline rebuild complete!"
 echo "============================================="
 echo ""
-echo "Verify results:"
-echo "  mysql $DB_NAME -e \"SELECT COUNT(*) AS dossiers FROM alliance_dossiers\""
-echo "  mysql $DB_NAME -e \"SELECT COUNT(*) AS corridors FROM threat_corridors\""
-echo "  mysql $DB_NAME -e \"SELECT COUNT(*) AS theaters FROM theaters\""
-echo "  mysql $DB_NAME -e \"SELECT COUNT(*) AS battles FROM battle_rollups\""
+echo "Services will be restarted automatically."


### PR DESCRIPTION
## Summary

- **Full consistency audit** of the alliance dossier flow across Python, PHP, Neo4j, and SQL — fixes 9 contract mismatches, semantic bugs, and silent degradation issues
- **Service-safe reset script** — stops all orchestrator workers and timers before truncating tables, restarts them automatically when done (even on failure via EXIT trap)

### Contract & Semantic Fixes

- `co_battles` → `shared_battles` everywhere (Python produced one key, PHP read another)
- Neo4j co-presence query used PARTICIPATED_IN (same battle, any side) — replaced with ON_SIDE (same side only, matching SQL semantics)
- Posture colors mapped `aggressive`/`defensive`/`skirmish` but Python produces `committed`/`opportunistic`/`infrequent`/`balanced`
- Added `source: "neo4j"|"sql"` tracking to all co-present/enemy results, shown dynamically in UI
- Removed dead triple-fallback key chains in PHP templates
- Added diagnostic logging for unresolved alliance names
- Added 2 missing jobs to reset script (`compute_graph_sync_doctrine_dependency`, `graph_model_audit`)

### Reset Script Service Control

- Auto-discovers and stops all running `supplycore-*` workers and timers before reset
- EXIT trap ensures services restart even if script fails midway
- `--no-service-control` flag for dev/testing without systemd
- Verification step prints row counts for key tables after rebuild

### Test Coverage

- Expanded from 15 → 27 tests covering contract integrity, SQL/Neo4j key parity, posture validation, and fallback paths

## Test plan

- [x] 27 dossier tests pass
- [x] 13 threat corridor tests pass (no regression)
- [x] All 35 registered compute jobs covered in reset script
- [ ] Run `sudo bash scripts/reset_and_rebuild.sh` — verify services stop, rebuild completes, services restart
- [ ] Verify dossier co-present/enemy sections show names and correct counts
- [ ] Verify posture badges have correct colors

https://claude.ai/code/session_016k5YMRfGKh1tEj28Zp2cKf