### PR TITLE
Wire up EveWho enrichment sync CLI command and queue population

### DIFF
--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -453,6 +453,12 @@ include __DIR__ . '/partials/_timeline.php';
 include __DIR__ . '/partials/_alliance_summary.php';
 include __DIR__ . '/partials/_participants.php';
 include __DIR__ . '/partials/_suspicion.php';
+
+// Queue battle participants for EveWho enrichment (idempotent — skips already-queued)
+if (isset($participantsAll) && $participantsAll !== []) {
+    db_enrichment_queue_from_battle($participantsAll);
+}
+
 include __DIR__ . '/partials/_cross_alliance_history.php';
 
 include __DIR__ . '/../../src/views/partials/footer.php';


### PR DESCRIPTION
## Summary

- **Add `evewho-enrichment-sync` as a top-level CLI command** — the job was registered in `processor_registry` but not exposed as a direct subcommand, so `python -m orchestrator evewho-enrichment-sync` now works (supports `--verbose` and `--dry-run`)
- **Call `db_enrichment_queue_from_battle()` from the theater view** — the function existed in `db.php` but was never invoked, leaving the `enrichment_queue` table permanently empty. Now battle participants are queued for EveWho enrichment when the theater intelligence view renders (idempotent via `ON DUPLICATE KEY`)

## Test plan

- [ ] Visit a theater intelligence view and verify `enrichment_queue` gets populated (`SELECT status, COUNT(*) FROM enrichment_queue GROUP BY status`)
- [ ] Run `python -m orchestrator evewho-enrichment-sync --verbose` and confirm it processes the queued characters
- [ ] Verify the cross-alliance history panel updates its enrichment progress bar
- [ ] Confirm re-visiting the same theater doesn't create duplicate queue entries

https://claude.ai/code/session_01Qf4xyk8c6Kvz2hL38PsG3X