### PR TITLE
Improve job health detection: stuck jobs, success validation, and overdue tracking

### DIFF
--- a/public/log-viewer/index.php
+++ b/public/log-viewer/index.php
@@ -35,7 +35,7 @@ if (!in_array($filter, $validFilters, true)) {
 }
 
 $filteredJobs = match ($filter) {
-    'failed' => array_filter($jobs, fn (array $j) => $j['health'] === 'failed'),
+    'failed' => array_filter($jobs, fn (array $j) => $j['health'] === 'failed' || $j['health'] === 'stuck'),
     'timeout' => array_filter($jobs, fn (array $j) => $j['health'] === 'timeout'),
     'never_ran' => array_filter($jobs, fn (array $j) => $j['health'] === 'never_ran'),
     'overdue' => array_filter($jobs, fn (array $j) => $j['overdue']),

--- a/src/functions.php
+++ b/src/functions.php
@@ -30040,6 +30040,22 @@ function log_viewer_page_data(): array
         $status = strtolower(trim((string) ($s['latest_status'] ?? $s['last_status'] ?? 'unknown')));
         $pressure = strtolower(trim((string) ($s['current_pressure_state'] ?? 'healthy')));
 
+        // Detect stuck "running" jobs: status is running but last_started_at is
+        // older than the job's timeout (or a generous fallback).  These are
+        // almost certainly zombie processes whose workers crashed without
+        // reporting a final status.
+        $isStuckRunning = false;
+        if ($status === 'running' && $s['last_run_at'] !== null) {
+            $startedTs = strtotime((string) ($s['last_started_at'] ?? $s['last_run_at']));
+            $stuckThreshold = max((int) ($meta['timeout_seconds'] ?? $defaultTimeout), (int) $s['interval_seconds']) * 2;
+            if ($stuckThreshold < 600) {
+                $stuckThreshold = 600; // at least 10 minutes
+            }
+            if ($startedTs !== false && (time() - $startedTs) > $stuckThreshold) {
+                $isStuckRunning = true;
+            }
+        }
+
         // Determine health bucket
         if (!$s['enabled']) {
             $health = 'disabled';
@@ -30049,10 +30065,10 @@ function log_viewer_page_data(): array
             $health = 'never_ran';
             $healthTone = 'border-violet-400/20 bg-violet-500/10 text-violet-100';
             $healthLabel = 'Never ran';
-        } elseif ($status === 'failed' || $status === 'error') {
-            $health = 'failed';
+        } elseif ($status === 'failed' || $status === 'error' || $isStuckRunning) {
+            $health = $isStuckRunning ? 'stuck' : 'failed';
             $healthTone = 'border-rose-400/20 bg-rose-500/10 text-rose-100';
-            $healthLabel = 'Failed';
+            $healthLabel = $isStuckRunning ? 'Stuck' : 'Failed';
         } elseif ($pressure === 'critical' || ($s['recent_timeout_count'] ?? 0) > 2) {
             $health = 'timeout';
             $healthTone = 'border-orange-400/20 bg-orange-500/10 text-orange-100';
@@ -30066,21 +30082,40 @@ function log_viewer_page_data(): array
             $healthTone = 'border-sky-400/20 bg-sky-500/10 text-sky-100';
             $healthLabel = 'Running';
         } elseif ($status === 'success' || $status === 'completed') {
-            $health = 'healthy';
-            $healthTone = 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100';
-            $healthLabel = 'Healthy';
+            // If the job reports success but has never actually succeeded
+            // (last_success_at is NULL), demote it to "Unhealthy" so the
+            // operator knows it has not produced useful output yet.
+            $hasEverSucceeded = ($s['last_success_at'] ?? null) !== null;
+            if ($hasEverSucceeded) {
+                $health = 'healthy';
+                $healthTone = 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100';
+                $healthLabel = 'Healthy';
+            } else {
+                $health = 'unhealthy';
+                $healthTone = 'border-amber-400/20 bg-amber-500/10 text-amber-100';
+                $healthLabel = 'Unhealthy';
+            }
         } else {
             $health = 'unknown';
             $healthTone = 'border-slate-400/20 bg-slate-500/10 text-slate-200';
             $healthLabel = 'Unknown';
         }
 
-        // Check overdue: enabled, has interval, last_run_at + interval * 2 < NOW
+        // Check overdue: enabled, has interval, last_run_at + interval * 2 < NOW.
+        // Also flag enabled jobs that have *never* run as overdue when they've
+        // existed for longer than twice their interval (created_at based).
         $overdue = false;
-        if ($s['enabled'] && $s['last_run_at'] !== null && (int) $s['interval_seconds'] > 0) {
-            $lastRun = strtotime((string) $s['last_run_at']);
-            if ($lastRun !== false && (time() - $lastRun) > ((int) $s['interval_seconds'] * 2)) {
-                $overdue = true;
+        if ($s['enabled'] && (int) $s['interval_seconds'] > 0) {
+            if ($s['last_run_at'] !== null) {
+                $lastRun = strtotime((string) $s['last_run_at']);
+                if ($lastRun !== false && (time() - $lastRun) > ((int) $s['interval_seconds'] * 2)) {
+                    $overdue = true;
+                }
+            } elseif (($s['created_at'] ?? null) !== null) {
+                $createdAt = strtotime((string) $s['created_at']);
+                if ($createdAt !== false && (time() - $createdAt) > ((int) $s['interval_seconds'] * 2)) {
+                    $overdue = true;
+                }
             }
         }
 
@@ -30113,7 +30148,7 @@ function log_viewer_page_data(): array
 
     // ── KPI counts ────────────────────────────────────────────────────
     $totalEnabled = count(array_filter($jobs, fn (array $j) => $j['enabled']));
-    $totalFailed = count(array_filter($jobs, fn (array $j) => $j['health'] === 'failed'));
+    $totalFailed = count(array_filter($jobs, fn (array $j) => $j['health'] === 'failed' || $j['health'] === 'stuck'));
     $totalTimeout = count(array_filter($jobs, fn (array $j) => $j['health'] === 'timeout'));
     $totalNeverRan = count($neverRan);
     $totalOverdue = count(array_filter($jobs, fn (array $j) => $j['overdue']));


### PR DESCRIPTION
## Summary
Enhanced the job health monitoring system to better detect and report on problematic job states, including stuck running jobs, jobs that report success without ever succeeding, and jobs that have never run but are overdue.

## Key Changes

- **Stuck Job Detection**: Added logic to identify jobs stuck in "running" status where `last_started_at` exceeds a threshold (max of job timeout, interval × 2, or 10 minutes minimum). These are flagged as "stuck" health status, indicating likely zombie processes from crashed workers.

- **Success Validation**: Jobs reporting "success" or "completed" status are now demoted to "unhealthy" if they have never actually succeeded (i.e., `last_success_at` is NULL), ensuring operators know the job hasn't produced useful output yet.

- **Enhanced Overdue Detection**: Extended overdue tracking to flag enabled jobs that have *never* run (`last_run_at` is NULL) but have existed longer than twice their interval (based on `created_at`). Previously only checked jobs that had run at least once.

- **KPI Aggregation**: Updated failed job counts to include both "failed" and "stuck" health statuses, and updated the filter logic to group these together in the UI.

## Implementation Details

- Stuck job detection uses `last_started_at` with fallback to `last_run_at` for timestamp calculation
- Threshold calculation ensures a minimum of 10 minutes to avoid false positives on short-interval jobs
- Success validation checks `last_success_at` field presence to distinguish between reported success and actual success
- Overdue logic now handles both historical runs and jobs that have never executed
- Filter matching updated in both the data generation and UI layer for consistency

https://claude.ai/code/session_015UAeddPkGVrA1LgQLku7kA