### PR TITLE
Refactor Neo4j queries to use ISO datetime strings and remove type coercion

### DIFF
--- a/python/orchestrator/jobs/counterintel_pipeline.py
+++ b/python/orchestrator/jobs/counterintel_pipeline.py
@@ -1021,7 +1021,7 @@ def run_compute_counterintel_pipeline(
                     neo4j.query(
                         """
                         UNWIND $rows AS row
-                        MERGE (c:Character {character_id: toInteger(row.character_id)})
+                        MERGE (c:Character {character_id: row.character_id})
                         MERGE (b:Battle {battle_id: row.battle_id})
                         MERGE (c)-[r:PRESENT_IN_ANOMALOUS_BATTLE]->(b)
                         SET r.review_priority_score = row.review_priority_score,
@@ -1040,8 +1040,8 @@ def run_compute_counterintel_pipeline(
                     neo4j.query(
                         """
                         UNWIND $rows AS row
-                        MATCH (left:Character {character_id: toInteger(row.left_character_id)})
-                        MATCH (right:Character {character_id: toInteger(row.right_character_id)})
+                        MATCH (left:Character {character_id: row.left_character_id})
+                        MATCH (right:Character {character_id: row.right_character_id})
                         MERGE (left)-[r:CO_PRESENT_WITH]->(right)
                         SET r.count = toInteger(COALESCE(r.count, 0)) + toInteger(row.count),
                             r.anomalous_count = toInteger(COALESCE(r.anomalous_count, 0)) + toInteger(row.anomalous_count),
@@ -1055,7 +1055,7 @@ def run_compute_counterintel_pipeline(
                         """
                         UNWIND $rows AS row
                         WITH row WHERE row.start IS NOT NULL AND row.source IS NOT NULL
-                        MERGE (c:Character {character_id: toInteger(row.character_id)})
+                        MERGE (c:Character {character_id: row.character_id})
                         MERGE (corp:Corporation {corporation_id: toInteger(row.corporation_id)})
                         MERGE (c)-[r:HISTORICALLY_IN]->(corp)
                         SET r.start = COALESCE(row.start, r.start),

--- a/python/orchestrator/jobs/graph_community_detection.py
+++ b/python/orchestrator/jobs/graph_community_detection.py
@@ -89,7 +89,7 @@ def _export_community_assignments(client: Neo4jClient, db: SupplyCoreDb, compute
         OPTIONAL MATCH (c)-[r:CO_OCCURS_WITH|DIRECT_COMBAT|ASSISTED_KILL|SAME_FLEET]-(:Character)
         WITH c, count(r) AS degree
         RETURN
-            toInteger(c.character_id) AS character_id,
+            c.character_id AS character_id,
             toInteger(c.community_label) AS community_id,
             toFloat(COALESCE(c.pr, 0.0)) AS pagerank_score,
             toFloat(COALESCE(c.betweenness_approx, 0.0)) AS betweenness_centrality,
@@ -114,7 +114,7 @@ def _export_community_assignments(client: Neo4jClient, db: SupplyCoreDb, compute
         WHERE c.community_label IS NOT NULL AND n.community_label IS NOT NULL
         WITH c, collect(DISTINCT n.community_label) AS neighbor_communities
         WHERE size(neighbor_communities) >= $threshold
-        RETURN toInteger(c.character_id) AS character_id
+        RETURN c.character_id AS character_id
         """,
         {"threshold": BRIDGE_COMMUNITY_THRESHOLD},
     )

--- a/python/orchestrator/jobs/graph_evidence_paths.py
+++ b/python/orchestrator/jobs/graph_evidence_paths.py
@@ -61,7 +61,7 @@ def run_graph_evidence_paths_sync(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | 
         """
         MATCH (c:Character)
         WHERE COALESCE(c.suspicion_score, 0) > $threshold
-        RETURN toInteger(c.character_id) AS character_id,
+        RETURN c.character_id AS character_id,
                COALESCE(c.name, 'Character #' + toString(c.character_id)) AS name,
                toFloat(c.suspicion_score) AS suspicion_score
         ORDER BY c.suspicion_score DESC

--- a/python/orchestrator/jobs/graph_motif_detection.py
+++ b/python/orchestrator/jobs/graph_motif_detection.py
@@ -21,7 +21,7 @@ def _detect_triangles(client: Neo4jClient) -> list[dict[str, Any]]:
         WITH a, b, c, collect(DISTINCT battle.battle_id)[..10] AS battle_ids
         RETURN
             'triangle' AS motif_type,
-            [toInteger(a.character_id), toInteger(b.character_id), toInteger(c.character_id)] AS member_ids,
+            [a.character_id, b.character_id, c.character_id] AS member_ids,
             battle_ids,
             1 AS occurrence_count,
             toFloat(
@@ -45,7 +45,7 @@ def _detect_stars(client: Neo4jClient) -> list[dict[str, Any]]:
         WITH hub, isolated_leaves[..8] AS top_leaves
         RETURN
             'star' AS motif_type,
-            [toInteger(hub.character_id)] + [l IN top_leaves | toInteger(l.character_id)] AS member_ids,
+            [hub.character_id] + [l IN top_leaves | l.character_id] AS member_ids,
             [] AS battle_ids,
             1 AS occurrence_count,
             toFloat(COALESCE(hub.suspicion_score, 0)) AS suspicion_relevance
@@ -69,7 +69,7 @@ def _detect_chains(client: Neo4jClient) -> list[dict[str, Any]]:
         WITH a, b, c, d
         RETURN
             'chain' AS motif_type,
-            [toInteger(a.character_id), toInteger(b.character_id), toInteger(c.character_id), toInteger(d.character_id)] AS member_ids,
+            [a.character_id, b.character_id, c.character_id, d.character_id] AS member_ids,
             [] AS battle_ids,
             1 AS occurrence_count,
             toFloat(
@@ -93,8 +93,8 @@ def _detect_fleet_cores(client: Neo4jClient) -> list[dict[str, Any]]:
           AND d.character_id > c.character_id
         WITH a, b, c, collect(d)[..5] AS extras
         WHERE size(extras) >= 2
-        WITH [toInteger(a.character_id), toInteger(b.character_id), toInteger(c.character_id)]
-             + [e IN extras | toInteger(e.character_id)] AS member_ids,
+        WITH [a.character_id, b.character_id, c.character_id]
+             + [e IN extras | e.character_id] AS member_ids,
              (COALESCE(a.suspicion_score, 0) + COALESCE(b.suspicion_score, 0) + COALESCE(c.suspicion_score, 0)) / 3.0 AS avg_suspicion
         RETURN
             'fleet_core' AS motif_type,
@@ -115,7 +115,7 @@ def _detect_rotating_scouts(client: Neo4jClient) -> list[dict[str, Any]]:
         WHERE COALESCE(cr.side_transition_count, 0) >= 3
         RETURN
             'rotating_scout' AS motif_type,
-            [toInteger(c.character_id)] AS member_ids,
+            [c.character_id] AS member_ids,
             [] AS battle_ids,
             toInteger(cr.side_transition_count) AS occurrence_count,
             toFloat(COALESCE(c.suspicion_score, 0) * 1.5) AS suspicion_relevance

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 import math
 import time
 from pathlib import Path
@@ -34,6 +34,10 @@ RELATIONSHIP_WINDOW_DAYS = 30
 STALE_DAYS = 45
 DEFAULT_BATCH_SIZE = 1000
 SYNC_DATASET_GRAPH_INSIGHTS_FIT_OVERLAP = "graph_insights_fit_overlap"
+
+
+def _utc_cutoff_iso(days: int) -> str:
+    return (datetime.now(UTC) - timedelta(days=days)).isoformat()
 
 
 def _utc_now_sql() -> str:
@@ -476,7 +480,7 @@ def run_compute_graph_sync_battle_intelligence(db: SupplyCoreDb, neo4j_raw: dict
             MERGE (b)-[:HAS_SIDE]->(side)
 
             WITH row, side, b
-            MERGE (c:Character {character_id: toInteger(row.character_id)})
+            MERGE (c:Character {character_id: row.character_id})
             MERGE (c)-[:PARTICIPATED_IN]->(b)
             MERGE (c)-[:ON_SIDE]->(side)
 
@@ -506,7 +510,7 @@ def run_compute_graph_sync_battle_intelligence(db: SupplyCoreDb, neo4j_raw: dict
             UNWIND $rows AS row
             WITH row
             WHERE toInteger(COALESCE(row.ship_type_id, 0)) > 0
-            MATCH (c:Character {character_id: toInteger(row.character_id)})
+            MATCH (c:Character {character_id: row.character_id})
             MATCH (ship:ShipType {type_id: toInteger(row.ship_type_id)})
             OPTIONAL MATCH (c)-[legacy:FLEW]->(ship)
             DELETE legacy
@@ -600,8 +604,8 @@ def run_compute_graph_derived_relationships(db: SupplyCoreDb, neo4j_raw: dict[st
         anchor_rows = client.query(
             """
             MATCH (c:Character)
-            WHERE toInteger(c.character_id) > $cursor
-            RETURN toInteger(c.character_id) AS character_id
+            WHERE c.character_id > $cursor
+            RETURN c.character_id AS character_id
             ORDER BY character_id ASC
             LIMIT $batch_size
             """,
@@ -614,20 +618,23 @@ def run_compute_graph_derived_relationships(db: SupplyCoreDb, neo4j_raw: dict[st
         if not anchor_ids:
             break
 
+        cutoff = _utc_cutoff_iso(RELATIONSHIP_WINDOW_DAYS)
+        recent_cutoff = _utc_cutoff_iso(7)
+
         client.query(
             """
             UNWIND $anchor_ids AS anchor_id
-            MATCH (c1:Character {character_id: toInteger(anchor_id)})
+            MATCH (c1:Character {character_id: anchor_id})
             MATCH (c1)-[:PARTICIPATED_IN]->(b:Battle)<-[:PARTICIPATED_IN]-(c2:Character)
             WHERE c1.character_id < c2.character_id
-              AND datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days:$window_days})
+              AND b.started_at >= $cutoff
             OPTIONAL MATCH (c1)-[:ON_SIDE]->(s1:BattleSide)<-[:HAS_SIDE]-(b)
             OPTIONAL MATCH (c2)-[:ON_SIDE]->(s2:BattleSide)<-[:HAS_SIDE]-(b)
             WITH c1, c2,
-                 min(datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z'))) AS first_seen,
-                 max(datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z'))) AS last_seen,
+                 min(b.started_at) AS first_seen,
+                 max(b.started_at) AS last_seen,
                  count(DISTINCT b) AS occurrence_count,
-                 count(DISTINCT CASE WHEN datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days:7}) THEN b END) AS recent_occurrence_count,
+                 count(DISTINCT CASE WHEN b.started_at >= $recent_cutoff THEN b END) AS recent_occurrence_count,
                  count(DISTINCT CASE WHEN s1.anomaly_class = 'high_sustain' OR s2.anomaly_class = 'high_sustain' THEN b END) AS high_sustain_battle_count
             WHERE occurrence_count >= $co_threshold
             MERGE (c1)-[r:CO_OCCURS_WITH]->(c2)
@@ -640,12 +647,12 @@ def run_compute_graph_derived_relationships(db: SupplyCoreDb, neo4j_raw: dict[st
                   r.all_time_weight = toFloat(occurrence_count + high_sustain_battle_count * 2),
                   r.weight = toFloat((recent_occurrence_count * 2) + occurrence_count + (high_sustain_battle_count * 2))
             """,
-            {"anchor_ids": anchor_ids, "window_days": RELATIONSHIP_WINDOW_DAYS, "co_threshold": CO_OCCUR_THRESHOLD},
+            {"anchor_ids": anchor_ids, "cutoff": cutoff, "recent_cutoff": recent_cutoff, "co_threshold": CO_OCCUR_THRESHOLD},
         )
         client.query(
             """
             UNWIND $anchor_ids AS anchor_id
-            MATCH (c:Character {character_id: toInteger(anchor_id)})-[r:CO_OCCURS_WITH]->(:Character)
+            MATCH (c:Character {character_id: anchor_id})-[r:CO_OCCURS_WITH]->(:Character)
             WITH c, r ORDER BY r.weight DESC
             WITH c, collect(r) AS rels
             FOREACH(rel IN rels[$top_k..] | DELETE rel)
@@ -655,7 +662,7 @@ def run_compute_graph_derived_relationships(db: SupplyCoreDb, neo4j_raw: dict[st
         client.query(
             """
             UNWIND $anchor_ids AS anchor_id
-            MATCH (c:Character {character_id: toInteger(anchor_id)})-[r:ASSOCIATED_WITH_ANOMALY]->(:Battle)
+            MATCH (c:Character {character_id: anchor_id})-[r:ASSOCIATED_WITH_ANOMALY]->(:Battle)
             WHERE datetime(COALESCE(r.last_seen, '1970-01-01T00:00:00Z')) < datetime() - duration({days:$window_days})
             DELETE r
             """,
@@ -664,12 +671,12 @@ def run_compute_graph_derived_relationships(db: SupplyCoreDb, neo4j_raw: dict[st
         client.query(
             """
             UNWIND $anchor_ids AS anchor_id
-            MATCH (c:Character {character_id: toInteger(anchor_id)})
+            MATCH (c:Character {character_id: anchor_id})
             OPTIONAL MATCH (c)-[:ON_SIDE]->(s:BattleSide)<-[:HAS_SIDE]-(b:Battle)
-            WHERE datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days:$window_days})
+            WHERE b.started_at >= $cutoff
             WITH c, collect(DISTINCT s.side_key) AS side_keys,
-                 min(datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z'))) AS first_seen,
-                 max(datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z'))) AS last_seen,
+                 min(b.started_at) AS first_seen,
+                 max(b.started_at) AS last_seen,
                  count(DISTINCT b) AS occurrence_count
             WHERE size(side_keys) > 1
             MERGE (c)-[r:CROSSED_SIDES]->(c)
@@ -682,33 +689,33 @@ def run_compute_graph_derived_relationships(db: SupplyCoreDb, neo4j_raw: dict[st
                   r.recent_weight = toFloat(size(side_keys)),
                   r.all_time_weight = toFloat(size(side_keys) + occurrence_count)
             """,
-            {"anchor_ids": anchor_ids, "window_days": RELATIONSHIP_WINDOW_DAYS},
+            {"anchor_ids": anchor_ids, "cutoff": cutoff},
         )
         client.query(
             """
             UNWIND $anchor_ids AS anchor_id
-            MATCH (c:Character {character_id: toInteger(anchor_id)})
+            MATCH (c:Character {character_id: anchor_id})
             OPTIONAL MATCH (c)-[:ON_SIDE]->(s:BattleSide)<-[:HAS_SIDE]-(b:Battle)
-            WHERE datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days:$window_days})
+            WHERE b.started_at >= $cutoff
             WITH c, collect(DISTINCT s.side_key) AS side_keys
             WHERE size(side_keys) <= 1
             MATCH (c)-[r:CROSSED_SIDES]->(c)
             DELETE r
             """,
-            {"anchor_ids": anchor_ids, "window_days": RELATIONSHIP_WINDOW_DAYS},
+            {"anchor_ids": anchor_ids, "cutoff": cutoff},
         )
         client.query(
             """
             UNWIND $anchor_ids AS anchor_id
-            MATCH (c:Character {character_id: toInteger(anchor_id)})-[:ON_SIDE]->(s:BattleSide)<-[:HAS_SIDE]-(b:Battle)
+            MATCH (c:Character {character_id: anchor_id})-[:ON_SIDE]->(s:BattleSide)<-[:HAS_SIDE]-(b:Battle)
             WHERE s.anomaly_class IN ['high_sustain', 'low_sustain']
-              AND datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days:$window_days})
+              AND b.started_at >= $cutoff
             WITH c, b,
-                 min(datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z'))) AS first_seen,
-                 max(datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z'))) AS last_seen,
+                 min(b.started_at) AS first_seen,
+                 max(b.started_at) AS last_seen,
                  count(*) AS occurrence_count,
                  avg(toFloat(s.z_efficiency_score)) AS avg_z_score,
-                 count(CASE WHEN datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days:7}) THEN 1 END) AS recent_occurrence_count
+                 count(CASE WHEN b.started_at >= $recent_cutoff THEN 1 END) AS recent_occurrence_count
             WHERE occurrence_count >= $anom_threshold
             MERGE (c)-[r:ASSOCIATED_WITH_ANOMALY]->(b)
               SET r.first_seen = toString(first_seen),
@@ -720,7 +727,7 @@ def run_compute_graph_derived_relationships(db: SupplyCoreDb, neo4j_raw: dict[st
                   r.all_time_weight = toFloat(occurrence_count + avg_z_score),
                   r.count = toInteger(occurrence_count)
             """,
-            {"anchor_ids": anchor_ids, "window_days": RELATIONSHIP_WINDOW_DAYS, "anom_threshold": ANOMALY_ASSOC_THRESHOLD},
+            {"anchor_ids": anchor_ids, "cutoff": cutoff, "recent_cutoff": recent_cutoff, "anom_threshold": ANOMALY_ASSOC_THRESHOLD},
         )
 
         character_cursor = max(anchor_ids)
@@ -1056,7 +1063,7 @@ def run_compute_graph_topology_metrics(db: SupplyCoreDb, neo4j_raw: dict[str, An
              max(COALESCE(cross.side_transition_count, 0)) AS side_transitions,
              avg(COALESCE(anom.avg_z_score, 0.0)) AS anomalous_neighbor_density
         RETURN
-            toInteger(c.character_id) AS character_id,
+            c.character_id AS character_id,
             toFloat(degree_count) AS pagerank_score,
             toFloat(avg_co_weight) AS bridge_score,
             toInteger(side_transitions) AS community_id,
@@ -1074,11 +1081,12 @@ def run_compute_graph_topology_metrics(db: SupplyCoreDb, neo4j_raw: dict[str, An
     # opposing alliance.  A character who consistently has anomalous
     # (high_sustain) battles specifically against one alliance — while
     # fighting normally against all others — is flagged for avoidance.
+    cutoff = _utc_cutoff_iso(RELATIONSHIP_WINDOW_DAYS)
     avoidance_rows = client.query(
         """
         MATCH (c:Character)-[:ON_SIDE]->(my_side:BattleSide)<-[:HAS_SIDE]-(b:Battle)-[:HAS_SIDE]->(opp_side:BattleSide)
         WHERE my_side.side_key <> opp_side.side_key
-          AND datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days: $window_days})
+          AND b.started_at >= $cutoff
         MATCH (opp_side)-[:REPRESENTED_BY_ALLIANCE]->(a:Alliance)
         WITH c, a.alliance_id AS opp_alliance,
              collect(DISTINCT b) AS battles,
@@ -1098,12 +1106,12 @@ def run_compute_graph_topology_metrics(db: SupplyCoreDb, neo4j_raw: dict[str, An
                  CASE WHEN s.encounters > mx_enc THEN s.encounters ELSE mx_enc END
              ) AS max_encounters_single
         RETURN
-            toInteger(c.character_id) AS character_id,
+            c.character_id AS character_id,
             toFloat(max_avoidance_delta) AS engagement_avoidance_score,
             toInteger(alliances_faced) AS alliances_encountered,
             toInteger(max_encounters_single) AS max_encounters_single_alliance
         """,
-        {"window_days": RELATIONSHIP_WINDOW_DAYS},
+        {"cutoff": cutoff},
     )
     avoidance_map: dict[int, float] = {}
     for row in avoidance_rows:

--- a/python/orchestrator/jobs/graph_temporal_metrics.py
+++ b/python/orchestrator/jobs/graph_temporal_metrics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from ..db import SupplyCoreDb
@@ -18,6 +18,10 @@ WINDOWS = [
 DRIFT_THRESHOLD = 0.15
 
 
+def _utc_cutoff_iso(days: int) -> str:
+    return (datetime.now(UTC) - timedelta(days=days)).isoformat()
+
+
 def run_graph_temporal_metrics_sync(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:
     started = time.perf_counter()
     job_name = "graph_temporal_metrics_sync"
@@ -31,10 +35,11 @@ def run_graph_temporal_metrics_sync(db: SupplyCoreDb, neo4j_raw: dict[str, Any] 
     total_rows_written = 0
 
     for window_label, window_days in WINDOWS:
+        cutoff = _utc_cutoff_iso(window_days)
         rows = client.query(
             """
             MATCH (c:Character)-[:ON_SIDE]->(:BattleSide)<-[:HAS_SIDE]-(b:Battle)
-            WHERE datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days: $window_days})
+            WHERE b.started_at >= $cutoff
             OPTIONAL MATCH (c)-[:ATTACKED_ON]->(k:Killmail)<-[:OCCURRED_IN]-(b)
             OPTIONAL MATCH (c)-[:VICTIM_OF]->(v:Killmail)<-[:OCCURRED_IN]-(b)
             OPTIONAL MATCH (c)-[co:CO_OCCURS_WITH]-(:Character)
@@ -50,7 +55,7 @@ def run_graph_temporal_metrics_sync(db: SupplyCoreDb, neo4j_raw: dict[str, Any] 
                       ELSE 0.0 END AS engagement_rate_avg
             WHERE battles_present > 0
             RETURN
-                toInteger(c.character_id) AS character_id,
+                c.character_id AS character_id,
                 toInteger(battles_present) AS battles_present,
                 toInteger(kills_total) AS kills_total,
                 toInteger(losses_total) AS losses_total,
@@ -59,7 +64,7 @@ def run_graph_temporal_metrics_sync(db: SupplyCoreDb, neo4j_raw: dict[str, Any] 
                 toFloat(co_presence_density) AS co_presence_density,
                 toFloat(engagement_rate_avg) AS engagement_rate_avg
             """,
-            {"window_days": window_days},
+            {"cutoff": cutoff},
         )
 
         if not rows:

--- a/python/orchestrator/jobs/graph_typed_interactions.py
+++ b/python/orchestrator/jobs/graph_typed_interactions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from ..db import SupplyCoreDb
@@ -13,22 +13,27 @@ RELATIONSHIP_WINDOW_DAYS = 90
 SAME_FLEET_MIN_CO_BATTLES = 3
 
 
+def _utc_cutoff_iso(days: int) -> str:
+    return (datetime.now(UTC) - timedelta(days=days)).isoformat()
+
+
 def _create_typed_relationships(client: Neo4jClient, window_days: int) -> dict[str, int]:
     """Create typed Neo4j relationships and return counts per type."""
     counts: dict[str, int] = {}
+    cutoff = _utc_cutoff_iso(window_days)
 
     # Direct combat: A attacked a killmail where B was victim
     result = client.query(
         """
         MATCH (a:Character)-[:ATTACKED_ON]->(k:Killmail)<-[:VICTIM_OF]-(b:Character)
         WHERE a.character_id <> b.character_id
-          AND datetime(COALESCE(k.occurred_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days: $window_days})
+          AND k.occurred_at >= $cutoff
         WITH a, b, count(DISTINCT k) AS cnt, max(k.occurred_at) AS last_at
         MERGE (a)-[r:DIRECT_COMBAT]->(b)
         SET r.count = cnt, r.last_at = last_at, r.updated_at = datetime()
         RETURN count(r) AS total
         """,
-        {"window_days": window_days},
+        {"cutoff": cutoff},
     )
     counts["direct_combat"] = int((result[0] if result else {}).get("total") or 0)
 
@@ -37,13 +42,13 @@ def _create_typed_relationships(client: Neo4jClient, window_days: int) -> dict[s
         """
         MATCH (a:Character)-[:ATTACKED_ON]->(k:Killmail)<-[:ATTACKED_ON]-(b:Character)
         WHERE a.character_id < b.character_id
-          AND datetime(COALESCE(k.occurred_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days: $window_days})
+          AND k.occurred_at >= $cutoff
         WITH a, b, count(DISTINCT k) AS cnt, max(k.occurred_at) AS last_at
         MERGE (a)-[r:ASSISTED_KILL]->(b)
         SET r.count = cnt, r.last_at = last_at, r.updated_at = datetime()
         RETURN count(r) AS total
         """,
-        {"window_days": window_days},
+        {"cutoff": cutoff},
     )
     counts["assisted_kill"] = int((result[0] if result else {}).get("total") or 0)
 
@@ -79,8 +84,8 @@ def _export_typed_interactions(client: Neo4jClient, db: SupplyCoreDb, computed_a
             f"""
             MATCH (a:Character)-[r:{rel_type}]->(b:Character)
             RETURN
-                toInteger(a.character_id) AS character_a_id,
-                toInteger(b.character_id) AS character_b_id,
+                a.character_id AS character_a_id,
+                b.character_id AS character_b_id,
                 toInteger(r.count) AS interaction_count,
                 toString(r.last_at) AS last_interaction_at
             """,

--- a/python/orchestrator/jobs/intelligence_pipeline.py
+++ b/python/orchestrator/jobs/intelligence_pipeline.py
@@ -728,7 +728,7 @@ def _export_suspicion_signals(client: Neo4jClient, db: SupplyCoreDb, computed_at
                     engagement_rate: e.engagement_rate
                 }) AS engagement_rates
            RETURN
-               toInteger(c.character_id) AS character_id,
+               c.character_id AS character_id,
                toInteger(alliance_id) AS alliance_id,
                toInteger(COALESCE(c.battles_present, 0)) AS battles_present,
                toInteger(COALESCE(c.kills_total, 0)) AS kills_total,
@@ -800,7 +800,7 @@ def _export_alliance_overlap(client: Neo4jClient, db: SupplyCoreDb, computed_at:
              AND COALESCE(c.historical_overlap_score, 0) > 0
            OPTIONAL MATCH (c)-[:MEMBER_OF_ALLIANCE]->(a:Alliance)
            RETURN
-               toInteger(c.character_id) AS character_id,
+               c.character_id AS character_id,
                toInteger(COALESCE(a.alliance_id, 0)) AS alliance_id,
                toInteger(COALESCE(c.former_allies_attacking, 0)) AS former_allies_attacking,
                toInteger(COALESCE(c.losses_to_former_allies, 0)) AS losses_to_former_allies,


### PR DESCRIPTION
## Summary
This PR refactors Neo4j query patterns across the graph pipeline to improve type safety and query efficiency by:
1. Removing unnecessary `toInteger()` coercions on `character_id` properties (which are already integers in the database)
2. Replacing complex datetime calculations with pre-computed ISO 8601 cutoff strings
3. Introducing a shared `_utc_cutoff_iso()` helper function for consistent datetime handling

## Key Changes

### Datetime Handling Improvements
- Added `_utc_cutoff_iso(days: int)` helper function in three modules (`graph_pipeline.py`, `graph_typed_interactions.py`, `graph_temporal_metrics.py`) to generate ISO 8601 datetime strings for the past N days
- Replaced inline `datetime() - duration({days: $window_days})` calculations with pre-computed `$cutoff` parameters
- Simplified datetime comparisons from `datetime(COALESCE(b.started_at, '1970-01-01T00:00:00Z')) >= datetime() - duration({days:$window_days})` to `b.started_at >= $cutoff`
- Removed unnecessary `COALESCE()` and `datetime()` wrapping around `started_at` and `occurred_at` fields (which are already ISO strings)

### Type Coercion Removals
- Removed `toInteger()` calls on `character_id` properties in MERGE/MATCH clauses across all modules since character_id is already an integer property
- Removed `toInteger()` calls in RETURN statements for character_id (now returned as-is)
- Affected files: `graph_pipeline.py`, `graph_typed_interactions.py`, `graph_temporal_metrics.py`, `graph_motif_detection.py`, `counterintel_pipeline.py`, `graph_community_detection.py`, `intelligence_pipeline.py`, `graph_evidence_paths.py`

## Implementation Details
- The `_utc_cutoff_iso()` function computes cutoff times once per batch/window rather than in every query, reducing redundant calculations
- Parameter passing simplified: replaced `window_days` parameters with pre-computed `cutoff` and `recent_cutoff` ISO strings
- All datetime comparisons now use direct string comparison against ISO 8601 formatted timestamps, which is more efficient in Neo4j

https://claude.ai/code/session_0199PhV6SboRjEAZEhojK8pB