### PR TITLE
Set default args when no subcommand is provided

### DIFF
--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -154,7 +154,12 @@ def _print_cli_result(command: str, started_at: float, result: dict[str, Any]) -
 
 def main() -> int:
     args = parse_args()
-    command = args.command or "supervisor"
+    command = args.command
+    if command is None:
+        # No subcommand given – supply defaults that the supervisor subparser would have set.
+        args.app_root = str(Path(__file__).resolve().parents[2])
+        args.verbose = False
+        command = "supervisor"
     if command == "worker-pool":
         return run_worker_pool([
             "--app-root", args.app_root,


### PR DESCRIPTION
## Summary
Refactored the default command handling in the CLI to explicitly set required argument defaults when no subcommand is provided, rather than relying on implicit defaults.

## Key Changes
- Changed from inline default assignment (`args.command or "supervisor"`) to explicit conditional logic
- When no subcommand is provided, now explicitly sets:
  - `args.app_root` to the orchestrator root directory (2 levels up from main.py)
  - `args.verbose` to `False`
  - `args.command` to `"supervisor"`

## Implementation Details
This change ensures that the `supervisor` subcommand receives the same default argument values that its subparser would have set, making the default behavior more explicit and maintainable. The app_root is calculated relative to the main.py file location to ensure it works correctly regardless of where the script is invoked from.

https://claude.ai/code/session_01XJBzWi5aSN9JT3bBowGxs6