### PR TITLE
Improve Theater Intelligence UI: participant sorting, badges, and battle size styling

### DIFF
--- a/public/theater-intelligence/partials/_battles.php
+++ b/public/theater-intelligence/partials/_battles.php
@@ -7,12 +7,12 @@
         }
         $maxParticipants = max($maxParticipants, 1);
         $sizeClasses = [
-            'MICRO' => 'bg-slate-700/60 text-slate-400 border border-slate-600/50',
-            'SMALL' => 'bg-indigo-900/50 text-indigo-300 border border-indigo-500/30',
-            'MEDIUM'=> 'bg-cyan-900/50 text-cyan-300 border border-cyan-500/30',
-            'LARGE' => 'bg-yellow-900/50 text-yellow-300 border border-yellow-500/30',
-            'MEGA'  => 'bg-orange-900/50 text-orange-300 border border-orange-500/30',
-            'ULTRA' => 'bg-red-900/50 text-red-300 border border-red-500/30',
+            'MICRO' => 'bg-slate-900/70 text-slate-300 border border-slate-500/70 ring-1 ring-slate-500/30',
+            'SMALL' => 'bg-indigo-900/60 text-indigo-200 border border-indigo-400/60 ring-1 ring-indigo-400/30',
+            'MEDIUM'=> 'bg-cyan-900/60 text-cyan-200 border border-cyan-400/60 ring-1 ring-cyan-400/30',
+            'LARGE' => 'bg-yellow-900/60 text-yellow-200 border border-yellow-400/70 ring-1 ring-yellow-400/30',
+            'MEGA'  => 'bg-orange-900/60 text-orange-200 border border-orange-400/70 ring-1 ring-orange-400/30',
+            'ULTRA' => 'bg-red-900/60 text-red-200 border border-red-400/70 ring-1 ring-red-400/30',
         ];
     ?>
     <div class="mt-3 table-shell">
@@ -52,7 +52,7 @@
                                 </div>
                             </td>
                             <td class="px-3 py-2" data-val="<?= htmlspecialchars($battleSize, ENT_QUOTES) ?>">
-                                <span class="inline-block rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider <?= $sizeClass ?>">
+                                <span class="inline-block rounded-full px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] <?= $sizeClass ?>">
                                     <?= htmlspecialchars((string) ($b['battle_size_class'] ?? ''), ENT_QUOTES) ?>
                                 </span>
                             </td>

--- a/public/theater-intelligence/partials/_header.php
+++ b/public/theater-intelligence/partials/_header.php
@@ -1,9 +1,9 @@
 <section class="surface-primary">
     <a href="/theater-intelligence" class="text-sm text-accent">&#8592; Back to Theater Overview</a>
 
-    <div class="mt-3 flex items-start justify-between gap-4">
-        <div class="flex-1">
-            <div class="flex items-center gap-2">
+    <div class="mt-3 flex items-start justify-center gap-4">
+        <div class="flex-1 text-center">
+            <div class="flex items-center justify-center gap-2">
                 <p class="text-xs uppercase tracking-[0.16em] text-muted">Battle Intelligence — Theater Detail</p>
                 <?php if ($isLocked): ?>
                     <span class="inline-flex items-center gap-1 rounded-full bg-amber-600/20 border border-amber-500/30 px-2 py-0.5 text-[10px] uppercase tracking-wider text-amber-300">
@@ -18,7 +18,7 @@
                     <span class="text-sm text-muted font-normal">+<?= (int) ($theater['system_count'] ?? 0) - 1 ?> systems</span>
                 <?php endif; ?>
             </h1>
-            <div class="mt-2 flex flex-wrap items-center gap-2 text-base">
+            <div class="mt-2 flex flex-wrap items-center justify-center gap-2 text-base">
                 <span class="text-blue-300 font-semibold"><?= htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES) ?></span>
                 <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5">Friendly</span>
                 <span class="text-slate-500">vs</span>
@@ -29,7 +29,7 @@
                     <span class="text-slate-400 text-sm">(+<?= $thirdPartyCount ?> unidentified)</span>
                 <?php endif; ?>
             </div>
-            <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
+            <div class="mt-2 flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs text-muted">
                 <span><?= htmlspecialchars((string) ($theater['region_name'] ?? ''), ENT_QUOTES) ?></span>
                 <span><?= htmlspecialchars($theaterStartActual, ENT_QUOTES) ?> — <?= htmlspecialchars($theaterEndActual, ENT_QUOTES) ?></span>
                 <span>Friendly: <?= number_format(count($sideAlliancesByPilots['friendly'] ?? [])) ?> alliances</span>

--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -41,6 +41,11 @@ function _render_participant_row(array $p, array $resolvedEntities, array $shipT
     $isSusp = (int) ($p['is_suspicious'] ?? 0);
     $charName = killmail_entity_preferred_name($resolvedEntities, 'character', (int) ($p['character_id'] ?? 0), (string) ($p['character_name'] ?? ''), 'Character');
     $fleetRole = (string) ($p['role_proxy'] ?? 'mainline_dps');
+    $roleRank = match ($fleetRole) {
+        'fc' => 0,
+        'supercapital', 'capital_dps', 'capital_logistics', 'capital' => 1,
+        default => 2,
+    };
     $kills = (int) ($p['kills'] ?? 0);
     $deaths = (int) ($p['deaths'] ?? 0);
     $dmgDone = (float) ($p['damage_done'] ?? 0);
@@ -102,6 +107,7 @@ function _render_participant_row(array $p, array $resolvedEntities, array $shipT
 
     // ── Row data attributes for client-side filtering/sorting ──
     $kdRatio = $deaths > 0 ? $kills / $deaths : $kills;
+    $sortHull = strtolower(trim($flyingShipName !== '' ? $flyingShipName : 'zzzz-unknown'));
 
     ob_start();
     ?>
@@ -109,6 +115,8 @@ function _render_participant_row(array $p, array $resolvedEntities, array $shipT
         data-deaths="<?= $deaths ?>"
         data-kills="<?= $kills ?>"
         data-kd="<?= number_format($kdRatio, 4) ?>"
+        data-role-rank="<?= $roleRank ?>"
+        data-hull="<?= htmlspecialchars($sortHull, ENT_QUOTES) ?>"
         data-damage="<?= $dmgDone ?>"
         data-isk="<?= $iskLost ?>">
         <td class="px-2 py-1.5">
@@ -149,7 +157,7 @@ function _render_participant_row(array $p, array $resolvedEntities, array $shipT
             </div>
         </td>
         <td class="px-2 py-1.5">
-            <span class="inline-block rounded-full px-1.5 py-0.5 text-[9px] uppercase tracking-wider <?= fleet_function_color_class($fleetRole) ?>">
+            <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] border border-white/15 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] <?= fleet_function_color_class($fleetRole) ?>">
                 <?= htmlspecialchars(fleet_function_label($fleetRole), ENT_QUOTES) ?>
             </span>
         </td>
@@ -235,6 +243,7 @@ function _fmt_damage(float $v): string {
                 <button type="button" class="sc-filter-btn text-[11px] px-2.5 py-1 rounded bg-slate-800 text-slate-400 border border-slate-700 cursor-pointer transition-colors hover:bg-slate-700 hover:text-slate-200" data-filter="dead">&#x2715; Deaths only</button>
                 <button type="button" class="sc-filter-btn text-[11px] px-2.5 py-1 rounded bg-slate-800 text-slate-400 border border-slate-700 cursor-pointer transition-colors hover:bg-slate-700 hover:text-slate-200" data-filter="clean">&#10003; No losses</button>
                 <select class="sc-sort-select text-[11px] bg-slate-800 border border-slate-700 rounded text-slate-400 px-2 py-1 ml-auto cursor-pointer focus:outline-none focus:border-blue-500/60">
+                    <option value="role_hull" selected>Sort: FC & CAPs, then hull</option>
                     <option value="kd_ratio">Sort: K/D ratio</option>
                     <option value="kills">Sort: kills</option>
                     <option value="isk_lost">Sort: ISK lost</option>
@@ -295,6 +304,15 @@ function _fmt_damage(float $v): string {
 
             function applySort(mode) {
                 allRows.sort(function(a, b) {
+                    if (mode === 'role_hull') {
+                        var roleCmp = parseInt(a.dataset.roleRank || '99', 10) - parseInt(b.dataset.roleRank || '99', 10);
+                        if (roleCmp !== 0) return roleCmp;
+                        var hullA = (a.dataset.hull || '');
+                        var hullB = (b.dataset.hull || '');
+                        var hullCmp = hullA.localeCompare(hullB);
+                        if (hullCmp !== 0) return hullCmp;
+                        return parseFloat(b.dataset.kd) - parseFloat(a.dataset.kd);
+                    }
                     if (mode === 'kd_ratio') return parseFloat(b.dataset.kd) - parseFloat(a.dataset.kd);
                     if (mode === 'kills') return parseInt(b.dataset.kills) - parseInt(a.dataset.kills);
                     if (mode === 'isk_lost') return parseFloat(b.dataset.isk) - parseFloat(a.dataset.isk);
@@ -327,6 +345,7 @@ function _fmt_damage(float $v): string {
                 sortSelect.addEventListener('change', function() {
                     applySort(sortSelect.value);
                 });
+                applySort(sortSelect.value || 'role_hull');
             }
         });
     })();
@@ -478,7 +497,7 @@ function _fmt_damage(float $v): string {
                                 </div>
                             </td>
                             <td class="px-3 py-2">
-                                <span class="inline-block rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider <?= fleet_function_color_class($fleetRole) ?>">
+                                <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] border border-white/15 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] <?= fleet_function_color_class($fleetRole) ?>">
                                     <?= htmlspecialchars(fleet_function_label($fleetRole), ENT_QUOTES) ?>
                                 </span>
                             </td>


### PR DESCRIPTION
### Motivation

- Improve visual clarity and consistency of the Theater Intelligence UI by refining badge and size styling and centering the header content.
- Make participant lists easier to read by prioritizing Fleet Command and capital roles in the sort order and then grouping by hull type.

### Description

- Updated battle size palette and pill styling in `public/theater-intelligence/partials/_battles.php` by changing `sizeClasses` values and the size label span to use bolder font and adjusted padding.
- Centered and tightened header layout in `public/theater-intelligence/partials/_header.php` by changing alignment and justification classes for the theater header block.
- Refactored participant rendering in `public/theater-intelligence/partials/_participants.php` to add a `roleRank` computed via `match`, compute a `sortHull` fallback, and emit `data-role-rank` and `data-hull` attributes on rows for client-side sorting.
- Enhanced fleet role badge markup and styling to use `inline-flex`, stronger font weight and subtle border/shadow, and added a new default sort option `role_hull` to the sort select.
- Implemented client-side sorting behavior for the `role_hull` mode in the participants JS so rows are sorted by role rank, then hull name, then fallback to K/D ratio, and applied this sort on initialization when the select exists.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c968f68d78832fa52f91a6ae11637f)