### PR TITLE
Write threat corridor SVGs under public web root and update asset URLs

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -30634,14 +30634,14 @@ function supplycore_threat_corridor_graph_svg(int $corridorId, array $corridorSy
         return null;
     }
     $surroundingHops = max(0, min(3, $surroundingHops));
-    $cacheDir = dirname(__DIR__) . '/storage/cache/threat-corridor-maps';
+    $cacheDir = dirname(__DIR__) . '/public/threat-corridors/svg';
     if (!is_dir($cacheDir) && !@mkdir($cacheDir, 0775, true) && !is_dir($cacheDir)) {
         return null;
     }
     $cacheFile = sprintf('%s/corridor-%d-h%d.svg', $cacheDir, $corridorId, $surroundingHops);
     $cacheTtl = supplycore_threat_corridor_map_cache_minutes() * 60;
     if (is_file($cacheFile) && ((time() - (int) filemtime($cacheFile)) < $cacheTtl)) {
-        return '/storage/cache/threat-corridor-maps/' . basename($cacheFile);
+        return '/threat-corridors/svg/' . basename($cacheFile);
     }
     $graph = db_threat_corridor_graph_subgraph($corridorSystemIds, $surroundingHops);
     $nodes = (array) ($graph['nodes'] ?? []);
@@ -30788,5 +30788,5 @@ function supplycore_threat_corridor_graph_svg(int $corridorId, array $corridorSy
         return null;
     }
 
-    return '/storage/cache/threat-corridor-maps/' . basename($cacheFile);
+    return '/threat-corridors/svg/' . basename($cacheFile);
 }


### PR DESCRIPTION
### Motivation
- Generated threat corridor SVGs were being written to `storage/cache/threat-corridor-maps` (outside the web document root), preventing the site from serving the images; they need to live under `public/` so browsers can fetch them.

### Description
- Change cache directory in `supplycore_threat_corridor_graph_svg` from `dirname(__DIR__) . '/storage/cache/threat-corridor-maps'` to `dirname(__DIR__) . '/public/threat-corridors/svg'`.
- Update returned asset URLs from `/storage/cache/threat-corridor-maps/...` to `/threat-corridors/svg/...` so generated maps resolve from the public directory.
- Preserve existing directory creation and file-write logic.

### Testing
- Ran `php -l src/functions.php` which succeeded with "No syntax errors detected." 
- No unit tests required changes and existing tests were left untouched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb51c7f360832fa9fff66691037cbb)