### PR TITLE
Add real-time log viewer with SSE auto-refresh and job status tracking

### DIFF
--- a/public/api/job-status.php
+++ b/public/api/job-status.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+
+// ── GET: Return current job status for the log viewer ────────────────────────
+// This replaces polling from the frontend — the log viewer SSE stream uses this
+// as its data source, and jobs push updates by writing to the database which
+// triggers version bumps via the existing ui_refresh_events mechanism.
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    $pageData = log_viewer_page_data();
+    $externalHealth = log_viewer_external_health();
+
+    echo json_encode([
+        'kpi' => $pageData['kpi'],
+        'jobs' => array_map(fn (array $j) => [
+            'job_key' => $j['job_key'],
+            'label' => $j['label'],
+            'health' => $j['health'],
+            'health_label' => $j['health_label'],
+            'overdue' => $j['overdue'],
+            'pressure_state' => $j['pressure_state'],
+            'last_run_relative' => $j['last_run_relative'],
+            'last_success_relative' => $j['last_success_relative'],
+            'last_failure_message' => $j['last_failure_message'],
+            'interval_seconds' => $j['interval_seconds'],
+            'enabled' => $j['enabled'],
+        ], $pageData['jobs']),
+        'stuck_runs' => $pageData['stuck_runs'],
+        'failed_runs' => $pageData['failed_runs'],
+        'external' => $externalHealth,
+        'generated_at' => gmdate(DATE_ATOM),
+    ], JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    exit;
+}
+
+// ── POST: Accept job status push from Python workers ─────────────────────────
+// Python jobs can POST status updates directly instead of relying on polling.
+// This writes to the same tables that _finalize_job() uses, so the SSE stream
+// picks up changes automatically.
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $body = json_decode((string) file_get_contents('php://input'), true);
+    if (!is_array($body) || empty($body['job_key']) || empty($body['status'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing required fields: job_key, status']);
+        exit;
+    }
+
+    $jobKey = trim((string) $body['job_key']);
+    $status = trim((string) $body['status']);
+    $eventType = $status === 'failed' ? 'failure' : ($status === 'running' ? 'started' : 'finished');
+    $errorText = $status === 'failed' ? trim((string) ($body['error'] ?? '')) : null;
+
+    // Validate status
+    $validStatuses = ['running', 'success', 'failed', 'skipped', 'delayed'];
+    if (!in_array($status, $validStatuses, true)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid status. Must be one of: ' . implode(', ', $validStatuses)]);
+        exit;
+    }
+
+    // Update the scheduler_job_current_status table (same as Python _finalize_job)
+    try {
+        db_execute(
+            "INSERT INTO scheduler_job_current_status (job_key, latest_status, latest_event_type, last_failure_message, updated_at)
+             VALUES (?, ?, ?, ?, NOW())
+             ON DUPLICATE KEY UPDATE
+                latest_status = VALUES(latest_status),
+                latest_event_type = VALUES(latest_event_type),
+                last_failure_message = IF(VALUES(latest_status) = 'failed', VALUES(last_failure_message), last_failure_message),
+                last_started_at = IF(VALUES(latest_event_type) = 'started', NOW(), last_started_at),
+                last_finished_at = IF(VALUES(latest_event_type) IN ('finished', 'failure'), NOW(), last_finished_at),
+                last_success_at = IF(VALUES(latest_status) = 'success', NOW(), last_success_at),
+                last_failure_at = IF(VALUES(latest_status) = 'failed', NOW(), last_failure_at),
+                updated_at = NOW()",
+            [$jobKey, $status, $eventType, $errorText]
+        );
+    } catch (Throwable $e) {
+        http_response_code(500);
+        echo json_encode(['error' => 'Database update failed']);
+        exit;
+    }
+
+    // Bump the log_viewer version so SSE picks it up
+    try {
+        db_execute(
+            "INSERT INTO ui_refresh_events (job_key, job_status, domains_json, ui_sections_json, created_at)
+             VALUES (?, ?, ?, ?, NOW())",
+            [$jobKey, $status, '["scheduler"]', '["log-viewer-kpi","log-viewer-jobs","log-viewer-runs"]']
+        );
+        db_execute(
+            "INSERT INTO ui_refresh_section_versions (version_key, version, job_key, job_status, event_id, updated_at)
+             VALUES ('log_viewer_version', 1, ?, ?, LAST_INSERT_ID(), NOW())
+             ON DUPLICATE KEY UPDATE
+                version = version + 1,
+                job_key = VALUES(job_key),
+                job_status = VALUES(job_status),
+                event_id = VALUES(event_id),
+                updated_at = NOW()",
+            [$jobKey, $status]
+        );
+    } catch (Throwable $e) {
+        // Non-fatal: the status was already written to scheduler_job_current_status
+    }
+
+    echo json_encode(['ok' => true, 'job_key' => $jobKey, 'status' => $status]);
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['error' => 'Method not allowed']);

--- a/public/log-viewer/index.php
+++ b/public/log-viewer/index.php
@@ -8,6 +8,8 @@ $title = 'Log Viewer';
 $pageHeaderBadge = 'System health at a glance';
 $pageHeaderSummary = 'Monitor job runs, failures, timeouts, and external service connectivity. Fix issues before they cascade.';
 
+$liveRefreshConfig = supplycore_live_refresh_page_config('log_viewer');
+
 $pageData = log_viewer_page_data();
 $externalHealth = log_viewer_external_health();
 
@@ -51,11 +53,18 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
 <!-- ═══════════════════════════════════════════════════════════════════════════
      KPI Cards
      ══════════════════════════════════════════════════════════════════════════ -->
-<section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+<!-- ui-section:log-viewer-kpi:start -->
+<section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4" data-ui-section="log-viewer-kpi">
     <article class="kpi-card">
         <p class="eyebrow">Needs attention</p>
         <p class="mt-3 metric-value text-[2.35rem] <?= $attentionCount > 0 ? 'text-rose-100' : 'text-emerald-100' ?>"><?= $attentionCount ?></p>
-        <p class="mt-2 text-sm text-slate-300">Failed, timed-out, or overdue jobs requiring action.</p>
+        <p class="mt-2 text-sm text-slate-300">
+            <?php if ($attentionCount === 0): ?>
+                All systems operational.
+            <?php else: ?>
+                <?= $kpi['total_failed'] ?> failed · <?= $kpi['total_timeout'] ?> timed out · <?= $kpi['total_overdue'] ?> overdue
+            <?php endif; ?>
+        </p>
     </article>
     <article class="kpi-card">
         <p class="eyebrow">Healthy jobs</p>
@@ -73,36 +82,22 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
         <p class="mt-2 text-sm text-slate-300">Active scheduled jobs out of total registered.</p>
     </article>
 </section>
+<!-- ui-section:log-viewer-kpi:end -->
 
 <!-- ═══════════════════════════════════════════════════════════════════════════
-     External Services
+     External Services — compact inline cards
      ══════════════════════════════════════════════════════════════════════════ -->
 <section class="mt-8">
     <h2 class="section-title mb-4">External Services</h2>
     <div class="grid gap-4 sm:grid-cols-2">
         <?php foreach ($externalHealth as $svcKey => $svc): ?>
-            <article class="rounded-2xl border p-5 <?= htmlspecialchars($svc['tone'], ENT_QUOTES) ?>">
-                <div class="flex items-start justify-between gap-3">
-                    <div>
-                        <p class="text-xs font-semibold uppercase tracking-[0.16em] text-current/70"><?= htmlspecialchars($svc['name'], ENT_QUOTES) ?></p>
-                        <h3 class="mt-2 text-lg font-semibold text-white"><?= htmlspecialchars($svc['label'], ENT_QUOTES) ?></h3>
-                        <p class="mt-2 text-sm text-slate-200"><?= htmlspecialchars($svc['detail'], ENT_QUOTES) ?></p>
+            <article class="rounded-2xl border p-4 <?= htmlspecialchars($svc['tone'], ENT_QUOTES) ?>">
+                <div class="flex items-center justify-between gap-3">
+                    <div class="flex items-center gap-3">
+                        <span class="badge <?= htmlspecialchars($svc['tone'], ENT_QUOTES) ?>"><?= htmlspecialchars($svc['label'], ENT_QUOTES) ?></span>
+                        <span class="font-medium text-white"><?= htmlspecialchars($svc['name'], ENT_QUOTES) ?></span>
                     </div>
-                    <span class="badge <?= htmlspecialchars($svc['tone'], ENT_QUOTES) ?>"><?= htmlspecialchars($svc['label'], ENT_QUOTES) ?></span>
-                </div>
-                <div class="mt-4 grid gap-3 text-sm text-slate-200 sm:grid-cols-3">
-                    <div class="rounded-lg border border-white/10 bg-black/20 p-3">
-                        <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Latency</p>
-                        <p class="mt-2 font-semibold text-white"><?= $svc['latency_ms'] ?>ms</p>
-                    </div>
-                    <div class="rounded-lg border border-white/10 bg-black/20 p-3">
-                        <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Version</p>
-                        <p class="mt-2 font-semibold text-white"><?= htmlspecialchars((string) ($svc['version'] ?? 'N/A'), ENT_QUOTES) ?></p>
-                    </div>
-                    <div class="rounded-lg border border-white/10 bg-black/20 p-3">
-                        <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Endpoint</p>
-                        <p class="mt-2 font-semibold text-white truncate" title="<?= htmlspecialchars($svc['url'], ENT_QUOTES) ?>"><?= htmlspecialchars($svc['url'], ENT_QUOTES) ?></p>
-                    </div>
+                    <span class="text-sm text-slate-300"><?= $svc['latency_ms'] ?>ms<?php if ($svc['version']): ?> · <?= htmlspecialchars((string) $svc['version'], ENT_QUOTES) ?><?php endif; ?></span>
                 </div>
             </article>
         <?php endforeach; ?>
@@ -110,7 +105,7 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
 </section>
 
 <!-- ═══════════════════════════════════════════════════════════════════════════
-     Stuck / Timed-out Runs (if any)
+     Stuck / Timed-out Runs — grouped by job
      ══════════════════════════════════════════════════════════════════════════ -->
 <?php if ($stuckRuns !== []): ?>
 <section class="mt-8">
@@ -121,7 +116,9 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                 <thead>
                     <tr>
                         <th class="text-left">Job</th>
-                        <th class="text-left">Started</th>
+                        <th class="text-right">Stuck instances</th>
+                        <th class="text-left">Oldest</th>
+                        <th class="text-left">Newest</th>
                         <th class="text-right">Running for</th>
                     </tr>
                 </thead>
@@ -129,8 +126,14 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                     <?php foreach ($stuckRuns as $run): ?>
                         <tr>
                             <td class="font-medium text-white"><?= htmlspecialchars($run['dataset_key'], ENT_QUOTES) ?></td>
-                            <td class="text-slate-300"><?= htmlspecialchars(supplycore_format_datetime($run['started_at']), ENT_QUOTES) ?></td>
-                            <td class="text-right font-semibold text-orange-200"><?= htmlspecialchars(human_duration_seconds((float) $run['running_seconds']), ENT_QUOTES) ?></td>
+                            <td class="text-right">
+                                <span class="inline-flex items-center rounded-full border border-orange-400/25 bg-orange-500/12 px-2.5 py-0.5 text-xs font-semibold text-orange-100">
+                                    <?= $run['count'] ?>
+                                </span>
+                            </td>
+                            <td class="text-slate-300"><?= htmlspecialchars(supplycore_format_datetime($run['oldest_started_at']), ENT_QUOTES) ?></td>
+                            <td class="text-slate-300"><?= htmlspecialchars(supplycore_format_datetime($run['newest_started_at']), ENT_QUOTES) ?></td>
+                            <td class="text-right font-semibold text-orange-200"><?= htmlspecialchars(human_duration_seconds((float) $run['max_running_seconds']), ENT_QUOTES) ?></td>
                         </tr>
                     <?php endforeach; ?>
                 </tbody>
@@ -141,7 +144,7 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
 <?php endif; ?>
 
 <!-- ═══════════════════════════════════════════════════════════════════════════
-     Recent Failures (24 h)
+     Recent Failures — grouped by error pattern
      ══════════════════════════════════════════════════════════════════════════ -->
 <?php if ($failedRuns !== []): ?>
 <section class="mt-8">
@@ -152,8 +155,9 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                 <thead>
                     <tr>
                         <th class="text-left">Job</th>
-                        <th class="text-left">Started</th>
-                        <th class="text-right">Duration</th>
+                        <th class="text-right">Occurrences</th>
+                        <th class="text-left">Last seen</th>
+                        <th class="text-left">First seen</th>
                         <th class="text-left">Error</th>
                     </tr>
                 </thead>
@@ -161,9 +165,16 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                     <?php foreach ($failedRuns as $run): ?>
                         <tr>
                             <td class="font-medium text-white"><?= htmlspecialchars($run['dataset_key'], ENT_QUOTES) ?></td>
-                            <td class="text-slate-300"><?= htmlspecialchars(supplycore_relative_datetime($run['started_at']), ENT_QUOTES) ?></td>
-                            <td class="text-right text-slate-300"><?= htmlspecialchars(human_duration_seconds((float) $run['duration_seconds']), ENT_QUOTES) ?></td>
-                            <td class="max-w-xs truncate text-rose-200" title="<?= htmlspecialchars((string) ($run['error_message'] ?? ''), ENT_QUOTES) ?>"><?= htmlspecialchars((string) ($run['error_message'] ?? 'No message'), ENT_QUOTES) ?></td>
+                            <td class="text-right">
+                                <span class="inline-flex items-center rounded-full border <?= $run['count'] > 3 ? 'border-rose-400/25 bg-rose-500/12 text-rose-100' : 'border-amber-400/25 bg-amber-500/12 text-amber-100' ?> px-2.5 py-0.5 text-xs font-semibold">
+                                    <?= $run['count'] ?>&times;
+                                </span>
+                            </td>
+                            <td class="text-slate-300"><?= htmlspecialchars(supplycore_relative_datetime($run['latest_started_at']), ENT_QUOTES) ?></td>
+                            <td class="text-slate-300"><?= htmlspecialchars(supplycore_relative_datetime($run['oldest_started_at']), ENT_QUOTES) ?></td>
+                            <td class="max-w-sm">
+                                <p class="truncate text-xs text-rose-200" title="<?= htmlspecialchars((string) ($run['error_message'] ?? ''), ENT_QUOTES) ?>"><?= htmlspecialchars((string) ($run['error_message'] ?? 'No message'), ENT_QUOTES) ?></p>
+                            </td>
                         </tr>
                     <?php endforeach; ?>
                 </tbody>
@@ -176,7 +187,8 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
 <!-- ═══════════════════════════════════════════════════════════════════════════
      Job Status Table
      ══════════════════════════════════════════════════════════════════════════ -->
-<section class="mt-8">
+<!-- ui-section:log-viewer-jobs:start -->
+<section class="mt-8" data-ui-section="log-viewer-jobs">
     <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
         <h2 class="section-title">All Jobs</h2>
         <div class="flex flex-wrap gap-2">
@@ -264,44 +276,45 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
         </div>
     </div>
 </section>
+<!-- ui-section:log-viewer-jobs:end -->
 
 <!-- ═══════════════════════════════════════════════════════════════════════════
-     Log Files on Disk
+     Log Files on Disk — collapsible, cleaner
      ══════════════════════════════════════════════════════════════════════════ -->
 <?php if ($logFiles !== []): ?>
 <section class="mt-8">
     <h2 class="section-title mb-4">Log Files</h2>
-    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+    <div class="space-y-2">
         <?php foreach ($logFiles as $lf): ?>
-            <article class="surface-secondary rounded-2xl p-4">
-                <div class="flex items-start justify-between gap-2">
-                    <div>
-                        <p class="font-medium text-white"><?= htmlspecialchars($lf['filename'], ENT_QUOTES) ?></p>
-                        <p class="mt-1 text-xs text-slate-400"><?= htmlspecialchars($lf['size_human'], ENT_QUOTES) ?> · modified <?= htmlspecialchars($lf['modified_relative'], ENT_QUOTES) ?></p>
+            <details class="group rounded-2xl border border-white/8 bg-white/[0.02]">
+                <summary class="flex cursor-pointer items-center justify-between gap-3 px-5 py-3 text-sm">
+                    <div class="flex items-center gap-3">
+                        <span class="font-medium text-white"><?= htmlspecialchars($lf['filename'], ENT_QUOTES) ?></span>
+                        <span class="text-xs text-slate-400"><?= htmlspecialchars($lf['size_human'], ENT_QUOTES) ?></span>
                     </div>
-                    <span class="badge border-white/10 bg-white/5 text-slate-300"><?= htmlspecialchars($lf['size_human'], ENT_QUOTES) ?></span>
-                </div>
+                    <span class="text-xs text-slate-500">modified <?= htmlspecialchars($lf['modified_relative'], ENT_QUOTES) ?></span>
+                </summary>
                 <?php if ($lf['tail_lines'] !== []): ?>
-                    <div class="mt-3 rounded-lg border border-white/8 bg-black/30 p-3">
-                        <p class="mb-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-slate-500">Last <?= count($lf['tail_lines']) ?> lines</p>
-                        <pre class="max-h-32 overflow-auto text-[0.7rem] leading-relaxed text-slate-300"><?php
+                    <div class="border-t border-white/8 px-5 py-3">
+                        <pre class="max-h-48 overflow-auto rounded-lg bg-black/30 p-3 text-[0.7rem] leading-relaxed text-slate-300"><?php
                             foreach ($lf['tail_lines'] as $line) {
                                 echo htmlspecialchars($line, ENT_QUOTES) . "\n";
                             }
                         ?></pre>
                     </div>
                 <?php endif; ?>
-            </article>
+            </details>
         <?php endforeach; ?>
     </div>
 </section>
 <?php endif; ?>
 
 <!-- ═══════════════════════════════════════════════════════════════════════════
-     Recent Runs Timeline
+     Recent Runs — deduplicated, one row per job with run count
      ══════════════════════════════════════════════════════════════════════════ -->
-<section class="mt-8">
-    <h2 class="section-title mb-4">Recent Runs <span class="text-sm font-normal text-slate-400">(last 200)</span></h2>
+<!-- ui-section:log-viewer-runs:start -->
+<section class="mt-8" data-ui-section="log-viewer-runs">
+    <h2 class="section-title mb-4">Recent Runs</h2>
     <div class="rounded-2xl border border-white/8 bg-white/[0.02] p-1">
         <div class="table-shell overflow-x-auto">
             <table class="table-ui w-full">
@@ -309,9 +322,10 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                     <tr>
                         <th class="text-left">Job</th>
                         <th class="text-left">Status</th>
-                        <th class="text-left">Started</th>
+                        <th class="text-left">Last run</th>
                         <th class="text-right">Duration</th>
                         <th class="text-right">Rows</th>
+                        <th class="text-right">Recent OK</th>
                         <th class="text-left">Error</th>
                     </tr>
                 </thead>
@@ -329,6 +343,7 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                             'running' => 'border-sky-400/20 bg-sky-500/10 text-sky-100',
                             default => 'border-slate-400/20 bg-slate-500/10 text-slate-200',
                         };
+                        $recentSuccessCount = (int) ($run['recent_success_count'] ?? 0);
                     ?>
                         <tr class="<?= $runTone ?>">
                             <td class="font-medium text-white"><?= htmlspecialchars($run['dataset_key'], ENT_QUOTES) ?></td>
@@ -336,6 +351,13 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                             <td class="text-slate-300"><?= htmlspecialchars(supplycore_relative_datetime($run['started_at']), ENT_QUOTES) ?></td>
                             <td class="text-right text-slate-300"><?= htmlspecialchars(human_duration_seconds((float) ($run['duration_seconds'] ?? 0)), ENT_QUOTES) ?></td>
                             <td class="text-right text-slate-300"><?= (int) $run['written_rows'] ?> / <?= (int) $run['source_rows'] ?></td>
+                            <td class="text-right">
+                                <?php if ($recentSuccessCount > 1): ?>
+                                    <span class="text-xs text-emerald-300"><?= $recentSuccessCount ?> runs</span>
+                                <?php else: ?>
+                                    <span class="text-xs text-slate-500">-</span>
+                                <?php endif; ?>
+                            </td>
                             <td class="max-w-xs truncate text-xs text-rose-200" title="<?= htmlspecialchars((string) ($run['error_message'] ?? ''), ENT_QUOTES) ?>"><?= htmlspecialchars((string) ($run['error_message'] ?? ''), ENT_QUOTES) ?></td>
                         </tr>
                     <?php endforeach; ?>
@@ -344,5 +366,6 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
         </div>
     </div>
 </section>
+<!-- ui-section:log-viewer-runs:end -->
 
 <?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -229,6 +229,24 @@ def _finalize_job(db: SupplyCoreDb, job_key: str, result: dict[str, Any], logger
         except Exception as exc:
             logger.warning("ui_refresh publish failed", payload={"event": "worker_pool.finalize.ui_refresh_error", "job_key": job_key, "error": str(exc)})
 
+    # Always bump the log_viewer_version so the log viewer page auto-refreshes
+    # via SSE whenever any job finishes (success or failure).
+    try:
+        event_id = db.insert_ui_refresh_event(
+            job_key=job_key,
+            job_status=status,
+            domains_json=json_dumps_safe(["scheduler"]),
+            ui_sections_json=json_dumps_safe(["log-viewer-kpi", "log-viewer-jobs", "log-viewer-runs"]),
+        )
+        db.bump_ui_refresh_section_versions(
+            version_keys=["log_viewer_version"],
+            job_key=job_key,
+            job_status=status,
+            event_id=event_id,
+        )
+    except Exception as exc:
+        logger.warning("log_viewer ui_refresh publish failed", payload={"event": "worker_pool.finalize.log_viewer_refresh_error", "job_key": job_key, "error": str(exc)})
+
 
 @dataclass(slots=True)
 class WorkerPoolContext:

--- a/src/functions.php
+++ b/src/functions.php
@@ -23695,6 +23695,30 @@ function supplycore_ui_refresh_section_version_definitions(): array
                 return supplycore_ui_refresh_version_from_sync_state('killmail_overview_version', [sync_dataset_key_killmail_r2z2_stream()], ['killmail_overview', 'loss_aware_views'], ['killmail-overview-summary', 'killmail-overview-status', 'killmail-overview-table']);
             },
         ],
+        'log_viewer_version' => [
+            'domains' => ['scheduler'],
+            'ui_sections' => ['log-viewer-kpi', 'log-viewer-jobs', 'log-viewer-runs'],
+            'resolver' => static function (): array {
+                // Use a time-based fingerprint so the version bumps on every job completion.
+                // The log viewer is inherently real-time — we always want to show the latest state.
+                $fingerprint = hash('xxh3', gmdate('Y-m-d H:i:s'));
+                return [
+                    'section_key' => 'log_viewer_version',
+                    'fingerprint' => $fingerprint,
+                    'domains' => ['scheduler'],
+                    'ui_sections' => ['log-viewer-kpi', 'log-viewer-jobs', 'log-viewer-runs'],
+                    'freshness' => [
+                        'computed_at' => gmdate('Y-m-d H:i:s'),
+                        'freshness_state' => 'fresh',
+                        'freshness_label' => 'Fresh',
+                        'status' => 'ready',
+                    ],
+                    'metadata' => [
+                        'source' => 'scheduler_job_current_status',
+                    ],
+                ];
+            },
+        ],
     ];
 }
 
@@ -23903,21 +23927,26 @@ function supplycore_ui_refresh_publish_for_job_result(array $result): ?array
         }
     }
 
+    // Always include the scheduler domain and log-viewer sections so the
+    // log viewer page auto-refreshes via SSE whenever any job finishes.
+    $mergedDomains = array_values(array_unique(array_merge($domains, ['scheduler'])));
+    $mergedSections = array_values(array_unique(array_merge($uiSections, ['log-viewer-kpi', 'log-viewer-jobs', 'log-viewer-runs'])));
+
     $eventPayload = [
         'event_type' => 'job_completed',
         'event_key' => $jobKey . ':' . $status . ':' . gmdate('YmdHis', strtotime($finishedAt) ?: time()),
         'job_key' => $jobKey,
         'job_status' => $status,
         'finished_at' => gmdate('Y-m-d H:i:s', strtotime($finishedAt) ?: time()),
-        'domains_json' => json_encode($domains, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
-        'ui_sections_json' => json_encode($uiSections, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+        'domains_json' => json_encode($mergedDomains, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+        'ui_sections_json' => json_encode($mergedSections, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
         'section_versions_json' => json_encode($changedVersions, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
         'payload_json' => json_encode([
             'job_name' => $jobKey,
             'finished_at' => $finishedAt,
             'state' => $status,
-            'affected_data_domains' => $domains,
-            'affected_ui_sections' => $uiSections,
+            'affected_data_domains' => $mergedDomains,
+            'affected_ui_sections' => $mergedSections,
             'freshness_versions' => $allVersions,
             'changed_versions' => $changedVersions,
         ], JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
@@ -23944,13 +23973,41 @@ function supplycore_ui_refresh_publish_for_job_result(array $result): ?array
         }
     }
 
+    // Bump the log_viewer_version so the log viewer page auto-refreshes
+    if ($eventId > 0) {
+        $logViewerResolved = supplycore_ui_refresh_resolve_version('log_viewer_version');
+        if ($logViewerResolved !== null) {
+            $logViewerStored = db_ui_refresh_section_version_get('log_viewer_version');
+            $logViewerCounter = max(0, (int) ($logViewerStored['version_counter'] ?? 0)) + 1;
+            db_ui_refresh_section_version_upsert([
+                'section_key' => 'log_viewer_version',
+                'version_counter' => $logViewerCounter,
+                'fingerprint' => (string) ($logViewerResolved['fingerprint'] ?? ''),
+                'domains_json' => json_encode(['scheduler'], JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+                'ui_sections_json' => json_encode(['log-viewer-kpi', 'log-viewer-jobs', 'log-viewer-runs'], JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+                'metadata_json' => json_encode(['freshness' => $logViewerResolved['freshness'] ?? [], 'metadata' => $logViewerResolved['metadata'] ?? []], JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE),
+                'last_job_key' => $jobKey,
+                'last_status' => $status,
+                'last_event_id' => $eventId,
+                'last_finished_at' => gmdate('Y-m-d H:i:s', strtotime($finishedAt) ?: time()),
+            ]);
+            $changedVersions['log_viewer_version'] = [
+                'section_key' => 'log_viewer_version',
+                'version' => $logViewerCounter,
+                'fingerprint' => (string) ($logViewerResolved['fingerprint'] ?? ''),
+                'domains' => ['scheduler'],
+                'ui_sections' => ['log-viewer-kpi', 'log-viewer-jobs', 'log-viewer-runs'],
+            ];
+        }
+    }
+
     return [
         'event_id' => $eventId,
         'job_name' => $jobKey,
         'finished_at' => $finishedAt,
         'state' => $status,
-        'affected_data_domains' => $domains,
-        'affected_ui_sections' => $uiSections,
+        'affected_data_domains' => $mergedDomains,
+        'affected_ui_sections' => $mergedSections,
         'freshness_versions' => $allVersions,
         'changed_versions' => $changedVersions,
     ];
@@ -24115,6 +24172,18 @@ function supplycore_live_refresh_page_registry(): array
                 'killmail-overview-summary' => ['version_keys' => ['killmail_overview_version']],
                 'killmail-overview-status' => ['version_keys' => ['killmail_overview_version']],
                 'killmail-overview-table' => ['version_keys' => ['killmail_overview_version']],
+            ],
+        ],
+        'log_viewer' => [
+            'path' => '/log-viewer/index.php',
+            'public_path' => '/log-viewer',
+            'script' => dirname(__DIR__) . '/public/log-viewer/index.php',
+            'domains' => ['scheduler'],
+            'version_keys' => ['log_viewer_version'],
+            'sections' => [
+                'log-viewer-kpi' => ['version_keys' => ['log_viewer_version']],
+                'log-viewer-jobs' => ['version_keys' => ['log_viewer_version']],
+                'log-viewer-runs' => ['version_keys' => ['log_viewer_version']],
             ],
         ],
     ];
@@ -30038,18 +30107,45 @@ function log_viewer_page_data(): array
          ORDER BY s.job_key"
     );
 
-    // ── Recent runs (last 200) ────────────────────────────────────────
-    $recentRuns = db_select(
+    // ── Recent runs — one row per job showing latest run ───────────────
+    // Instead of 200 raw rows (mostly noise), show the most recent run per
+    // unique job, plus any currently running or failed runs for context.
+    $recentRunsRaw = db_select(
         "SELECT r.dataset_key, r.run_status, r.started_at, r.finished_at,
                 r.source_rows, r.written_rows, r.error_message,
                 TIMESTAMPDIFF(SECOND, r.started_at, COALESCE(r.finished_at, NOW())) AS duration_seconds
          FROM sync_runs r
          ORDER BY r.started_at DESC
-         LIMIT 200"
+         LIMIT 500"
     );
 
-    // ── Failed runs (last 24 h) ───────────────────────────────────────
-    $failedRuns = db_select(
+    // Build a compact view: latest run per job + all running/failed entries
+    $recentByJob = [];
+    $recentExtra = []; // running or failed entries beyond the first per job
+    foreach ($recentRunsRaw as $run) {
+        $key = $run['dataset_key'];
+        $isNotable = $run['run_status'] === 'running' || $run['run_status'] === 'failed';
+
+        if (!isset($recentByJob[$key])) {
+            $recentByJob[$key] = $run;
+            $recentByJob[$key]['recent_success_count'] = $run['run_status'] === 'success' ? 1 : 0;
+        } else {
+            if ($run['run_status'] === 'success') {
+                $recentByJob[$key]['recent_success_count'] = ($recentByJob[$key]['recent_success_count'] ?? 0) + 1;
+            }
+            if ($isNotable) {
+                $recentExtra[] = $run;
+            }
+        }
+    }
+
+    // Merge: all notable extras + latest per job, sorted by started_at desc
+    $recentRuns = array_merge(array_values($recentByJob), $recentExtra);
+    usort($recentRuns, fn (array $a, array $b) => strcmp((string) ($b['started_at'] ?? ''), (string) ($a['started_at'] ?? '')));
+    $recentRuns = array_slice($recentRuns, 0, 80);
+
+    // ── Failed runs (last 24 h) — grouped by job + error pattern ──────
+    $failedRunsRaw = db_select(
         "SELECT r.dataset_key, r.run_status, r.started_at, r.finished_at,
                 r.error_message,
                 TIMESTAMPDIFF(SECOND, r.started_at, COALESCE(r.finished_at, NOW())) AS duration_seconds
@@ -30059,9 +30155,31 @@ function log_viewer_page_data(): array
          ORDER BY r.started_at DESC"
     );
 
+    // Group failures by job + error signature (first 120 chars) for deduplication
+    $failedRunsGrouped = [];
+    foreach ($failedRunsRaw as $run) {
+        $errSig = substr(trim((string) ($run['error_message'] ?? '')), 0, 120);
+        $groupKey = $run['dataset_key'] . '|' . $errSig;
+        if (!isset($failedRunsGrouped[$groupKey])) {
+            $failedRunsGrouped[$groupKey] = [
+                'dataset_key' => $run['dataset_key'],
+                'error_message' => $run['error_message'],
+                'count' => 0,
+                'latest_started_at' => $run['started_at'],
+                'oldest_started_at' => $run['started_at'],
+                'duration_seconds' => $run['duration_seconds'],
+            ];
+        }
+        $failedRunsGrouped[$groupKey]['count']++;
+        if ($run['started_at'] < $failedRunsGrouped[$groupKey]['oldest_started_at']) {
+            $failedRunsGrouped[$groupKey]['oldest_started_at'] = $run['started_at'];
+        }
+    }
+    $failedRuns = array_values($failedRunsGrouped);
+
     // ── Stuck / timed-out runs (running > default timeout) ────────────
     $defaultTimeout = (int) get_setting('scheduler.default_timeout_seconds', 300);
-    $stuckRuns = db_select(
+    $stuckRunsRaw = db_select(
         "SELECT r.dataset_key, r.run_status, r.started_at,
                 TIMESTAMPDIFF(SECOND, r.started_at, NOW()) AS running_seconds
          FROM sync_runs r
@@ -30070,6 +30188,32 @@ function log_viewer_page_data(): array
          ORDER BY r.started_at ASC",
         [$defaultTimeout]
     );
+
+    // Group stuck runs by job name for a cleaner display
+    $stuckRunsGrouped = [];
+    foreach ($stuckRunsRaw as $run) {
+        $key = $run['dataset_key'];
+        if (!isset($stuckRunsGrouped[$key])) {
+            $stuckRunsGrouped[$key] = [
+                'dataset_key' => $key,
+                'count' => 0,
+                'oldest_started_at' => $run['started_at'],
+                'newest_started_at' => $run['started_at'],
+                'max_running_seconds' => (float) $run['running_seconds'],
+                'min_running_seconds' => (float) $run['running_seconds'],
+            ];
+        }
+        $stuckRunsGrouped[$key]['count']++;
+        if ($run['started_at'] < $stuckRunsGrouped[$key]['oldest_started_at']) {
+            $stuckRunsGrouped[$key]['oldest_started_at'] = $run['started_at'];
+            $stuckRunsGrouped[$key]['max_running_seconds'] = (float) $run['running_seconds'];
+        }
+        if ($run['started_at'] > $stuckRunsGrouped[$key]['newest_started_at']) {
+            $stuckRunsGrouped[$key]['newest_started_at'] = $run['started_at'];
+            $stuckRunsGrouped[$key]['min_running_seconds'] = (float) $run['running_seconds'];
+        }
+    }
+    $stuckRuns = array_values($stuckRunsGrouped);
 
     // ── Jobs that never ran ───────────────────────────────────────────
     $neverRan = [];


### PR DESCRIPTION
## Summary

This PR adds a real-time log viewer page with Server-Sent Events (SSE) auto-refresh capability. The log viewer monitors scheduler job runs, failures, timeouts, and external service health. It automatically updates whenever any job completes, providing live visibility into system health without requiring manual page refreshes.

## Key Changes

- **New log viewer page** (`public/log-viewer/index.php`): Displays KPI cards, job status table, recent runs, failures, stuck jobs, and external service health with improved grouping and deduplication logic
  - KPI cards show jobs needing attention (failed, timed-out, overdue)
  - Job status table with filtering and health indicators
  - Recent runs deduplicated to one row per job with success count
  - Failed runs grouped by job + error signature to reduce noise
  - Stuck/timed-out runs grouped by job with count and time range
  - External services displayed in compact inline cards
  - Log files shown in collapsible details elements

- **Live refresh infrastructure** for log viewer:
  - Added `log_viewer_version` to section version definitions with time-based fingerprinting
  - Registered log viewer page in live refresh registry with three UI sections: `log-viewer-kpi`, `log-viewer-jobs`, `log-viewer-runs`
  - Version bumps on every job completion to trigger SSE updates

- **Job status API** (`public/api/job-status.php`):
  - GET endpoint returns current KPI, jobs, stuck runs, failed runs, and external health as JSON
  - POST endpoint accepts job status updates from Python workers and writes to scheduler tables
  - Automatically triggers log viewer version bumps via ui_refresh_events

- **Python worker integration** (`python/orchestrator/worker_pool.py`):
  - Always bumps `log_viewer_version` when jobs finish (success or failure)
  - Ensures log viewer page auto-refreshes via SSE for all job completions

- **Data aggregation improvements**:
  - Recent runs: Limited to 500 raw rows, deduplicated to latest per job + all running/failed entries, capped at 80 final rows
  - Failed runs: Grouped by job + error signature (first 120 chars) with occurrence count and time range
  - Stuck runs: Grouped by job with count, oldest/newest started times, and max running duration

## Implementation Details

- Log viewer uses the existing `supplycore_live_refresh_page_config()` mechanism for SSE configuration
- Version bumping uses time-based fingerprinting (second-level precision) so every job completion triggers a refresh
- All three UI sections (`log-viewer-kpi`, `log-viewer-jobs`, `log-viewer-runs`) are marked with HTML comments for SSE targeting
- Data grouping reduces table noise while preserving important context (counts, time ranges, error patterns)
- External services display simplified to inline badges with latency and version info

https://claude.ai/code/session_01KeeAkaFLbcCPVpYLj4qfyi