### PR TITLE
Make corridor graph preview a fixed right-hand thumbnail

### DIFF
--- a/public/threat-corridors/index.php
+++ b/public/threat-corridors/index.php
@@ -141,7 +141,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
                         <?php if (is_string($mapPath) && $mapPath !== ''): ?>
                             <?php $dialogId = 'corridor-graph-dialog-' . $corridorId; ?>
-                            <div class="w-full lg:ml-auto lg:w-72 xl:w-80 shrink-0 rounded border border-border/60 bg-slate-950/60 p-2">
+                            <div class="corridor-graph w-full shrink-0 self-start rounded border border-border/60 bg-slate-950/60 p-2 lg:ml-auto lg:w-[320px] lg:min-w-[320px] lg:max-w-[320px]">
                                 <div class="flex items-center justify-between gap-2">
                                     <p class="text-[10px] uppercase tracking-[0.15em] text-muted">Corridor Graph</p>
                                     <button type="button"
@@ -151,7 +151,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 <p class="text-[10px] text-muted">Corridor links highlighted in red · Adjacent links in slate · Outer ring: security · Inner core: threat</p>
                                 <img src="<?= htmlspecialchars($mapPath, ENT_QUOTES) ?>"
                                      alt="Threat corridor graph for corridor #<?= $corridorId ?>"
-                                     class="mt-2 h-36 w-full object-contain rounded border border-border/50 bg-slate-950 cursor-zoom-in"
+                                     class="mt-2 h-[180px] w-full object-contain rounded border border-border/50 bg-slate-950 cursor-zoom-in"
                                      data-dialog-open="<?= htmlspecialchars($dialogId, ENT_QUOTES) ?>"
                                      loading="lazy">
                             </div>


### PR DESCRIPTION
### Motivation
- The corridor graph preview was taking full width above the card content instead of behaving as a compact right-side preview, which allowed the SVG to dominate layout and push the text down.

### Description
- Added a `corridor-graph` wrapper in `public/threat-corridors/index.php` and enforced right-column behavior at `lg` with `lg:w-[320px] lg:min-w-[320px] lg:max-w-[320px]` and `self-start` so the preview acts as a sidebar.
- Changed the inline preview image sizing from `h-36` to `h-[180px]` and kept `w-full object-contain` so the image is a compact thumbnail while preserving the existing popout dialog attributes (`data-dialog-open` / `data-dialog-close`).

### Testing
- Ran the PHP linter with `php -l public/threat-corridors/index.php` and it reported no syntax errors.
- Reviewed the updated markup to confirm the dialog triggers remain present and unchanged (manual review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb866973d8832f808b074911b00d66)