### PR TITLE
Add job warning tracking and display in scheduler

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -2558,6 +2558,22 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                         <?php endforeach; ?>
                                     </div>
                                 <?php endif; ?>
+                                <?php
+                                    $syncWarningIssues = array_filter((array) ($schedule['issues'] ?? []), static fn (array $issue): bool => in_array((string) ($issue['type'] ?? ''), ['missing_token', 'sync_warning'], true));
+                                ?>
+                                <?php if ($syncWarningIssues !== []): ?>
+                                    <?php foreach ($syncWarningIssues as $syncWarning): ?>
+                                        <div class="mt-3 rounded-lg border <?= (string) ($syncWarning['severity'] ?? 'high') === 'critical' ? 'border-rose-400/40 bg-rose-500/10' : 'border-amber-400/40 bg-amber-500/10' ?> p-3">
+                                            <div class="flex items-start gap-2">
+                                                <span class="mt-0.5 text-base leading-none"><?= (string) ($syncWarning['severity'] ?? 'high') === 'critical' ? '&#9888;' : '&#9888;' ?></span>
+                                                <div>
+                                                    <p class="text-sm font-medium <?= (string) ($syncWarning['severity'] ?? 'high') === 'critical' ? 'text-rose-100' : 'text-amber-100' ?>"><?= htmlspecialchars((string) ($syncWarning['title'] ?? ''), ENT_QUOTES) ?></p>
+                                                    <p class="mt-1 text-xs <?= (string) ($syncWarning['severity'] ?? 'high') === 'critical' ? 'text-rose-200/70' : 'text-amber-200/70' ?>"><?= htmlspecialchars((string) ($syncWarning['description'] ?? ''), ENT_QUOTES) ?></p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    <?php endforeach; ?>
+                                <?php endif; ?>
                                 <div class="mt-3 flex flex-wrap items-center gap-2">
                                     <?php if (!empty($schedule['needs_attention_action'])): ?>
                                         <button type="submit" name="data_sync_action" value="stop-investigate-job" class="inline-flex items-center rounded-full border border-amber-400/40 bg-amber-500/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-amber-100 hover:bg-amber-500/20" formaction="/settings?section=data-sync&amp;job_action_job_key=<?= urlencode($jobKey) ?>" formnovalidate>

--- a/src/db.php
+++ b/src/db.php
@@ -8380,6 +8380,7 @@ function db_sync_schedule_mark_success(int $scheduleId, ?array $runtime = null):
             'last_execution_context_json' => $runtime['last_execution_context_json'] ?? null,
             'last_no_change_skip_at' => $runtime['last_no_change_skip_at'] ?? null,
             'last_no_change_reason' => $runtime['last_no_change_reason'] ?? null,
+            'last_warnings_json' => $runtime['last_warnings_json'] ?? null,
             'last_event_at' => $finishedAt,
         ]);
     }
@@ -9579,6 +9580,7 @@ function db_scheduler_job_current_status_ensure(): void
     db_ensure_table_column('scheduler_job_current_status', 'last_execution_context_json', 'LONGTEXT DEFAULT NULL AFTER last_change_detection_json');
     db_ensure_table_column('scheduler_job_current_status', 'last_no_change_skip_at', 'DATETIME DEFAULT NULL AFTER last_execution_context_json');
     db_ensure_table_column('scheduler_job_current_status', 'last_no_change_reason', 'VARCHAR(500) DEFAULT NULL AFTER last_no_change_skip_at');
+    db_ensure_table_column('scheduler_job_current_status', 'last_warnings_json', 'LONGTEXT DEFAULT NULL AFTER last_no_change_reason');
 }
 
 function db_scheduler_job_current_status_upsert(string $jobKey, array $status): bool
@@ -9641,6 +9643,12 @@ function db_scheduler_job_current_status_upsert(string $jobKey, array $status): 
             ? $status['last_execution_context_json']
             : json_encode($status['last_execution_context_json'], JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
     }
+    $lastWarningsJson = null;
+    if (array_key_exists('last_warnings_json', $status) && $status['last_warnings_json'] !== null) {
+        $lastWarningsJson = is_string($status['last_warnings_json'])
+            ? $status['last_warnings_json']
+            : json_encode($status['last_warnings_json'], JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    }
     $changeAware = array_key_exists('change_aware', $status) && $status['change_aware'] !== null
         ? (!empty($status['change_aware']) ? 1 : 0)
         : (!empty($current['change_aware']) ? 1 : 0);
@@ -9668,12 +9676,13 @@ function db_scheduler_job_current_status_upsert(string $jobKey, array $status): 
             last_execution_context_json,
             last_no_change_skip_at,
             last_no_change_reason,
+            last_warnings_json,
             last_resource_metrics_summary_json,
             last_planner_decision_type,
             last_planner_reason_text,
             last_planner_decided_at,
             last_event_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE
             dataset_key = COALESCE(VALUES(dataset_key), dataset_key),
             latest_status = VALUES(latest_status),
@@ -9701,6 +9710,7 @@ function db_scheduler_job_current_status_upsert(string $jobKey, array $status): 
                 WHEN VALUES(last_no_change_reason) IS NULL AND VALUES(last_no_change_skip_at) IS NULL THEN last_no_change_reason
                 ELSE VALUES(last_no_change_reason)
             END,
+            last_warnings_json = VALUES(last_warnings_json),
             last_resource_metrics_summary_json = COALESCE(VALUES(last_resource_metrics_summary_json), last_resource_metrics_summary_json),
             last_planner_decision_type = COALESCE(VALUES(last_planner_decision_type), last_planner_decision_type),
             last_planner_reason_text = COALESCE(VALUES(last_planner_reason_text), last_planner_reason_text),
@@ -9731,6 +9741,7 @@ function db_scheduler_job_current_status_upsert(string $jobKey, array $status): 
             array_key_exists('last_no_change_reason', $status) && $status['last_no_change_reason'] !== null
                 ? mb_substr(trim((string) $status['last_no_change_reason']), 0, 500)
                 : null,
+            $lastWarningsJson,
             $resourceSummaryJson,
             $lastPlannerDecisionType,
             $lastPlannerReasonText,
@@ -9745,7 +9756,7 @@ function db_scheduler_job_current_status_fetch_map(array $jobKeys = []): array
     db_scheduler_job_current_status_ensure();
 
     $params = [];
-    $sql = 'SELECT job_key, dataset_key, latest_status, latest_event_type, last_started_at, last_finished_at, last_success_at, last_failure_at, last_failure_message, current_pressure_state, last_pressure_state, recent_timeout_count, recent_lock_conflict_count, recent_deferral_count, recent_skip_count, change_aware, dependencies_json, last_change_detection_json, last_execution_context_json, last_no_change_skip_at, last_no_change_reason, last_resource_metrics_summary_json, last_planner_decision_type, last_planner_reason_text, last_planner_decided_at, last_event_at, created_at, updated_at
+    $sql = 'SELECT job_key, dataset_key, latest_status, latest_event_type, last_started_at, last_finished_at, last_success_at, last_failure_at, last_failure_message, current_pressure_state, last_pressure_state, recent_timeout_count, recent_lock_conflict_count, recent_deferral_count, recent_skip_count, change_aware, dependencies_json, last_change_detection_json, last_execution_context_json, last_no_change_skip_at, last_no_change_reason, last_warnings_json, last_resource_metrics_summary_json, last_planner_decision_type, last_planner_reason_text, last_planner_decided_at, last_event_at, created_at, updated_at
             FROM scheduler_job_current_status';
 
     $normalizedKeys = array_values(array_filter(array_map(static fn (mixed $jobKey): string => trim((string) $jobKey), $jobKeys), static fn (string $jobKey): bool => $jobKey !== ''));
@@ -9768,6 +9779,14 @@ function db_scheduler_job_current_status_fetch_map(array $jobKeys = []): array
             $decoded = json_decode($summaryJson, true);
             if (is_array($decoded)) {
                 $row['last_resource_metrics_summary'] = $decoded;
+            }
+        }
+        $row['last_warnings'] = [];
+        $warningsJson = $row['last_warnings_json'] ?? null;
+        if (is_string($warningsJson) && trim($warningsJson) !== '') {
+            $decodedWarnings = json_decode($warningsJson, true);
+            if (is_array($decodedWarnings)) {
+                $row['last_warnings'] = $decodedWarnings;
             }
         }
         foreach ([

--- a/src/functions.php
+++ b/src/functions.php
@@ -6227,6 +6227,35 @@ function scheduler_console_detect_job_issues(array $job, int $memoryThresholdByt
         ];
     }
 
+    $lastWarnings = (array) ($job['last_warnings'] ?? []);
+    foreach ($lastWarnings as $warning) {
+        $warningLower = strtolower((string) $warning);
+        if (str_contains($warningLower, 'no active esi oauth token') || str_contains($warningLower, 'oauth token')) {
+            $issues[] = [
+                'severity' => 'critical',
+                'type' => 'missing_token',
+                'job_key' => $jobKey,
+                'job_label' => $jobLabel,
+                'title' => 'Missing ESI token',
+                'description' => (string) $warning,
+                'action_label' => 'Configure ESI token',
+            ];
+            break;
+        }
+    }
+
+    if ($lastWarnings !== [] && !array_filter($issues, static fn (array $issue): bool => ($issue['type'] ?? '') === 'missing_token')) {
+        $issues[] = [
+            'severity' => 'high',
+            'type' => 'sync_warning',
+            'job_key' => $jobKey,
+            'job_label' => $jobLabel,
+            'title' => 'Sync warning',
+            'description' => (string) $lastWarnings[0],
+            'action_label' => 'Investigate',
+        ];
+    }
+
     return $issues;
 }
 
@@ -6578,6 +6607,7 @@ function sync_schedule_settings_view_model(): array
                 : null,
             'last_change_detection' => $changeDetection,
             'last_execution_context' => $executionContext,
+            'last_warnings' => (array) ($statusProjection['last_warnings'] ?? []),
             'upstream_dependency_labels' => array_values(array_filter(array_map(
                 static fn (array $signal): string => (string) ($signal['label'] ?? $signal['signal_key'] ?? ''),
                 (array) ($dependencyMetadata['upstream_signals'] ?? [])
@@ -13904,6 +13934,7 @@ function scheduler_run_job(array $job): array
                     'change_aware' => !empty($changeDecision['change_aware']),
                     'dependencies_json' => $dependencyMetadata,
                     'last_change_detection_json' => $changeContext,
+                    'last_warnings_json' => $warnings !== [] ? $warnings : null,
                 ]);
             }
             db_scheduler_job_event_insert($jobKey, 'finished', [
@@ -13926,6 +13957,7 @@ function scheduler_run_job(array $job): array
                     'dependencies_json' => $dependencyMetadata,
                     'last_change_detection_json' => $changeContext,
                     'last_execution_context_json' => $changeContext,
+                    'last_warnings_json' => $warnings !== [] ? $warnings : null,
                 ]);
             }
             db_scheduler_job_event_insert($jobKey, $status, [
@@ -15461,6 +15493,7 @@ function scheduler_finalize_python_job_result(array $job, array $pythonResult): 
             db_sync_schedule_mark_success($scheduleId, scheduler_job_runtime_snapshot($jobKey, $status) + [
                 'last_duration_seconds' => $durationSeconds,
                 'current_pressure_state' => $job['current_pressure_state'] ?? 'healthy',
+                'last_warnings_json' => $warnings !== [] ? $warnings : null,
             ]);
         }
         db_scheduler_job_event_insert($jobKey, $status === 'skipped' ? 'skipped' : 'finished', [
@@ -15469,6 +15502,7 @@ function scheduler_finalize_python_job_result(array $job, array $pythonResult): 
             'rows_seen' => $rowsSeen,
             'rows_written' => $rowsWritten,
             'summary' => $summary,
+            'warnings' => $warnings,
             'meta' => $meta,
         ], 0, $durationSeconds);
     }


### PR DESCRIPTION
## Summary
This PR adds comprehensive warning tracking to the job scheduler system, allowing warnings from job executions to be captured, stored, and displayed in the UI. This enables better visibility into job health issues, particularly OAuth token problems.

## Key Changes

- **Warning Capture**: Modified `scheduler_run_job()` and `scheduler_finalize_python_job_result()` to capture warnings from job executions and store them in the database via `last_warnings_json` field
- **Database Schema**: Added `last_warnings_json` column to `scheduler_job_current_status` table to persist warnings across job runs
- **Issue Detection**: Enhanced `scheduler_console_detect_job_issues()` to detect and categorize warnings:
  - Critical severity for missing ESI OAuth tokens
  - High severity for other sync warnings
- **UI Display**: Added warning display section in the settings page that shows detected issues with appropriate styling (red for critical, amber for high severity)
- **Data Flow**: Updated `sync_schedule_settings_view_model()` to include `last_warnings` in the job status data passed to the UI

## Implementation Details

- Warnings are stored as JSON arrays in the database and decoded when fetched
- The issue detection logic checks for OAuth token-related warnings first (critical), then displays other warnings as sync warnings (high severity)
- UI warnings are displayed with warning icons and color-coded severity indicators
- Warnings are only stored when non-empty to avoid unnecessary database updates

https://claude.ai/code/session_017rpaijqR2S7MRaCJFrTxzX