### PR TITLE
Constrain threat corridor graph preview sizing

### DIFF
--- a/public/threat-corridors/index.php
+++ b/public/threat-corridors/index.php
@@ -141,7 +141,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
                         <?php if (is_string($mapPath) && $mapPath !== ''): ?>
                             <?php $dialogId = 'corridor-graph-dialog-' . $corridorId; ?>
-                            <div class="w-full lg:w-1/2 lg:ml-auto shrink-0 rounded border border-border/60 bg-slate-950/60 p-2">
+                            <div class="w-full lg:ml-auto lg:w-[min(100%,48rem)] shrink-0 rounded border border-border/60 bg-slate-950/60 p-2">
                                 <div class="flex items-center justify-between gap-2">
                                     <p class="text-[10px] uppercase tracking-[0.15em] text-muted">Corridor Graph</p>
                                     <button type="button"
@@ -151,7 +151,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 <p class="text-[10px] text-muted">Corridor links highlighted in red · Adjacent links in slate · Outer ring: security · Inner core: threat</p>
                                 <img src="<?= htmlspecialchars($mapPath, ENT_QUOTES) ?>"
                                      alt="Threat corridor graph for corridor #<?= $corridorId ?>"
-                                     class="mt-2 w-full max-h-72 object-contain rounded border border-border/50 bg-slate-950 cursor-zoom-in"
+                                     class="mt-2 h-72 w-full object-contain rounded border border-border/50 bg-slate-950 cursor-zoom-in"
                                      data-dialog-open="<?= htmlspecialchars($dialogId, ENT_QUOTES) ?>"
                                      loading="lazy">
                             </div>


### PR DESCRIPTION
### Motivation
- Prevent the inline threat corridor SVG preview from stretching/inflating the corridor card on very wide layouts while keeping the pop-out dialog intact.

### Description
- Cap the inline graph panel width on large screens by changing the container to `lg:w-[min(100%,48rem)]` so it does not expand across ultra-wide layouts.
- Force a fixed preview height by replacing `max-h-72` with `h-72` on the inline `<img>` so large SVG intrinsic dimensions cannot blow out card height.

### Testing
- Ran `php -l public/threat-corridors/index.php` and the file reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb8255b4b0832fb4a5478adf9819ea)