### PR TITLE
Track last_finished_at timestamp for sync schedules

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -738,6 +738,7 @@ class SupplyCoreDb:
             """UPDATE sync_schedules
                SET last_status = %s,
                    last_run_at = UTC_TIMESTAMP(),
+                   last_finished_at = UTC_TIMESTAMP(),
                    locked_until = NULL
                WHERE job_key = %s AND execution_mode = 'python'""",
             (status[:20], job_key[:120]),


### PR DESCRIPTION
## Summary
Added tracking of the `last_finished_at` timestamp when updating sync schedule status, allowing better visibility into when sync operations complete.

## Key Changes
- Updated `update_sync_schedule_status()` method to set `last_finished_at` to the current UTC timestamp whenever a sync schedule status is updated
- This timestamp is set alongside the existing `last_run_at` update for consistency

## Implementation Details
- The `last_finished_at` column is now populated using `UTC_TIMESTAMP()` during status updates
- This change applies to all Python execution mode sync schedules
- The timestamp provides a clear record of when each sync operation completed, enabling better monitoring and debugging of sync schedule performance

https://claude.ai/code/session_018LFds2QQ9JYPnf8NMN7ax7