### PR TITLE
Exclude capsules from flying ship display and top hulls

### DIFF
--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -31,8 +31,9 @@ function _is_monitor_or_flag_ship_name(string $shipName): bool {
 }
 
 function _participant_flying_ship_name(array $participant, array $shipTypeNames): string {
+    $_podIds = [670, 33328];
     $flyingShipId = (int) ($participant['flying_ship_type_id'] ?? 0);
-    if ($flyingShipId > 0) {
+    if ($flyingShipId > 0 && !in_array($flyingShipId, $_podIds, true)) {
         return (string) ($shipTypeNames[$flyingShipId] ?? '');
     }
 
@@ -44,12 +45,13 @@ function _participant_flying_ship_name(array $participant, array $shipTypeNames)
     if (!is_array($decoded) || $decoded === []) {
         return '';
     }
-    $fallbackShipId = (int) $decoded[0];
-    if ($fallbackShipId <= 0) {
-        return '';
+    foreach ($decoded as $stid) {
+        $stid = (int) $stid;
+        if ($stid > 0 && !in_array($stid, $_podIds, true)) {
+            return (string) ($shipTypeNames[$stid] ?? '');
+        }
     }
-
-    return (string) ($shipTypeNames[$fallbackShipId] ?? '');
+    return '';
 }
 
 $hasMonitorOrFlagShips = false;
@@ -88,35 +90,8 @@ function _render_participant_row(array $p, array $resolvedEntities, array $shipT
     $dmgPct = $maxDmgForPanel > 0 ? ($dmgDone / $maxDmgForPanel) * 100 : 0;
     $hasDeath = $deaths > 0;
 
-    // ── Flying ship (most common attacker ship) ──
-    $flyingShipId = (int) ($p['flying_ship_type_id'] ?? 0);
-    $flyingShipName = '';
-    if ($flyingShipId > 0) {
-        $flyingShipName = (string) ($shipTypeNames[$flyingShipId] ?? '');
-    }
-    // Fallback to first ship_type_ids entry if no flying_ship_type_id
-    if ($flyingShipId <= 0) {
-        $shipIds = [];
-        $shipJson = $p['ship_type_ids'] ?? null;
-        if (is_string($shipJson)) {
-            $decoded = json_decode($shipJson, true);
-            if (is_array($decoded)) $shipIds = $decoded;
-        }
-        if ($shipIds) {
-            $flyingShipId = (int) $shipIds[0];
-            $flyingShipName = (string) ($shipTypeNames[$flyingShipId] ?? '');
-        }
-    }
-
-    if ($fleetRole === 'command') {
-        if (_is_monitor_or_flag_ship_name($flyingShipName)) {
-            $fleetRole = 'links';
-        } elseif (!$hasMonitorOrFlagShips) {
-            $fleetRole = 'fc_links';
-        }
-    }
-
-    // ── Lost ship (highest-ISK non-pod from ships_lost_detail) ──
+    // ── Lost ship (highest-ISK non-pod from ships_lost_detail) — computed first ──
+    // so we can fall back to it when the flying ship is only a capsule.
     $lostShipId = 0;
     $lostShipName = '';
     $lostShipCount = 0;
@@ -138,7 +113,54 @@ function _render_participant_row(array $p, array $resolvedEntities, array $shipT
         foreach ($lostDisplay as $entry) {
             $lostShipCount += (int) ($entry['count'] ?? 1);
         }
-        $lostSameAsFlying = ($lostShipId === $flyingShipId);
+    }
+
+    // ── Flying ship (most common attacker ship, never a bare capsule) ──
+    // A capsule is always the pilot's escape pod / "driver" — the actual ship
+    // they flew is what matters for display.  If the analysis resolved flying
+    // ship to a capsule (because the pilot only appeared as a victim), use the
+    // best non-pod ship from their loss record instead.
+    $_podTypeIds = [670, 33328];
+    $flyingShipId = (int) ($p['flying_ship_type_id'] ?? 0);
+    $flyingShipName = '';
+    if ($flyingShipId > 0 && !in_array($flyingShipId, $_podTypeIds, true)) {
+        $flyingShipName = (string) ($shipTypeNames[$flyingShipId] ?? '');
+    } else {
+        // flying_ship_type_id is absent or is a capsule — prefer the highest-ISK
+        // lost ship (already filtered to non-pod above), then fall back to
+        // ship_type_ids list (also skipping pods).
+        $flyingShipId = 0;
+        if ($lostShipId > 0) {
+            $flyingShipId   = $lostShipId;
+            $flyingShipName = $lostShipName;
+        } else {
+            $shipIds = [];
+            $shipJson = $p['ship_type_ids'] ?? null;
+            if (is_string($shipJson)) {
+                $decoded = json_decode($shipJson, true);
+                if (is_array($decoded)) $shipIds = $decoded;
+            }
+            foreach ($shipIds as $stid) {
+                $stid = (int) $stid;
+                if ($stid > 0 && !in_array($stid, $_podTypeIds, true)) {
+                    $flyingShipId   = $stid;
+                    $flyingShipName = (string) ($shipTypeNames[$stid] ?? '');
+                    break;
+                }
+            }
+        }
+    }
+
+    // When flying ship came from the loss record, mark it so the row doesn't
+    // also render a redundant "lost" badge for the same hull.
+    $lostSameAsFlying = ($lostShipId > 0 && $lostShipId === $flyingShipId);
+
+    if ($fleetRole === 'command') {
+        if (_is_monitor_or_flag_ship_name($flyingShipName)) {
+            $fleetRole = 'links';
+        } elseif (!$hasMonitorOrFlagShips) {
+            $fleetRole = 'fc_links';
+        }
     }
 
     // ── Death styling ──

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -374,6 +374,46 @@ if ($viewSnapshot !== null && !$pendingLock) {
             'pilots' => $pilots,
         ];
     }
+    // ── Top-hulls补丁: pilots whose flying_ship_type_id is a capsule are skipped
+    // by the fleet-composition query filter above, so their real ships never
+    // appear in the "Top Hulls" list.  Walk participants and credit their
+    // highest-ISK non-pod lost ship instead.
+    $_podTypeIdsFC = [670, 33328];
+    $extraShipCounts = [];   // side → [type_id => ['name'=>…, 'pilots'=>…]]
+    foreach ($participantsAll as $_p) {
+        $_flyId = (int) ($_p['flying_ship_type_id'] ?? 0);
+        if ($_flyId > 0 && !in_array($_flyId, $_podTypeIdsFC, true)) {
+            continue; // already counted by fleet composition query
+        }
+        $_pSide = $classifyAlliance((int) ($_p['alliance_id'] ?? 0));
+        if (!isset($sidePanels[$_pSide])) continue;
+        // Find the best non-pod lost ship for this pilot
+        $_lostJson = $_p['ships_lost_detail'] ?? null;
+        if (!is_string($_lostJson)) continue;
+        $_lostArr = json_decode($_lostJson, true);
+        if (!is_array($_lostArr) || $_lostArr === []) continue;
+        $_nonPod = array_values(array_filter($_lostArr, static fn(array $e): bool => !in_array((int) ($e['ship_type_id'] ?? 0), [670, 33328], true)));
+        if ($_nonPod === []) continue;
+        usort($_nonPod, static fn(array $a, array $b): int => (float) ($b['isk_lost'] ?? 0) <=> (float) ($a['isk_lost'] ?? 0));
+        $_bestId = (int) ($_nonPod[0]['ship_type_id'] ?? 0);
+        if ($_bestId <= 0) continue;
+        if (!isset($extraShipCounts[$_pSide][$_bestId])) {
+            $extraShipCounts[$_pSide][$_bestId] = ['type_id' => $_bestId, 'name' => '', 'pilots' => 0];
+        }
+        $extraShipCounts[$_pSide][$_bestId]['pilots']++;
+    }
+    // Merge extras into sidePanels (names resolved after ship-type name lookup below)
+    foreach ($extraShipCounts as $_side => $_ships) {
+        foreach ($_ships as $_sid => $_info) {
+            $sidePanels[$_side]['ships'][] = [
+                'type_id' => $_info['type_id'],
+                'name'    => '', // placeholder — filled after name resolution
+                'pilots'  => $_info['pilots'],
+            ];
+            $sidePanels[$_side]['ship_pilots'] += $_info['pilots'];
+        }
+    }
+
     foreach ($sidePanels as $side => $data) {
         usort($data['ships'], static fn(array $l, array $r): int => $r['pilots'] <=> $l['pilots']);
         $sidePanels[$side]['ships'] = array_slice($data['ships'], 0, 12);
@@ -405,6 +445,16 @@ if ($viewSnapshot !== null && !$pendingLock) {
         }
     }
     $shipTypeNames = !empty($allShipTypeIds) ? db_market_orders_current_compact_type_names(array_keys($allShipTypeIds)) : [];
+
+    // Fill ship names for any extra top-hull entries added from lost-ship fallback
+    foreach ($sidePanels as $side => $data) {
+        foreach ($sidePanels[$side]['ships'] as &$_sh) {
+            if ($_sh['name'] === '' && $_sh['type_id'] > 0) {
+                $_sh['name'] = (string) ($shipTypeNames[$_sh['type_id']] ?? ('Type #' . $_sh['type_id']));
+            }
+        }
+        unset($_sh);
+    }
 
     // ── Handle pending lock: save full view snapshot ──────────────────────
     if ($pendingLock) {

--- a/src/db.php
+++ b/src/db.php
@@ -15809,6 +15809,7 @@ function db_theater_final_blows_by_side(string $theaterId): array
               AND tas.alliance_id = ka.alliance_id
          WHERE tb.theater_id = ?
            AND ka.final_blow = 1
+           AND ke.victim_ship_type_id NOT IN (670, 33328)
          GROUP BY side",
         [$theaterId]
     );

--- a/src/functions.php
+++ b/src/functions.php
@@ -30970,10 +30970,11 @@ function supplycore_theater_map_svg(string $theaterId, array $systemIds, int $ho
     }
     $hops = max(1, min(2, $hops));
 
-    // Single system: reuse existing radial map (shows 2-hop neighborhood)
-    if (count($systemIds) === 1) {
-        return supplycore_system_area_svg($systemIds[0], 2);
-    }
+    // Single-system battles: show 1-hop gate neighbours via neo4j using the
+    // same compact horizontal layout as multi-system battles, rather than the
+    // tall 2-hop radial map (which left most of the canvas empty).
+    // The radial helper (supplycore_system_area_svg) is kept for the dedicated
+    // system-map page; here we want consistency and connected-system context.
 
     $cacheDir = dirname(__DIR__) . '/public/threat-corridors/svg';
     if (!is_dir($cacheDir) && !@mkdir($cacheDir, 0775, true) && !is_dir($cacheDir)) {


### PR DESCRIPTION
## Summary
This PR fixes the display of participant ships in theater intelligence reports by excluding capsules (pod type IDs 670 and 33328) from being shown as the "flying ship" and from top-hull statistics. When a pilot's flying ship resolves to a capsule, the system now falls back to their highest-ISK lost ship or ship_type_ids list instead.

## Key Changes

- **Capsule exclusion in `_participant_flying_ship_name()`**: Added pod type ID filtering to prevent capsules from being returned as the flying ship. Updated the fallback logic to iterate through all ship_type_ids entries (not just the first) while skipping pods.

- **Flying ship resolution in participant row rendering**: Refactored to compute the lost ship first, then use it as a fallback when flying_ship_type_id is absent or is a capsule. This ensures the displayed ship is always a meaningful combat vessel rather than an escape pod.

- **Top hulls patch in view.php**: Added logic to credit pilots whose flying_ship_type_id is a capsule with their highest-ISK non-pod lost ship in the "Top Hulls" statistics. These pilots were previously skipped by the fleet-composition query filter, causing their actual ships to never appear in rankings.

- **Final blows query filter**: Added `AND ke.victim_ship_type_id NOT IN (670, 33328)` to exclude capsule kills from final-blow statistics, ensuring only meaningful ship losses are counted.

- **System map layout change**: Removed the special case for single-system battles that used the radial 2-hop map. Single-system battles now use the same compact horizontal layout as multi-system battles for consistency and better canvas utilization.

## Implementation Details

- Pod type IDs (670 = Capsule, 33328 = Capsule - Upgraded) are now consistently defined and checked across multiple functions.
- The fallback chain for flying ship is: explicit flying_ship_type_id → lost ship record → ship_type_ids list, with capsules filtered at each step.
- The `$lostSameAsFlying` flag prevents redundant "lost" badges when the flying ship came from the loss record.

https://claude.ai/code/session_01KLhUnxt6n7DFadBNbjjbyK