### PR TITLE
Optimize suspicion scores and batch all row-by-row DB writes

### DIFF
--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -392,11 +392,16 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
             batch_written = 0
             if not dry_run:
                 with db.transaction() as (_, cursor):
+                    rollup_batch = []
                     for battle in battles.values():
                         started = datetime.strptime(str(battle["started_at"]), "%Y-%m-%d %H:%M:%S")
                         ended = datetime.strptime(str(battle["ended_at"]), "%Y-%m-%d %H:%M:%S")
                         duration_seconds = max(1, int((ended - started).total_seconds()))
-                        cursor.execute(
+                        rollup_batch.append(
+                            (str(battle["battle_id"]), int(battle["system_id"]), str(battle["started_at"]), str(battle["ended_at"]), duration_seconds, computed_at),
+                        )
+                    if rollup_batch:
+                        cursor.executemany(
                             """
                             INSERT INTO battle_rollups (
                                 battle_id, system_id, started_at, ended_at, duration_seconds,
@@ -414,16 +419,32 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
                                     VALUES(computed_at),
                                     computed_at
                                 )
-                            """
-                            ,
-                            (str(battle["battle_id"]), int(battle["system_id"]), str(battle["started_at"]), str(battle["ended_at"]), duration_seconds, computed_at),
+                            """,
+                            rollup_batch,
                         )
-                        batch_written += max(0, int(cursor.rowcount or 0))
+                        batch_written += len(rollup_batch)
 
+                    participant_batch = []
                     for participant in participant_rows.values():
                         ship_type_id = int(participant.get("ship_type_id") or 0)
                         flags = role_map.get(ship_type_id, (0, 0, 0))
-                        cursor.execute(
+                        participant_batch.append(
+                            (
+                                str(participant["battle_id"]),
+                                int(participant["character_id"]),
+                                participant.get("corporation_id"),
+                                participant.get("alliance_id"),
+                                str(participant["side_key"]),
+                                participant.get("ship_type_id"),
+                                int(flags[0]),
+                                int(flags[1]),
+                                int(flags[2]),
+                                int(participant.get("participation_count") or 0),
+                                computed_at,
+                            ),
+                        )
+                    if participant_batch:
+                        cursor.executemany(
                             """
                             INSERT INTO battle_participants (
                                 battle_id, character_id, corporation_id, alliance_id, side_key, ship_type_id,
@@ -440,41 +461,48 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
                                 participation_count = participation_count + VALUES(participation_count),
                                 computed_at = VALUES(computed_at)
                             """,
-                            (
-                                str(participant["battle_id"]),
-                                int(participant["character_id"]),
-                                participant.get("corporation_id"),
-                                participant.get("alliance_id"),
-                                str(participant["side_key"]),
-                                participant.get("ship_type_id"),
-                                int(flags[0]),
-                                int(flags[1]),
-                                int(flags[2]),
-                                int(participant.get("participation_count") or 0),
-                                computed_at,
-                            ),
+                            participant_batch,
                         )
-                        batch_written += max(0, int(cursor.rowcount or 0))
+                        batch_written += len(participant_batch)
 
-                    for battle_id_value, sequence_id in killmail_assignments:
-                        cursor.execute(
+                    if killmail_assignments:
+                        cursor.executemany(
                             "UPDATE killmail_events SET battle_id = %s WHERE sequence_id = %s AND COALESCE(battle_id, '') <> %s",
-                            (battle_id_value, sequence_id, battle_id_value),
+                            [(bid, sid, bid) for bid, sid in killmail_assignments],
                         )
-                        batch_written += max(0, int(cursor.rowcount or 0))
+                        batch_written += len(killmail_assignments)
 
-                    for battle_id_value in touched_battles:
+                    if touched_battles:
+                        tb_list = list(touched_battles)
+                        tb_placeholders = ",".join(["%s"] * len(tb_list))
+                        # Compute participant counts for all touched battles in one query.
                         cursor.execute(
-                            """
-                            SELECT COUNT(*) AS participant_count
+                            f"""
+                            SELECT battle_id, COUNT(*) AS participant_count
                             FROM battle_participants
-                            WHERE battle_id = %s
+                            WHERE battle_id IN ({tb_placeholders})
+                            GROUP BY battle_id
                             """,
-                            (battle_id_value,),
+                            tuple(tb_list),
                         )
-                        summary_row = cursor.fetchone() or {}
-                        participant_count = int(summary_row.get("participant_count") or 0)
-                        cursor.execute(
+                        counts = {str(r["battle_id"]): int(r["participant_count"]) for r in cursor.fetchall()}
+                        update_batch = []
+                        for battle_id_value in tb_list:
+                            participant_count = counts.get(str(battle_id_value), 0)
+                            update_batch.append(
+                                (
+                                    participant_count,
+                                    1 if participant_count >= MIN_ELIGIBLE_PARTICIPANTS else 0,
+                                    _battle_size_class(participant_count),
+                                    computed_at,
+                                    battle_id_value,
+                                    participant_count,
+                                    1 if participant_count >= MIN_ELIGIBLE_PARTICIPANTS else 0,
+                                    _battle_size_class(participant_count),
+                                    computed_at,
+                                ),
+                            )
+                        cursor.executemany(
                             """
                             UPDATE battle_rollups
                             SET participant_count = %s,
@@ -489,19 +517,9 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
                                 OR computed_at <> %s
                               )
                             """,
-                            (
-                                participant_count,
-                                1 if participant_count >= MIN_ELIGIBLE_PARTICIPANTS else 0,
-                                _battle_size_class(participant_count),
-                                computed_at,
-                                battle_id_value,
-                                participant_count,
-                                1 if participant_count >= MIN_ELIGIBLE_PARTICIPANTS else 0,
-                                _battle_size_class(participant_count),
-                                computed_at,
-                            ),
+                            update_batch,
                         )
-                        batch_written += max(0, int(cursor.rowcount or 0))
+                        batch_written += len(update_batch)
 
             cursor_end = max_sequence_id
             rows_written += batch_written
@@ -827,6 +845,8 @@ def run_compute_battle_anomalies(db: SupplyCoreDb, runtime: dict[str, Any] | Non
                 cursor.execute("DELETE FROM battle_side_metrics")
 
                 efficiency_sorted = sorted((float(item["efficiency_score"]) for item in shaped))
+                metrics_batch: list[tuple[Any, ...]] = []
+                anomalies_batch: list[tuple[Any, ...]] = []
                 for item in shaped:
                     mean, stddev = stats.get(str(item["battle_size_class"]), (0.0, 0.0))
                     z = _safe_div(float(item["efficiency_score"]) - mean, stddev, 0.0) if stddev > 0 else 0.0
@@ -837,14 +857,7 @@ def run_compute_battle_anomalies(db: SupplyCoreDb, runtime: dict[str, Any] | Non
                     elif z < -1.0:
                         anomaly_class = "low_sustain"
 
-                    cursor.execute(
-                        """
-                        INSERT INTO battle_side_metrics (
-                            battle_id, side_key, participant_count, logi_count, command_count, capital_count,
-                            total_kills, kill_rate_per_minute, median_sustain_factor, average_sustain_factor,
-                            switch_pressure, efficiency_score, z_efficiency_score, computed_at
-                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                        """,
+                    metrics_batch.append(
                         (
                             str(item["battle_id"]),
                             str(item["side_key"]),
@@ -870,12 +883,7 @@ def run_compute_battle_anomalies(db: SupplyCoreDb, runtime: dict[str, Any] | Non
                         "z_efficiency_score": z,
                         "peer_group": item["battle_size_class"],
                     }
-                    cursor.execute(
-                        """
-                        INSERT INTO battle_anomalies (
-                            battle_id, side_key, anomaly_class, z_efficiency_score, percentile_rank, explanation_json, computed_at
-                        ) VALUES (%s, %s, %s, %s, %s, %s, %s)
-                        """,
+                    anomalies_batch.append(
                         (
                             str(item["battle_id"]),
                             str(item["side_key"]),
@@ -885,6 +893,26 @@ def run_compute_battle_anomalies(db: SupplyCoreDb, runtime: dict[str, Any] | Non
                             json_dumps_safe(explanation),
                             computed_at,
                         ),
+                    )
+                if metrics_batch:
+                    cursor.executemany(
+                        """
+                        INSERT INTO battle_side_metrics (
+                            battle_id, side_key, participant_count, logi_count, command_count, capital_count,
+                            total_kills, kill_rate_per_minute, median_sustain_factor, average_sustain_factor,
+                            switch_pressure, efficiency_score, z_efficiency_score, computed_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        metrics_batch,
+                    )
+                if anomalies_batch:
+                    cursor.executemany(
+                        """
+                        INSERT INTO battle_anomalies (
+                            battle_id, side_key, anomaly_class, z_efficiency_score, percentile_rank, explanation_json, computed_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        anomalies_batch,
                     )
         rows_written = len(shaped) * 2
 

--- a/python/orchestrator/jobs/intelligence_pipeline.py
+++ b/python/orchestrator/jobs/intelligence_pipeline.py
@@ -752,20 +752,12 @@ def _export_suspicion_signals(client: Neo4jClient, db: SupplyCoreDb, computed_at
 
     with db.transaction() as (_, cursor):
         cursor.execute("DELETE FROM character_suspicion_signals")
+        batch: list[tuple[Any, ...]] = []
         for r in rows:
             cid = int(r.get("character_id") or 0)
             if cid <= 0:
                 continue
-            cursor.execute(
-                """INSERT INTO character_suspicion_signals
-                   (character_id, alliance_id, battles_present, kills_total, losses_total,
-                    damage_total, primary_fleet_function,
-                    selective_non_engagement_score, high_presence_low_output_score,
-                    token_participation_score, loss_without_attack_ratio,
-                    peer_normalized_kills_delta, peer_normalized_damage_delta,
-                    composition_adjusted_delta, side_expected_performance,
-                    suspicion_score, suspicion_flags, engagement_rate_by_alliance, computed_at)
-                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+            batch.append(
                 (
                     cid,
                     int(r.get("alliance_id") or 0),
@@ -787,6 +779,19 @@ def _export_suspicion_signals(client: Neo4jClient, db: SupplyCoreDb, computed_at
                     json_dumps_safe(r.get("engagement_rates") or []),
                     computed_at,
                 ),
+            )
+        if batch:
+            cursor.executemany(
+                """INSERT INTO character_suspicion_signals
+                   (character_id, alliance_id, battles_present, kills_total, losses_total,
+                    damage_total, primary_fleet_function,
+                    selective_non_engagement_score, high_presence_low_output_score,
+                    token_participation_score, loss_without_attack_ratio,
+                    peer_normalized_kills_delta, peer_normalized_damage_delta,
+                    composition_adjusted_delta, side_expected_performance,
+                    suspicion_score, suspicion_flags, engagement_rate_by_alliance, computed_at)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+                batch,
             )
 
     return len(rows)
@@ -816,16 +821,12 @@ def _export_alliance_overlap(client: Neo4jClient, db: SupplyCoreDb, computed_at:
 
     with db.transaction() as (_, cursor):
         cursor.execute("DELETE FROM character_alliance_overlap")
+        batch: list[tuple[Any, ...]] = []
         for r in rows:
             cid = int(r.get("character_id") or 0)
             if cid <= 0:
                 continue
-            cursor.execute(
-                """INSERT INTO character_alliance_overlap
-                   (character_id, alliance_id, former_allies_attacking, losses_to_former_allies,
-                    repeat_former_ally_attackers, total_repeat_kills_by_former,
-                    historical_overlap_score, correlated_flag, combined_risk_score, computed_at)
-                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+            batch.append(
                 (
                     cid,
                     int(r.get("alliance_id") or 0),
@@ -838,6 +839,15 @@ def _export_alliance_overlap(client: Neo4jClient, db: SupplyCoreDb, computed_at:
                     float(r.get("combined_risk_score") or 0),
                     computed_at,
                 ),
+            )
+        if batch:
+            cursor.executemany(
+                """INSERT INTO character_alliance_overlap
+                   (character_id, alliance_id, former_allies_attacking, losses_to_former_allies,
+                    repeat_former_ally_attackers, total_repeat_kills_by_former,
+                    historical_overlap_score, correlated_flag, combined_risk_score, computed_at)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+                batch,
             )
 
     return len(rows)

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -852,31 +852,35 @@ def _flush_analysis(
         cursor.execute("DELETE FROM theater_participants WHERE theater_id = %s", (theater_id,))
 
         # Clean turning points for battles in this theater
-        for bid in battle_ids:
-            cursor.execute("DELETE FROM battle_turning_points WHERE battle_id = %s", (bid,))
+        if battle_ids:
+            placeholders = ",".join(["%s"] * len(battle_ids))
+            cursor.execute(f"DELETE FROM battle_turning_points WHERE battle_id IN ({placeholders})", tuple(battle_ids))
 
         # Timeline
-        for t in timeline_rows:
-            cursor.execute(
+        if timeline_rows:
+            cursor.executemany(
                 """
                 INSERT INTO theater_timeline (
                     theater_id, bucket_time, bucket_seconds, kills, isk_destroyed,
                     side_a_kills, side_b_kills, side_a_isk, side_b_isk, momentum_score
                 ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
-                (
-                    theater_id, t["bucket_time"], TIMELINE_BUCKET_SECONDS,
-                    t["kills"], t["isk_destroyed"],
-                    t["side_a_kills"], t["side_b_kills"],
-                    t["side_a_isk"], t["side_b_isk"],
-                    t["momentum_score"],
-                ),
+                [
+                    (
+                        theater_id, t["bucket_time"], TIMELINE_BUCKET_SECONDS,
+                        t["kills"], t["isk_destroyed"],
+                        t["side_a_kills"], t["side_b_kills"],
+                        t["side_a_isk"], t["side_b_isk"],
+                        t["momentum_score"],
+                    )
+                    for t in timeline_rows
+                ],
             )
-            rows_written += 1
+            rows_written += len(timeline_rows)
 
         # Alliance summary
-        for a in alliance_rows:
-            cursor.execute(
+        if alliance_rows:
+            cursor.executemany(
                 """
                 INSERT INTO theater_alliance_summary (
                     theater_id, alliance_id, alliance_name, side,
@@ -884,14 +888,17 @@ def _flush_analysis(
                     total_damage, total_isk_lost, total_isk_killed, efficiency
                 ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
-                (
-                    theater_id, a["alliance_id"], a["alliance_name"], a["side"],
-                    a["participant_count"], a["total_kills"], a["total_losses"],
-                    a["total_damage"], a["total_isk_lost"], a["total_isk_killed"],
-                    a["efficiency"],
-                ),
+                [
+                    (
+                        theater_id, a["alliance_id"], a["alliance_name"], a["side"],
+                        a["participant_count"], a["total_kills"], a["total_losses"],
+                        a["total_damage"], a["total_isk_lost"], a["total_isk_killed"],
+                        a["efficiency"],
+                    )
+                    for a in alliance_rows
+                ],
             )
-            rows_written += 1
+            rows_written += len(alliance_rows)
 
         # Participants (batch insert)
         for chunk_start in range(0, len(participant_rows), BATCH_SIZE):
@@ -923,36 +930,35 @@ def _flush_analysis(
             rows_written += len(chunk)
 
         # Turning points
-        for tp in turning_points:
-            # Assign to the first battle in the theater (convention)
+        if turning_points:
             bid = battle_ids[0] if battle_ids else theater_id
-            cursor.execute(
+            cursor.executemany(
                 """
                 INSERT INTO battle_turning_points (
                     battle_id, turning_point_at, direction, magnitude, description
                 ) VALUES (%s, %s, %s, %s, %s)
                 """,
-                (bid, tp["bucket_time"], tp["direction"], tp["magnitude"], tp["description"]),
+                [(bid, tp["bucket_time"], tp["direction"], tp["magnitude"], tp["description"]) for tp in turning_points],
             )
-            rows_written += 1
+            rows_written += len(turning_points)
 
         # Side composition
         if side_composition_rows:
             cursor.execute("DELETE FROM theater_side_composition WHERE theater_id = %s", (theater_id,))
-            for sc in side_composition_rows:
-                cursor.execute(
-                    """
-                    INSERT INTO theater_side_composition (
-                        theater_id, side, pilot_count,
-                        hull_small_count, hull_medium_count, hull_large_count, hull_capital_count,
-                        role_mainline_dps, role_capital_dps, role_logistics, role_capital_logistics,
-                        role_tackle, role_heavy_tackle, role_bubble_control, role_command, role_ewar,
-                        role_bomber, role_scout, role_supercapital, role_non_combat,
-                        side_hull_weight_score, side_role_balance_score,
-                        side_logi_strength_score, side_command_strength_score,
-                        side_capital_ratio, side_expected_performance_score
-                    ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-                    """,
+            cursor.executemany(
+                """
+                INSERT INTO theater_side_composition (
+                    theater_id, side, pilot_count,
+                    hull_small_count, hull_medium_count, hull_large_count, hull_capital_count,
+                    role_mainline_dps, role_capital_dps, role_logistics, role_capital_logistics,
+                    role_tackle, role_heavy_tackle, role_bubble_control, role_command, role_ewar,
+                    role_bomber, role_scout, role_supercapital, role_non_combat,
+                    side_hull_weight_score, side_role_balance_score,
+                    side_logi_strength_score, side_command_strength_score,
+                    side_capital_ratio, side_expected_performance_score
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                """,
+                [
                     (
                         sc["theater_id"], sc["side"], sc["pilot_count"],
                         sc["hull_small_count"], sc["hull_medium_count"],
@@ -966,9 +972,11 @@ def _flush_analysis(
                         sc["side_hull_weight_score"], sc["side_role_balance_score"],
                         sc["side_logi_strength_score"], sc["side_command_strength_score"],
                         sc["side_capital_ratio"], sc["side_expected_performance_score"],
-                    ),
-                )
-                rows_written += 1
+                    )
+                    for sc in side_composition_rows
+                ],
+            )
+            rows_written += len(side_composition_rows)
 
         # Update theater aggregates
         cursor.execute(


### PR DESCRIPTION
## Summary

- **54x speedup on `compute_suspicion_scores`** (810s → 15s): eliminate O(n²) enemy efficiency loop by pre-computing global z-efficiency totals, use `bisect` for O(log n) percentile lookups, batch all INSERTs with `executemany`
- **Parallelize `compute_suspicion_scores_v2`** chunked queries using `ThreadPoolExecutor` (4 workers), with optional Neo4j fast path for neighbor lookups via pre-computed `CO_OCCURS_WITH` edges
- **Batch all row-by-row INSERTs/UPDATEs** across the job pipeline: `battle_side_metrics`, `battle_anomalies`, `battle_rollups`, `battle_participants`, `killmail_events`, `character_suspicion_signals`, `character_alliance_overlap`, `theater_timeline`, `theater_alliance_summary`, `battle_turning_points`, `theater_side_composition`
- Collapse per-battle SELECT+UPDATE for touched_battles into a single grouped COUNT query + batched UPDATE

## Test plan

- [x] `compute_suspicion_scores` runs successfully (82K rows → 15s, output matches expected row counts)
- [x] `compute_suspicion_scores_v2` runs successfully (16K rows → 3s)
- [ ] Run `compute_battle_anomalies` and verify `battle_side_metrics` / `battle_anomalies` output
- [ ] Run `compute_battle_rollups` and verify upsert behavior
- [ ] Run `theater_analysis` and verify timeline/summary/composition tables
- [ ] Run `intelligence_pipeline` and verify `character_suspicion_signals` output

https://claude.ai/code/session_01KxyDoR1uUxL7Z7HuY56aX5