### PR TITLE
Fix graph sync worker failures: schema mismatches, value overflows, a…

### DIFF
--- a/python/orchestrator/jobs/counterintel_pipeline.py
+++ b/python/orchestrator/jobs/counterintel_pipeline.py
@@ -1054,10 +1054,13 @@ def run_compute_counterintel_pipeline(
                     neo4j.query(
                         """
                         UNWIND $rows AS row
+                        WITH row WHERE row.start IS NOT NULL AND row.source IS NOT NULL
                         MERGE (c:Character {character_id: toInteger(row.character_id)})
                         MERGE (corp:Corporation {corporation_id: toInteger(row.corporation_id)})
-                        MERGE (c)-[r:HISTORICALLY_IN {start: row.start, source: row.source}]->(corp)
-                        SET r.end = row.end
+                        MERGE (c)-[r:HISTORICALLY_IN]->(corp)
+                        SET r.start = COALESCE(row.start, r.start),
+                            r.source = COALESCE(row.source, r.source),
+                            r.end = row.end
                         """,
                         {"rows": historical_membership_rows},
                     )

--- a/python/orchestrator/jobs/graph_evidence_paths.py
+++ b/python/orchestrator/jobs/graph_evidence_paths.py
@@ -88,10 +88,14 @@ def run_graph_evidence_paths_sync(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | 
             continue
 
         # Find shortest paths to other suspicious or notable entities
+        # Use explicit relationship types and shortestPath to avoid
+        # unbounded variable-length expansion that causes timeouts.
         path_rows = client.query(
             """
             MATCH (c:Character {character_id: $char_id})
-            MATCH p = (c)-[*1..4]-(target)
+            MATCH p = shortestPath(
+                (c)-[:SHARED_ALLIANCE_WITH|CO_OCCURS_WITH|DIRECT_COMBAT|ASSISTED_KILL|SAME_FLEET|CROSSED_SIDES|ASSOCIATED_WITH_ANOMALY|ON_SIDE|ATTACKED_ON|VICTIM_OF*1..4]-(target)
+            )
             WHERE (target:Character OR target:Alliance OR target:Battle)
               AND target <> c
               AND (target:Alliance OR target:Battle OR COALESCE(target.suspicion_score, 0) > 0.3)

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -1979,11 +1979,12 @@ def run_compute_graph_sync_killmail_entities(
     if new_cursor > last_cursor:
         db.execute(
             """
-            INSERT INTO sync_state (dataset_key, last_cursor, last_row_count, last_synced_at)
-            VALUES (%s, %s, %s, UTC_TIMESTAMP())
+            INSERT INTO sync_state (dataset_key, last_cursor, last_row_count, last_success_at, status)
+            VALUES (%s, %s, %s, UTC_TIMESTAMP(), 'success')
             ON DUPLICATE KEY UPDATE last_cursor = VALUES(last_cursor),
                                     last_row_count = VALUES(last_row_count),
-                                    last_synced_at = VALUES(last_synced_at)
+                                    last_success_at = VALUES(last_success_at),
+                                    status = 'success'
             """,
             (_KILLMAIL_CURSOR_KEY, str(new_cursor), rows_written),
         )

--- a/python/orchestrator/jobs/graph_temporal_metrics.py
+++ b/python/orchestrator/jobs/graph_temporal_metrics.py
@@ -83,9 +83,9 @@ def run_graph_temporal_metrics_sync(db: SupplyCoreDb, neo4j_raw: dict[str, Any] 
                     int(r.get("kills_total") or 0),
                     int(r.get("losses_total") or 0),
                     int(r.get("damage_total") or 0),
-                    float(r.get("suspicion_score") or 0.0),
-                    float(r.get("co_presence_density") or 0.0),
-                    float(r.get("engagement_rate_avg") or 0.0),
+                    max(-9999.999999, min(9999.999999, float(r.get("suspicion_score") or 0.0))),
+                    max(-9999.999999, min(9999.999999, float(r.get("co_presence_density") or 0.0))),
+                    max(-9999.999999, min(9999.999999, float(r.get("engagement_rate_avg") or 0.0))),
                     computed_at,
                 ])
             if values:

--- a/python/orchestrator/jobs/graph_universe_sync.py
+++ b/python/orchestrator/jobs/graph_universe_sync.py
@@ -139,6 +139,11 @@ def run_graph_universe_sync(
         """,
         ("graph_universe_sync", now_sql),
     )
+    db.upsert_sync_state(
+        dataset_key="graph_universe_sync",
+        status="success",
+        row_count=rows_written,
+    )
 
     duration_ms = int((time.perf_counter() - started) * 1000)
     return JobResult.success(

--- a/python/orchestrator/jobs/intelligence_pipeline.py
+++ b/python/orchestrator/jobs/intelligence_pipeline.py
@@ -772,11 +772,11 @@ def _export_suspicion_signals(client: Neo4jClient, db: SupplyCoreDb, computed_at
                     float(r.get("high_presence_low_output_score") or 0),
                     float(r.get("token_participation_score") or 0),
                     float(r.get("loss_without_attack_ratio") or 0),
-                    float(r.get("peer_norm_kills_delta") or 0),
-                    float(r.get("peer_norm_damage_delta") or 0),
-                    float(r.get("composition_advantage_ratio") or 1.0) - 1.0,  # delta from neutral
-                    float(r.get("composition_advantage_ratio") or 1.0),
-                    float(r.get("suspicion_score") or 0),
+                    max(-9999.999999, min(9999.999999, float(r.get("peer_norm_kills_delta") or 0))),
+                    max(-9999.999999, min(9999.999999, float(r.get("peer_norm_damage_delta") or 0))),
+                    max(-9999.999999, min(9999.999999, float(r.get("composition_advantage_ratio") or 1.0) - 1.0)),  # delta from neutral
+                    max(-9999.999999, min(9999.999999, float(r.get("composition_advantage_ratio") or 1.0))),
+                    max(-9999.999999, min(9999.999999, float(r.get("suspicion_score") or 0))),
                     json_dumps_safe(r.get("suspicion_flags") or []),
                     json_dumps_safe(r.get("engagement_rates") or []),
                     computed_at,


### PR DESCRIPTION
…nd query timeouts

- graph_pipeline.py: Fix sync_state INSERT using non-existent 'last_synced_at' column (should be 'last_success_at')
- intelligence_pipeline.py: Clamp DECIMAL(10,6) values (peer_normalized_damage_delta, suspicion_score, etc.) to prevent out-of-range errors
- graph_temporal_metrics.py: Clamp suspicion_score and other DECIMAL(10,6) fields before INSERT
- graph_evidence_paths.py: Replace unbounded variable-length path query with shortestPath and explicit relationship types to fix timeouts
- counterintel_pipeline.py: Remove null-unsafe MERGE properties on HISTORICALLY_IN relationships to prevent Neo4j 500 errors
- graph_universe_sync.py: Add sync_state tracking via upsert_sync_state for consistency with other jobs

https://claude.ai/code/session_018Vea9sZsZLEt1hvGCwMB2f