### PR TITLE
Threat corridor: preserve gate links, highlight route edges, and add compact popout UI

### DIFF
--- a/public/threat-corridors/index.php
+++ b/public/threat-corridors/index.php
@@ -98,7 +98,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     }
                 ?>
                 <div class="rounded-lg border border-border/50 bg-slate-900/50 p-4">
-                    <div class="flex items-start justify-between gap-3">
+                    <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                         <div class="flex-1 min-w-0">
                             <div class="flex items-center gap-2 flex-wrap">
                                 <span class="inline-block rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider <?= $badgeClass ?>"><?= $label ?></span>
@@ -106,55 +106,76 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 <span class="text-xs text-muted"><?= $length ?> systems</span>
                             </div>
                             <p class="mt-1.5 text-sm text-slate-200 font-medium truncate" title="<?= htmlspecialchars(implode(' → ', $systemNames), ENT_QUOTES) ?>"><?= $routeLabel ?></p>
+
+                            <div class="mt-3 h-1.5 rounded-full bg-slate-800 overflow-hidden">
+                                <div class="h-full rounded-full <?= $barColor ?> transition-all" style="width: <?= number_format($scorePct, 1) ?>%"></div>
+                            </div>
+
+                            <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
+                                <span>Battles: <?= number_format((int) ($c['battle_count'] ?? 0)) ?></span>
+                                <span>Recent: <?= number_format((int) ($c['recent_battle_count'] ?? 0)) ?></span>
+                                <span>ISK: <?= supplycore_format_isk((float) ($c['total_isk_destroyed'] ?? 0)) ?></span>
+                                <?php if ($c['last_activity_at']): ?>
+                                    <span>Last: <?= date('M j, H:i', strtotime($c['last_activity_at'])) ?></span>
+                                <?php endif; ?>
+                            </div>
+
+                            <?php
+                                $hostileIds = $c['hostile_alliance_ids'] ?? [];
+                                if ($hostileIds !== []):
+                            ?>
+                                <div class="mt-2 flex items-center gap-1">
+                                    <span class="text-[10px] text-muted uppercase tracking-wider mr-1">Hostiles:</span>
+                                    <?php foreach (array_slice($hostileIds, 0, 8) as $hid): ?>
+                                        <img src="https://images.evetech.net/alliances/<?= (int) $hid ?>/logo?size=32"
+                                             alt="" class="w-4 h-4 rounded" loading="lazy"
+                                             title="Alliance #<?= (int) $hid ?>">
+                                    <?php endforeach; ?>
+                                    <?php if (count($hostileIds) > 8): ?>
+                                        <span class="text-xs text-muted">+<?= count($hostileIds) - 8 ?></span>
+                                    <?php endif; ?>
+                                </div>
+                            <?php endif; ?>
                         </div>
+
                         <div class="text-right shrink-0">
                             <p class="text-lg font-semibold text-slate-100"><?= number_format($score, 1) ?></p>
                             <p class="text-[10px] text-muted uppercase">Score</p>
                         </div>
-                    </div>
 
-                    <div class="mt-3 h-1.5 rounded-full bg-slate-800 overflow-hidden">
-                        <div class="h-full rounded-full <?= $barColor ?> transition-all" style="width: <?= number_format($scorePct, 1) ?>%"></div>
-                    </div>
+                        <?php if (is_string($mapPath) && $mapPath !== ''): ?>
+                            <?php $dialogId = 'corridor-graph-dialog-' . $corridorId; ?>
+                            <div class="w-full lg:w-[24rem] shrink-0 rounded border border-border/60 bg-slate-950/60 p-2">
+                                <div class="flex items-center justify-between gap-2">
+                                    <p class="text-[10px] uppercase tracking-[0.15em] text-muted">Corridor Graph</p>
+                                    <button type="button"
+                                            data-dialog-open="<?= htmlspecialchars($dialogId, ENT_QUOTES) ?>"
+                                            class="text-[10px] text-accent hover:text-accent/80">Pop out</button>
+                                </div>
+                                <p class="text-[10px] text-muted">Corridor links highlighted in red · Outer ring: security · Inner core: threat</p>
+                                <img src="<?= htmlspecialchars($mapPath, ENT_QUOTES) ?>"
+                                     alt="Threat corridor graph for corridor #<?= $corridorId ?>"
+                                     class="mt-2 w-full max-h-56 object-contain rounded border border-border/50 bg-slate-950 cursor-zoom-in"
+                                     data-dialog-open="<?= htmlspecialchars($dialogId, ENT_QUOTES) ?>"
+                                     loading="lazy">
+                            </div>
 
-                    <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
-                        <span>Battles: <?= number_format((int) ($c['battle_count'] ?? 0)) ?></span>
-                        <span>Recent: <?= number_format((int) ($c['recent_battle_count'] ?? 0)) ?></span>
-                        <span>ISK: <?= supplycore_format_isk((float) ($c['total_isk_destroyed'] ?? 0)) ?></span>
-                        <?php if ($c['last_activity_at']): ?>
-                            <span>Last: <?= date('M j, H:i', strtotime($c['last_activity_at'])) ?></span>
+                            <dialog id="<?= htmlspecialchars($dialogId, ENT_QUOTES) ?>" class="rounded-xl border border-border/60 bg-slate-950/95 p-0 text-slate-100 backdrop:bg-black/70">
+                                <div class="w-[min(92vw,960px)] p-3">
+                                    <div class="mb-2 flex items-center justify-between">
+                                        <p class="text-xs uppercase tracking-[0.15em] text-muted">Corridor #<?= $corridorId ?> graph</p>
+                                        <button type="button"
+                                                data-dialog-close="<?= htmlspecialchars($dialogId, ENT_QUOTES) ?>"
+                                                class="rounded border border-border/60 px-2 py-1 text-xs text-slate-200 hover:bg-slate-800/70">Close</button>
+                                    </div>
+                                    <img src="<?= htmlspecialchars($mapPath, ENT_QUOTES) ?>"
+                                         alt="Expanded threat corridor graph for corridor #<?= $corridorId ?>"
+                                         class="w-full rounded border border-border/50 bg-slate-950"
+                                         loading="lazy">
+                                </div>
+                            </dialog>
                         <?php endif; ?>
                     </div>
-
-                    <?php
-                        $hostileIds = $c['hostile_alliance_ids'] ?? [];
-                        if ($hostileIds !== []):
-                    ?>
-                        <div class="mt-2 flex items-center gap-1">
-                            <span class="text-[10px] text-muted uppercase tracking-wider mr-1">Hostiles:</span>
-                            <?php foreach (array_slice($hostileIds, 0, 8) as $hid): ?>
-                                <img src="https://images.evetech.net/alliances/<?= (int) $hid ?>/logo?size=32"
-                                     alt="" class="w-4 h-4 rounded" loading="lazy"
-                                     title="Alliance #<?= (int) $hid ?>">
-                            <?php endforeach; ?>
-                            <?php if (count($hostileIds) > 8): ?>
-                                <span class="text-xs text-muted">+<?= count($hostileIds) - 8 ?></span>
-                            <?php endif; ?>
-                        </div>
-                    <?php endif; ?>
-
-                    <?php if (is_string($mapPath) && $mapPath !== ''): ?>
-                        <div class="mt-3 rounded border border-border/60 bg-slate-950/60 p-2">
-                            <div class="flex items-center justify-between gap-2">
-                                <p class="text-[10px] uppercase tracking-[0.15em] text-muted">Corridor Graph</p>
-                                <p class="text-[10px] text-muted">Outer ring: security · Inner core: threat</p>
-                            </div>
-                            <img src="<?= htmlspecialchars($mapPath, ENT_QUOTES) ?>"
-                                 alt="Threat corridor graph for corridor #<?= $corridorId ?>"
-                                 class="mt-2 w-full rounded border border-border/50 bg-slate-950"
-                                 loading="lazy">
-                        </div>
-                    <?php endif; ?>
                 </div>
             <?php endforeach; ?>
         </div>
@@ -174,5 +195,39 @@ include __DIR__ . '/../../src/views/partials/header.php';
         <?php endif; ?>
     <?php endif; ?>
 </section>
+
+<script>
+document.querySelectorAll('[data-dialog-open]').forEach((trigger) => {
+    trigger.addEventListener('click', () => {
+        const dialogId = trigger.getAttribute('data-dialog-open');
+        if (!dialogId) {
+            return;
+        }
+        const dialog = document.getElementById(dialogId);
+        if (dialog && typeof dialog.showModal === 'function') {
+            dialog.showModal();
+        }
+    });
+});
+document.querySelectorAll('[data-dialog-close]').forEach((trigger) => {
+    trigger.addEventListener('click', () => {
+        const dialogId = trigger.getAttribute('data-dialog-close');
+        if (!dialogId) {
+            return;
+        }
+        const dialog = document.getElementById(dialogId);
+        if (dialog && typeof dialog.close === 'function') {
+            dialog.close();
+        }
+    });
+});
+document.querySelectorAll('dialog').forEach((dialog) => {
+    dialog.addEventListener('click', (event) => {
+        if (event.target === dialog && typeof dialog.close === 'function') {
+            dialog.close();
+        }
+    });
+});
+</script>
 
 <?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/src/db.php
+++ b/src/db.php
@@ -16200,7 +16200,7 @@ function db_threat_corridor_graph_subgraph(array $corridorSystemIds, int $surrou
         WITH collect(DISTINCT n.system_id) AS node_ids
         UNWIND node_ids AS a_id
         MATCH (a:System {system_id: a_id})-[:CONNECTS_TO]-(b:System)
-        WHERE b.system_id IN node_ids AND a.system_id < b.system_id
+        WHERE b.system_id IN node_ids
         RETURN node_ids,
                collect(DISTINCT [a.system_id, b.system_id]) AS edge_pairs
         ',
@@ -16216,8 +16216,9 @@ function db_threat_corridor_graph_subgraph(array $corridorSystemIds, int $surrou
             if ($a <= 0 || $b <= 0 || $a === $b) {
                 continue;
             }
-            $key = $a < $b ? ($a . ':' . $b) : ($b . ':' . $a);
-            $edgePairs[$key] = [$a, $b];
+            $left = min($a, $b);
+            $right = max($a, $b);
+            $edgePairs[$left . ':' . $right] = [$left, $right];
         }
     }
 
@@ -16257,8 +16258,7 @@ function db_threat_corridor_graph_subgraph(array $corridorSystemIds, int $surrou
                 "SELECT system_id, dest_system_id
                  FROM ref_stargates
                  WHERE system_id IN ({$nodePlaceholders})
-                   AND dest_system_id IN ({$nodePlaceholders})
-                   AND system_id < dest_system_id",
+                   AND dest_system_id IN ({$nodePlaceholders})",
                 array_merge($nodeIds, $nodeIds)
             );
             foreach ($rows as $r) {
@@ -16267,7 +16267,9 @@ function db_threat_corridor_graph_subgraph(array $corridorSystemIds, int $surrou
                 if ($a <= 0 || $b <= 0 || $a === $b) {
                     continue;
                 }
-                $edgePairs[$a . ':' . $b] = [$a, $b];
+                $left = min($a, $b);
+                $right = max($a, $b);
+                $edgePairs[$left . ':' . $right] = [$left, $right];
             }
         }
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -30651,6 +30651,17 @@ function supplycore_threat_corridor_graph_svg(int $corridorId, array $corridorSy
     }
 
     $corridorSet = array_fill_keys($corridorSystemIds, true);
+    $corridorPathEdges = [];
+    for ($i = 0, $n = count($corridorSystemIds) - 1; $i < $n; $i++) {
+        $a = (int) $corridorSystemIds[$i];
+        $b = (int) $corridorSystemIds[$i + 1];
+        if ($a <= 0 || $b <= 0 || $a === $b) {
+            continue;
+        }
+        $left = min($a, $b);
+        $right = max($a, $b);
+        $corridorPathEdges[$left . ':' . $right] = true;
+    }
     $nodeMap = [];
     foreach ($nodes as $node) {
         $sid = (int) ($node['system_id'] ?? 0);
@@ -30726,8 +30737,8 @@ function supplycore_threat_corridor_graph_svg(int $corridorId, array $corridorSy
         }
     }
 
-    $width = 760;
-    $height = 250;
+    $width = 640;
+    $height = 220;
     $pad = 24;
     $sx = static fn (float $x): float => $pad + ($x * ($width - ($pad * 2)));
     $sy = static fn (float $y): float => $pad + ($y * ($height - ($pad * 2)));
@@ -30755,7 +30766,7 @@ function supplycore_threat_corridor_graph_svg(int $corridorId, array $corridorSy
     $svg[] = '<defs><style><![CDATA['
         . '.label-c{font:600 11px Inter,Segoe UI,sans-serif;fill:#e2e8f0}'
         . '.node-surround:hover + .label-s{opacity:1}'
-        . '.label-s{font:500 10px Inter,Segoe UI,sans-serif;fill:#94a3b8;opacity:0;transition:opacity .2s ease}'
+        . '.label-s{font:500 10px Inter,Segoe UI,sans-serif;fill:#94a3b8;opacity:.75;transition:opacity .2s ease}'
         . ']]></style></defs>';
     $svg[] = '<rect x="0" y="0" width="' . $width . '" height="' . $height . '" rx="12" fill="#020617"/>';
 
@@ -30765,7 +30776,14 @@ function supplycore_threat_corridor_graph_svg(int $corridorId, array $corridorSy
         if (!isset($positions[$a], $positions[$b])) {
             continue;
         }
-        $svg[] = '<line x1="' . number_format($sx((float) $positions[$a]['x']), 2, '.', '') . '" y1="' . number_format($sy((float) $positions[$a]['y']), 2, '.', '') . '" x2="' . number_format($sx((float) $positions[$b]['x']), 2, '.', '') . '" y2="' . number_format($sy((float) $positions[$b]['y']), 2, '.', '') . '" stroke="#334155" stroke-opacity="0.8" stroke-width="1.2"/>';
+        $left = min($a, $b);
+        $right = max($a, $b);
+        $edgeKey = $left . ':' . $right;
+        $isCorridorPathEdge = isset($corridorPathEdges[$edgeKey]);
+        $stroke = $isCorridorPathEdge ? '#f87171' : '#334155';
+        $strokeOpacity = $isCorridorPathEdge ? '0.95' : '0.8';
+        $strokeWidth = $isCorridorPathEdge ? '2.6' : '1.2';
+        $svg[] = '<line x1="' . number_format($sx((float) $positions[$a]['x']), 2, '.', '') . '" y1="' . number_format($sy((float) $positions[$a]['y']), 2, '.', '') . '" x2="' . number_format($sx((float) $positions[$b]['x']), 2, '.', '') . '" y2="' . number_format($sy((float) $positions[$b]['y']), 2, '.', '') . '" stroke="' . $stroke . '" stroke-opacity="' . $strokeOpacity . '" stroke-width="' . $strokeWidth . '"/>';
     }
     foreach ($nodeMap as $sid => $node) {
         if (!isset($positions[$sid])) {


### PR DESCRIPTION
### Motivation
- Corridor maps were missing gate links and adjacent systems and the rendered SVG was too large for the card, reducing usability and readability.
- The goal is to preserve stargate connectivity regardless of direction/order and make the corridor graph fit and be explorable in-place or via popout.

### Description
- Normalize and preserve edge pairs in both the Neo4j query and SQL fallback by deduplicating edges as `min:max` keys so stargate links are not dropped due to ordering; changes in `src/db.php` implement this.
- Compute canonical corridor path edges from the ordered `system_ids` and pass them to the SVG renderer so those links are highlighted (red) in the graph; changes in `src/functions.php` add `corridorPathEdges` and edge highlighting.
- Tweak SVG layout and styling by reducing canvas size and making surrounding-system labels visible by default to better fit cards and improve legibility; implemented in `src/functions.php`.
- Constrain the graph into a right-side panel on large screens and add a dialog-based popout/zoom interaction with minimal JS so clicking the graph or the “Pop out” button opens a larger preview; implemented in `public/threat-corridors/index.php`.

### Testing
- Ran `php -l public/threat-corridors/index.php` and the file passed syntax checks (no errors).
- Ran `php -l src/functions.php` and the file passed syntax checks (no errors).
- Ran `php -l src/db.php` and the file passed syntax checks (no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb553937d4832fb31f0c966f566341)