### PR TITLE
Remove graph_derived_relationships feature flag

### DIFF
--- a/database/export-schema.sql
+++ b/database/export-schema.sql
@@ -1815,7 +1815,6 @@ INSERT INTO app_settings (setting_key, setting_value) VALUES
     ('market_order_snapshots_summary_read_mode', 'legacy'),
     ('market_order_snapshots_summary_write_mode', 'legacy'),
     ('killmail_ingestion_enabled', '0'),
-    ('graph_derived_relationships_enabled', '0'),
     ('killmail_r2z2_sequence_url', 'https://r2z2.zkillboard.com/ephemeral/sequence.json'),
     ('killmail_r2z2_base_url', 'https://r2z2.zkillboard.com/ephemeral'),
     ('killmail_ingestion_poll_sleep_seconds', '10'),

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -2946,7 +2946,6 @@ INSERT INTO app_settings (setting_key, setting_value) VALUES
     ('market_order_snapshots_summary_read_mode', 'legacy'),
     ('market_order_snapshots_summary_write_mode', 'legacy'),
     ('killmail_ingestion_enabled', '0'),
-    ('graph_derived_relationships_enabled', '0'),
     ('killmail_r2z2_sequence_url', 'https://r2z2.zkillboard.com/ephemeral/sequence.json'),
     ('killmail_r2z2_base_url', 'https://r2z2.zkillboard.com/ephemeral'),
     ('killmail_ingestion_poll_sleep_seconds', '10'),

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -403,7 +403,6 @@ $settingValues = get_settings([
     'alliance_history_pipeline_enabled',
     'hub_history_pipeline_enabled',
     'market_hub_local_history_pipeline_enabled',
-    'graph_derived_relationships_enabled',
     'alliance_current_backfill_start_date',
     'alliance_history_backfill_start_date',
     'hub_history_backfill_start_date',
@@ -2136,11 +2135,6 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             <span class="text-sm">Hub local history pipeline</span>
                         </label>
                     </div>
-                    <label class="flex items-center gap-3 rounded-lg border border-border bg-black/20 p-3">
-                        <input type="hidden" name="graph_derived_relationships_enabled" value="0">
-                        <input type="checkbox" name="graph_derived_relationships_enabled" value="1" <?= ($dataSyncSettingValues['graph_derived_relationships_enabled'] ?? '0') === '1' ? 'checked' : '' ?> class="size-4 rounded border-border bg-black">
-                        <span class="text-sm">Enable graph derived relationships</span>
-                    </label>
                     <button class="btn-primary" name="automation_action" value="save-flags">Save Runtime Toggles</button>
                 </section>
 
@@ -3074,7 +3068,6 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             ['key' => 'alliance_history_pipeline_enabled', 'label' => 'Alliance history/backfill pipeline'],
                             ['key' => 'hub_history_pipeline_enabled', 'label' => 'Market hub history pipeline'],
                             ['key' => 'market_hub_local_history_pipeline_enabled', 'label' => 'Hub snapshot-history refresh pipeline'],
-                            ['key' => 'graph_derived_relationships_enabled', 'label' => 'Graph derived relationships'],
                         ];
                         foreach ($pipelineFlags as $flag):
                             $flagEnabled = ($dataSyncSettingValues[$flag['key']] ?? '1') === '1';

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -583,8 +583,6 @@ def run_compute_graph_sync_battle_intelligence(db: SupplyCoreDb, neo4j_raw: dict
 def run_compute_graph_derived_relationships(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:
     started = time.perf_counter()
     job_name = "compute_graph_derived_relationships"
-    if db.fetch_app_setting("graph_derived_relationships_enabled", "0") != "1":
-        return _job_payload(job_name, started, "skipped", error_text="graph derived relationships disabled")
     config = Neo4jConfig.from_runtime(neo4j_raw or {})
     if not config.enabled:
         return _job_payload(job_name, started, "skipped", error_text="neo4j disabled")

--- a/src/functions.php
+++ b/src/functions.php
@@ -2808,7 +2808,6 @@ function data_sync_pipeline_setting_defaults(): array
         'alliance_history_pipeline_enabled' => '1',
         'hub_history_pipeline_enabled' => '1',
         'market_hub_local_history_pipeline_enabled' => '1',
-        'graph_derived_relationships_enabled' => '0',
         ...data_sync_market_history_retention_defaults(),
         'static_data_source_url' => 'https://developers.eveonline.com/static-data/eve-online-static-data-latest-jsonl.zip',
         'redis_cache_enabled' => config('redis.enabled', false) ? '1' : '0',
@@ -2842,7 +2841,6 @@ function data_sync_pipeline_setting_value(array $settings, string $key): string
         'alliance_history_pipeline_enabled',
         'hub_history_pipeline_enabled',
         'market_hub_local_history_pipeline_enabled',
-        'graph_derived_relationships_enabled',
         'redis_cache_enabled',
         'redis_locking_enabled' => sanitize_pipeline_enabled($value),
         'incremental_strategy' => sanitize_incremental_strategy((string) $value),
@@ -6927,7 +6925,6 @@ function automation_runtime_settings_from_request(array $request): array
         'alliance_history_pipeline_enabled' => sanitize_pipeline_enabled($request['alliance_history_pipeline_enabled'] ?? null),
         'hub_history_pipeline_enabled' => sanitize_pipeline_enabled($request['hub_history_pipeline_enabled'] ?? null),
         'market_hub_local_history_pipeline_enabled' => sanitize_pipeline_enabled($request['market_hub_local_history_pipeline_enabled'] ?? null),
-        'graph_derived_relationships_enabled' => sanitize_pipeline_enabled($request['graph_derived_relationships_enabled'] ?? null),
     ];
 }
 


### PR DESCRIPTION
## Summary
This PR removes the `graph_derived_relationships_enabled` feature flag and its associated UI controls, making the graph derived relationships computation always enabled.

## Key Changes
- **Settings UI**: Removed the checkbox toggle for "Enable graph derived relationships" from the runtime toggles section in the settings page
- **Settings Configuration**: Removed the feature flag from:
  - Default pipeline settings
  - Pipeline setting value validation
  - Runtime settings request parsing
- **Graph Pipeline**: Removed the conditional check that would skip the `run_compute_graph_derived_relationships` job when the flag was disabled
- **Database Schema**: Removed the `graph_derived_relationships_enabled` setting from both schema initialization files

## Implementation Details
The graph derived relationships computation will now run unconditionally whenever the Neo4j graph pipeline executes, without requiring an explicit feature flag to be enabled. This simplifies the codebase by removing a toggle that was likely always intended to be enabled in production environments.

https://claude.ai/code/session_01SvVjvafLLqQVX92gvg5BEy