### PR TITLE
Handle null battle_id in killmail entity sync

### DIFF
--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -2041,7 +2041,7 @@ def run_compute_graph_sync_killmail_entities(
                    effective_killmail_at, zkb_total_value AS total_value,
                    victim_ship_type_id
             FROM killmail_events
-            WHERE id > %s AND battle_id IS NOT NULL
+            WHERE id > %s
             ORDER BY id ASC
             LIMIT %s
             """,
@@ -2058,7 +2058,7 @@ def run_compute_graph_sync_killmail_entities(
             neo4j_rows.append({
                 "killmail_id": int(row["killmail_id"]),
                 "solar_system_id": int(row["solar_system_id"]),
-                "battle_id": str(row["battle_id"]),
+                "battle_id": str(row["battle_id"]) if row.get("battle_id") else None,
                 "killed_at": str(row.get("effective_killmail_at") or ""),
                 "total_value": float(row.get("total_value") or 0),
                 "victim_ship_type_id": int(row.get("victim_ship_type_id") or 0),
@@ -2075,8 +2075,10 @@ def run_compute_graph_sync_killmail_entities(
             MERGE (sys:System {system_id: toInteger(row.solar_system_id)})
             MERGE (km)-[:OCCURRED_IN]->(sys)
             WITH km, row
-            MERGE (b:Battle {battle_id: row.battle_id})
-            MERGE (km)-[:PART_OF_BATTLE]->(b)
+            FOREACH (_ IN CASE WHEN row.battle_id IS NOT NULL THEN [1] ELSE [] END |
+              MERGE (b:Battle {battle_id: row.battle_id})
+              MERGE (km)-[:PART_OF_BATTLE]->(b)
+            )
             """,
             {"rows": neo4j_rows},
         )


### PR DESCRIPTION
## Summary
Updated the killmail entity synchronization logic to properly handle cases where `battle_id` is null, allowing killmail events without associated battles to be processed.

## Key Changes
- Removed the `battle_id IS NOT NULL` filter from the SQL query to include all killmail events regardless of battle association
- Added null-safe handling when converting `battle_id` to string in the Python data processing layer
- Updated the Neo4j Cypher query to conditionally create battle relationships only when `battle_id` is not null using a `FOREACH` clause

## Implementation Details
The changes ensure that:
1. Killmail events without battles are no longer filtered out at the database level
2. The `battle_id` field is safely converted to `None` when null instead of causing errors
3. Neo4j graph relationships are only created for killmails that have an associated battle, preventing orphaned or invalid relationships

https://claude.ai/code/session_01LLPFdjChmbAicj6Tpf2TYb