### PR TITLE
Restyle theater view: coalition panels, hull renders, and sortable battles table

### DIFF
--- a/public/theater-intelligence/partials/_battle_report.php
+++ b/public/theater-intelligence/partials/_battle_report.php
@@ -20,7 +20,7 @@
     <!-- Efficiency Bar -->
     <div class="flex items-center gap-3 mb-3">
         <span class="text-xs font-semibold text-blue-300"><?= number_format(($ourPanel['efficiency'] ?? 0) * 100, 1) ?>%</span>
-        <div class="flex-1 h-2.5 rounded-full overflow-hidden bg-slate-800 flex">
+        <div class="flex-1 h-3 rounded-full overflow-hidden bg-slate-800 flex shadow-inner">
             <div class="bg-blue-500 h-full transition-all" style="width: <?= number_format($ourBarPct, 1) ?>%"></div>
             <div class="bg-red-500 h-full transition-all" style="width: <?= number_format($enemyBarPct, 1) ?>%"></div>
         </div>
@@ -30,28 +30,30 @@
     <!-- Two-column side comparison -->
     <div class="grid gap-4 md:grid-cols-2">
         <!-- Friendly panel -->
-        <div class="bg-blue-900/60 rounded-lg p-4">
-            <h3 class="text-sm font-semibold text-blue-300 mb-3">
-                <?= htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES) ?>
+        <div class="coalition-panel rounded-lg overflow-hidden border border-blue-500/25">
+            <div class="bg-blue-900/40 px-4 py-3 flex items-center justify-between border-b border-blue-500/20">
+                <h3 class="text-sm font-semibold text-blue-300"><?= htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES) ?></h3>
                 <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Friendly</span>
-            </h3>
+            </div>
+            <div class="px-4 pt-3">
             <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted">Friendly coalition overview</p>
+            </div>
 
-            <div class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-                <div>
+            <div class="grid grid-cols-2 divide-x divide-y divide-white/5 border-b border-white/5 text-sm">
+                <div class="px-4 py-3">
                     <p class="text-xs text-muted">Unique Pilots</p>
                     <p class="text-slate-100 font-semibold"><?= number_format((int) ($ourPanel['pilots'] ?? 0)) ?></p>
                 </div>
-                <div>
+                <div class="px-4 py-3">
                     <p class="text-xs text-muted">ISK Efficiency</p>
                     <p class="text-slate-100 font-semibold"><?= number_format(($ourPanel['efficiency'] ?? 0) * 100, 1) ?>%</p>
                 </div>
-                <div>
+                <div class="px-4 py-3">
                     <p class="text-xs text-muted">Final Blows / Losses</p>
                     <p class="text-slate-100 font-semibold"><?= number_format((int) ($ourPanel['final_blows'] ?? 0)) ?> / <?= number_format((int) ($ourPanel['losses'] ?? 0)) ?></p>
                     <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($ourPanel['kill_involvements'] ?? 0)) ?></p>
                 </div>
-                <div>
+                <div class="px-4 py-3">
                     <p class="text-xs text-muted">ISK Killed / Lost</p>
                     <p class="text-slate-100 font-semibold"><?= supplycore_format_isk((float) ($ourPanel['isk_killed'] ?? 0)) ?> / <?= supplycore_format_isk((float) ($ourPanel['isk_lost'] ?? 0)) ?></p>
                 </div>
@@ -59,13 +61,13 @@
 
             <?php $panelAlliances = $ourPanel['alliances'] ?? []; ?>
             <?php if ($panelAlliances): ?>
-                <div class="mt-3 border-t border-slate-700/50 pt-2">
-                    <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Alliances</p>
+                <div class="divide-y divide-white/5">
+                    <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2">Alliances</p>
                     <?php foreach ($panelAlliances as $allianceRow): ?>
                         <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
-                        <div class="flex items-center gap-2 py-0.5">
+                        <div class="flex items-center gap-2.5 px-4 py-2">
                             <?php if ($allianceId > 0): ?>
-                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=32" alt="" class="w-4 h-4 rounded-sm" loading="lazy">
+                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
                             <?php endif; ?>
                             <span class="text-xs text-slate-200 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
                             <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
@@ -76,16 +78,16 @@
 
             <?php $panelShips = $ourPanel['ships'] ?? []; ?>
             <?php if ($panelShips): ?>
-                <div class="mt-3 border-t border-slate-700/50 pt-2">
+                <div class="mt-3 border-t border-slate-700/50 px-4 py-2">
                     <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
-                    <div class="flex flex-wrap gap-1.5">
+                    <div class="flex flex-wrap gap-2">
                         <?php foreach (array_slice($panelShips, 0, 12) as $ship): ?>
-                            <div class="flex items-center gap-1 bg-slate-800/60 rounded px-1.5 py-0.5">
+                            <div class="flex flex-col items-center gap-1 bg-slate-800/50 border border-white/6 rounded-md px-2 py-2 min-w-[72px]">
                                 <?php if (($ship['type_id'] ?? 0) > 0): ?>
-                                    <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/icon?size=32" alt="" class="w-4 h-4" loading="lazy">
+                                    <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/render?size=64" alt="" class="w-12 h-12 object-contain" loading="lazy">
                                 <?php endif; ?>
-                                <span class="text-[11px] text-slate-300"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
-                                <span class="text-[10px] text-muted">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
+                                <span class="text-[11px] text-slate-300 text-center leading-tight max-w-[68px] truncate"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
+                                <span class="text-[10px] text-slate-500 font-semibold">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
                             </div>
                         <?php endforeach; ?>
                         <?php if (count($panelShips) > 12): ?>
@@ -97,30 +99,35 @@
         </div>
 
         <!-- Opposition + Third Party panel -->
-        <div class="bg-red-900/60 rounded-lg p-4">
-            <h3 class="text-sm font-semibold text-red-300 mb-3">
-                <?= htmlspecialchars($sideLabels['opponent'] ?? 'Opposition', ENT_QUOTES) ?>
-                <?php if (($thirdPartyPanel['pilots'] ?? 0) > 0): ?>
-                    <span class="text-slate-400 text-xs font-normal ml-1">+ Third Party</span>
-                <?php endif; ?>
-            </h3>
+        <div class="coalition-panel rounded-lg overflow-hidden border border-red-500/25">
+            <div class="bg-red-900/40 px-4 py-3 flex items-center justify-between border-b border-red-500/20">
+                <h3 class="text-sm font-semibold text-red-300">
+                    <?= htmlspecialchars($sideLabels['opponent'] ?? 'Opposition', ENT_QUOTES) ?>
+                    <?php if (($thirdPartyPanel['pilots'] ?? 0) > 0): ?>
+                        <span class="text-slate-400 text-xs font-normal ml-1">+ Third Party</span>
+                    <?php endif; ?>
+                </h3>
+                <span class="text-[10px] uppercase tracking-wider bg-red-900/60 text-red-300 rounded-full px-1.5 py-0.5 ml-1">Hostile</span>
+            </div>
+            <div class="px-4 pt-3">
             <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted">Opposition coalition overview</p>
+            </div>
 
-            <div class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-                <div>
+            <div class="grid grid-cols-2 divide-x divide-y divide-white/5 border-b border-white/5 text-sm">
+                <div class="px-4 py-3">
                     <p class="text-xs text-muted">Unique Pilots</p>
                     <p class="text-slate-100 font-semibold"><?= number_format($enemyCombinedPilots) ?></p>
                 </div>
-                <div>
+                <div class="px-4 py-3">
                     <p class="text-xs text-muted">ISK Efficiency</p>
                     <p class="text-slate-100 font-semibold"><?= number_format($enemyCombinedEfficiency * 100, 1) ?>%</p>
                 </div>
-                <div>
+                <div class="px-4 py-3">
                     <p class="text-xs text-muted">Final Blows / Losses</p>
                     <p class="text-slate-100 font-semibold"><?= number_format((int) ($enemyPanel['final_blows'] ?? 0) + (int) ($thirdPartyPanel['final_blows'] ?? 0)) ?> / <?= number_format($enemyCombinedLosses) ?></p>
                     <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($enemyPanel['kill_involvements'] ?? 0) + (int) ($thirdPartyPanel['kill_involvements'] ?? 0)) ?></p>
                 </div>
-                <div>
+                <div class="px-4 py-3">
                     <p class="text-xs text-muted">ISK Killed / Lost</p>
                     <p class="text-slate-100 font-semibold"><?= supplycore_format_isk($enemyCombinedIskKilled) ?> / <?= supplycore_format_isk($enemyCombinedIskLost) ?></p>
                 </div>
@@ -128,13 +135,13 @@
 
             <?php $opponentAlliances = $enemyPanel['alliances'] ?? []; ?>
             <?php if ($opponentAlliances): ?>
-                <div class="mt-3 border-t border-slate-700/50 pt-2">
-                    <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Opponent Alliances</p>
+                <div class="divide-y divide-white/5">
+                    <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2">Opponent Alliances</p>
                     <?php foreach ($opponentAlliances as $allianceRow): ?>
                         <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
-                        <div class="flex items-center gap-2 py-0.5">
+                        <div class="flex items-center gap-2.5 px-4 py-2">
                             <?php if ($allianceId > 0): ?>
-                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=32" alt="" class="w-4 h-4 rounded-sm" loading="lazy">
+                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
                             <?php endif; ?>
                             <span class="text-xs text-slate-200 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
                             <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
@@ -145,13 +152,13 @@
 
             <?php $tpAlliances = $thirdPartyPanel['alliances'] ?? []; ?>
             <?php if ($tpAlliances): ?>
-                <div class="mt-3 border-t border-slate-700/50 pt-2">
-                    <p class="text-[10px] uppercase tracking-wider text-slate-400 mb-1">Third Party</p>
+                <div class="divide-y divide-white/5 border-t border-slate-700/50">
+                    <p class="text-[10px] uppercase tracking-wider text-slate-400 px-4 py-2">Third Party</p>
                     <?php foreach ($tpAlliances as $allianceRow): ?>
                         <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
-                        <div class="flex items-center gap-2 py-0.5">
+                        <div class="flex items-center gap-2.5 px-4 py-2">
                             <?php if ($allianceId > 0): ?>
-                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=32" alt="" class="w-4 h-4 rounded-sm" loading="lazy">
+                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
                             <?php endif; ?>
                             <span class="text-xs text-slate-400 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
                             <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
@@ -164,16 +171,16 @@
             <?php usort($panelShips, static fn(array $l, array $r): int => ($r['pilots'] ?? 0) <=> ($l['pilots'] ?? 0)); ?>
             <?php $panelShips = array_slice($panelShips, 0, 12); ?>
             <?php if ($panelShips): ?>
-                <div class="mt-3 border-t border-slate-700/50 pt-2">
+                <div class="mt-3 border-t border-slate-700/50 px-4 py-2">
                     <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
-                    <div class="flex flex-wrap gap-1.5">
+                    <div class="flex flex-wrap gap-2">
                         <?php foreach ($panelShips as $ship): ?>
-                            <div class="flex items-center gap-1 bg-slate-800/60 rounded px-1.5 py-0.5">
+                            <div class="flex flex-col items-center gap-1 bg-slate-800/50 border border-white/6 rounded-md px-2 py-2 min-w-[72px]">
                                 <?php if (($ship['type_id'] ?? 0) > 0): ?>
-                                    <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/icon?size=32" alt="" class="w-4 h-4" loading="lazy">
+                                    <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/render?size=64" alt="" class="w-12 h-12 object-contain" loading="lazy">
                                 <?php endif; ?>
-                                <span class="text-[11px] text-slate-300"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
-                                <span class="text-[10px] text-muted">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
+                                <span class="text-[11px] text-slate-300 text-center leading-tight max-w-[68px] truncate"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
+                                <span class="text-[10px] text-slate-500 font-semibold">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
                             </div>
                         <?php endforeach; ?>
                     </div>

--- a/public/theater-intelligence/partials/_battles.php
+++ b/public/theater-intelligence/partials/_battles.php
@@ -1,15 +1,30 @@
 <section class="surface-primary mt-4">
     <h2 class="text-lg font-semibold text-slate-50">Constituent Battles</h2>
+    <?php
+        $maxParticipants = 0;
+        foreach ($battles as $battleRow) {
+            $maxParticipants = max($maxParticipants, (int) ($battleRow['participant_count'] ?? 0));
+        }
+        $maxParticipants = max($maxParticipants, 1);
+        $sizeClasses = [
+            'MICRO' => 'bg-slate-700/60 text-slate-400 border border-slate-600/50',
+            'SMALL' => 'bg-indigo-900/50 text-indigo-300 border border-indigo-500/30',
+            'MEDIUM'=> 'bg-cyan-900/50 text-cyan-300 border border-cyan-500/30',
+            'LARGE' => 'bg-yellow-900/50 text-yellow-300 border border-yellow-500/30',
+            'MEGA'  => 'bg-orange-900/50 text-orange-300 border border-orange-500/30',
+            'ULTRA' => 'bg-red-900/50 text-red-300 border border-red-500/30',
+        ];
+    ?>
     <div class="mt-3 table-shell">
-        <table class="table-ui">
+        <table id="battles-table" class="table-ui">
             <thead>
                 <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
-                    <th class="px-3 py-2 text-left">System</th>
-                    <th class="px-3 py-2 text-right">Participants</th>
-                    <th class="px-3 py-2 text-left">Size</th>
-                    <th class="px-3 py-2 text-left">Start</th>
-                    <th class="px-3 py-2 text-left">End</th>
-                    <th class="px-3 py-2 text-right">Weight</th>
+                    <th data-sort class="px-3 py-2 text-left cursor-pointer select-none hover:text-slate-200">System <span class="sort-indicator">↕</span></th>
+                    <th data-sort class="px-3 py-2 text-right cursor-pointer select-none hover:text-slate-200">Participants <span class="sort-indicator">↕</span></th>
+                    <th data-sort class="px-3 py-2 text-left cursor-pointer select-none hover:text-slate-200">Size <span class="sort-indicator">↕</span></th>
+                    <th data-sort class="px-3 py-2 text-left cursor-pointer select-none hover:text-slate-200">Start <span class="sort-indicator">↕</span></th>
+                    <th data-sort class="px-3 py-2 text-left cursor-pointer select-none hover:text-slate-200">End <span class="sort-indicator">↕</span></th>
+                    <th data-sort class="px-3 py-2 text-right cursor-pointer select-none hover:text-slate-200">Weight <span class="sort-indicator">↕</span></th>
                     <th class="px-3 py-2 text-right"></th>
                 </tr>
             </thead>
@@ -18,17 +33,32 @@
                     <tr><td colspan="7" class="px-3 py-6 text-sm text-muted">No battles linked.</td></tr>
                 <?php else: ?>
                     <?php foreach ($battles as $b): ?>
+                        <?php
+                            $participants = (int) ($b['participant_count'] ?? 0);
+                            $participantPct = (int) round(($participants / $maxParticipants) * 100);
+                            $battleSize = strtoupper((string) ($b['battle_size_class'] ?? 'MICRO'));
+                            $sizeClass = $sizeClasses[$battleSize] ?? $sizeClasses['MICRO'];
+                            $startAt = (string) ($b['started_at'] ?? '');
+                            $endAt = (string) ($b['ended_at'] ?? '');
+                        ?>
                         <tr class="border-b border-border/50">
-                            <td class="px-3 py-2 text-slate-100"><?= htmlspecialchars((string) ($b['system_name'] ?? '-'), ENT_QUOTES) ?></td>
-                            <td class="px-3 py-2 text-right"><?= number_format((int) ($b['participant_count'] ?? 0)) ?></td>
-                            <td class="px-3 py-2">
-                                <span class="inline-block rounded-full bg-slate-700 px-2 py-0.5 text-[10px] uppercase tracking-wider text-slate-300">
+                            <td class="px-3 py-2 text-slate-100" data-val="<?= htmlspecialchars((string) ($b['system_name'] ?? '-'), ENT_QUOTES) ?>"><?= htmlspecialchars((string) ($b['system_name'] ?? '-'), ENT_QUOTES) ?></td>
+                            <td class="px-3 py-2 text-right" data-val="<?= $participants ?>">
+                                <div class="flex items-center justify-end gap-2">
+                                    <div class="w-16 h-1.5 rounded-full bg-slate-700 overflow-hidden">
+                                        <div class="h-full rounded-full bg-blue-500/70" style="width: <?= $participantPct ?>%"></div>
+                                    </div>
+                                    <span><?= number_format($participants) ?></span>
+                                </div>
+                            </td>
+                            <td class="px-3 py-2" data-val="<?= htmlspecialchars($battleSize, ENT_QUOTES) ?>">
+                                <span class="inline-block rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider <?= $sizeClass ?>">
                                     <?= htmlspecialchars((string) ($b['battle_size_class'] ?? ''), ENT_QUOTES) ?>
                                 </span>
                             </td>
-                            <td class="px-3 py-2 text-slate-300 text-xs"><?= htmlspecialchars((string) ($b['started_at'] ?? ''), ENT_QUOTES) ?></td>
-                            <td class="px-3 py-2 text-slate-300 text-xs"><?= htmlspecialchars((string) ($b['ended_at'] ?? ''), ENT_QUOTES) ?></td>
-                            <td class="px-3 py-2 text-right"><?= number_format((float) ($b['weight'] ?? 0), 2) ?></td>
+                            <td class="px-3 py-2 text-slate-300 text-xs" data-val="<?= strtotime($startAt) ?: 0 ?>"><?= htmlspecialchars($startAt, ENT_QUOTES) ?></td>
+                            <td class="px-3 py-2 text-slate-300 text-xs" data-val="<?= strtotime($endAt) ?: 0 ?>"><?= htmlspecialchars($endAt, ENT_QUOTES) ?></td>
+                            <td class="px-3 py-2 text-right" data-val="<?= (float) ($b['weight'] ?? 0) ?>"><?= number_format((float) ($b['weight'] ?? 0), 2) ?></td>
                             <td class="px-3 py-2 text-right">
                                 <a class="text-accent text-sm" href="/battle-intelligence/battle.php?battle_id=<?= urlencode((string) ($b['battle_id'] ?? '')) ?>">Detail</a>
                             </td>
@@ -39,3 +69,33 @@
         </table>
     </div>
 </section>
+<script>
+(() => {
+    const table = document.getElementById('battles-table');
+    if (!table) return;
+    let sortCol = -1;
+    let sortDir = 1;
+    table.querySelectorAll('thead th[data-sort]').forEach((th, i) => {
+        th.addEventListener('click', () => {
+            sortDir = (sortCol === i) ? -sortDir : 1;
+            sortCol = i;
+            const tbody = table.querySelector('tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+            rows.sort((a, b) => {
+                const va = a.cells[i].dataset.val ?? a.cells[i].textContent.trim();
+                const vb = b.cells[i].dataset.val ?? b.cells[i].textContent.trim();
+                return (isNaN(va) ? va.localeCompare(vb) : va - vb) * sortDir;
+            });
+            rows.forEach((row) => tbody.appendChild(row));
+            table.querySelectorAll('thead th').forEach((header) => {
+                header.classList.remove('sort-asc', 'sort-desc');
+                const indicator = header.querySelector('.sort-indicator');
+                if (indicator) indicator.textContent = '↕';
+            });
+            th.classList.add(sortDir === 1 ? 'sort-asc' : 'sort-desc');
+            const activeIndicator = th.querySelector('.sort-indicator');
+            if (activeIndicator) activeIndicator.textContent = sortDir === 1 ? '▲' : '▼';
+        });
+    });
+})();
+</script>

--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -441,7 +441,7 @@ function _fmt_damage(float $v): string {
                                 <div class="flex items-center gap-1.5">
                                     <?php $allianceId = (int) ($p['alliance_id'] ?? 0); $corpId = (int) ($p['corporation_id'] ?? 0); ?>
                                     <?php if ($allianceId > 0): ?>
-                                        <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=32" alt="" class="w-4 h-4" loading="lazy">
+                                        <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5" loading="lazy">
                                     <?php elseif ($corpId > 0): ?>
                                         <img src="https://images.evetech.net/corporations/<?= $corpId ?>/logo?size=32" alt="" class="w-4 h-4" loading="lazy">
                                     <?php endif; ?>


### PR DESCRIPTION
### Motivation
- Improve visual polish of the theater intelligence detail page to match a WarBeacon-inspired battle-report aesthetic while preserving all existing content and layout order. 
- Make the Constituent Battles list easier to scan by adding sortable columns and a participants mini-bar without changing any underlying data.

### Description
- Restyled coalition comparison panels by wrapping friendly/hostile panels with a bordered header bar and tightened stat grid cells, and increased efficiency bar height plus `shadow-inner` for subtle depth (`public/theater-intelligence/partials/_battle_report.php`).
- Replaced top-hull icons with EVE render images and card wrappers: image URL changed from `/types/{ID}/icon?size=32` to `/types/{ID}/render?size=64`, thumbnail class updated to `w-12 h-12 object-contain`, and hulls wrapped in card boxes with adjusted text sizing and spacing (`public/theater-intelligence/partials/_battle_report.php`).
- Increased alliance logo resolution across the theater panels and participants list by changing `logo?size=32` → `logo?size=64` and display class `w-4 h-4` → `w-5 h-5` where applicable (`public/theater-intelligence/partials/_battle_report.php`, `public/theater-intelligence/partials/_participants.php`).
- Enhanced the Constituent Battles table by adding a `$sizeClasses` map for size-colored badges, computing `$maxParticipants` to render a participants mini-bar, adding `data-val` attributes for numeric/date sorting, making headers clickable with `data-sort`, and adding a scoped client-side sorter with visual indicators bound to `#battles-table` (`public/theater-intelligence/partials/_battles.php`).

### Testing
- Ran PHP syntax checks: `php -l public/theater-intelligence/partials/_battle_report.php` (no syntax errors).
- Ran PHP syntax checks: `php -l public/theater-intelligence/partials/_battles.php` (no syntax errors).
- Ran PHP syntax checks: `php -l public/theater-intelligence/partials/_participants.php` (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9667ea0c0832f957a32e9b7d0406b)