### PR TITLE
Fix DAG scheduling migration backfill query

### DIFF
--- a/database/migrations/20260404_dag_aware_scheduling.sql
+++ b/database/migrations/20260404_dag_aware_scheduling.sql
@@ -42,12 +42,14 @@ CREATE TABLE IF NOT EXISTS scheduler_dag_log (
   COMMENT='Audit log for DAG scheduler dispatch decisions';
 
 -- 4. Backfill concurrency_group from existing lock_group values
-UPDATE sync_schedules
-   SET concurrency_group = COALESCE(
-       (SELECT JSON_UNQUOTE(JSON_EXTRACT(
-           (SELECT payload_json FROM worker_jobs wj WHERE wj.job_key = sync_schedules.job_key ORDER BY id DESC LIMIT 1),
-           '$.lock_group'
-       )), ''),
-       ''
-   )
- WHERE concurrency_group = '' OR concurrency_group IS NULL;
+UPDATE sync_schedules ss
+  JOIN LATERAL (
+       SELECT JSON_UNQUOTE(JSON_EXTRACT(wj.payload_json, '$.lock_group')) AS lg
+         FROM worker_jobs wj
+        WHERE wj.job_key = ss.job_key
+          AND wj.payload_json IS NOT NULL
+        ORDER BY wj.id DESC
+        LIMIT 1
+  ) sub ON sub.lg IS NOT NULL AND sub.lg != ''
+   SET ss.concurrency_group = sub.lg
+ WHERE ss.concurrency_group = '' OR ss.concurrency_group IS NULL;


### PR DESCRIPTION
## Summary
- Fixes the `20260404_dag_aware_scheduling.sql` migration that failed with `SQLSTATE[21000]: Cardinality violation: 1241 Operand should contain 1 column(s)`
- The backfill query used a nested scalar subquery inside `JSON_EXTRACT()` which MariaDB rejected as a multi-column operand
- Replaced with a `JOIN LATERAL` that fetches the latest `payload_json` per job_key first, then extracts `$.lock_group` from it

## Test plan
- [ ] Re-run migration on production: `./scripts/update-and-restart.sh`
- [ ] Verify `sync_schedules.concurrency_group` is populated from existing `lock_group` values
- [ ] Confirm worker pool starts cleanly after migration

https://claude.ai/code/session_01M7Yd637B5HowPf1Ssexkbo