### PR TITLE
Add support for local configuration file overrides

### DIFF
--- a/src/config/app.php
+++ b/src/config/app.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-return [
+$config = [
     'app' => [
         'name' => 'SupplyCore',
         'env' => getenv('APP_ENV') ?: 'development',
@@ -90,3 +90,16 @@ return [
         'zkill_state_file' => 'storage/run/zkill-heartbeat.json',
     ],
 ];
+
+$localConfigPath = __DIR__ . '/local.php';
+if (is_file($localConfigPath)) {
+    $localConfig = (static function (string $path): mixed {
+        return require $path;
+    })($localConfigPath);
+
+    if (is_array($localConfig)) {
+        $config = array_replace_recursive($config, $localConfig);
+    }
+}
+
+return $config;


### PR DESCRIPTION
## Summary
This change introduces support for environment-specific configuration overrides through an optional `local.php` configuration file, allowing developers to customize settings without modifying the main configuration.

## Key Changes
- Changed the main config from a direct return statement to a variable assignment (`$config = [...]`)
- Added logic to load and merge a `local.php` configuration file if it exists in the config directory
- Used `array_replace_recursive()` to deeply merge local configuration with the base configuration
- Wrapped the local config require in an IIFE to isolate its scope and prevent variable pollution

## Implementation Details
- The local configuration file is optional and only loaded if `config/local.php` exists
- Local configuration values recursively override base configuration values, allowing partial overrides
- Type-safe validation ensures only array configurations are merged
- The IIFE pattern prevents the local config file from polluting the global scope with unwanted variables

https://claude.ai/code/session_013MVddypQi8PahL3jCauUEH