### PR TITLE
Fix character feature windows event query and provision EveWho schedule

### DIFF
--- a/database/migrations/20260405_evewho_alliance_member_sync_schedule.sql
+++ b/database/migrations/20260405_evewho_alliance_member_sync_schedule.sql
@@ -1,0 +1,5 @@
+-- Register evewho_alliance_member_sync in sync_schedules.
+-- Disabled by default; enable via settings when Neo4j/EveWho integration is configured.
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode)
+VALUES ('evewho_alliance_member_sync', 0, 1800, 'python')
+ON DUPLICATE KEY UPDATE enabled = enabled;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -3017,7 +3017,8 @@ INSERT INTO sync_schedules (
     ('compute_cohort_baselines', 1, 15, 900, 1550, 25, 'normal', 'single', 'python', 420, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
     ('compute_counterintel_pipeline', 1, 15, 900, 1560, 26, 'high', 'single', 'python', 900, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
     ('compute_suspicion_scores', 1, 10, 600, 1500, 25, 'normal', 'single', 'python', 420, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('compute_character_feature_windows', 1, 30, 1800, 1620, 27, 'normal', 'single', 'python', 900, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL)
+    ('compute_character_feature_windows', 1, 30, 1800, 1620, 27, 'normal', 'single', 'python', 900, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
+    ('evewho_alliance_member_sync', 0, 30, 1800, 2280, 38, 'normal', 'single', 'python', 3600, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL)
 ON DUPLICATE KEY UPDATE
     enabled = VALUES(enabled),
     interval_minutes = VALUES(interval_minutes),

--- a/python/orchestrator/jobs/character_feature_windows.py
+++ b/python/orchestrator/jobs/character_feature_windows.py
@@ -123,14 +123,14 @@ def _fetch_org_transitions(
     params: list[Any] = list(character_ids)
     where_cutoff = ""
     if cutoff:
-        where_cutoff = "AND event_date >= %s"
+        where_cutoff = "AND event_at >= %s"
         params.append(cutoff)
     rows = db.fetch_all(
         f"""
         SELECT
             character_id,
-            SUM(CASE WHEN event_type = 'corp_change' THEN 1 ELSE 0 END) AS corp_transitions,
-            SUM(CASE WHEN event_type = 'alliance_change' THEN 1 ELSE 0 END) AS alliance_transitions
+            SUM(CASE WHEN event_type = 'joined' THEN 1 ELSE 0 END) AS corp_transitions,
+            SUM(CASE WHEN event_type = 'departed' THEN 1 ELSE 0 END) AS alliance_transitions
         FROM character_org_history_events
         WHERE character_id IN ({placeholders})
           {where_cutoff}


### PR DESCRIPTION
### Motivation
- Resolve scheduler failures where `compute_character_feature_windows` referenced a non-existent timestamp column and produced incorrect transition counts.
- Ensure `evewho_alliance_member_sync` is present in deployed scheduler state so the job in the registry is provisionable.

### Description
- Change the org-transition cutoff column in `python/orchestrator/jobs/character_feature_windows.py` from `event_date` to `event_at` to match the schema.
- Fix transition aggregation in `character_feature_windows.py` to use the actual enum values `joined` / `departed` instead of the incorrect `corp_change` / `alliance_change` values.
- Add a migration `database/migrations/20260405_evewho_alliance_member_sync_schedule.sql` to insert a disabled `evewho_alliance_member_sync` row into `sync_schedules` for existing deployments.
- Update `database/schema.sql` seed data to include `evewho_alliance_member_sync` so fresh installs have the schedule entry by default.

### Testing
- Ran `python -m py_compile python/orchestrator/jobs/character_feature_windows.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab8377f90832f812f6af2f2fbe242)