### PR TITLE
Fix stuck sync_runs rows never being reaped

### DIFF
--- a/python/orchestrator/jobs/killmail.py
+++ b/python/orchestrator/jobs/killmail.py
@@ -793,29 +793,36 @@ def run_killmail_r2z2_stream(context: Any) -> dict[str, Any]:
     except Exception as error:
         if first_failure_message == "":
             first_failure_message = str(error)
-        _sync_run_finish(
-            bridge,
-            job_context,
-            run_id,
-            JobResult.failed(
-                job_key="sync_killmail_feed",
-                error=str(error),
-                meta={
-                    "rows_seen": totals["rows_seen"],
-                    "rows_written": totals["rows_written"],
-                    "rows_failed": max(1, totals["rows_failed"]),
-                    "checkpoint_before": str(last_saved_sequence or 0),
-                    "checkpoint_after": str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0)),
-                    "rows_matched": totals["rows_matched"],
-                    "rows_filtered_out": totals["rows_filtered_out"],
-                    "rows_skipped_existing": totals["rows_skipped_existing"],
-                    "rows_write_attempted": totals["rows_write_attempted"],
-                    "first_sequence_seen": first_sequence_seen,
-                    "last_sequence_seen": last_sequence_seen,
-                    "reason_for_zero_write": "transaction_rolled_back",
-                    "checkpoint_state": "unchanged",
-                    "outcome_reason": first_failure_message,
-                },
-            ).to_dict(),
-        )
+        try:
+            _sync_run_finish(
+                bridge,
+                job_context,
+                run_id,
+                JobResult.failed(
+                    job_key="sync_killmail_feed",
+                    error=str(error),
+                    meta={
+                        "rows_seen": totals["rows_seen"],
+                        "rows_written": totals["rows_written"],
+                        "rows_failed": max(1, totals["rows_failed"]),
+                        "checkpoint_before": str(last_saved_sequence or 0),
+                        "checkpoint_after": str(last_processed_sequence if last_processed_sequence is not None else (last_saved_sequence or 0)),
+                        "rows_matched": totals["rows_matched"],
+                        "rows_filtered_out": totals["rows_filtered_out"],
+                        "rows_skipped_existing": totals["rows_skipped_existing"],
+                        "rows_write_attempted": totals["rows_write_attempted"],
+                        "first_sequence_seen": first_sequence_seen,
+                        "last_sequence_seen": last_sequence_seen,
+                        "reason_for_zero_write": "transaction_rolled_back",
+                        "checkpoint_state": "unchanged",
+                        "outcome_reason": first_failure_message,
+                    },
+                ).to_dict(),
+            )
+        except Exception:
+            context.emit("zkill.sync_run_finish_failed", {
+                "job_key": context.job_key,
+                "run_id": run_id,
+                "original_error": first_failure_message,
+            })
         raise

--- a/src/db.php
+++ b/src/db.php
@@ -6618,6 +6618,23 @@ function db_sync_run_finish(
     );
 }
 
+function db_sync_runs_reap_stale(int $staleGraceSeconds = 300): int
+{
+    $safeGrace = max(60, min(7200, $staleGraceSeconds));
+    $stmt = db()->prepare(
+        "UPDATE sync_runs
+         SET run_status = 'failed',
+             finished_at = UTC_TIMESTAMP(),
+             error_message = 'Reaped: run exceeded timeout while still marked as running (worker likely crashed).',
+             updated_at = CURRENT_TIMESTAMP
+         WHERE run_status = 'running'
+           AND started_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL ? SECOND)"
+    );
+    $stmt->execute([$safeGrace]);
+
+    return (int) $stmt->rowCount();
+}
+
 function db_sync_run_latest_by_dataset(string $datasetKey): ?array
 {
     return db_select_one(

--- a/src/functions.php
+++ b/src/functions.php
@@ -3486,6 +3486,13 @@ function scheduler_daemon_recover_runtime_state(string $ownerToken, ?callable $l
         $recoveredCount += $staleSchedules;
     }
 
+    $staleRuns = db_sync_runs_reap_stale(scheduler_daemon_watchdog_grace_seconds());
+    if ($staleRuns > 0) {
+        $details['reaped_sync_run_count'] = $staleRuns;
+        $messageParts[] = 'Reaped ' . $staleRuns . ' stuck sync_runs row(s).';
+        $recoveredCount += $staleRuns;
+    }
+
     $message = $messageParts !== [] ? implode(' ', $messageParts) : 'No stale scheduler runtime artifacts required recovery.';
     scheduler_daemon_write_heartbeat($ownerToken, [
         'status' => 'running',
@@ -3714,8 +3721,10 @@ function scheduler_watchdog_run(?callable $logger = null): array
 
     $recoveryMessage = 'Watchdog observed a stale or stopped scheduler daemon and prepared recovery.';
     $recoveredSchedules = db_sync_schedule_recover_stale_running_jobs($recoveryMessage, scheduler_daemon_watchdog_grace_seconds());
+    $reapedRuns = db_sync_runs_reap_stale(scheduler_daemon_watchdog_grace_seconds());
     $result['recovery'] = [
         'recovered_schedule_count' => $recoveredSchedules,
+        'reaped_sync_run_count' => $reapedRuns,
         'message' => $recoveryMessage,
     ];
 


### PR DESCRIPTION
## Summary

- **Add `db_sync_runs_reap_stale()`** to mark orphaned `sync_runs` rows (stuck in `run_status='running'` past the grace period) as `'failed'` — mirrors the existing `db_sync_schedule_recover_stale_running_jobs()` logic for `sync_schedules`
- **Call the new reaper from both recovery paths** (daemon startup and watchdog) so stuck rows are cleaned up automatically
- **Wrap `_sync_run_finish()` in the killmail error handler** with a try/except so a PHP bridge failure during cleanup doesn't swallow the original error or leave the run orphaned

## Context

`sync_schedules` had stale-job recovery, but `sync_runs` had none. When the killmail worker crashed or the PHP bridge finish call failed, rows stayed `run_status='running'` indefinitely — the dashboard detected them as stuck but nothing ever cleaned them up.

## Test plan

- [ ] Deploy and verify the 19 currently stuck `killmail.r2z2.stream` rows are reaped on next daemon startup or watchdog cycle
- [ ] Confirm the "Stuck / Timed-out Runs" section in the log viewer clears after recovery runs
- [ ] Simulate a killmail worker crash and verify the orphaned `sync_runs` row is reaped within the watchdog grace period

https://claude.ai/code/session_01WDUgAYWab44ZeGi6mqvRSb