### PR TITLE
Fix timezone handling in character feature window comparisons

### DIFF
--- a/python/orchestrator/jobs/character_feature_windows.py
+++ b/python/orchestrator/jobs/character_feature_windows.py
@@ -22,6 +22,15 @@ from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+def _ensure_utc(dt: datetime | None) -> datetime | None:
+    """Return *dt* as a UTC-aware datetime; treat naive values as UTC."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
 from ..db import SupplyCoreDb
 from ..job_result import JobResult
 from ..job_utils import finish_job_run, start_job_run
@@ -212,7 +221,7 @@ def _compute_window_features(
     """
     if window_delta is not None:
         cutoff = now_dt - window_delta
-        rows = [p for p in participations if p["started_at"] and p["started_at"] >= cutoff]
+        rows = [p for p in participations if p["started_at"] and _ensure_utc(p["started_at"]) >= cutoff]
     else:
         rows = participations
 
@@ -385,7 +394,7 @@ def run_compute_character_feature_windows(
                     # Track battles per character per window for co-presence
                     cutoff = (now_dt - wdelta) if wdelta else None
                     for p in parts:
-                        if cutoff is None or (p["started_at"] and p["started_at"] >= cutoff):
+                        if cutoff is None or (p["started_at"] and _ensure_utc(p["started_at"]) >= cutoff):
                             char_battles[cid][wlabel].add(str(p["battle_id"]))
 
             # Enrich co-presence counts


### PR DESCRIPTION
## Summary
This PR fixes timezone-related bugs in the character feature windows job by ensuring datetime comparisons are consistently performed against UTC-aware datetime objects.

## Key Changes
- Added `_ensure_utc()` helper function that converts naive datetime objects to UTC-aware datetimes, treating naive values as UTC
- Updated two datetime comparison operations in `_compute_window_features()` and `run_compute_character_feature_windows()` to use `_ensure_utc()` when comparing `started_at` timestamps against cutoff times

## Implementation Details
The `_ensure_utc()` function handles three cases:
- Returns `None` if the input is `None`
- Adds UTC timezone info to naive datetime objects via `replace(tzinfo=UTC)`
- Returns timezone-aware datetimes unchanged

This ensures that comparisons like `p["started_at"] >= cutoff` work correctly regardless of whether the participation's `started_at` timestamp is timezone-aware or naive, preventing potential comparison errors or incorrect filtering of participation records.

https://claude.ai/code/session_01VY1mUT3RxoiTpb8FQPr9sL