### PR TITLE
Compact threat corridor preview rail and thumbnail image

### DIFF
--- a/public/threat-corridors/index.php
+++ b/public/threat-corridors/index.php
@@ -141,7 +141,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
                         <?php if (is_string($mapPath) && $mapPath !== ''): ?>
                             <?php $dialogId = 'corridor-graph-dialog-' . $corridorId; ?>
-                            <div class="w-full lg:ml-auto lg:w-[min(100%,48rem)] shrink-0 rounded border border-border/60 bg-slate-950/60 p-2">
+                            <div class="w-full lg:ml-auto lg:w-72 xl:w-80 shrink-0 rounded border border-border/60 bg-slate-950/60 p-2">
                                 <div class="flex items-center justify-between gap-2">
                                     <p class="text-[10px] uppercase tracking-[0.15em] text-muted">Corridor Graph</p>
                                     <button type="button"
@@ -151,7 +151,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 <p class="text-[10px] text-muted">Corridor links highlighted in red · Adjacent links in slate · Outer ring: security · Inner core: threat</p>
                                 <img src="<?= htmlspecialchars($mapPath, ENT_QUOTES) ?>"
                                      alt="Threat corridor graph for corridor #<?= $corridorId ?>"
-                                     class="mt-2 h-72 w-full object-contain rounded border border-border/50 bg-slate-950 cursor-zoom-in"
+                                     class="mt-2 h-36 w-full object-contain rounded border border-border/50 bg-slate-950 cursor-zoom-in"
                                      data-dialog-open="<?= htmlspecialchars($dialogId, ENT_QUOTES) ?>"
                                      loading="lazy">
                             </div>


### PR DESCRIPTION
### Motivation
- Shrink the right-hand threat corridor preview rail and thumbnail so the text column stays visually dominant while preserving the full-size popout dialog.

### Description
- Replace `lg:w-[min(100%,48rem)]` with `lg:w-72 xl:w-80` and change the inline preview image class from `h-72` to `h-36` in `public/threat-corridors/index.php`, leaving the popout dialog and full-size image behavior unchanged.

### Testing
- Ran `php -l public/threat-corridors/index.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb854dcc08832fa5e7733a49d1f42c)