### PR TITLE
Fix worker pool diagnostics reporting in main function

### DIFF
--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -435,7 +435,7 @@ def main(argv: list[str] | None = None) -> int:
             "seed_result": seed_result,
             "job": job,
             "memory_usage_bytes": memory_usage,
-            "worker_counts": worker_counts,
+            "worker_counts": diagnostics,
             "dag_scheduler": {
                 "dispatchable": dispatchable[:20] if dispatchable else [],
                 "blocked_count": len(plan.blocked_jobs) if plan else 0,


### PR DESCRIPTION
## Summary
Fixed incorrect variable reference in the worker pool diagnostics output. The `main()` function was reporting `worker_counts` instead of the actual `diagnostics` object in the telemetry data.

## Changes
- Updated the diagnostics dictionary to use the correct `diagnostics` variable instead of the undefined `worker_counts` variable
- This ensures that proper diagnostic information is captured and reported when the worker pool completes execution

## Details
The change corrects a bug where the telemetry output was attempting to reference a variable that wasn't available in that scope. The `diagnostics` variable contains the actual diagnostic data that should be reported alongside other metrics like seed results, job information, and memory usage.

https://claude.ai/code/session_01AfD1DXUs7kMeyGkJrAFYJU