### PR TITLE
Add Log Viewer dashboard for system health monitoring

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -30,4 +30,6 @@ RewriteRule ^doctrine/group/?$ doctrine/group.php [L,QSA]
 RewriteRule ^doctrine/fit/?$ doctrine/fit.php [L,QSA]
 RewriteRule ^doctrine/import/?$ doctrine/import.php [L,QSA]
 
+RewriteRule ^log-viewer/?$ log-viewer/index.php [L,QSA]
+
 RewriteRule ^$ index.php [L,QSA]

--- a/public/api/log-viewer-health.php
+++ b/public/api/log-viewer-health.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: private, max-age=15');
+
+$health = log_viewer_external_health();
+$pageData = log_viewer_page_data();
+
+echo json_encode([
+    'external' => $health,
+    'kpi' => $pageData['kpi'],
+    'stuck_count' => count($pageData['stuck_runs']),
+    'failed_24h_count' => count($pageData['failed_runs']),
+]);

--- a/public/log-viewer/index.php
+++ b/public/log-viewer/index.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Log Viewer';
+$pageHeaderBadge = 'System health at a glance';
+$pageHeaderSummary = 'Monitor job runs, failures, timeouts, and external service connectivity. Fix issues before they cascade.';
+
+$pageData = log_viewer_page_data();
+$externalHealth = log_viewer_external_health();
+
+$jobs = $pageData['jobs'];
+$failedRuns = $pageData['failed_runs'];
+$stuckRuns = $pageData['stuck_runs'];
+$neverRan = $pageData['never_ran'];
+$logFiles = $pageData['log_files'];
+$kpi = $pageData['kpi'];
+$recentRuns = $pageData['recent_runs'];
+
+// Determine page freshness from data
+$pageFreshness = [];
+
+include __DIR__ . '/../../src/views/partials/header.php';
+
+if (function_exists('ob_flush')) { @ob_flush(); }
+@flush();
+
+// ── Filter state ──────────────────────────────────────────────────────────────
+$filter = trim((string) ($_GET['filter'] ?? 'all'));
+$validFilters = ['all', 'failed', 'timeout', 'never_ran', 'overdue', 'healthy', 'disabled'];
+if (!in_array($filter, $validFilters, true)) {
+    $filter = 'all';
+}
+
+$filteredJobs = match ($filter) {
+    'failed' => array_filter($jobs, fn (array $j) => $j['health'] === 'failed'),
+    'timeout' => array_filter($jobs, fn (array $j) => $j['health'] === 'timeout'),
+    'never_ran' => array_filter($jobs, fn (array $j) => $j['health'] === 'never_ran'),
+    'overdue' => array_filter($jobs, fn (array $j) => $j['overdue']),
+    'healthy' => array_filter($jobs, fn (array $j) => $j['health'] === 'healthy'),
+    'disabled' => array_filter($jobs, fn (array $j) => $j['health'] === 'disabled'),
+    default => $jobs,
+};
+
+// Needs-attention count
+$attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_overdue'];
+?>
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     KPI Cards
+     ══════════════════════════════════════════════════════════════════════════ -->
+<section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+    <article class="kpi-card">
+        <p class="eyebrow">Needs attention</p>
+        <p class="mt-3 metric-value text-[2.35rem] <?= $attentionCount > 0 ? 'text-rose-100' : 'text-emerald-100' ?>"><?= $attentionCount ?></p>
+        <p class="mt-2 text-sm text-slate-300">Failed, timed-out, or overdue jobs requiring action.</p>
+    </article>
+    <article class="kpi-card">
+        <p class="eyebrow">Healthy jobs</p>
+        <p class="mt-3 metric-value text-[2.35rem] text-emerald-100"><?= $kpi['total_healthy'] ?></p>
+        <p class="mt-2 text-sm text-slate-300">Jobs that completed their last run successfully.</p>
+    </article>
+    <article class="kpi-card">
+        <p class="eyebrow">Never ran</p>
+        <p class="mt-3 metric-value text-[2.35rem] <?= $kpi['total_never_ran'] > 0 ? 'text-violet-100' : 'text-slate-300' ?>"><?= $kpi['total_never_ran'] ?></p>
+        <p class="mt-2 text-sm text-slate-300">Enabled jobs that have never executed.</p>
+    </article>
+    <article class="kpi-card">
+        <p class="eyebrow">Enabled / Total</p>
+        <p class="mt-3 metric-value text-[2.35rem] text-sky-100"><?= $kpi['total_enabled'] ?> <span class="text-lg text-slate-400">/ <?= count($jobs) ?></span></p>
+        <p class="mt-2 text-sm text-slate-300">Active scheduled jobs out of total registered.</p>
+    </article>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     External Services
+     ══════════════════════════════════════════════════════════════════════════ -->
+<section class="mt-8">
+    <h2 class="section-title mb-4">External Services</h2>
+    <div class="grid gap-4 sm:grid-cols-2">
+        <?php foreach ($externalHealth as $svcKey => $svc): ?>
+            <article class="rounded-2xl border p-5 <?= htmlspecialchars($svc['tone'], ENT_QUOTES) ?>">
+                <div class="flex items-start justify-between gap-3">
+                    <div>
+                        <p class="text-xs font-semibold uppercase tracking-[0.16em] text-current/70"><?= htmlspecialchars($svc['name'], ENT_QUOTES) ?></p>
+                        <h3 class="mt-2 text-lg font-semibold text-white"><?= htmlspecialchars($svc['label'], ENT_QUOTES) ?></h3>
+                        <p class="mt-2 text-sm text-slate-200"><?= htmlspecialchars($svc['detail'], ENT_QUOTES) ?></p>
+                    </div>
+                    <span class="badge <?= htmlspecialchars($svc['tone'], ENT_QUOTES) ?>"><?= htmlspecialchars($svc['label'], ENT_QUOTES) ?></span>
+                </div>
+                <div class="mt-4 grid gap-3 text-sm text-slate-200 sm:grid-cols-3">
+                    <div class="rounded-lg border border-white/10 bg-black/20 p-3">
+                        <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Latency</p>
+                        <p class="mt-2 font-semibold text-white"><?= $svc['latency_ms'] ?>ms</p>
+                    </div>
+                    <div class="rounded-lg border border-white/10 bg-black/20 p-3">
+                        <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Version</p>
+                        <p class="mt-2 font-semibold text-white"><?= htmlspecialchars((string) ($svc['version'] ?? 'N/A'), ENT_QUOTES) ?></p>
+                    </div>
+                    <div class="rounded-lg border border-white/10 bg-black/20 p-3">
+                        <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Endpoint</p>
+                        <p class="mt-2 font-semibold text-white truncate" title="<?= htmlspecialchars($svc['url'], ENT_QUOTES) ?>"><?= htmlspecialchars($svc['url'], ENT_QUOTES) ?></p>
+                    </div>
+                </div>
+            </article>
+        <?php endforeach; ?>
+    </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     Stuck / Timed-out Runs (if any)
+     ══════════════════════════════════════════════════════════════════════════ -->
+<?php if ($stuckRuns !== []): ?>
+<section class="mt-8">
+    <h2 class="section-title mb-4 text-orange-200">Stuck / Timed-out Runs</h2>
+    <div class="rounded-2xl border border-orange-400/20 bg-orange-500/6 p-1">
+        <div class="table-shell overflow-x-auto">
+            <table class="table-ui w-full">
+                <thead>
+                    <tr>
+                        <th class="text-left">Job</th>
+                        <th class="text-left">Started</th>
+                        <th class="text-right">Running for</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($stuckRuns as $run): ?>
+                        <tr>
+                            <td class="font-medium text-white"><?= htmlspecialchars($run['dataset_key'], ENT_QUOTES) ?></td>
+                            <td class="text-slate-300"><?= htmlspecialchars(supplycore_format_datetime($run['started_at']), ENT_QUOTES) ?></td>
+                            <td class="text-right font-semibold text-orange-200"><?= htmlspecialchars(human_duration_seconds((float) $run['running_seconds']), ENT_QUOTES) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+<?php endif; ?>
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     Recent Failures (24 h)
+     ══════════════════════════════════════════════════════════════════════════ -->
+<?php if ($failedRuns !== []): ?>
+<section class="mt-8">
+    <h2 class="section-title mb-4 text-rose-200">Recent Failures <span class="text-sm font-normal text-slate-400">(last 24 h)</span></h2>
+    <div class="rounded-2xl border border-rose-400/20 bg-rose-500/6 p-1">
+        <div class="table-shell overflow-x-auto">
+            <table class="table-ui w-full">
+                <thead>
+                    <tr>
+                        <th class="text-left">Job</th>
+                        <th class="text-left">Started</th>
+                        <th class="text-right">Duration</th>
+                        <th class="text-left">Error</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($failedRuns as $run): ?>
+                        <tr>
+                            <td class="font-medium text-white"><?= htmlspecialchars($run['dataset_key'], ENT_QUOTES) ?></td>
+                            <td class="text-slate-300"><?= htmlspecialchars(supplycore_relative_datetime($run['started_at']), ENT_QUOTES) ?></td>
+                            <td class="text-right text-slate-300"><?= htmlspecialchars(human_duration_seconds((float) $run['duration_seconds']), ENT_QUOTES) ?></td>
+                            <td class="max-w-xs truncate text-rose-200" title="<?= htmlspecialchars((string) ($run['error_message'] ?? ''), ENT_QUOTES) ?>"><?= htmlspecialchars((string) ($run['error_message'] ?? 'No message'), ENT_QUOTES) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+<?php endif; ?>
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     Job Status Table
+     ══════════════════════════════════════════════════════════════════════════ -->
+<section class="mt-8">
+    <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <h2 class="section-title">All Jobs</h2>
+        <div class="flex flex-wrap gap-2">
+            <?php
+            $filterOptions = [
+                'all' => ['label' => 'All (' . count($jobs) . ')', 'tone' => ''],
+                'failed' => ['label' => 'Failed (' . $kpi['total_failed'] . ')', 'tone' => $kpi['total_failed'] > 0 ? 'text-rose-200' : ''],
+                'timeout' => ['label' => 'Timeout (' . $kpi['total_timeout'] . ')', 'tone' => $kpi['total_timeout'] > 0 ? 'text-orange-200' : ''],
+                'overdue' => ['label' => 'Overdue (' . $kpi['total_overdue'] . ')', 'tone' => $kpi['total_overdue'] > 0 ? 'text-amber-200' : ''],
+                'never_ran' => ['label' => 'Never ran (' . $kpi['total_never_ran'] . ')', 'tone' => $kpi['total_never_ran'] > 0 ? 'text-violet-200' : ''],
+                'healthy' => ['label' => 'Healthy (' . $kpi['total_healthy'] . ')', 'tone' => ''],
+                'disabled' => ['label' => 'Disabled', 'tone' => ''],
+            ];
+            foreach ($filterOptions as $fKey => $fOpt): ?>
+                <a href="?filter=<?= $fKey ?>"
+                   class="rounded-lg border px-3 py-1.5 text-xs font-medium transition <?= $filter === $fKey ? 'border-sky-400/40 bg-sky-500/15 text-sky-100' : 'border-white/10 bg-white/5 text-slate-300 hover:bg-white/10' ?> <?= $fOpt['tone'] ?>">
+                    <?= htmlspecialchars($fOpt['label'], ENT_QUOTES) ?>
+                </a>
+            <?php endforeach; ?>
+        </div>
+    </div>
+
+    <div class="rounded-2xl border border-white/8 bg-white/[0.02] p-1">
+        <div class="table-shell overflow-x-auto">
+            <table class="table-ui w-full">
+                <thead>
+                    <tr>
+                        <th class="text-left">Job</th>
+                        <th class="text-left">Status</th>
+                        <th class="text-left">Last run</th>
+                        <th class="text-left">Last success</th>
+                        <th class="text-left">Interval</th>
+                        <th class="text-left">Pressure</th>
+                        <th class="text-left">Issue</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if ($filteredJobs === []): ?>
+                        <tr><td colspan="7" class="py-8 text-center text-slate-400">No jobs match this filter.</td></tr>
+                    <?php endif; ?>
+                    <?php foreach ($filteredJobs as $job): ?>
+                        <tr class="<?= $job['overdue'] ? 'bg-amber-500/5' : '' ?>">
+                            <td>
+                                <p class="font-medium text-white"><?= htmlspecialchars($job['label'], ENT_QUOTES) ?></p>
+                                <p class="mt-0.5 text-xs text-slate-400"><?= htmlspecialchars($job['job_key'], ENT_QUOTES) ?></p>
+                            </td>
+                            <td>
+                                <span class="badge <?= htmlspecialchars($job['health_tone'], ENT_QUOTES) ?>">
+                                    <?= htmlspecialchars($job['health_label'], ENT_QUOTES) ?>
+                                </span>
+                                <?php if ($job['overdue']): ?>
+                                    <span class="badge border-amber-400/20 bg-amber-500/10 text-amber-100 ml-1">Overdue</span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="text-slate-300"><?= htmlspecialchars($job['last_run_relative'], ENT_QUOTES) ?></td>
+                            <td class="text-slate-300"><?= htmlspecialchars($job['last_success_relative'], ENT_QUOTES) ?></td>
+                            <td class="text-slate-300"><?= $job['interval_seconds'] > 0 ? htmlspecialchars(human_duration_seconds((float) $job['interval_seconds']), ENT_QUOTES) : '-' ?></td>
+                            <td>
+                                <?php
+                                $pressureTone = match ($job['pressure_state']) {
+                                    'critical' => 'text-rose-300',
+                                    'elevated' => 'text-amber-300',
+                                    default => 'text-emerald-300',
+                                };
+                                ?>
+                                <span class="text-sm <?= $pressureTone ?>"><?= htmlspecialchars(ucfirst($job['pressure_state']), ENT_QUOTES) ?></span>
+                            </td>
+                            <td class="max-w-xs">
+                                <?php if ($job['last_failure_message']): ?>
+                                    <p class="truncate text-xs text-rose-200" title="<?= htmlspecialchars($job['last_failure_message'], ENT_QUOTES) ?>"><?= htmlspecialchars($job['last_failure_message'], ENT_QUOTES) ?></p>
+                                <?php elseif ($job['recent_timeout_count'] > 0): ?>
+                                    <p class="text-xs text-orange-200"><?= $job['recent_timeout_count'] ?> recent timeout(s)</p>
+                                <?php elseif ($job['recent_deferral_count'] > 0): ?>
+                                    <p class="text-xs text-slate-400"><?= $job['recent_deferral_count'] ?> deferral(s)</p>
+                                <?php elseif ($job['last_planner_reason']): ?>
+                                    <p class="truncate text-xs text-slate-400" title="<?= htmlspecialchars($job['last_planner_reason'], ENT_QUOTES) ?>"><?= htmlspecialchars($job['last_planner_reason'], ENT_QUOTES) ?></p>
+                                <?php else: ?>
+                                    <span class="text-xs text-slate-500">-</span>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     Log Files on Disk
+     ══════════════════════════════════════════════════════════════════════════ -->
+<?php if ($logFiles !== []): ?>
+<section class="mt-8">
+    <h2 class="section-title mb-4">Log Files</h2>
+    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <?php foreach ($logFiles as $lf): ?>
+            <article class="surface-secondary rounded-2xl p-4">
+                <div class="flex items-start justify-between gap-2">
+                    <div>
+                        <p class="font-medium text-white"><?= htmlspecialchars($lf['filename'], ENT_QUOTES) ?></p>
+                        <p class="mt-1 text-xs text-slate-400"><?= htmlspecialchars($lf['size_human'], ENT_QUOTES) ?> · modified <?= htmlspecialchars($lf['modified_relative'], ENT_QUOTES) ?></p>
+                    </div>
+                    <span class="badge border-white/10 bg-white/5 text-slate-300"><?= htmlspecialchars($lf['size_human'], ENT_QUOTES) ?></span>
+                </div>
+                <?php if ($lf['tail_lines'] !== []): ?>
+                    <div class="mt-3 rounded-lg border border-white/8 bg-black/30 p-3">
+                        <p class="mb-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-slate-500">Last <?= count($lf['tail_lines']) ?> lines</p>
+                        <pre class="max-h-32 overflow-auto text-[0.7rem] leading-relaxed text-slate-300"><?php
+                            foreach ($lf['tail_lines'] as $line) {
+                                echo htmlspecialchars($line, ENT_QUOTES) . "\n";
+                            }
+                        ?></pre>
+                    </div>
+                <?php endif; ?>
+            </article>
+        <?php endforeach; ?>
+    </div>
+</section>
+<?php endif; ?>
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     Recent Runs Timeline
+     ══════════════════════════════════════════════════════════════════════════ -->
+<section class="mt-8">
+    <h2 class="section-title mb-4">Recent Runs <span class="text-sm font-normal text-slate-400">(last 200)</span></h2>
+    <div class="rounded-2xl border border-white/8 bg-white/[0.02] p-1">
+        <div class="table-shell overflow-x-auto">
+            <table class="table-ui w-full">
+                <thead>
+                    <tr>
+                        <th class="text-left">Job</th>
+                        <th class="text-left">Status</th>
+                        <th class="text-left">Started</th>
+                        <th class="text-right">Duration</th>
+                        <th class="text-right">Rows</th>
+                        <th class="text-left">Error</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($recentRuns as $run):
+                        $runTone = match ($run['run_status']) {
+                            'success' => '',
+                            'failed' => 'bg-rose-500/5',
+                            'running' => 'bg-sky-500/5',
+                            default => '',
+                        };
+                        $statusBadge = match ($run['run_status']) {
+                            'success' => 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100',
+                            'failed' => 'border-rose-400/20 bg-rose-500/10 text-rose-100',
+                            'running' => 'border-sky-400/20 bg-sky-500/10 text-sky-100',
+                            default => 'border-slate-400/20 bg-slate-500/10 text-slate-200',
+                        };
+                    ?>
+                        <tr class="<?= $runTone ?>">
+                            <td class="font-medium text-white"><?= htmlspecialchars($run['dataset_key'], ENT_QUOTES) ?></td>
+                            <td><span class="badge <?= $statusBadge ?>"><?= htmlspecialchars(ucfirst($run['run_status']), ENT_QUOTES) ?></span></td>
+                            <td class="text-slate-300"><?= htmlspecialchars(supplycore_relative_datetime($run['started_at']), ENT_QUOTES) ?></td>
+                            <td class="text-right text-slate-300"><?= htmlspecialchars(human_duration_seconds((float) ($run['duration_seconds'] ?? 0)), ENT_QUOTES) ?></td>
+                            <td class="text-right text-slate-300"><?= (int) $run['written_rows'] ?> / <?= (int) $run['source_rows'] ?></td>
+                            <td class="max-w-xs truncate text-xs text-rose-200" title="<?= htmlspecialchars((string) ($run['error_message'] ?? ''), ENT_QUOTES) ?>"><?= htmlspecialchars((string) ($run['error_message'] ?? ''), ENT_QUOTES) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/src/functions.php
+++ b/src/functions.php
@@ -278,6 +278,12 @@ function nav_items(): array
             ],
         ],
         [
+            'label' => 'Log Viewer',
+            'path' => '/log-viewer',
+            'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v0a2 2 0 0 1-2 2h-2a2 2 0 0 1-2-2Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6M9 16h6"/></svg>',
+            'children' => [],
+        ],
+        [
             'label' => 'Settings',
             'path' => '/settings',
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 15.5A3.5 3.5 0 1 0 12 8.5a3.5 3.5 0 0 0 0 7Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06A1.65 1.65 0 0 0 15 19.4a1.65 1.65 0 0 0-1 .6 1.65 1.65 0 0 0-.33 1V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-.33-1 1.65 1.65 0 0 0-1-.6 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-.6-1 1.65 1.65 0 0 0-1-.33H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1-.33 1.65 1.65 0 0 0 .6-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-.6 1.65 1.65 0 0 0 .33-1V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 .33 1 1.65 1.65 0 0 0 1 .6 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9c.3.3.5.68.6 1 .23.1.66.1 1 .1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1 .33c-.44.25-.79.6-1.01 1.07Z"/></svg>',
@@ -30357,4 +30363,388 @@ function page_cache_flush_expired(): int
     db_execute("DELETE FROM page_cache WHERE expires_at <= NOW()");
 
     return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Log Viewer
+// ---------------------------------------------------------------------------
+
+function log_viewer_page_data(): array
+{
+    $registry = supplycore_authoritative_job_registry();
+
+    // ── Schedules with current status ─────────────────────────────────
+    $schedules = db_select(
+        "SELECT s.*, cs.latest_status, cs.latest_event_type,
+                cs.last_started_at, cs.last_finished_at,
+                cs.last_success_at, cs.last_failure_at, cs.last_failure_message,
+                cs.current_pressure_state, cs.recent_timeout_count,
+                cs.recent_lock_conflict_count, cs.recent_deferral_count,
+                cs.recent_skip_count, cs.last_planner_decision_type,
+                cs.last_planner_reason_text
+         FROM sync_schedules s
+         LEFT JOIN scheduler_job_current_status cs ON cs.job_key = s.job_key
+         ORDER BY s.job_key"
+    );
+
+    // ── Recent runs (last 200) ────────────────────────────────────────
+    $recentRuns = db_select(
+        "SELECT r.dataset_key, r.run_status, r.started_at, r.finished_at,
+                r.source_rows, r.written_rows, r.error_message,
+                TIMESTAMPDIFF(SECOND, r.started_at, COALESCE(r.finished_at, NOW())) AS duration_seconds
+         FROM sync_runs r
+         ORDER BY r.started_at DESC
+         LIMIT 200"
+    );
+
+    // ── Failed runs (last 24 h) ───────────────────────────────────────
+    $failedRuns = db_select(
+        "SELECT r.dataset_key, r.run_status, r.started_at, r.finished_at,
+                r.error_message,
+                TIMESTAMPDIFF(SECOND, r.started_at, COALESCE(r.finished_at, NOW())) AS duration_seconds
+         FROM sync_runs r
+         WHERE r.run_status = 'failed'
+           AND r.started_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR)
+         ORDER BY r.started_at DESC"
+    );
+
+    // ── Stuck / timed-out runs (running > default timeout) ────────────
+    $defaultTimeout = (int) get_setting('scheduler.default_timeout_seconds', 300);
+    $stuckRuns = db_select(
+        "SELECT r.dataset_key, r.run_status, r.started_at,
+                TIMESTAMPDIFF(SECOND, r.started_at, NOW()) AS running_seconds
+         FROM sync_runs r
+         WHERE r.run_status = 'running'
+           AND r.started_at < DATE_SUB(NOW(), INTERVAL ? SECOND)
+         ORDER BY r.started_at ASC",
+        [$defaultTimeout]
+    );
+
+    // ── Jobs that never ran ───────────────────────────────────────────
+    $neverRan = [];
+    foreach ($schedules as $s) {
+        if ($s['enabled'] && $s['last_run_at'] === null) {
+            $neverRan[] = $s;
+        }
+    }
+
+    // ── Build unified job rows ────────────────────────────────────────
+    $jobs = [];
+    foreach ($schedules as $s) {
+        $key = $s['job_key'];
+        $meta = $registry[$key] ?? [];
+        $label = $meta['label'] ?? $key;
+
+        $status = strtolower(trim((string) ($s['latest_status'] ?? $s['last_status'] ?? 'unknown')));
+        $pressure = strtolower(trim((string) ($s['current_pressure_state'] ?? 'healthy')));
+
+        // Determine health bucket
+        if (!$s['enabled']) {
+            $health = 'disabled';
+            $healthTone = 'border-slate-400/20 bg-slate-500/10 text-slate-300';
+            $healthLabel = 'Disabled';
+        } elseif ($s['last_run_at'] === null) {
+            $health = 'never_ran';
+            $healthTone = 'border-violet-400/20 bg-violet-500/10 text-violet-100';
+            $healthLabel = 'Never ran';
+        } elseif ($status === 'failed' || $status === 'error') {
+            $health = 'failed';
+            $healthTone = 'border-rose-400/20 bg-rose-500/10 text-rose-100';
+            $healthLabel = 'Failed';
+        } elseif ($pressure === 'critical' || ($s['recent_timeout_count'] ?? 0) > 2) {
+            $health = 'timeout';
+            $healthTone = 'border-orange-400/20 bg-orange-500/10 text-orange-100';
+            $healthLabel = 'Timeout';
+        } elseif ($pressure === 'elevated' || $status === 'delayed' || $status === 'degraded') {
+            $health = 'degraded';
+            $healthTone = 'border-amber-400/20 bg-amber-500/10 text-amber-100';
+            $healthLabel = 'Degraded';
+        } elseif ($status === 'running') {
+            $health = 'running';
+            $healthTone = 'border-sky-400/20 bg-sky-500/10 text-sky-100';
+            $healthLabel = 'Running';
+        } elseif ($status === 'success' || $status === 'completed') {
+            $health = 'healthy';
+            $healthTone = 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100';
+            $healthLabel = 'Healthy';
+        } else {
+            $health = 'unknown';
+            $healthTone = 'border-slate-400/20 bg-slate-500/10 text-slate-200';
+            $healthLabel = 'Unknown';
+        }
+
+        // Check overdue: enabled, has interval, last_run_at + interval * 2 < NOW
+        $overdue = false;
+        if ($s['enabled'] && $s['last_run_at'] !== null && (int) $s['interval_seconds'] > 0) {
+            $lastRun = strtotime((string) $s['last_run_at']);
+            if ($lastRun !== false && (time() - $lastRun) > ((int) $s['interval_seconds'] * 2)) {
+                $overdue = true;
+            }
+        }
+
+        $jobs[] = [
+            'job_key' => $key,
+            'label' => $label,
+            'description' => $meta['description'] ?? '',
+            'enabled' => (bool) $s['enabled'],
+            'interval_seconds' => (int) $s['interval_seconds'],
+            'last_run_at' => $s['last_run_at'],
+            'last_run_relative' => supplycore_relative_datetime($s['last_run_at']),
+            'last_success_at' => $s['last_success_at'] ?? null,
+            'last_success_relative' => supplycore_relative_datetime($s['last_success_at'] ?? null),
+            'last_failure_at' => $s['last_failure_at'] ?? null,
+            'last_failure_message' => $s['last_failure_message'] ?? null,
+            'next_run_at' => $s['next_run_at'],
+            'next_run_relative' => supplycore_relative_datetime($s['next_run_at']),
+            'health' => $health,
+            'health_tone' => $healthTone,
+            'health_label' => $healthLabel,
+            'overdue' => $overdue,
+            'pressure_state' => $pressure,
+            'recent_timeout_count' => (int) ($s['recent_timeout_count'] ?? 0),
+            'recent_deferral_count' => (int) ($s['recent_deferral_count'] ?? 0),
+            'recent_skip_count' => (int) ($s['recent_skip_count'] ?? 0),
+            'last_planner_reason' => $s['last_planner_reason_text'] ?? null,
+            'timeout_seconds' => $meta['timeout_seconds'] ?? $defaultTimeout,
+        ];
+    }
+
+    // ── KPI counts ────────────────────────────────────────────────────
+    $totalEnabled = count(array_filter($jobs, fn (array $j) => $j['enabled']));
+    $totalFailed = count(array_filter($jobs, fn (array $j) => $j['health'] === 'failed'));
+    $totalTimeout = count(array_filter($jobs, fn (array $j) => $j['health'] === 'timeout'));
+    $totalNeverRan = count($neverRan);
+    $totalOverdue = count(array_filter($jobs, fn (array $j) => $j['overdue']));
+    $totalHealthy = count(array_filter($jobs, fn (array $j) => $j['health'] === 'healthy'));
+
+    // ── Log files on disk ─────────────────────────────────────────────
+    $logDir = rtrim((string) realpath(__DIR__ . '/../storage/logs'), '/');
+    $logFiles = [];
+    if ($logDir !== '' && is_dir($logDir)) {
+        $entries = scandir($logDir);
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..' || $entry === '.gitkeep') {
+                continue;
+            }
+            $fullPath = $logDir . '/' . $entry;
+            if (is_file($fullPath)) {
+                $sizeBytes = filesize($fullPath);
+                $modifiedAt = filemtime($fullPath);
+                $logFiles[] = [
+                    'filename' => $entry,
+                    'size_bytes' => $sizeBytes,
+                    'size_human' => log_viewer_format_bytes($sizeBytes),
+                    'modified_at' => $modifiedAt !== false ? gmdate('Y-m-d H:i:s', $modifiedAt) : null,
+                    'modified_relative' => $modifiedAt !== false ? human_duration_ago(max(0, time() - $modifiedAt)) . ' ago' : 'Unknown',
+                    'tail_lines' => log_viewer_tail_file($fullPath, 5),
+                ];
+            }
+        }
+        usort($logFiles, fn (array $a, array $b) => ($b['size_bytes'] ?? 0) <=> ($a['size_bytes'] ?? 0));
+    }
+
+    return [
+        'jobs' => $jobs,
+        'recent_runs' => $recentRuns,
+        'failed_runs' => $failedRuns,
+        'stuck_runs' => $stuckRuns,
+        'never_ran' => $neverRan,
+        'log_files' => $logFiles,
+        'kpi' => [
+            'total_enabled' => $totalEnabled,
+            'total_failed' => $totalFailed,
+            'total_timeout' => $totalTimeout,
+            'total_never_ran' => $totalNeverRan,
+            'total_overdue' => $totalOverdue,
+            'total_healthy' => $totalHealthy,
+        ],
+    ];
+}
+
+function log_viewer_format_bytes(int|false $bytes): string
+{
+    if ($bytes === false || $bytes < 0) {
+        return '0 B';
+    }
+    if ($bytes < 1024) {
+        return $bytes . ' B';
+    }
+    if ($bytes < 1048576) {
+        return round($bytes / 1024, 1) . ' KB';
+    }
+    return round($bytes / 1048576, 1) . ' MB';
+}
+
+function log_viewer_tail_file(string $path, int $lines = 5): array
+{
+    if (!is_file($path) || !is_readable($path)) {
+        return [];
+    }
+    $fp = fopen($path, 'r');
+    if ($fp === false) {
+        return [];
+    }
+
+    $buffer = [];
+    while (($line = fgets($fp)) !== false) {
+        $buffer[] = rtrim($line, "\r\n");
+        if (count($buffer) > $lines) {
+            array_shift($buffer);
+        }
+    }
+    fclose($fp);
+
+    return $buffer;
+}
+
+function log_viewer_external_health(): array
+{
+    $results = [];
+
+    // ── Neo4j ─────────────────────────────────────────────────────────
+    $neo4jEnabled = (bool) config('neo4j.enabled', false);
+    $neo4jUrl = rtrim((string) config('neo4j.url', 'http://127.0.0.1:7474'), '/');
+    $neo4jTimeout = max(3, (int) config('neo4j.timeout_seconds', 15));
+
+    if ($neo4jEnabled && $neo4jUrl !== '') {
+        $neo4jHealthUrl = $neo4jUrl;
+        $ch = curl_init($neo4jHealthUrl);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => min($neo4jTimeout, 5),
+            CURLOPT_CONNECTTIMEOUT => 3,
+            CURLOPT_HTTPHEADER => ['Accept: application/json'],
+            CURLOPT_NOBODY => false,
+        ]);
+        $username = (string) config('neo4j.username', 'neo4j');
+        $password = (string) config('neo4j.password', '');
+        if ($username !== '') {
+            curl_setopt($ch, CURLOPT_USERPWD, $username . ':' . $password);
+        }
+        $response = curl_exec($ch);
+        $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError = curl_error($ch);
+        $connectTime = round((float) curl_getinfo($ch, CURLINFO_CONNECT_TIME) * 1000);
+        $totalTime = round((float) curl_getinfo($ch, CURLINFO_TOTAL_TIME) * 1000);
+        curl_close($ch);
+
+        $neo4jData = is_string($response) ? @json_decode($response, true) : null;
+        $neo4jVersion = is_array($neo4jData) ? ($neo4jData['neo4j_version'] ?? null) : null;
+
+        if ($httpCode >= 200 && $httpCode < 400) {
+            $results['neo4j'] = [
+                'name' => 'Neo4j',
+                'status' => 'online',
+                'tone' => 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100',
+                'label' => 'Online',
+                'url' => $neo4jUrl,
+                'http_code' => $httpCode,
+                'latency_ms' => $totalTime,
+                'connect_ms' => $connectTime,
+                'version' => $neo4jVersion,
+                'detail' => 'Connected in ' . $totalTime . 'ms',
+            ];
+        } else {
+            $results['neo4j'] = [
+                'name' => 'Neo4j',
+                'status' => 'offline',
+                'tone' => 'border-rose-400/20 bg-rose-500/10 text-rose-100',
+                'label' => 'Offline',
+                'url' => $neo4jUrl,
+                'http_code' => $httpCode,
+                'latency_ms' => $totalTime,
+                'connect_ms' => $connectTime,
+                'version' => null,
+                'detail' => $curlError !== '' ? $curlError : ('HTTP ' . $httpCode),
+            ];
+        }
+    } else {
+        $results['neo4j'] = [
+            'name' => 'Neo4j',
+            'status' => 'disabled',
+            'tone' => 'border-slate-400/20 bg-slate-500/10 text-slate-300',
+            'label' => 'Disabled',
+            'url' => $neo4jUrl ?? '',
+            'http_code' => 0,
+            'latency_ms' => 0,
+            'connect_ms' => 0,
+            'version' => null,
+            'detail' => 'Neo4j integration is disabled in configuration.',
+        ];
+    }
+
+    // ── InfluxDB ──────────────────────────────────────────────────────
+    $influxEnabled = (bool) config('influxdb.enabled', false);
+    $influxUrl = rtrim((string) config('influxdb.url', 'http://127.0.0.1:8086'), '/');
+    $influxTimeout = max(3, (int) config('influxdb.timeout_seconds', 15));
+    $influxToken = (string) config('influxdb.token', '');
+
+    if ($influxEnabled && $influxUrl !== '') {
+        $influxHealthUrl = $influxUrl . '/health';
+        $ch = curl_init($influxHealthUrl);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => min($influxTimeout, 5),
+            CURLOPT_CONNECTTIMEOUT => 3,
+            CURLOPT_HTTPHEADER => array_filter([
+                'Accept: application/json',
+                $influxToken !== '' ? ('Authorization: Token ' . $influxToken) : null,
+            ]),
+        ]);
+        $response = curl_exec($ch);
+        $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError = curl_error($ch);
+        $connectTime = round((float) curl_getinfo($ch, CURLINFO_CONNECT_TIME) * 1000);
+        $totalTime = round((float) curl_getinfo($ch, CURLINFO_TOTAL_TIME) * 1000);
+        curl_close($ch);
+
+        $influxData = is_string($response) ? @json_decode($response, true) : null;
+        $influxStatus = is_array($influxData) ? ($influxData['status'] ?? null) : null;
+        $influxVersion = is_array($influxData) ? ($influxData['version'] ?? null) : null;
+
+        $isHealthy = ($httpCode >= 200 && $httpCode < 400) && ($influxStatus === 'pass' || $influxStatus === null);
+
+        if ($isHealthy) {
+            $results['influxdb'] = [
+                'name' => 'InfluxDB',
+                'status' => 'online',
+                'tone' => 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100',
+                'label' => 'Online',
+                'url' => $influxUrl,
+                'http_code' => $httpCode,
+                'latency_ms' => $totalTime,
+                'connect_ms' => $connectTime,
+                'version' => $influxVersion,
+                'detail' => 'Connected in ' . $totalTime . 'ms',
+            ];
+        } else {
+            $results['influxdb'] = [
+                'name' => 'InfluxDB',
+                'status' => 'offline',
+                'tone' => 'border-rose-400/20 bg-rose-500/10 text-rose-100',
+                'label' => 'Offline',
+                'url' => $influxUrl,
+                'http_code' => $httpCode,
+                'latency_ms' => $totalTime,
+                'connect_ms' => $connectTime,
+                'version' => null,
+                'detail' => $curlError !== '' ? $curlError : ('HTTP ' . $httpCode . ($influxStatus !== null ? ' · status=' . $influxStatus : '')),
+            ];
+        }
+    } else {
+        $results['influxdb'] = [
+            'name' => 'InfluxDB',
+            'status' => 'disabled',
+            'tone' => 'border-slate-400/20 bg-slate-500/10 text-slate-300',
+            'label' => 'Disabled',
+            'url' => $influxUrl ?? '',
+            'http_code' => 0,
+            'latency_ms' => 0,
+            'connect_ms' => 0,
+            'version' => null,
+            'detail' => 'InfluxDB integration is disabled in configuration.',
+        ];
+    }
+
+    return $results;
 }


### PR DESCRIPTION
## Summary
Introduces a comprehensive Log Viewer dashboard that provides real-time visibility into scheduled job execution, system health, and external service connectivity. This enables operators to quickly identify and diagnose issues with job runs, timeouts, and service dependencies.

## Key Changes

- **New Log Viewer Page** (`public/log-viewer/index.php`): Full-featured dashboard displaying:
  - KPI cards showing jobs needing attention, healthy jobs, never-ran jobs, and enabled/total counts
  - External service health status (Neo4j and InfluxDB) with latency and version information
  - Stuck/timed-out runs alert section
  - Recent failures from the last 24 hours
  - Comprehensive job status table with filtering (all, failed, timeout, overdue, never ran, healthy, disabled)
  - Log files on disk with size, modification time, and tail preview
  - Recent runs timeline (last 200 runs)

- **Backend Functions** (`src/functions.php`):
  - `log_viewer_page_data()`: Aggregates job schedules, run history, and system metrics from database
  - `log_viewer_format_bytes()`: Human-readable file size formatting
  - `log_viewer_tail_file()`: Reads last N lines from log files
  - `log_viewer_external_health()`: Probes Neo4j and InfluxDB endpoints with timeout handling, latency measurement, and version detection

- **Health Check API** (`public/api/log-viewer-health.php`): JSON endpoint for external monitoring with 15-second cache, returning external service status, KPI metrics, and stuck/failed run counts

- **Navigation Integration**: Added "Log Viewer" menu item with clipboard icon to main navigation

- **URL Routing**: Added `.htaccess` rewrite rule for `/log-viewer` path

## Implementation Details

- Job health determination uses multi-factor logic: enabled status, run history, pressure state, timeout counts, and planner decisions
- Overdue detection compares last run time against interval × 2 threshold
- External service probes use configurable timeouts (max 5 seconds) with fallback for disabled services
- Database queries use LEFT JOINs to handle jobs without run history
- All user output is properly HTML-escaped for security
- Responsive grid layouts for KPI cards and service status
- Color-coded health badges (emerald/healthy, rose/failed, orange/timeout, violet/never ran, slate/disabled)

https://claude.ai/code/session_01WeEiyFjLoJwFci1WrGoNRn