### PR TITLE
Implement esi:payload:v1 Redis cache + three-tier corp lookup

### DIFF
--- a/docs/ESI_REDIS_MULTISTORE_AUDIT_2026-03-29.md
+++ b/docs/ESI_REDIS_MULTISTORE_AUDIT_2026-03-29.md
@@ -169,6 +169,20 @@ Behavior contract:
    - 429: honor Retry-After and set suppression key
 6. For paginated reads: enforce identical Last-Modified across pages in one retrieval cycle.
 
+#### Payload caching (implemented)
+The gateway stores response bodies in Redis (`esi:payload:v1:{endpoint_key}`)
+alongside metadata, with the same Expires-driven TTL. On Expires-gate hits,
+the cached body is returned in the `GatewayResponse` so callers get the payload
+without making an ESI request.
+
+This eliminates the previous "body-swallow" issue where Expires-gated responses
+returned `body=None`, breaking lookup/enrichment endpoints that need the payload
+(character/corporation profiles, individual killmails).
+
+For corporation → alliance lookups, `entity_metadata_cache` in MariaDB provides
+an additional durable cache tier that survives Redis restarts and is bulk-loaded
+at job start for fast in-memory access.
+
 #### PHP role
 - No ESI requests.
 - Read-only consumer of Redis/MariaDB results prepared by Python.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -245,7 +245,7 @@ All keys are version-prefixed (`v1`) and use the configured prefix
 | Key pattern | Purpose | TTL |
 |-------------|---------|-----|
 | `esi:meta:v1:{endpoint_key}` | Endpoint metadata (etag, expires, etc.) | Expires-driven (60s–3600s) |
-| `esi:payload:v1:{endpoint_key}` | Optional cached response body | Expires-driven |
+| `esi:payload:v1:{endpoint_key}` | Cached response body | Expires-driven |
 | `esi:ratelimit:v1:{group}:{identity}` | Rate-limit bucket state | Window + 60s |
 | `esi:retry_after:v1:{group}:{identity}` | Retry-after deadline (Unix timestamp) | Retry-After + 5s |
 | `esi:suppress:v1:{endpoint_or_group}` | Request suppression (429 storm protection) | Retry-After + 5s |

--- a/python/orchestrator/esi_gateway.py
+++ b/python/orchestrator/esi_gateway.py
@@ -33,6 +33,7 @@ from .redis_keys import (
     build_endpoint_key,
     esi_fetch_lock_key,
     esi_meta_key,
+    esi_payload_key,
     esi_suppress_key,
 )
 
@@ -202,10 +203,11 @@ class EsiGateway:
             # Expires-gating: skip request if data is still fresh.
             now = time.time()
             if meta and meta.expires_at > now:
-                logger.debug("Expires-gated %s (%.0fs remaining)", ep_key, meta.expires_at - now)
+                cached_body = self._load_payload(ep_key)
+                logger.debug("Expires-gated %s (%.0fs remaining, payload=%s)", ep_key, meta.expires_at - now, "hit" if cached_body is not None else "miss")
                 return GatewayResponse(
                     status_code=meta.last_status_code or 200,
-                    body=None,
+                    body=cached_body,
                     headers={},
                     from_cache=True,
                     endpoint_key=ep_key,
@@ -409,6 +411,7 @@ class EsiGateway:
             meta.x_pages = resp.pages
             meta.success_count += 1
             self._save_meta(meta)
+            self._save_payload(ep_key, resp.body, expires_at)
             self._persist_endpoint_state(meta, route_template, params, identity, page)
             self._record_rate_observation(resp.headers, resp.status_code)
             return GatewayResponse(
@@ -505,6 +508,19 @@ class EsiGateway:
         if self._redis and self._redis.available:
             ttl = max(_MIN_TTL_SECONDS, min(_MAX_TTL_SECONDS, int(meta.expires_at - time.time())))
             self._redis.set_json(esi_meta_key(meta.endpoint_key), meta.to_dict(), ex=ttl)
+
+    def _save_payload(self, ep_key: str, body: Any, expires_at: float) -> None:
+        """Cache response body in Redis (esi:payload:v1:*)."""
+        if not self._redis or not self._redis.available or body is None:
+            return
+        ttl = max(_MIN_TTL_SECONDS, min(_MAX_TTL_SECONDS, int(expires_at - time.time())))
+        self._redis.set_json(esi_payload_key(ep_key), body, ex=ttl)
+
+    def _load_payload(self, ep_key: str) -> Any:
+        """Load cached response body from Redis."""
+        if not self._redis or not self._redis.available:
+            return None
+        return self._redis.get_json(esi_payload_key(ep_key))
 
     # -- Distributed fetch lock --------------------------------------------
 

--- a/python/orchestrator/jobs/esi_alliance_history_sync.py
+++ b/python/orchestrator/jobs/esi_alliance_history_sync.py
@@ -7,9 +7,18 @@ joining against the existing corp-to-alliance mapping in MariaDB.
 When an :class:`~orchestrator.esi_gateway.EsiGateway` is available (Redis
 enabled), requests go through the gateway for Expires-gating, conditional
 request handling, and distributed rate-limit coordination.
+
+Corporation → alliance lookups use a three-tier cache:
+
+1. **In-memory dict** — fastest, populated from tiers below.
+2. **MySQL ``entity_metadata_cache``** — persisted across runs, bulk-loaded
+   at job start.
+3. **ESI ``/v5/corporations/{id}/``** via gateway — authoritative source;
+   results are written back to ``entity_metadata_cache`` for future runs.
 """
 from __future__ import annotations
 
+import json
 import sys
 import time
 import traceback
@@ -44,11 +53,17 @@ def _init_gateway(db: SupplyCoreDb, raw_config: dict[str, Any] | None) -> None:
 
 
 def _esi_get(path: str) -> Any:
-    """Fetch via gateway if available, otherwise direct client."""
+    """Fetch via gateway if available, otherwise direct client.
+
+    The gateway now caches response bodies in Redis (esi:payload:v1:*),
+    so Expires-gated responses include the body.  ``from_cache`` with a
+    non-None body is a cache hit we can use; ``from_cache`` with
+    ``body=None`` means the payload wasn't in Redis (first run or evicted).
+    """
     if _gateway is not None:
         resp = _gateway.get(path, route_template=path)
         if resp.from_cache or resp.not_modified:
-            return None  # Treat as no-new-data
+            return resp.body  # May be the cached payload, or None if not in Redis
         if 200 <= resp.status_code < 300:
             return resp.body
         return None
@@ -67,16 +82,97 @@ def _fetch_corporation_history(character_id: int) -> list[dict[str, Any]] | None
 
 
 _corp_alliance_cache: dict[int, int | None] = {}
+_CORP_CACHE_EXPIRE_HOURS = 24
+
+# Sentinel to distinguish "we looked it up and it's None" from "not checked yet".
+_NOT_CHECKED = object()
 
 
-def _lookup_corp_alliance(corp_id: int) -> int | None:
-    """Look up the current alliance for a corporation, cached per session."""
+def _warm_corp_cache(db: SupplyCoreDb) -> int:
+    """Bulk-load known corporation → alliance mappings from entity_metadata_cache."""
+    rows = db.fetch_all(
+        """SELECT entity_id,
+                  JSON_UNQUOTE(JSON_EXTRACT(metadata_json, '$.alliance_id')) AS alliance_id
+           FROM entity_metadata_cache
+           WHERE entity_type = 'corporation'
+             AND resolution_status = 'resolved'
+             AND metadata_json IS NOT NULL
+             AND JSON_EXTRACT(metadata_json, '$.alliance_id') IS NOT NULL"""
+    )
+    loaded = 0
+    for row in rows:
+        corp_id = int(row.get("entity_id") or 0)
+        raw_aid = row.get("alliance_id")
+        if corp_id > 0 and raw_aid is not None:
+            aid = int(raw_aid) if str(raw_aid).isdigit() else 0
+            _corp_alliance_cache[corp_id] = aid if aid > 0 else None
+            loaded += 1
+    return loaded
+
+
+def _lookup_corp_alliance_db(db: SupplyCoreDb, corp_id: int) -> Any:
+    """Check entity_metadata_cache for a single corporation. Returns sentinel if not found."""
+    row = db.fetch_one(
+        """SELECT metadata_json FROM entity_metadata_cache
+           WHERE entity_type = 'corporation' AND entity_id = %s
+             AND resolution_status = 'resolved'
+             AND metadata_json IS NOT NULL""",
+        (corp_id,),
+    )
+    if not row or not row.get("metadata_json"):
+        return _NOT_CHECKED
+    try:
+        meta = row["metadata_json"]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+        aid = int(meta.get("alliance_id") or 0)
+        return aid if aid > 0 else None
+    except (ValueError, TypeError, KeyError):
+        return _NOT_CHECKED
+
+
+def _store_corp_metadata(db: SupplyCoreDb, corp_id: int, body: dict[str, Any]) -> None:
+    """Write corporation ESI response to entity_metadata_cache for future lookups."""
+    corp_name = str(body.get("name") or "").strip()
+    alliance_id = int(body.get("alliance_id") or 0) or None
+    meta = {"alliance_id": alliance_id}
+    try:
+        db.execute(
+            """INSERT INTO entity_metadata_cache
+               (entity_type, entity_id, entity_name, metadata_json,
+                source_system, resolution_status, expires_at, resolved_at)
+               VALUES ('corporation', %s, %s, %s, 'esi', 'resolved',
+                       DATE_ADD(UTC_TIMESTAMP(), INTERVAL %s HOUR), UTC_TIMESTAMP())
+               ON DUPLICATE KEY UPDATE
+                   entity_name = COALESCE(VALUES(entity_name), entity_name),
+                   metadata_json = VALUES(metadata_json),
+                   resolution_status = 'resolved',
+                   expires_at = VALUES(expires_at),
+                   resolved_at = VALUES(resolved_at)""",
+            (corp_id, corp_name or None, json.dumps(meta), _CORP_CACHE_EXPIRE_HOURS),
+        )
+    except Exception:
+        pass  # Best-effort cache write — don't fail the job.
+
+
+def _lookup_corp_alliance(corp_id: int, db: SupplyCoreDb) -> int | None:
+    """Three-tier corp → alliance lookup: memory → MySQL → ESI (via gateway)."""
+    # Tier 1: in-memory
     if corp_id in _corp_alliance_cache:
         return _corp_alliance_cache[corp_id]
+
+    # Tier 2: MySQL entity_metadata_cache
+    db_result = _lookup_corp_alliance_db(db, corp_id)
+    if db_result is not _NOT_CHECKED:
+        _corp_alliance_cache[corp_id] = db_result
+        return db_result
+
+    # Tier 3: ESI via gateway (payload now cached in Redis)
     body = _esi_get(f"/v5/corporations/{corp_id}/")
     alliance_id = None
     if isinstance(body, dict):
         alliance_id = int(body.get("alliance_id") or 0) or None
+        _store_corp_metadata(db, corp_id, body)
     _corp_alliance_cache[corp_id] = alliance_id
     return alliance_id
 
@@ -84,6 +180,7 @@ def _lookup_corp_alliance(corp_id: int) -> int | None:
 def _derive_alliance_history(
     character_id: int,
     corp_history: list[dict[str, Any]],
+    db: SupplyCoreDb,
 ) -> list[tuple[int, int, str, str | None]]:
     """Derive alliance membership periods from corporation history.
 
@@ -95,12 +192,12 @@ def _derive_alliance_history(
     # Sort by start_date ascending.
     entries = sorted(corp_history, key=lambda e: e.get("start_date", ""))
 
-    # Look up alliance for each corporation via ESI (cached).
+    # Look up alliance for each corporation (memory → MySQL → ESI).
     corp_to_alliance: dict[int, int | None] = {}
     for entry in entries:
         corp_id = int(entry.get("corporation_id") or 0)
         if corp_id > 0 and corp_id not in corp_to_alliance:
-            corp_to_alliance[corp_id] = _lookup_corp_alliance(corp_id)
+            corp_to_alliance[corp_id] = _lookup_corp_alliance(corp_id, db)
 
     # Build alliance tenure periods — collapse consecutive entries in same alliance.
     periods: list[tuple[int, int, str, str | None]] = []
@@ -144,6 +241,11 @@ def run_esi_alliance_history_sync(db: SupplyCoreDb, raw_config: dict[str, Any] |
         print(f"[{elapsed:7.2f}s] {msg}", file=sys.stderr, flush=True)
 
     _vlog(f"gateway={'redis' if _gateway else 'direct'}, batch_size={BATCH_SIZE}")
+
+    # Warm corp → alliance cache from MySQL.
+    _vlog("warming corp cache from entity_metadata_cache ...")
+    warmed = _warm_corp_cache(db)
+    _vlog(f"warmed {warmed} corp→alliance mappings from DB")
 
     # Fetch batch of pending characters, skipping recently fetched ones.
     _vlog("querying pending characters ...")
@@ -222,7 +324,7 @@ def run_esi_alliance_history_sync(db: SupplyCoreDb, raw_config: dict[str, Any] |
             _vlog(f"  [{idx + 1}/{len(batch)}] char {character_id}: got {len(corp_history)} entries, {unique_corps} corps ({cached_corps} cached), deriving alliances ...")
 
             derive_started = time.perf_counter()
-            periods = _derive_alliance_history(character_id, corp_history)
+            periods = _derive_alliance_history(character_id, corp_history, db)
             derive_ms = int((time.perf_counter() - derive_started) * 1000)
 
             if periods:
@@ -269,5 +371,7 @@ def run_esi_alliance_history_sync(db: SupplyCoreDb, raw_config: dict[str, Any] |
             "errors": total_errors,
             "skipped": total_skipped,
             "batch_size": len(batch),
+            "corp_cache_size": len(_corp_alliance_cache),
+            "corp_cache_warmed": warmed,
         },
     ).to_dict()

--- a/python/orchestrator/jobs/killmail.py
+++ b/python/orchestrator/jobs/killmail.py
@@ -297,10 +297,14 @@ class KillmailEntityResolver:
         self._corporation_cache: dict[int, dict[str, Any] | None] = {}
 
     def _fetch_profile(self, path: str) -> dict[str, Any] | None:
+        """Fetch a profile endpoint.  The gateway caches response bodies in
+        Redis, so Expires-gated hits return the cached payload directly."""
         if self._gateway is not None:
             resp = self._gateway.get(path, params={"datasource": "tranquility"}, route_template=path)
             if resp.from_cache or resp.not_modified:
-                return None
+                if isinstance(resp.body, dict):
+                    return resp.body
+                return None  # Payload not in Redis — cache miss
             if 200 <= resp.status_code < 300 and isinstance(resp.body, dict):
                 return resp.body
             return None

--- a/python/orchestrator/jobs/killmail_history_backfill.py
+++ b/python/orchestrator/jobs/killmail_history_backfill.py
@@ -89,14 +89,18 @@ def _fetch_esi_killmail(killmail_id: int, killmail_hash: str, esi_client: EsiCli
 
     When *gateway* is provided, the request goes through the ESI compliance
     gateway for Expires-gating, conditional request handling, and distributed
-    rate-limit coordination.  Otherwise falls back to direct EsiClient usage.
+    rate-limit coordination.  The gateway caches response bodies in Redis,
+    so Expires-gated hits return the payload directly.
     """
     path = f"/latest/killmails/{killmail_id}/{killmail_hash}/"
     if gateway is not None:
         resp = gateway.get(path, route_template="/latest/killmails/{killmail_id}/{killmail_hash}/")
         if resp.from_cache or resp.not_modified:
-            return None
-        if not (200 <= resp.status_code < 300) or not isinstance(resp.body, dict):
+            if isinstance(resp.body, dict):
+                pass  # Use cached payload — fall through to body extraction
+            else:
+                return None  # Payload not in Redis cache
+        elif not (200 <= resp.status_code < 300) or not isinstance(resp.body, dict):
             return None
     else:
         resp = esi_client.get(path)


### PR DESCRIPTION
## Summary

- **Implements `esi:payload:v1:*` Redis payload cache** — the key schema was defined in `redis_keys.py` and documented in `docs/caching.md` but never wired up. Three small changes in `esi_gateway.py`:
  - `_save_payload()`: stores response body in Redis on 2xx with Expires-driven TTL
  - `_load_payload()`: loads cached body from Redis
  - Expires-gate path: returns cached body instead of `None`

- **Fixes the body-swallow bug** across all affected jobs — the gateway previously returned `body=None` for Expires-gated responses, breaking lookup/enrichment endpoints:
  - `killmail.py` `_fetch_profile()` — now uses cached body for character/corp enrichment
  - `killmail_history_backfill.py` `_fetch_esi_killmail()` — now uses cached killmail bodies
  - `esi_alliance_history_sync.py` `_esi_get()` — now returns cached body on gateway hits

- **Three-tier corp→alliance cache** for alliance history sync:
  1. In-memory dict (bulk-warmed from MySQL at job start)
  2. MySQL `entity_metadata_cache` (durable, survives Redis restarts, `metadata_json` stores `alliance_id`)
  3. ESI via gateway (writes back to `entity_metadata_cache` for future runs)

- **Docs updated**: `docs/caching.md` changes "Optional" to reflect payload cache is implemented. ESI audit doc section 5.1 documents the payload caching and corp→alliance durable cache tier.

## Files changed

| File | Change |
|------|--------|
| `python/orchestrator/esi_gateway.py` | `_save_payload`, `_load_payload`, Expires-gate returns cached body, 2xx stores body |
| `python/orchestrator/jobs/esi_alliance_history_sync.py` | Three-tier cache, `_esi_get` returns cached body, `_warm_corp_cache`, `_store_corp_metadata` |
| `python/orchestrator/jobs/killmail.py` | `_fetch_profile` uses cached body from gateway |
| `python/orchestrator/jobs/killmail_history_backfill.py` | `_fetch_esi_killmail` uses cached body from gateway |
| `docs/caching.md` | Payload cache no longer "Optional" |
| `docs/ESI_REDIS_MULTISTORE_AUDIT_2026-03-29.md` | Payload caching section + corp cache documentation |

## Test plan

- [ ] Run `python -m orchestrator run-job --app-root /var/www/SupplyCore --job-key esi_alliance_history_sync --verbose` — confirm derive times near-zero after first run
- [ ] Verify Redis has `esi:payload:v1:*` keys after ESI requests (e.g. `redis-cli keys '*esi:payload*' | head`)
- [ ] Run killmail processing and verify actors have corporation_id/alliance_id enriched
- [ ] Verify `entity_metadata_cache` rows with `entity_type='corporation'` and `metadata_json` containing `alliance_id`
- [ ] Stop Redis, verify jobs still work (degraded — cache miss falls through to ESI)

https://claude.ai/code/session_017ztFywSjGG8HwGN5KkWiw5