### PR TITLE
Add threat corridor graph SVG maps and surrounding-hops filter

### DIFF
--- a/public/threat-corridors/index.php
+++ b/public/threat-corridors/index.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/../../src/bootstrap.php';
 $title = 'Battle Intelligence — Threat Corridors';
 
 $regionId = isset($_GET['region_id']) ? (int) $_GET['region_id'] : 0;
+$surroundingHops = isset($_GET['surrounding_hops']) ? (int) $_GET['surrounding_hops'] : 1;
+$surroundingHops = max(0, min(3, $surroundingHops));
 $page = max(1, (int) ($_GET['page'] ?? 1));
 $perPage = 30;
 $offset = ($page - 1) * $perPage;
@@ -45,6 +47,14 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <?php endforeach; ?>
             </select>
         </div>
+        <div>
+            <label class="text-xs text-muted block mb-1">Surrounding Jumps</label>
+            <select name="surrounding_hops" class="w-44 rounded bg-slate-800 border border-border px-2 py-1.5 text-sm text-slate-100">
+                <?php for ($i = 0; $i <= 3; $i++): ?>
+                    <option value="<?= $i ?>" <?= $surroundingHops === $i ? 'selected' : '' ?>><?= $i ?> jumps</option>
+                <?php endfor; ?>
+            </select>
+        </div>
         <button type="submit" class="btn-secondary h-fit">Filter</button>
         <?php if ($regionId > 0): ?>
             <a href="/threat-corridors" class="text-sm text-accent">Clear</a>
@@ -63,6 +73,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     $scorePct = $score > 0 ? min(100, $score * 10) : 0;
                     $length = (int) ($c['corridor_length'] ?? 0);
                     $systemNames = $c['system_names'] ?? [];
+                    $corridorId = (int) ($c['corridor_id'] ?? 0);
+                    $mapPath = supplycore_threat_corridor_graph_svg($corridorId, (array) ($c['system_ids'] ?? []), $surroundingHops);
                     $routeLabel = $systemNames !== [] ? implode(' → ', array_map(fn($n) => htmlspecialchars((string) $n, ENT_QUOTES), $systemNames)) : ($length . ' systems');
                     $regionName = htmlspecialchars((string) ($c['region_name'] ?? ''), ENT_QUOTES);
 
@@ -130,6 +142,19 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             <?php endif; ?>
                         </div>
                     <?php endif; ?>
+
+                    <?php if (is_string($mapPath) && $mapPath !== ''): ?>
+                        <div class="mt-3 rounded border border-border/60 bg-slate-950/60 p-2">
+                            <div class="flex items-center justify-between gap-2">
+                                <p class="text-[10px] uppercase tracking-[0.15em] text-muted">Corridor Graph</p>
+                                <p class="text-[10px] text-muted">Outer ring: security · Inner core: threat</p>
+                            </div>
+                            <img src="<?= htmlspecialchars($mapPath, ENT_QUOTES) ?>"
+                                 alt="Threat corridor graph for corridor #<?= $corridorId ?>"
+                                 class="mt-2 w-full rounded border border-border/50 bg-slate-950"
+                                 loading="lazy">
+                        </div>
+                    <?php endif; ?>
                 </div>
             <?php endforeach; ?>
         </div>
@@ -139,10 +164,10 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 <span>Showing <?= number_format($offset + 1) ?>–<?= number_format(min($offset + $perPage, $totalCount)) ?> of <?= number_format($totalCount) ?></span>
                 <div class="flex gap-2">
                     <?php if ($page > 1): ?>
-                        <a href="?page=<?= $page - 1 ?><?= $regionId > 0 ? '&region_id=' . $regionId : '' ?>" class="btn-secondary text-xs">Previous</a>
+                        <a href="?page=<?= $page - 1 ?><?= $regionId > 0 ? '&region_id=' . $regionId : '' ?>&surrounding_hops=<?= $surroundingHops ?>" class="btn-secondary text-xs">Previous</a>
                     <?php endif; ?>
                     <?php if ($page < $totalPages): ?>
-                        <a href="?page=<?= $page + 1 ?><?= $regionId > 0 ? '&region_id=' . $regionId : '' ?>" class="btn-secondary text-xs">Next</a>
+                        <a href="?page=<?= $page + 1 ?><?= $regionId > 0 ? '&region_id=' . $regionId : '' ?>&surrounding_hops=<?= $surroundingHops ?>" class="btn-secondary text-xs">Next</a>
                     <?php endif; ?>
                 </div>
             </div>

--- a/src/db.php
+++ b/src/db.php
@@ -16180,6 +16180,142 @@ function db_threat_corridor_regions(): array
     );
 }
 
+function db_threat_corridor_graph_subgraph(array $corridorSystemIds, int $surroundingHops = 1): array
+{
+    $corridorSystemIds = array_values(array_unique(array_map('intval', $corridorSystemIds)));
+    $corridorSystemIds = array_values(array_filter($corridorSystemIds, static fn (int $sid): bool => $sid > 0));
+    if ($corridorSystemIds === []) {
+        return ['nodes' => [], 'edges' => []];
+    }
+
+    $surroundingHops = max(0, min(3, $surroundingHops));
+    $nodeIds = [];
+    $edgePairs = [];
+
+    $neoRows = neo4j_query(
+        '
+        UNWIND $corridor_ids AS corridor_id
+        MATCH (c:System {system_id: corridor_id})
+        MATCH (c)-[:CONNECTS_TO*0..' . $surroundingHops . ']-(n:System)
+        WITH collect(DISTINCT n.system_id) AS node_ids
+        UNWIND node_ids AS a_id
+        MATCH (a:System {system_id: a_id})-[:CONNECTS_TO]-(b:System)
+        WHERE b.system_id IN node_ids AND a.system_id < b.system_id
+        RETURN node_ids,
+               collect(DISTINCT [a.system_id, b.system_id]) AS edge_pairs
+        ',
+        ['corridor_ids' => $corridorSystemIds]
+    );
+
+    if ($neoRows !== []) {
+        $row = $neoRows[0];
+        $nodeIds = array_values(array_unique(array_map('intval', (array) ($row['node_ids'] ?? []))));
+        foreach ((array) ($row['edge_pairs'] ?? []) as $pair) {
+            $a = (int) ($pair[0] ?? 0);
+            $b = (int) ($pair[1] ?? 0);
+            if ($a <= 0 || $b <= 0 || $a === $b) {
+                continue;
+            }
+            $key = $a < $b ? ($a . ':' . $b) : ($b . ':' . $a);
+            $edgePairs[$key] = [$a, $b];
+        }
+    }
+
+    if ($nodeIds === []) {
+        $nodeIds = $corridorSystemIds;
+        $frontier = $corridorSystemIds;
+        $seen = array_fill_keys($corridorSystemIds, true);
+        for ($hop = 0; $hop < $surroundingHops; $hop++) {
+            if ($frontier === []) {
+                break;
+            }
+            $placeholders = implode(',', array_fill(0, count($frontier), '?'));
+            $rows = db_select(
+                "SELECT system_id, dest_system_id
+                 FROM ref_stargates
+                 WHERE system_id IN ({$placeholders})",
+                $frontier
+            );
+            $nextFrontier = [];
+            foreach ($rows as $r) {
+                $a = (int) ($r['system_id'] ?? 0);
+                $b = (int) ($r['dest_system_id'] ?? 0);
+                if ($a <= 0 || $b <= 0 || $a === $b) {
+                    continue;
+                }
+                if (!isset($seen[$b])) {
+                    $seen[$b] = true;
+                    $nextFrontier[] = $b;
+                }
+            }
+            $frontier = array_values(array_unique($nextFrontier));
+        }
+        $nodeIds = array_map('intval', array_keys($seen));
+        if ($nodeIds !== []) {
+            $nodePlaceholders = implode(',', array_fill(0, count($nodeIds), '?'));
+            $rows = db_select(
+                "SELECT system_id, dest_system_id
+                 FROM ref_stargates
+                 WHERE system_id IN ({$nodePlaceholders})
+                   AND dest_system_id IN ({$nodePlaceholders})
+                   AND system_id < dest_system_id",
+                array_merge($nodeIds, $nodeIds)
+            );
+            foreach ($rows as $r) {
+                $a = (int) ($r['system_id'] ?? 0);
+                $b = (int) ($r['dest_system_id'] ?? 0);
+                if ($a <= 0 || $b <= 0 || $a === $b) {
+                    continue;
+                }
+                $edgePairs[$a . ':' . $b] = [$a, $b];
+            }
+        }
+    }
+
+    if ($nodeIds === []) {
+        return ['nodes' => [], 'edges' => []];
+    }
+
+    $nodePlaceholders = implode(',', array_fill(0, count($nodeIds), '?'));
+    $nodes = db_select(
+        "SELECT rs.system_id, rs.system_name, rs.security, sts.threat_level
+         FROM ref_systems rs
+         LEFT JOIN system_threat_scores sts ON sts.system_id = rs.system_id
+         WHERE rs.system_id IN ({$nodePlaceholders})",
+        $nodeIds
+    );
+    $nodeMap = [];
+    foreach ($nodes as $row) {
+        $sid = (int) ($row['system_id'] ?? 0);
+        if ($sid <= 0) {
+            continue;
+        }
+        $nodeMap[$sid] = [
+            'system_id' => $sid,
+            'system_name' => (string) ($row['system_name'] ?? (string) $sid),
+            'security' => (float) ($row['security'] ?? 0.0),
+            'threat_level' => (string) ($row['threat_level'] ?? ''),
+        ];
+    }
+    foreach ($nodeIds as $sid) {
+        $sid = (int) $sid;
+        if ($sid <= 0 || isset($nodeMap[$sid])) {
+            continue;
+        }
+        $nodeMap[$sid] = [
+            'system_id' => $sid,
+            'system_name' => (string) $sid,
+            'security' => 0.0,
+            'threat_level' => '',
+        ];
+    }
+
+    return [
+        'nodes' => array_values($nodeMap),
+        'edges' => array_values($edgePairs),
+    ];
+}
+
 // ---------------------------------------------------------------------------
 // Neo4j Intelligence Graph — PHP query layer (HTTP transactional endpoint)
 // ---------------------------------------------------------------------------

--- a/src/functions.php
+++ b/src/functions.php
@@ -30620,3 +30620,173 @@ function log_viewer_external_health(): array
 
     return $results;
 }
+
+function supplycore_threat_corridor_map_cache_minutes(): int
+{
+    return max(5, min(240, (int) get_setting('threat_corridor_map_cache_minutes', '20')));
+}
+
+function supplycore_threat_corridor_graph_svg(int $corridorId, array $corridorSystemIds, int $surroundingHops = 1): ?string
+{
+    $corridorSystemIds = array_values(array_unique(array_map('intval', $corridorSystemIds)));
+    $corridorSystemIds = array_values(array_filter($corridorSystemIds, static fn (int $sid): bool => $sid > 0));
+    if ($corridorId <= 0 || $corridorSystemIds === []) {
+        return null;
+    }
+    $surroundingHops = max(0, min(3, $surroundingHops));
+    $cacheDir = dirname(__DIR__) . '/storage/cache/threat-corridor-maps';
+    if (!is_dir($cacheDir) && !@mkdir($cacheDir, 0775, true) && !is_dir($cacheDir)) {
+        return null;
+    }
+    $cacheFile = sprintf('%s/corridor-%d-h%d.svg', $cacheDir, $corridorId, $surroundingHops);
+    $cacheTtl = supplycore_threat_corridor_map_cache_minutes() * 60;
+    if (is_file($cacheFile) && ((time() - (int) filemtime($cacheFile)) < $cacheTtl)) {
+        return '/storage/cache/threat-corridor-maps/' . basename($cacheFile);
+    }
+    $graph = db_threat_corridor_graph_subgraph($corridorSystemIds, $surroundingHops);
+    $nodes = (array) ($graph['nodes'] ?? []);
+    $edges = (array) ($graph['edges'] ?? []);
+    if ($nodes === []) {
+        return null;
+    }
+
+    $corridorSet = array_fill_keys($corridorSystemIds, true);
+    $nodeMap = [];
+    foreach ($nodes as $node) {
+        $sid = (int) ($node['system_id'] ?? 0);
+        if ($sid <= 0) {
+            continue;
+        }
+        $nodeMap[$sid] = [
+            'system_id' => $sid,
+            'name' => (string) ($node['system_name'] ?? (string) $sid),
+            'security' => (float) ($node['security'] ?? 0.0),
+            'threat_level' => strtolower((string) ($node['threat_level'] ?? '')),
+            'is_corridor' => isset($corridorSet[$sid]),
+        ];
+    }
+    if ($nodeMap === []) {
+        return null;
+    }
+
+    $nodeIds = array_keys($nodeMap);
+    $positions = [];
+    $seed = max(11, $corridorId * 131 + ($surroundingHops * 17));
+    mt_srand($seed);
+    foreach ($nodeIds as $sid) {
+        $positions[$sid] = ['x' => mt_rand(50, 950) / 1000.0, 'y' => mt_rand(50, 950) / 1000.0, 'vx' => 0.0, 'vy' => 0.0];
+    }
+    $nodeCount = max(1, count($nodeIds));
+    $k = sqrt(1.0 / $nodeCount);
+    for ($iter = 0; $iter < 200; $iter++) {
+        foreach ($nodeIds as $sid) {
+            $positions[$sid]['vx'] = 0.0;
+            $positions[$sid]['vy'] = 0.0;
+        }
+        $idsLen = count($nodeIds);
+        for ($i = 0; $i < $idsLen; $i++) {
+            $a = $nodeIds[$i];
+            for ($j = $i + 1; $j < $idsLen; $j++) {
+                $b = $nodeIds[$j];
+                $dx = $positions[$a]['x'] - $positions[$b]['x'];
+                $dy = $positions[$a]['y'] - $positions[$b]['y'];
+                $dist = max(0.001, sqrt(($dx * $dx) + ($dy * $dy)));
+                $force = ($k * $k) / $dist;
+                $fx = ($dx / $dist) * $force;
+                $fy = ($dy / $dist) * $force;
+                $positions[$a]['vx'] += $fx;
+                $positions[$a]['vy'] += $fy;
+                $positions[$b]['vx'] -= $fx;
+                $positions[$b]['vy'] -= $fy;
+            }
+        }
+        foreach ($edges as $edge) {
+            $a = (int) ($edge[0] ?? 0);
+            $b = (int) ($edge[1] ?? 0);
+            if (!isset($positions[$a], $positions[$b])) {
+                continue;
+            }
+            $dx = $positions[$a]['x'] - $positions[$b]['x'];
+            $dy = $positions[$a]['y'] - $positions[$b]['y'];
+            $dist = max(0.001, sqrt(($dx * $dx) + ($dy * $dy)));
+            $force = ($dist * $dist) / max(0.001, $k);
+            $fx = ($dx / $dist) * $force * 0.015;
+            $fy = ($dy / $dist) * $force * 0.015;
+            $positions[$a]['vx'] -= $fx;
+            $positions[$a]['vy'] -= $fy;
+            $positions[$b]['vx'] += $fx;
+            $positions[$b]['vy'] += $fy;
+        }
+        $temp = max(0.01, 0.12 - ($iter * 0.0005));
+        foreach ($nodeIds as $sid) {
+            $positions[$sid]['x'] += max(-$temp, min($temp, $positions[$sid]['vx']));
+            $positions[$sid]['y'] += max(-$temp, min($temp, $positions[$sid]['vy']));
+            $positions[$sid]['x'] = max(0.03, min(0.97, $positions[$sid]['x']));
+            $positions[$sid]['y'] = max(0.07, min(0.93, $positions[$sid]['y']));
+        }
+    }
+
+    $width = 760;
+    $height = 250;
+    $pad = 24;
+    $sx = static fn (float $x): float => $pad + ($x * ($width - ($pad * 2)));
+    $sy = static fn (float $y): float => $pad + ($y * ($height - ($pad * 2)));
+    $securityColor = static function (float $sec): string {
+        if ($sec >= 0.5) {
+            return '#10b981';
+        }
+        if ($sec > 0.0) {
+            return '#f59e0b';
+        }
+        return '#ef4444';
+    };
+    $threatColor = static function (string $threatLevel): string {
+        return match ($threatLevel) {
+            'critical' => '#ef4444',
+            'high' => '#f97316',
+            'medium' => '#eab308',
+            'low' => '#3b82f6',
+            default => '#94a3b8',
+        };
+    };
+
+    $svg = [];
+    $svg[] = '<svg xmlns="http://www.w3.org/2000/svg" width="' . $width . '" height="' . $height . '" viewBox="0 0 ' . $width . ' ' . $height . '">';
+    $svg[] = '<defs><style><![CDATA['
+        . '.label-c{font:600 11px Inter,Segoe UI,sans-serif;fill:#e2e8f0}'
+        . '.node-surround:hover + .label-s{opacity:1}'
+        . '.label-s{font:500 10px Inter,Segoe UI,sans-serif;fill:#94a3b8;opacity:0;transition:opacity .2s ease}'
+        . ']]></style></defs>';
+    $svg[] = '<rect x="0" y="0" width="' . $width . '" height="' . $height . '" rx="12" fill="#020617"/>';
+
+    foreach ($edges as $edge) {
+        $a = (int) ($edge[0] ?? 0);
+        $b = (int) ($edge[1] ?? 0);
+        if (!isset($positions[$a], $positions[$b])) {
+            continue;
+        }
+        $svg[] = '<line x1="' . number_format($sx((float) $positions[$a]['x']), 2, '.', '') . '" y1="' . number_format($sy((float) $positions[$a]['y']), 2, '.', '') . '" x2="' . number_format($sx((float) $positions[$b]['x']), 2, '.', '') . '" y2="' . number_format($sy((float) $positions[$b]['y']), 2, '.', '') . '" stroke="#334155" stroke-opacity="0.8" stroke-width="1.2"/>';
+    }
+    foreach ($nodeMap as $sid => $node) {
+        if (!isset($positions[$sid])) {
+            continue;
+        }
+        $x = number_format($sx((float) $positions[$sid]['x']), 2, '.', '');
+        $y = number_format($sy((float) $positions[$sid]['y']), 2, '.', '');
+        $outer = $securityColor((float) $node['security']);
+        $inner = $threatColor((string) $node['threat_level']);
+        $safeName = htmlspecialchars((string) $node['name'], ENT_QUOTES);
+        $title = $safeName . ' | sec=' . number_format((float) $node['security'], 1) . ' | threat=' . ($node['threat_level'] !== '' ? $node['threat_level'] : 'unknown');
+        if ($node['is_corridor'] === true) {
+            $svg[] = '<g><circle cx="' . $x . '" cy="' . $y . '" r="8.8" fill="none" stroke="' . $outer . '" stroke-width="2.6"/><circle cx="' . $x . '" cy="' . $y . '" r="5.2" fill="' . $inner . '" stroke="#0f172a" stroke-width="1.1"><title>' . htmlspecialchars($title, ENT_QUOTES) . '</title></circle><text class="label-c" x="' . ($x + 10) . '" y="' . ($y - 8) . '">' . $safeName . '</text></g>';
+        } else {
+            $svg[] = '<g><circle class="node-surround" cx="' . $x . '" cy="' . $y . '" r="6.1" fill="none" stroke="' . $outer . '" stroke-width="1.7"><title>' . htmlspecialchars($title, ENT_QUOTES) . '</title></circle><circle cx="' . $x . '" cy="' . $y . '" r="3.5" fill="' . $inner . '" stroke="#0f172a" stroke-width="1"/><text class="label-s" x="' . ($x + 8) . '" y="' . ($y - 6) . '">' . $safeName . '</text></g>';
+        }
+    }
+    $svg[] = '</svg>';
+    if (@file_put_contents($cacheFile, implode('', $svg)) === false) {
+        return null;
+    }
+
+    return '/storage/cache/threat-corridor-maps/' . basename($cacheFile);
+}


### PR DESCRIPTION
### Motivation
- Provide visual context for threat corridors by rendering a small graph of connected systems and their threat/security rings.  
- Allow users to include nearby systems around a corridor via a `surrounding_hops` filter to visualize local topology.  
- Improve performance by caching generated SVG maps to disk with a configurable TTL.

### Description
- Added a `surrounding_hops` query parameter and UI control to `public/threat-corridors/index.php` with bounds (0–3) and propagation through pagination links.  
- Implemented `db_threat_corridor_graph_subgraph()` in `src/db.php` to build a node/edge subgraph using Neo4j when enabled and falling back to SQL traversal of `ref_stargates` when not.  
- Added `supplycore_threat_corridor_graph_svg()` and `supplycore_threat_corridor_map_cache_minutes()` in `src/functions.php` to layout nodes with a simple force-directed algorithm, render an SVG with security/threat coloring, cache the output under `storage/cache/threat-corridor-maps`, and return a public cached path.  
- Updated the threat corridors list view to call the new SVG generator per corridor and display the cached image with explanatory labels and accessibility attributes.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb4c19229c832f9a370dc54af270ab)