### PR TITLE
Replace battle_participants with killmail-based alliance relationship queries

### DIFF
--- a/python/orchestrator/jobs/compute_alliance_dossiers.py
+++ b/python/orchestrator/jobs/compute_alliance_dossiers.py
@@ -324,54 +324,25 @@ def _query_enemies_sql(db: SupplyCoreDb, alliance_id: int) -> list[dict]:
 def _query_co_presence_neo4j(neo4j_client: Any, alliance_id: int) -> list[dict]:
     """Query Neo4j for alliances whose members fight on the same side.
 
-    Primary path: ON_SIDE → BattleSide — ensures same-side co-presence
-    (not just same-battle, which would conflate allies with enemies).
-
-    Fallback path: ENGAGED_ALLIANCE — alliances whose characters engage
-    the same target alliances (coalition alignment signal).
+    Uses killmail co-attacker relationships: two alliances are co-present
+    when their members appear as co-attackers (both ``ATTACKED_ON``) on the
+    same ``Killmail`` node.  The ``battle_id`` property on the Killmail is
+    used to count distinct shared battles.
 
     Returns canonical contract: ``{alliance_id, shared_battles, shared_pilots, source}``.
     """
     if neo4j_client is None:
         return []
     try:
-        # Primary: ON_SIDE path — same BattleSide = same side in battle
-        # This is semantically equivalent to the SQL fallback (same side_key)
         rows = neo4j_client.query(
             """
             MATCH (a:Alliance {alliance_id: $aid})<-[:MEMBER_OF_ALLIANCE]-(c:Character)
-                  -[:ON_SIDE]->(side:BattleSide)<-[:ON_SIDE]-(c2:Character)
+                  -[:ATTACKED_ON]->(k:Killmail)<-[:ATTACKED_ON]-(c2:Character)
                   -[:MEMBER_OF_ALLIANCE]->(a2:Alliance)
             WHERE a2.alliance_id <> $aid
+              AND k.battle_id IS NOT NULL AND k.battle_id <> ''
             WITH a2.alliance_id AS co_alliance_id,
-                 COUNT(DISTINCT side) AS shared_battles,
-                 COUNT(DISTINCT c2) AS shared_pilots
-            WHERE shared_battles >= 2
-            RETURN co_alliance_id, shared_battles, shared_pilots
-            ORDER BY shared_battles DESC
-            LIMIT 15
-            """,
-            {"aid": alliance_id},
-        )
-        if rows:
-            return [{"alliance_id": int(r["co_alliance_id"]),
-                     "shared_battles": int(r["shared_battles"]),
-                     "shared_pilots": int(r["shared_pilots"]),
-                     "source": "neo4j"} for r in rows]
-
-        # Fallback: ENGAGED_ALLIANCE path (intelligence_pipeline)
-        # Alliances whose characters engage the same target alliances
-        rows = neo4j_client.query(
-            """
-            MATCH (a:Alliance {alliance_id: $aid})<-[:MEMBER_OF_ALLIANCE]-(c:Character)
-                  -[:ENGAGED_ALLIANCE]->(target:Alliance)
-            WITH target, collect(DISTINCT c) AS our_chars
-            MATCH (c2:Character)-[:ENGAGED_ALLIANCE]->(target)
-            WHERE NOT c2 IN our_chars
-            MATCH (c2)-[:MEMBER_OF_ALLIANCE]->(a2:Alliance)
-            WHERE a2.alliance_id <> $aid
-            WITH a2.alliance_id AS co_alliance_id,
-                 COUNT(DISTINCT target) AS shared_battles,
+                 COUNT(DISTINCT k.battle_id) AS shared_battles,
                  COUNT(DISTINCT c2) AS shared_pilots
             WHERE shared_battles >= 2
             RETURN co_alliance_id, shared_battles, shared_pilots
@@ -391,46 +362,34 @@ def _query_co_presence_neo4j(neo4j_client: Any, alliance_id: int) -> list[dict]:
 def _query_enemies_neo4j(neo4j_client: Any, alliance_id: int) -> list[dict]:
     """Query Neo4j for alliances most often on the opposing side.
 
-    Primary: ENGAGED_ALLIANCE (intelligence_pipeline) — direct engagement
-    relationships with encounter counts.
-
-    Fallback: ON_SIDE/HAS_SIDE path (battle_intelligence sync) — opposite
-    side representation, semantically equivalent to the SQL fallback.
+    Uses killmail attacker/victim relationships.  An alliance is an enemy
+    when our members attack their members (they are victims on a ``Killmail``
+    we ``ATTACKED_ON``) or vice-versa.  Both directions are combined via
+    ``CALL {} UNION ALL`` and de-duplicated by ``battle_id``.
 
     Returns canonical contract: ``{alliance_id, engagements, source}``.
     """
     if neo4j_client is None:
         return []
     try:
-        # Primary: ENGAGED_ALLIANCE — direct engagement relationships
         rows = neo4j_client.query(
             """
-            MATCH (a:Alliance {alliance_id: $aid})<-[:MEMBER_OF_ALLIANCE]-(c:Character)
-                  -[e:ENGAGED_ALLIANCE]->(enemy:Alliance)
-            WHERE enemy.alliance_id <> $aid
-            WITH enemy.alliance_id AS enemy_id,
-                 SUM(e.encounters) AS total_encounters,
-                 COUNT(DISTINCT c) AS engaging_pilots
-            WHERE total_encounters >= 2
-            RETURN enemy_id, total_encounters AS engagements
-            ORDER BY engagements DESC
-            LIMIT 15
-            """,
-            {"aid": alliance_id},
-        )
-        if rows:
-            return [{"alliance_id": int(r["enemy_id"]), "engagements": int(r["engagements"]),
-                     "source": "neo4j"} for r in rows]
-
-        # Fallback: ON_SIDE/HAS_SIDE path — opposite side in battle
-        rows = neo4j_client.query(
-            """
-            MATCH (a:Alliance {alliance_id: $aid})<-[:MEMBER_OF_ALLIANCE]-(c:Character)
-                  -[:ON_SIDE]->(my_side:BattleSide)<-[:HAS_SIDE]-(b:Battle)
-                  -[:HAS_SIDE]->(opp_side:BattleSide)-[:REPRESENTED_BY_ALLIANCE]->(enemy:Alliance)
-            WHERE my_side.side_key <> opp_side.side_key
-              AND enemy.alliance_id <> $aid
-            WITH enemy.alliance_id AS enemy_id, COUNT(DISTINCT b) AS engagements
+            CALL {
+                MATCH (a:Alliance {alliance_id: $aid})<-[:MEMBER_OF_ALLIANCE]-(c:Character)
+                      -[:ATTACKED_ON]->(k:Killmail)<-[:VICTIM_OF]-(v:Character)
+                      -[:MEMBER_OF_ALLIANCE]->(e:Alliance)
+                WHERE e.alliance_id <> $aid
+                  AND k.battle_id IS NOT NULL AND k.battle_id <> ''
+                RETURN e.alliance_id AS enemy_id, k.battle_id AS bid
+                UNION ALL
+                MATCH (a:Alliance {alliance_id: $aid})<-[:MEMBER_OF_ALLIANCE]-(c:Character)
+                      -[:VICTIM_OF]->(k:Killmail)<-[:ATTACKED_ON]-(att:Character)
+                      -[:MEMBER_OF_ALLIANCE]->(e:Alliance)
+                WHERE e.alliance_id <> $aid
+                  AND k.battle_id IS NOT NULL AND k.battle_id <> ''
+                RETURN e.alliance_id AS enemy_id, k.battle_id AS bid
+            }
+            WITH enemy_id, COUNT(DISTINCT bid) AS engagements
             WHERE engagements >= 2
             RETURN enemy_id, engagements
             ORDER BY engagements DESC

--- a/python/orchestrator/jobs/intelligence_pipeline.py
+++ b/python/orchestrator/jobs/intelligence_pipeline.py
@@ -320,17 +320,23 @@ def _compute_fleet_function(client: Neo4jClient) -> None:
 
 
 def _compute_encounter_vs_engagement(client: Neo4jClient) -> None:
-    """Step 5.2: Encounter vs engagement per opposing alliance."""
+    """Step 5.2: Encounter vs engagement per opposing alliance.
+
+    Uses killmail attacker/victim relationships to determine opposition
+    rather than BattleSide side_key (which is per-alliance and cannot
+    distinguish friend from foe).  A character "encounters" an enemy
+    alliance when they attack a member of that alliance on a killmail,
+    counted as distinct battles via ``Killmail.battle_id``.
+    """
     client.query(
-        """MATCH (c:Character)-[:ON_SIDE]->(my_side:BattleSide)<-[:HAS_SIDE]-(b:Battle)
-                  -[:HAS_SIDE]->(opp_side:BattleSide)
-           WHERE c.tracked = true AND my_side.side_key <> opp_side.side_key
-           MATCH (opp_side)-[:REPRESENTED_BY_ALLIANCE]->(a:Alliance)
-           WHERE NOT (c)-[:MEMBER_OF_ALLIANCE]->(a)
-           WITH c, a, count(DISTINCT b) AS encountered
-           OPTIONAL MATCH (c)-[:ATTACKED_ON]->(k:Killmail)<-[:VICTIM_OF]-(victim:Character)
-                          -[:MEMBER_OF_ALLIANCE]->(a)
-           WITH c, a, encountered, count(DISTINCT k) AS kills
+        """MATCH (c:Character)-[:ATTACKED_ON]->(k:Killmail)<-[:VICTIM_OF]-(victim:Character)
+                  -[:MEMBER_OF_ALLIANCE]->(a:Alliance)
+           WHERE c.tracked = true
+             AND NOT (c)-[:MEMBER_OF_ALLIANCE]->(a)
+             AND k.battle_id IS NOT NULL AND k.battle_id <> ''
+           WITH c, a,
+                count(DISTINCT k) AS kills,
+                count(DISTINCT k.battle_id) AS encountered
            WITH c, a, encountered, kills,
                 CASE WHEN encountered > 0
                      THEN toFloat(kills) / encountered ELSE 0.0 END AS eng_rate

--- a/python/tests/test_alliance_dossiers.py
+++ b/python/tests/test_alliance_dossiers.py
@@ -235,22 +235,15 @@ class TestNeo4jCoPresence(unittest.TestCase):
             self.assertTrue(CO_PRESENT_REQUIRED_KEYS.issubset(item.keys()),
                           f"Missing keys: {CO_PRESENT_REQUIRED_KEYS - item.keys()}")
 
-    def test_fallback_to_engaged_alliance_path(self) -> None:
-        """When ON_SIDE path returns empty, falls back to ENGAGED_ALLIANCE."""
+    def test_empty_result_returns_empty_list(self) -> None:
+        """When killmail co-attacker query returns empty, returns empty list."""
         client = MagicMock()
-        # First query (ON_SIDE path) returns empty
-        # Second query (ENGAGED_ALLIANCE path) returns results
-        client.query.side_effect = [
-            [],
-            [{"co_alliance_id": 400, "shared_battles": 4, "shared_pilots": 6}],
-        ]
+        client.query.return_value = []
 
         result = _query_co_presence_neo4j(client, 100)
 
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["alliance_id"], 400)
-        self.assertEqual(result[0]["source"], "neo4j")
-        self.assertEqual(client.query.call_count, 2)
+        self.assertEqual(result, [])
+        self.assertEqual(client.query.call_count, 1)
 
 
 class TestSqlCoPresence(unittest.TestCase):
@@ -326,20 +319,15 @@ class TestNeo4jEnemies(unittest.TestCase):
             self.assertTrue(ENEMY_REQUIRED_KEYS.issubset(item.keys()),
                           f"Missing keys: {ENEMY_REQUIRED_KEYS - item.keys()}")
 
-    def test_fallback_to_on_side_path(self) -> None:
-        """When ENGAGED_ALLIANCE path returns empty, falls back to ON_SIDE."""
+    def test_empty_result_returns_empty_list(self) -> None:
+        """When killmail attacker/victim query returns empty, returns empty list."""
         client = MagicMock()
-        client.query.side_effect = [
-            [],
-            [{"enemy_id": 600, "engagements": 3}],
-        ]
+        client.query.return_value = []
 
         result = _query_enemies_neo4j(client, 100)
 
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["alliance_id"], 600)
-        self.assertEqual(result[0]["source"], "neo4j")
-        self.assertEqual(client.query.call_count, 2)
+        self.assertEqual(result, [])
+        self.assertEqual(client.query.call_count, 1)
 
 
 class TestSqlEnemies(unittest.TestCase):


### PR DESCRIPTION
## Summary
This PR refactors alliance co-presence and enemy detection logic to use killmail attacker/victim relationships instead of the `battle_participants` table and `BattleSide` side_key comparisons. This provides more reliable alliance relationship detection by using the natural attacker-vs-victim semantics from killmails rather than per-alliance side assignments that cannot distinguish friend from foe in multi-alliance engagements.

## Key Changes

- **SQL Queries (`compute_alliance_dossiers.py`)**:
  - `_query_co_presence_sql()`: Changed from joining `battle_participants` on matching `side_key` to joining `killmail_attackers` on the same `sequence_id` (co-attackers on same killmail)
  - `_query_enemies_sql()`: Replaced `battle_participants` opposite-side logic with a UNION query that captures both directions of killmail attacker/victim relationships
  - Updated docstrings to explain the killmail-based semantics

- **Neo4j Queries (`compute_alliance_dossiers.py`)**:
  - `_query_co_presence_neo4j()`: Removed dual-path logic (ON_SIDE primary + ENGAGED_ALLIANCE fallback); now uses single `ATTACKED_ON` relationship path to find co-attackers on the same killmail
  - `_query_enemies_neo4j()`: Removed dual-path logic (ENGAGED_ALLIANCE primary + ON_SIDE fallback); now uses `CALL {} UNION ALL` to combine both directions of `ATTACKED_ON`/`VICTIM_OF` relationships
  - Updated docstrings to clarify killmail-based semantics

- **Intelligence Pipeline (`intelligence_pipeline.py`)**:
  - `_compute_encounter_vs_engagement()`: Refactored to use `ATTACKED_ON`/`VICTIM_OF` killmail relationships instead of `ON_SIDE`/`BattleSide` logic for determining opposition
  - Now counts distinct battles via `Killmail.battle_id` instead of Battle nodes
  - Updated docstring to explain the new approach

- **Tests (`test_alliance_dossiers.py`)**:
  - Removed tests for fallback paths (`test_fallback_to_engaged_alliance_path`, `test_fallback_to_on_side_path`)
  - Replaced with simpler tests (`test_empty_result_returns_empty_list`) that verify empty result handling for the single query path

## Implementation Details

- The killmail-based approach is more semantically correct: co-attackers on the same killmail are definitively on the same side, and attacker-vs-victim relationships directly express opposition
- Removes dependency on `side_key` which is set per-alliance and cannot properly represent multi-alliance coalitions
- Battle grouping is now explicit via `Killmail.battle_id` rather than implicit through BattleSide nodes
- All queries maintain the same filtering (minimum 2 shared battles/engagements, limit 15 results)

https://claude.ai/code/session_01LujqUPrC8ZF2y4qMyzVa2U