### PR TITLE
Warm all known corps including null-alliance into cache

### DIFF
--- a/python/orchestrator/jobs/esi_alliance_history_sync.py
+++ b/python/orchestrator/jobs/esi_alliance_history_sync.py
@@ -89,24 +89,30 @@ _NOT_CHECKED = object()
 
 
 def _warm_corp_cache(db: SupplyCoreDb) -> int:
-    """Bulk-load known corporation → alliance mappings from entity_metadata_cache."""
+    """Bulk-load known corporation → alliance mappings from entity_metadata_cache.
+
+    Includes corps with no alliance (alliance_id=null) so they don't
+    trigger ESI lookups during derive.
+    """
     rows = db.fetch_all(
         """SELECT entity_id,
                   JSON_UNQUOTE(JSON_EXTRACT(metadata_json, '$.alliance_id')) AS alliance_id
            FROM entity_metadata_cache
            WHERE entity_type = 'corporation'
              AND resolution_status = 'resolved'
-             AND metadata_json IS NOT NULL
-             AND JSON_EXTRACT(metadata_json, '$.alliance_id') IS NOT NULL"""
+             AND metadata_json IS NOT NULL"""
     )
     loaded = 0
     for row in rows:
         corp_id = int(row.get("entity_id") or 0)
+        if corp_id <= 0:
+            continue
         raw_aid = row.get("alliance_id")
-        if corp_id > 0 and raw_aid is not None:
-            aid = int(raw_aid) if str(raw_aid).isdigit() else 0
-            _corp_alliance_cache[corp_id] = aid if aid > 0 else None
-            loaded += 1
+        if raw_aid is not None and str(raw_aid).isdigit() and int(raw_aid) > 0:
+            _corp_alliance_cache[corp_id] = int(raw_aid)
+        else:
+            _corp_alliance_cache[corp_id] = None  # No alliance — still cache it
+        loaded += 1
     return loaded
 
 


### PR DESCRIPTION
## Summary

- `_warm_corp_cache` filtered on `JSON_EXTRACT(metadata_json, '$.alliance_id') IS NOT NULL`, excluding every corporation without an alliance. Most EVE corps have no alliance, so the warm loaded only ~1764 of ~2177 known corps — the rest hit ESI at ~200ms each during derive.
- The row parser also skipped null-alliance rows (`if raw_aid is not None`), so even when the query returned them they wouldn't be cached.

Fix: removed the `IS NOT NULL` filter and fixed the parser to cache null-alliance corps as `None` (meaning "known, no alliance"). The warm should now load all ~2177 corps, making derive times near-zero for most characters.

## Before
```
warmed 1764 corp→alliance mappings from DB
[8/200] char 988390537: 7 corps (0 cached), derive=402ms
[18/200] char 1976030280: 29 corps (30 cached), derive=5294ms
```

## After (expected)
```
warmed ~2177 corp→alliance mappings from DB
[8/200] char 988390537: 7 corps (7 cached), derive=0ms
[18/200] char 1976030280: 29 corps (56 cached), derive=0ms
```

## Test plan

- [ ] Run with `--verbose` and confirm warmed count matches total known corps (~2177+)
- [ ] Confirm derive times are 0-1ms for characters whose corps are all known
- [ ] Only genuinely new corps (never seen before) should trigger ESI calls

https://claude.ai/code/session_017ztFywSjGG8HwGN5KkWiw5