### PR TITLE
Clear scheduler operational tables in reset script

### DIFF
--- a/scripts/reset_and_rebuild.sh
+++ b/scripts/reset_and_rebuild.sh
@@ -115,8 +115,20 @@ TRUNCATE TABLE graph_sync_state;
 TRUNCATE TABLE job_runs;
 TRUNCATE TABLE compute_job_locks;
 DELETE FROM sync_runs WHERE 1=1;
+
+-- Worker queue & scheduler operational tables
+TRUNCATE TABLE worker_jobs;
+TRUNCATE TABLE scheduler_job_events;
+TRUNCATE TABLE scheduler_job_resource_metrics;
+TRUNCATE TABLE scheduler_profiling_runs;
+TRUNCATE TABLE scheduler_profiling_samples;
+TRUNCATE TABLE scheduler_profiling_pairings;
+TRUNCATE TABLE scheduler_schedule_snapshots;
+TRUNCATE TABLE scheduler_tuning_actions;
+TRUNCATE TABLE scheduler_planner_decisions;
+DELETE FROM scheduler_job_current_status WHERE 1=1;
 "
-echo "  ✓ Sync cursors and job state cleared"
+echo "  ✓ Sync cursors, job state, and scheduler counters cleared"
 
 # ── Step 2: Clear all computed/derived tables ───────────────────────────────
 echo "[2/6] Clearing computed/derived tables..."


### PR DESCRIPTION
## Summary
Extended the database reset script to clear scheduler-related operational tables alongside existing sync and job state cleanup.

## Key Changes
- Added truncation of 9 scheduler operational tables:
  - `worker_jobs`
  - `scheduler_job_events`
  - `scheduler_job_resource_metrics`
  - `scheduler_profiling_runs`
  - `scheduler_profiling_samples`
  - `scheduler_profiling_pairings`
  - `scheduler_schedule_snapshots`
  - `scheduler_tuning_actions`
  - `scheduler_planner_decisions`
- Added deletion from `scheduler_job_current_status` table
- Updated the completion message to reflect that scheduler counters are now also cleared

## Implementation Details
The scheduler table cleanup is grouped together with a comment indicating these are "Worker queue & scheduler operational tables", maintaining consistency with the existing code organization pattern in the reset script.

https://claude.ai/code/session_01XDvoS9xLs6K6N3s5AY7WEL