### PR TITLE
Remove redundant per-job locks from compute_job_locks

### DIFF
--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -15,13 +15,13 @@ if __package__ in (None, ""):
     from orchestrator.db import SupplyCoreDb
     from orchestrator.job_result import JobResult
     from orchestrator.json_utils import json_dumps_safe
-    from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from orchestrator.job_utils import finish_job_run, start_job_run
     from orchestrator.neo4j import Neo4jClient, Neo4jConfig
 else:
     from ..db import SupplyCoreDb
     from ..job_result import JobResult
     from ..json_utils import json_dumps_safe
-    from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from ..job_utils import finish_job_run, start_job_run
     from ..neo4j import Neo4jClient, Neo4jConfig
 
 WINDOW_SECONDS = 15 * 60
@@ -263,13 +263,6 @@ def _neo4j_sync_participation(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None
 
 
 def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None = None, *, dry_run: bool = False) -> dict[str, Any]:
-    lock_key = "compute_battle_rollups"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
-    if owner is None:
-        result = JobResult.skipped(job_key="compute_battle_rollups", reason="lock-not-acquired").to_dict()
-        _battle_log(runtime, "battle_intelligence.job.skipped", result)
-        return result
-
     job = start_job_run(db, "compute_battle_rollups")
     started_monotonic = datetime.now(UTC)
     rows_processed = 0
@@ -575,18 +568,9 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
             {"job_name": "compute_battle_rollups", "status": "failed", "rows_processed": rows_processed, "rows_written": rows_written, "error_text": str(exc), "dry_run": dry_run},
         )
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)
 
 
 def run_compute_battle_target_metrics(db: SupplyCoreDb, runtime: dict[str, Any] | None = None, *, dry_run: bool = False) -> dict[str, Any]:
-    lock_key = "compute_battle_target_metrics"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
-    if owner is None:
-        result = JobResult.skipped(job_key="compute_battle_target_metrics", reason="lock-not-acquired").to_dict()
-        _battle_log(runtime, "battle_intelligence.job.skipped", result)
-        return result
-
     job = start_job_run(db, "compute_battle_target_metrics")
     started_monotonic = datetime.now(UTC)
     rows_processed = 0
@@ -775,18 +759,9 @@ def run_compute_battle_target_metrics(db: SupplyCoreDb, runtime: dict[str, Any] 
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         _battle_log(runtime, "battle_intelligence.job.failed", {"job_name": "compute_battle_target_metrics", "status": "failed", "error_text": str(exc), "rows_processed": rows_processed, "rows_written": rows_written, "dry_run": dry_run})
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)
 
 
 def run_compute_battle_anomalies(db: SupplyCoreDb, runtime: dict[str, Any] | None = None, *, dry_run: bool = False) -> dict[str, Any]:
-    lock_key = "compute_battle_anomalies"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
-    if owner is None:
-        result = JobResult.skipped(job_key="compute_battle_anomalies", reason="lock-not-acquired").to_dict()
-        _battle_log(runtime, "battle_intelligence.job.skipped", result)
-        return result
-
     job = start_job_run(db, "compute_battle_anomalies")
     started_monotonic = datetime.now(UTC)
     rows_processed = 0
@@ -954,8 +929,6 @@ def run_compute_battle_anomalies(db: SupplyCoreDb, runtime: dict[str, Any] | Non
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         _battle_log(runtime, "battle_intelligence.job.failed", {"job_name": "compute_battle_anomalies", "status": "failed", "error_text": str(exc), "rows_processed": rows_processed, "rows_written": rows_written, "dry_run": dry_run})
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)
 
 
 def run_compute_battle_actor_features(
@@ -965,13 +938,6 @@ def run_compute_battle_actor_features(
     *,
     dry_run: bool = False,
 ) -> dict[str, Any]:
-    lock_key = "compute_battle_actor_features"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
-    if owner is None:
-        result = JobResult.skipped(job_key="compute_battle_actor_features", reason="lock-not-acquired").to_dict()
-        _battle_log(runtime, "battle_intelligence.job.skipped", result)
-        return result
-
     job = start_job_run(db, "compute_battle_actor_features")
     started_monotonic = datetime.now(UTC)
     rows_processed = 0
@@ -1066,8 +1032,6 @@ def run_compute_battle_actor_features(
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         _battle_log(runtime, "battle_intelligence.job.failed", {"job_name": "compute_battle_actor_features", "status": "failed", "error_text": str(exc), "rows_processed": rows_processed, "rows_written": rows_written, "dry_run": dry_run})
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)
 
 
 def run_compute_suspicion_scores(db: SupplyCoreDb, runtime: dict[str, Any] | None = None, *, dry_run: bool = False) -> dict[str, Any]:
@@ -1076,13 +1040,6 @@ def run_compute_suspicion_scores(db: SupplyCoreDb, runtime: dict[str, Any] | Non
     # - scheduler-dispatched Python runtime
     # - manual Python CLI invocation
     # Missing runtime values only disable optional file logging via `_battle_log`.
-    lock_key = "compute_suspicion_scores"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
-    if owner is None:
-        result = JobResult.skipped(job_key="compute_suspicion_scores", reason="lock-not-acquired").to_dict()
-        _battle_log(runtime, "battle_intelligence.job.skipped", result)
-        return result
-
     job = start_job_run(db, "compute_suspicion_scores")
     started_monotonic = datetime.now(UTC)
     rows_processed = 0
@@ -1364,5 +1321,3 @@ def run_compute_suspicion_scores(db: SupplyCoreDb, runtime: dict[str, Any] | Non
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         _battle_log(runtime, "battle_intelligence.job.failed", {"job_name": "compute_suspicion_scores", "status": "failed", "error_text": str(exc), "rows_processed": rows_processed, "rows_written": rows_written, "dry_run": dry_run})
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)

--- a/python/orchestrator/jobs/compute_alliance_dossiers.py
+++ b/python/orchestrator/jobs/compute_alliance_dossiers.py
@@ -67,12 +67,12 @@ if __package__ in (None, ""):
     from orchestrator.db import SupplyCoreDb
     from orchestrator.job_result import JobResult
     from orchestrator.json_utils import json_dumps_safe
-    from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from orchestrator.job_utils import finish_job_run, start_job_run
 else:
     from ..db import SupplyCoreDb
     from ..job_result import JobResult
     from ..json_utils import json_dumps_safe
-    from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from ..job_utils import finish_job_run, start_job_run
 
 BATCH_SIZE = 200
 RECENT_DAYS = 30
@@ -521,12 +521,8 @@ def run_compute_alliance_dossiers(
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Compute alliance dossiers and persist to MariaDB."""
-    lock_key = "compute_alliance_dossiers"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=1800)
-    if owner is None:
-        return JobResult.skipped(job_key=lock_key, reason="lock-not-acquired").to_dict()
-
-    job = start_job_run(db, lock_key)
+    job_key = "compute_alliance_dossiers"
+    job = start_job_run(db, job_key)
     started = datetime.now(UTC)
     computed_at = _now_sql()
     rows_processed = 0
@@ -548,7 +544,7 @@ def run_compute_alliance_dossiers(
 
         if not alliances:
             finish_job_run(db, job, status="success", rows_processed=0, rows_written=0)
-            return JobResult.success(job_key=lock_key, summary="No alliances with battles found.",
+            return JobResult.success(job_key=job_key, summary="No alliances with battles found.",
                                     rows_processed=0, rows_written=0, duration_ms=0).to_dict()
 
         # Collect all alliance IDs for name resolution
@@ -637,7 +633,7 @@ def run_compute_alliance_dossiers(
         finish_job_run(db, job, status="success", rows_processed=rows_processed, rows_written=rows_written,
                        meta={"dossier_count": len(dossiers)})
         return JobResult.success(
-            job_key=lock_key,
+            job_key=job_key,
             summary=f"Computed {len(dossiers)} alliance dossiers.",
             rows_processed=rows_processed,
             rows_written=rows_written,
@@ -647,5 +643,3 @@ def run_compute_alliance_dossiers(
     except Exception as exc:
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)

--- a/python/orchestrator/jobs/compute_threat_corridors.py
+++ b/python/orchestrator/jobs/compute_threat_corridors.py
@@ -23,12 +23,12 @@ if __package__ in (None, ""):
     from orchestrator.db import SupplyCoreDb
     from orchestrator.job_result import JobResult
     from orchestrator.json_utils import json_dumps_safe
-    from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from orchestrator.job_utils import finish_job_run, start_job_run
 else:
     from ..db import SupplyCoreDb
     from ..job_result import JobResult
     from ..json_utils import json_dumps_safe
-    from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from ..job_utils import finish_job_run, start_job_run
 
 RECENT_DAYS = 30
 MIN_CORRIDOR_BATTLES = 3
@@ -380,12 +380,8 @@ def run_compute_threat_corridors(
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Compute threat corridors and system threat scores."""
-    lock_key = "compute_threat_corridors"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
-    if owner is None:
-        return JobResult.skipped(job_key=lock_key, reason="lock-not-acquired").to_dict()
-
-    job = start_job_run(db, lock_key)
+    job_key = "compute_threat_corridors"
+    job = start_job_run(db, job_key)
     started = datetime.now(UTC)
     computed_at = _now_sql()
     rows_processed = 0
@@ -402,7 +398,7 @@ def run_compute_threat_corridors(
 
         if not system_data:
             finish_job_run(db, job, status="success", rows_processed=0, rows_written=0)
-            return JobResult.success(job_key=lock_key, summary="No system activity found.",
+            return JobResult.success(job_key=job_key, summary="No system activity found.",
                                     rows_processed=0, rows_written=0, duration_ms=0).to_dict()
 
         # Find active systems (at least 2 battles)
@@ -463,7 +459,7 @@ def run_compute_threat_corridors(
                              "active_system_count": len(active_systems), "corridor_source": corridor_source,
                              "raw_corridors_found": len(raw_corridors)})
         return JobResult.success(
-            job_key=lock_key,
+            job_key=job_key,
             summary=f"Found {len(scored)} threat corridors across {len(system_data)} active systems.",
             rows_processed=rows_processed,
             rows_written=rows_written,
@@ -473,5 +469,3 @@ def run_compute_threat_corridors(
     except Exception as exc:
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)

--- a/python/orchestrator/jobs/counterintel_pipeline.py
+++ b/python/orchestrator/jobs/counterintel_pipeline.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from ..db import SupplyCoreDb
 from ..job_result import JobResult
-from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+from ..job_utils import finish_job_run, start_job_run
 from ..http_client import ipv4_opener
 from ..json_utils import json_dumps_safe
 from ..neo4j import Neo4jClient, Neo4jConfig
@@ -407,10 +407,6 @@ def run_compute_counterintel_pipeline(
     dry_run: bool = False,
 ) -> dict[str, Any]:
     lock_key = "compute_counterintel_pipeline"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=1200)
-    if owner is None:
-        return JobResult.skipped(job_key=lock_key, reason="lock-not-acquired").to_dict()
-
     job = start_job_run(db, lock_key)
     started = time.perf_counter()
     rows_processed = 0
@@ -1127,5 +1123,3 @@ def run_compute_counterintel_pipeline(
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         _sync_state_upsert(db, COUNTERINTEL_DATASET_KEY, "", "failed", rows_written)
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)

--- a/python/orchestrator/jobs/evewho_enrichment_sync.py
+++ b/python/orchestrator/jobs/evewho_enrichment_sync.py
@@ -20,7 +20,7 @@ from typing import Any
 from ..db import SupplyCoreDb
 from ..evewho_adapter import EveWhoAdapter
 from ..job_result import JobResult
-from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+from ..job_utils import finish_job_run, start_job_run
 from ..json_utils import json_dumps_safe
 from ..neo4j import Neo4jClient, Neo4jConfig, Neo4jError
 
@@ -279,12 +279,7 @@ def run_evewho_enrichment_sync(
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Main entry point for the EveWho enrichment sync job."""
-    lock_key = JOB_KEY
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
-    if owner is None:
-        return JobResult.skipped(job_key=lock_key, reason="lock-not-acquired").to_dict()
-
-    job = start_job_run(db, lock_key)
+    job = start_job_run(db, JOB_KEY)
     started = time.perf_counter()
     rows_processed = 0
     rows_written = 0
@@ -299,8 +294,7 @@ def run_evewho_enrichment_sync(
         neo4j_config = Neo4jConfig.from_runtime(neo4j_raw or {})
         if not neo4j_config.enabled:
             finish_job_run(db, job, status="skipped", rows_processed=0, rows_written=0, error_text="Neo4j disabled")
-            release_job_lock(db, lock_key, owner)
-            return JobResult.skipped(job_key=lock_key, reason="neo4j-disabled").to_dict()
+            return JobResult.skipped(job_key=JOB_KEY, reason="neo4j-disabled").to_dict()
 
         neo4j = Neo4jClient(neo4j_config)
         adapter = EveWhoAdapter(user_agent)
@@ -332,9 +326,8 @@ def run_evewho_enrichment_sync(
                 "duration_ms": duration_ms,
             },
         )
-        release_job_lock(db, lock_key, owner)
         return JobResult.success(
-            job_key=lock_key,
+            job_key=JOB_KEY,
             rows_seen=rows_processed,
             rows_written=rows_written,
             summary=f"Enriched {rows_written}/{rows_processed} characters in {batch_count} batch(es), {duration_ms}ms",
@@ -343,9 +336,8 @@ def run_evewho_enrichment_sync(
     except Exception as e:
         duration_ms = int((time.perf_counter() - started) * 1000)
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(e)[:500])
-        release_job_lock(db, lock_key, owner)
         return JobResult.failed(
-            job_key=lock_key,
+            job_key=JOB_KEY,
             error=str(e),
             rows_seen=rows_processed,
             rows_written=rows_written,

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -36,7 +36,7 @@ if __package__ in (None, ""):
     )
     from orchestrator.job_result import JobResult
     from orchestrator.json_utils import json_dumps_safe
-    from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from orchestrator.job_utils import finish_job_run, start_job_run
 else:
     from ..db import SupplyCoreDb
     from ..eve_constants import (
@@ -48,7 +48,7 @@ else:
     )
     from ..job_result import JobResult
     from ..json_utils import json_dumps_safe
-    from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from ..job_utils import finish_job_run, start_job_run
 
 # ── Configuration ────────────────────────────────────────────────────────────
 
@@ -996,13 +996,6 @@ def run_theater_analysis(
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Analyze all theaters: timeline, sides, participants, anomalies."""
-    lock_key = "theater_analysis"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=1800)
-    if owner is None:
-        result = JobResult.skipped(job_key="theater_analysis", reason="lock-not-acquired").to_dict()
-        _theater_log(runtime, "theater_analysis.job.skipped", result)
-        return result
-
     job = start_job_run(db, "theater_analysis")
     started_monotonic = datetime.now(UTC)
     rows_processed = 0
@@ -1130,5 +1123,3 @@ def run_theater_analysis(
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         _theater_log(runtime, "theater_analysis.job.failed", {"status": "failed", "error": str(exc)})
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)

--- a/python/orchestrator/jobs/theater_clustering.py
+++ b/python/orchestrator/jobs/theater_clustering.py
@@ -25,12 +25,12 @@ if __package__ in (None, ""):
     from orchestrator.db import SupplyCoreDb
     from orchestrator.job_result import JobResult
     from orchestrator.json_utils import json_dumps_safe
-    from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from orchestrator.job_utils import finish_job_run, start_job_run
 else:
     from ..db import SupplyCoreDb
     from ..job_result import JobResult
     from ..json_utils import json_dumps_safe
-    from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from ..job_utils import finish_job_run, start_job_run
 
 # ── Configuration ────────────────────────────────────────────────────────────
 
@@ -505,13 +505,6 @@ def run_theater_clustering(
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Cluster battles into theaters and persist results."""
-    lock_key = "theater_clustering"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
-    if owner is None:
-        result = JobResult.skipped(job_key="theater_clustering", reason="lock-not-acquired").to_dict()
-        _theater_log(runtime, "theater_clustering.job.skipped", result)
-        return result
-
     job = start_job_run(db, "theater_clustering")
     started_monotonic = datetime.now(UTC)
     rows_processed = 0
@@ -656,5 +649,3 @@ def run_theater_clustering(
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         _theater_log(runtime, "theater_clustering.job.failed", {"status": "failed", "error": str(exc)})
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)

--- a/python/orchestrator/jobs/theater_graph_integration.py
+++ b/python/orchestrator/jobs/theater_graph_integration.py
@@ -22,13 +22,13 @@ if __package__ in (None, ""):
     from orchestrator.db import SupplyCoreDb
     from orchestrator.job_result import JobResult
     from orchestrator.json_utils import json_dumps_safe
-    from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from orchestrator.job_utils import finish_job_run, start_job_run
     from orchestrator.neo4j import Neo4jClient, Neo4jConfig
 else:
     from ..db import SupplyCoreDb
     from ..job_result import JobResult
     from ..json_utils import json_dumps_safe
-    from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from ..job_utils import finish_job_run, start_job_run
     from ..neo4j import Neo4jClient, Neo4jConfig
 
 BATCH_SIZE = 500
@@ -231,11 +231,6 @@ def run_theater_graph_integration(
     if not config.enabled:
         return JobResult.skipped(job_key="theater_graph_integration", reason="neo4j disabled").to_dict()
 
-    lock_key = "theater_graph_integration"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
-    if owner is None:
-        return JobResult.skipped(job_key="theater_graph_integration", reason="lock-not-acquired").to_dict()
-
     job = start_job_run(db, "theater_graph_integration")
     started_monotonic = datetime.now(UTC)
     rows_processed = 0
@@ -317,5 +312,3 @@ def run_theater_graph_integration(
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         _theater_log(runtime, "theater_graph_integration.job.failed", {"error": str(exc)})
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)

--- a/python/orchestrator/jobs/theater_suspicion.py
+++ b/python/orchestrator/jobs/theater_suspicion.py
@@ -22,12 +22,12 @@ if __package__ in (None, ""):
     from orchestrator.db import SupplyCoreDb
     from orchestrator.job_result import JobResult
     from orchestrator.json_utils import json_dumps_safe
-    from orchestrator.job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from orchestrator.job_utils import finish_job_run, start_job_run
 else:
     from ..db import SupplyCoreDb
     from ..job_result import JobResult
     from ..json_utils import json_dumps_safe
-    from ..job_utils import acquire_job_lock, finish_job_run, release_job_lock, start_job_run
+    from ..job_utils import finish_job_run, start_job_run
 
 SUSPICION_THRESHOLD = 0.5
 BATCH_SIZE = 500
@@ -137,11 +137,6 @@ def run_theater_suspicion(
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Integrate suspicion signals into theater participants."""
-    lock_key = "theater_suspicion"
-    owner = acquire_job_lock(db, lock_key, ttl_seconds=900)
-    if owner is None:
-        return JobResult.skipped(job_key="theater_suspicion", reason="lock-not-acquired").to_dict()
-
     job = start_job_run(db, "theater_suspicion")
     started_monotonic = datetime.now(UTC)
     rows_processed = 0
@@ -264,5 +259,3 @@ def run_theater_suspicion(
         finish_job_run(db, job, status="failed", rows_processed=rows_processed, rows_written=rows_written, error_text=str(exc))
         _theater_log(runtime, "theater_suspicion.job.failed", {"error": str(exc)})
         raise
-    finally:
-        release_job_lock(db, lock_key, owner)


### PR DESCRIPTION
## Summary

- Removed `acquire_job_lock` / `release_job_lock` calls from all 9 job files (13 lock sites total). The worker pool already prevents concurrent execution via `claim_next_worker_job`, heartbeat threads, stale-job reaping, and concurrency groups — making the `compute_job_locks` table a redundant second lock layer.

- These locks caused jobs to skip with `"lock-not-acquired"` after worker crashes (orphaned lock rows survive until their 15-30 min TTL expires) and blocked manual `run-job` CLI invocations while the worker pool held the lock.

- Affected jobs: `compute_battle_rollups`, `compute_battle_target_metrics`, `compute_battle_anomalies`, `compute_battle_actor_features`, `compute_suspicion_scores`, `compute_counterintel_pipeline`, `evewho_enrichment_sync`, `theater_suspicion`, `theater_analysis`, `theater_clustering`, `theater_graph_integration`, `compute_alliance_dossiers`, `compute_threat_corridors`.

## Test plan

- [ ] Run `python -m orchestrator run-job --job-key compute_suspicion_scores` manually — should no longer skip with "lock-not-acquired"
- [ ] Verify worker pool still prevents concurrent execution of the same job via its own claim mechanism
- [ ] Confirm no orphaned `compute_job_locks` rows block jobs after a worker restart

https://claude.ai/code/session_015UAeddPkGVrA1LgQLku7kA