### PR TITLE
Ensure UTC timezone awareness for datetime objects

### DIFF
--- a/python/orchestrator/jobs/temporal_behavior_detection.py
+++ b/python/orchestrator/jobs/temporal_behavior_detection.py
@@ -27,7 +27,7 @@ import math
 import statistics
 import time
 from collections import defaultdict
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Any
 
 from ..db import SupplyCoreDb
@@ -226,6 +226,13 @@ def _detect_reactivation(
     }
 
 
+def _ensure_utc(dt: datetime) -> datetime:
+    """Ensure a datetime is UTC-aware; assume naive datetimes are already UTC."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
 # ---------------------------------------------------------------------------
 # Data fetch helpers
 # ---------------------------------------------------------------------------
@@ -283,12 +290,12 @@ def _fetch_killmail_timestamps(db: SupplyCoreDb) -> dict[int, list[datetime]]:
         cid = int(r["character_id"])
         ts = r["ts"]
         if isinstance(ts, datetime):
-            result[cid].append(ts)
+            result[cid].append(_ensure_utc(ts))
     for r in attacker_rows:
         cid = int(r["character_id"])
         ts = r["ts"]
         if isinstance(ts, datetime):
-            result[cid].append(ts)
+            result[cid].append(_ensure_utc(ts))
 
     # Sort per character
     for cid in result:
@@ -313,7 +320,7 @@ def _fetch_battle_timestamps(db: SupplyCoreDb) -> dict[int, list[datetime]]:
         cid = int(r["character_id"])
         ts = r["ts"]
         if isinstance(ts, datetime):
-            result[cid].append(ts)
+            result[cid].append(_ensure_utc(ts))
     for cid in result:
         result[cid].sort()
     return dict(result)


### PR DESCRIPTION
## Summary
This PR adds timezone awareness handling to datetime objects in the temporal behavior detection module to prevent timezone-related bugs and inconsistencies.

## Key Changes
- Added `timezone` import from the `datetime` module
- Introduced `_ensure_utc()` helper function that:
  - Converts naive datetimes to UTC-aware by assuming they are already in UTC
  - Passes through datetimes that already have timezone information
- Applied `_ensure_utc()` to all datetime objects fetched from the database in:
  - `_fetch_killmail_timestamps()` - for both victim and attacker rows
  - `_fetch_battle_timestamps()` - for battle timestamp rows

## Implementation Details
The `_ensure_utc()` function follows the principle that naive datetimes from the database should be treated as UTC rather than local time. This ensures consistent timezone handling throughout the temporal behavior detection logic and prevents potential issues when comparing or manipulating timestamps.

https://claude.ai/code/session_01PTxmXZmm9fx6Hd2DEaxEfX