### PR TITLE
Add MariaDB fallback for ESI payload cache (Redis → MariaDB → ESI)

### DIFF
--- a/docs/ESI_REDIS_MULTISTORE_AUDIT_2026-03-29.md
+++ b/docs/ESI_REDIS_MULTISTORE_AUDIT_2026-03-29.md
@@ -170,14 +170,21 @@ Behavior contract:
 6. For paginated reads: enforce identical Last-Modified across pages in one retrieval cycle.
 
 #### Payload caching (implemented)
-The gateway stores response bodies in Redis (`esi:payload:v1:{endpoint_key}`)
-alongside metadata, with the same Expires-driven TTL. On Expires-gate hits,
-the cached body is returned in the `GatewayResponse` so callers get the payload
-without making an ESI request.
+The gateway stores response bodies in both Redis (`esi:payload:v1:{endpoint_key}`)
+and MariaDB (`esi_cache_entries` with `namespace_key='esi.payload'`), following
+the same three-tier pattern as metadata:
 
-This eliminates the previous "body-swallow" issue where Expires-gated responses
-returned `body=None`, breaking lookup/enrichment endpoints that need the payload
-(character/corporation profiles, individual killmails).
+```
+_load_payload(endpoint_key):
+  1. Redis GET esi:payload:v1:{key}              → HIT? return it
+  2. MariaDB SELECT esi_cache_entries             → HIT? return it, repopulate Redis
+  3. None                                         → fall through to conditional ESI request
+```
+
+On Expires-gate hits with a cached body, the `GatewayResponse` includes the
+payload so callers get data without an ESI request. If neither Redis nor MariaDB
+has the payload (evicted or first run), the gateway falls through to a
+conditional ESI request (304 if unchanged, 200 with fresh data).
 
 For corporation → alliance lookups, `entity_metadata_cache` in MariaDB provides
 an additional durable cache tier that survives Redis restarts and is bulk-loaded

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -284,7 +284,7 @@ No PHP `serialize()` or Python `pickle` — always JSON.
 |----------|----------|
 | Redis down at startup | Gateway works with MariaDB + local memory. Logs warning once. |
 | Redis goes down mid-operation | Current operation completes. Next operation falls back. |
-| Redis payload evicted/missing | Gateway falls through to conditional ESI request (304 if unchanged). |
+| Redis payload evicted/missing | MariaDB `esi_cache_entries` checked next. If also missing, conditional ESI request. |
 | Redis restarts (empty) | MariaDB metadata repopulates Redis on first read per endpoint. |
 | Redis slow (>5s timeout) | Operation fails gracefully, marked unavailable until next success. |
 | Redis data corruption | JSON parse failure returns None, endpoint re-fetched from ESI. |
@@ -368,6 +368,7 @@ When PHP encounters an unknown entity ID (e.g. during killmail display):
 |------|-------------------|------------|--------|
 | Market orders | MariaDB `market_orders_current` | none | Python sync jobs |
 | ESI endpoint metadata | MariaDB `esi_endpoint_state` | fast read cache | Python gateway |
+| ESI response payloads | MariaDB `esi_cache_entries` | fast read cache (`esi:payload:v1:*`) | Python gateway |
 | Rate-limit observations | MariaDB `esi_rate_limit_observations` | live bucket state | Python gateway + limiter |
 | Entity names | MariaDB `entity_metadata_cache` | none | Python entity resolver |
 | Structure names | MariaDB `alliance_structure_metadata` | none | Python sync + PHP first-time setup |

--- a/python/orchestrator/esi_gateway.py
+++ b/python/orchestrator/esi_gateway.py
@@ -514,17 +514,56 @@ class EsiGateway:
             self._redis.set_json(esi_meta_key(meta.endpoint_key), meta.to_dict(), ex=ttl)
 
     def _save_payload(self, ep_key: str, body: Any, expires_at: float) -> None:
-        """Cache response body in Redis (esi:payload:v1:*)."""
-        if not self._redis or not self._redis.available or body is None:
+        """Cache response body in Redis + MariaDB (esi_cache_entries)."""
+        if body is None:
             return
-        ttl = max(_MIN_TTL_SECONDS, min(_MAX_TTL_SECONDS, int(expires_at - time.time())))
-        self._redis.set_json(esi_payload_key(ep_key), body, ex=ttl)
+        # Redis (fast, ephemeral)
+        if self._redis and self._redis.available:
+            ttl = max(_MIN_TTL_SECONDS, min(_MAX_TTL_SECONDS, int(expires_at - time.time())))
+            self._redis.set_json(esi_payload_key(ep_key), body, ex=ttl)
+        # MariaDB (durable, survives Redis restarts)
+        if self._db:
+            try:
+                from datetime import timezone
+                expires_dt = datetime.fromtimestamp(expires_at, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+                self._db.execute(
+                    """INSERT INTO esi_cache_entries (namespace_key, cache_key, payload_json, fetched_at, expires_at)
+                       VALUES ('esi.payload', %s, %s, UTC_TIMESTAMP(), %s)
+                       ON DUPLICATE KEY UPDATE
+                           payload_json = VALUES(payload_json),
+                           fetched_at = VALUES(fetched_at),
+                           expires_at = VALUES(expires_at)""",
+                    (ep_key, json.dumps(body, default=str), expires_dt),
+                )
+            except Exception as exc:
+                logger.debug("Failed to persist payload for %s: %s", ep_key, exc)
 
     def _load_payload(self, ep_key: str) -> Any:
-        """Load cached response body from Redis."""
-        if not self._redis or not self._redis.available:
-            return None
-        return self._redis.get_json(esi_payload_key(ep_key))
+        """Load cached response body: Redis → MariaDB esi_cache_entries."""
+        # 1. Redis (fast)
+        if self._redis and self._redis.available:
+            data = self._redis.get_json(esi_payload_key(ep_key))
+            if data is not None:
+                return data
+        # 2. MariaDB (durable)
+        if self._db:
+            try:
+                row = self._db.fetch_one(
+                    """SELECT payload_json FROM esi_cache_entries
+                       WHERE namespace_key = 'esi.payload' AND cache_key = %s
+                         AND (expires_at IS NULL OR expires_at > UTC_TIMESTAMP())
+                       LIMIT 1""",
+                    (ep_key,),
+                )
+                if row and row.get("payload_json"):
+                    body = json.loads(row["payload_json"]) if isinstance(row["payload_json"], str) else row["payload_json"]
+                    # Repopulate Redis for next hit
+                    if self._redis and self._redis.available and body is not None:
+                        self._redis.set_json(esi_payload_key(ep_key), body, ex=_MIN_TTL_SECONDS)
+                    return body
+            except Exception as exc:
+                logger.debug("Failed to load payload from MariaDB for %s: %s", ep_key, exc)
+        return None
 
     # -- Distributed fetch lock --------------------------------------------
 


### PR DESCRIPTION
## Summary

Follows up on #472 — the payload cache stored bodies in Redis only, so Redis going down or evicting keys left the gateway with `body=None` on Expires-gate hits.

- **MariaDB as second-tier payload store**: `_save_payload` now writes to both Redis and `esi_cache_entries` (with `namespace_key='esi.payload'`). `_load_payload` reads Redis → MariaDB, repopulating Redis on MariaDB hit.

- **Don't Expires-gate without a payload**: If metadata says the endpoint is still fresh but neither Redis nor MariaDB has the body, the gateway falls through to a conditional ESI request (304 if unchanged = cheap, 200 = fresh data that repopulates both caches).

The payload load path now mirrors the metadata load path:
```
_load_payload(endpoint_key):
  1. Redis GET esi:payload:v1:{key}   → HIT? return it
  2. MariaDB esi_cache_entries        → HIT? return it, repopulate Redis
  3. None                             → fall through to conditional ESI request
```

## Test plan

- [ ] Stop Redis, run ESI jobs — verify they still get data from MariaDB `esi_cache_entries` (not re-fetching from ESI)
- [ ] Verify `esi_cache_entries` rows with `namespace_key='esi.payload'` are created after ESI responses
- [ ] Restart Redis (empty), run jobs — verify MariaDB payload is loaded and Redis repopulated
- [ ] Verify normal Redis-available path still works (Redis hit, no MariaDB query)

https://claude.ai/code/session_017ztFywSjGG8HwGN5KkWiw5