### PR TITLE
Update evewho alliance sync checkpoint statuses and error handling

### DIFF
--- a/python/orchestrator/jobs/evewho_alliance_member_sync.py
+++ b/python/orchestrator/jobs/evewho_alliance_member_sync.py
@@ -346,7 +346,7 @@ def run_evewho_alliance_member_sync(
                         "alliance_id": alliance_id,
                         "last_char_id": member["character_id"],
                         "total_written": total_written,
-                    }, "partial", total_written)
+                    }, "running", total_written)
                     break
 
                 char_id = member["character_id"]
@@ -407,7 +407,7 @@ def run_evewho_alliance_member_sync(
 
         # If we completed all alliances, clear the checkpoint
         if budget_remaining > 0:
-            _save_checkpoint(db, {}, "complete", total_written)
+            _save_checkpoint(db, {}, "success", total_written)
 
         duration_ms = int((time.perf_counter() - started) * 1000)
         error_text = "; ".join(errors) if errors else None
@@ -451,6 +451,8 @@ def run_evewho_alliance_member_sync(
         return JobResult.failed(
             job_key=JOB_KEY,
             error=str(e),
-            rows_seen=total_members_found,
-            rows_written=total_written,
+            meta={
+                "rows_seen": total_members_found,
+                "rows_written": total_written,
+            },
         ).to_dict()


### PR DESCRIPTION
## Summary
This PR updates the evewho alliance member sync job to use more accurate checkpoint status values and improves error result handling by wrapping metadata in a dedicated field.

## Key Changes
- Changed checkpoint status from `"partial"` to `"running"` when pausing due to budget constraints, better reflecting the job's in-progress state
- Changed checkpoint status from `"complete"` to `"success"` when all alliances are successfully processed, providing clearer completion semantics
- Updated `JobResult.failed()` call to wrap `rows_seen` and `rows_written` in a `meta` dictionary instead of passing them as direct parameters, aligning with the expected API

## Implementation Details
These changes improve the semantic clarity of job status tracking and ensure proper error reporting structure. The status value updates make the checkpoint states more descriptive of the actual job execution state, while the error handling change ensures metadata is properly encapsulated in the job result.

https://claude.ai/code/session_017DZz1JErjCXJbV5dbbix4E