### PR TITLE
Fix date format parsing by replacing slashes with dashes

### DIFF
--- a/python/orchestrator/jobs/evewho_alliance_member_sync.py
+++ b/python/orchestrator/jobs/evewho_alliance_member_sync.py
@@ -164,8 +164,8 @@ def _enrich_character_to_neo4j(
         if h_corp_id <= 0:
             continue
         is_npc = h_corp_id < 2_000_000
-        start_raw = str(h.get("start_date") or "").strip().replace(" ", "T")
-        end_raw = str(h.get("end_date") or "").strip().replace(" ", "T") if h.get("end_date") else None
+        start_raw = str(h.get("start_date") or "").strip().replace(" ", "T").replace("/", "-")
+        end_raw = str(h.get("end_date") or "").strip().replace(" ", "T").replace("/", "-") if h.get("end_date") else None
         if not start_raw:
             continue
 

--- a/python/orchestrator/jobs/evewho_enrichment_sync.py
+++ b/python/orchestrator/jobs/evewho_enrichment_sync.py
@@ -156,8 +156,8 @@ def _enrich_character_to_neo4j(
         if h_corp_id <= 0:
             continue
         is_npc = h_corp_id < 2_000_000
-        start_raw = str(h.get("start_date") or "").strip().replace(" ", "T")
-        end_raw = str(h.get("end_date") or "").strip().replace(" ", "T") if h.get("end_date") else None
+        start_raw = str(h.get("start_date") or "").strip().replace(" ", "T").replace("/", "-")
+        end_raw = str(h.get("end_date") or "").strip().replace(" ", "T").replace("/", "-") if h.get("end_date") else None
 
         if not start_raw:
             continue


### PR DESCRIPTION
## Summary
Updated date parsing logic in character enrichment jobs to handle date formats containing slashes by converting them to dashes, ensuring proper ISO 8601 datetime format compatibility.

## Key Changes
- Modified `evewho_alliance_member_sync.py`: Added `.replace("/", "-")` to both `start_raw` and `end_raw` date parsing to convert slash-separated dates to dash-separated format
- Modified `evewho_enrichment_sync.py`: Applied the same date format normalization to maintain consistency across enrichment jobs

## Implementation Details
The changes normalize date strings by:
1. Converting spaces to "T" (ISO 8601 datetime separator)
2. Converting forward slashes to dashes (e.g., "2023/01/15" → "2023-01-15")

This ensures dates from the EVE Who API are properly formatted for downstream processing, regardless of whether they arrive in slash or dash-separated format.

https://claude.ai/code/session_01MW7156ZTGKtBAmcSYGEDqd