### PR TITLE
Fix threat corridor detection to support undirected graph traversal

### DIFF
--- a/python/orchestrator/jobs/compute_threat_corridors.py
+++ b/python/orchestrator/jobs/compute_threat_corridors.py
@@ -115,7 +115,7 @@ def _find_connected_corridors_neo4j(
             """
             UNWIND $system_ids AS start_id
             MATCH (s1:System {system_id: start_id})
-            MATCH path = (s1)-[:CONNECTS_TO*1..""" + str(max_length - 1) + """]->(s2:System)
+            MATCH path = (s1)-[:CONNECTS_TO*1..""" + str(max_length - 1) + """]-(s2:System)
             WHERE s2.system_id IN $system_ids
               AND s1.system_id < s2.system_id
               AND ALL(n IN nodes(path) WHERE n.system_id IN $system_ids)
@@ -383,10 +383,11 @@ def run_compute_threat_corridors(
         except Exception:
             neo4j_client = None
 
-        # Find connected corridors
+        # Find connected corridors (Neo4j preferred, SQL fallback)
+        raw_corridors: list[list[int]] = []
         if neo4j_client is not None:
             raw_corridors = _find_connected_corridors_neo4j(neo4j_client, list(active_systems))
-        else:
+        if not raw_corridors:
             raw_corridors = _find_connected_corridors_sql(db, active_systems)
 
         # Score and filter corridors


### PR DESCRIPTION
## Summary
This PR fixes the threat corridor detection logic to properly handle undirected graph relationships in Neo4j and improves the fallback mechanism between Neo4j and SQL implementations.

## Key Changes
- **Fixed Neo4j query relationship direction**: Changed the CONNECTS_TO relationship from directed (`->`) to undirected (`-`) traversal, allowing the algorithm to find corridors regardless of the direction of connections between systems
- **Improved fallback logic**: Changed the corridor detection from an if/else pattern to a conditional fallback pattern, ensuring the SQL implementation is used when Neo4j either fails or returns no results
- **Enhanced code clarity**: Updated the comment to clarify that Neo4j is preferred with SQL as a fallback option
- **Added explicit variable initialization**: Declared `raw_corridors` as an empty list before the conditional logic to ensure proper type handling

## Implementation Details
The key fix addresses a critical issue where threat corridors were only being detected when connections followed a specific direction. By using undirected relationship traversal (`-` instead of `->`), the algorithm can now identify all connected systems regardless of how the CONNECTS_TO relationships are oriented in the graph. The improved fallback mechanism ensures robustness by attempting Neo4j first but gracefully falling back to SQL if needed.

https://claude.ai/code/session_01Uj5VFZHnXEsh7qmtsDkdVQ