### PR TITLE
Add evewho-enrichment-sync command to orchestrator CLI

### DIFF
--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -160,6 +160,11 @@ def parse_args() -> argparse.Namespace:
         parser_job.add_argument("--dry-run", action="store_true", help="Compute and log counters without writing MariaDB tables.")
         parser_job.add_argument("--verbose", action="store_true")
 
+    evewho_sync = subparsers.add_parser("evewho-enrichment-sync", help="Batch-enrich characters from EveWho into Neo4j")
+    evewho_sync.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
+    evewho_sync.add_argument("--dry-run", action="store_true", help="Compute without writing to Neo4j or MariaDB.")
+    evewho_sync.add_argument("--verbose", action="store_true")
+
     scheduler_graph = subparsers.add_parser("scheduler-graph", help="Display the DAG-based job dependency graph and execution tiers")
     scheduler_graph.add_argument("--app-root", default=str(Path(__file__).resolve().parents[2]))
     scheduler_graph.add_argument("--validate", action="store_true", help="Validate the graph and report issues")
@@ -464,6 +469,18 @@ def main() -> int:
                 {"status": "failed", "error_text": str(exc), "rows_processed": 0, "rows_written": 0},
             )
             return 1
+
+    if command == "evewho-enrichment-sync":
+        app_root = Path(args.app_root).resolve()
+        config = load_php_runtime_config(app_root)
+        configure_logging(verbose=args.verbose, log_file=config.log_file)
+        from .db import SupplyCoreDb
+        db = SupplyCoreDb(config.raw.get("db", {}))
+        from .jobs.evewho_enrichment_sync import run_evewho_enrichment_sync
+        started_at = time.monotonic()
+        result = run_evewho_enrichment_sync(db, neo4j_runtime(config.raw), battle_runtime(config.raw), dry_run=bool(args.dry_run))
+        _print_cli_result(command, started_at, result)
+        return 0 if str(result.get("status") or "success") != "failed" else 1
 
     if command == "scheduler-graph":
         configure_logging(verbose=args.verbose)


### PR DESCRIPTION
## Summary
This PR adds a new `evewho-enrichment-sync` subcommand to the orchestrator CLI that enables batch enrichment of EVE Online characters from EveWho into Neo4j.

## Key Changes
- Added `evewho-enrichment-sync` argument parser with support for:
  - `--app-root`: Configurable application root directory
  - `--dry-run`: Compute enrichment without writing to Neo4j or MariaDB
  - `--verbose`: Enable verbose logging
- Implemented command handler that:
  - Loads PHP runtime configuration
  - Initializes database and Neo4j connections
  - Executes the `run_evewho_enrichment_sync` job
  - Reports execution results with timing information
  - Returns appropriate exit codes based on job status

## Implementation Details
The new command follows the existing orchestrator pattern by:
- Reusing the standard configuration loading and logging setup
- Integrating with the existing database and Neo4j runtime infrastructure
- Providing consistent CLI output formatting via `_print_cli_result()`
- Supporting dry-run mode for safe testing before actual data writes

https://claude.ai/code/session_01Qf4xyk8c6Kvz2hL38PsG3X