### PR TITLE
Fix ship/pod display, final blows, missing hulls, and battle map

### DIFF
--- a/public/theater-intelligence/partials/_header.php
+++ b/public/theater-intelligence/partials/_header.php
@@ -1,7 +1,20 @@
+<?php
+// Compute mini-map URL (1-hop gate neighbours from neo4j/stargates)
+$_miniMapUrl = null;
+if (isset($systems, $theaterId) && $systems !== []) {
+    $_miniMapSystemIds = array_values(array_filter(
+        array_map(static fn(array $s): int => (int) ($s['system_id'] ?? 0), $systems),
+        static fn(int $id): bool => $id > 0
+    ));
+    if ($_miniMapSystemIds !== []) {
+        $_miniMapUrl = supplycore_theater_map_svg($theaterId, $_miniMapSystemIds, 1);
+    }
+}
+?>
 <section class="surface-primary">
     <a href="/theater-intelligence" class="text-sm text-accent">&#8592; Back to Theater Overview</a>
 
-    <div class="mt-3 flex items-start justify-center gap-4">
+    <div class="mt-3 flex items-start gap-4">
         <div class="flex-1 text-center">
             <div class="flex items-center justify-center gap-2">
                 <p class="text-xs uppercase tracking-[0.16em] text-muted">Battle Intelligence — Theater Detail</p>
@@ -36,6 +49,11 @@
                 <span>Hostile: <?= number_format(count($sideAlliancesByPilots['opponent'] ?? [])) ?> alliances</span>
             </div>
         </div>
+        <?php if ($_miniMapUrl !== null): ?>
+        <div class="hidden md:block flex-shrink-0 self-center" style="width:260px">
+            <img src="<?= htmlspecialchars($_miniMapUrl, ENT_QUOTES) ?>" alt="Battle location" class="w-full rounded border border-slate-700/40" style="aspect-ratio:900/340" loading="lazy">
+        </div>
+        <?php endif; ?>
     </div>
 
     <div class="mt-3 grid gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-6">

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -523,7 +523,6 @@ include __DIR__ . '/partials/_header.php';
 include __DIR__ . '/partials/_battle_report.php';
 include __DIR__ . '/partials/_ai_briefing.php';
 include __DIR__ . '/partials/_battles.php';
-include __DIR__ . '/partials/_location_map.php';
 include __DIR__ . '/partials/_timeline.php';
 include __DIR__ . '/partials/_alliance_summary.php';
 include __DIR__ . '/partials/_participants.php';

--- a/src/db.php
+++ b/src/db.php
@@ -15809,7 +15809,7 @@ function db_theater_final_blows_by_side(string $theaterId): array
               AND tas.alliance_id = ka.alliance_id
          WHERE tb.theater_id = ?
            AND ka.final_blow = 1
-           AND ke.victim_ship_type_id NOT IN (670, 33328)
+           AND (ka.character_id IS NULL OR ka.character_id != ke.victim_character_id)
          GROUP BY side",
         [$theaterId]
     );

--- a/src/functions.php
+++ b/src/functions.php
@@ -30981,7 +30981,7 @@ function supplycore_theater_map_svg(string $theaterId, array $systemIds, int $ho
         return null;
     }
     $cacheKey = substr(md5($theaterId . ':' . implode(',', $systemIds)), 0, 12);
-    $cacheFile = sprintf('%s/theater-%s-h%d-v1.svg', $cacheDir, $cacheKey, $hops);
+    $cacheFile = sprintf('%s/theater-%s-h%d-v2.svg', $cacheDir, $cacheKey, $hops);
     $cacheTtl = supplycore_threat_corridor_map_cache_minutes() * 60;
     if (is_file($cacheFile) && ((time() - (int) filemtime($cacheFile)) < $cacheTtl)) {
         return '/threat-corridors/svg/' . basename($cacheFile);


### PR DESCRIPTION
## Summary

- **Final blows**: exclude only self-destructs (`attacker.character_id = victim.character_id`) from the final blow count — enemy pod kills remain legitimate final blows; only true self-destructs are filtered
- **Capsule as flying ship**: restructured participant row rendering to compute lost ships first; if `flying_ship_type_id` is absent or a capsule (670/33328), the highest-ISK non-pod lost ship is used as the display ship instead — capsule is the driver/escape pod, never the ship label
- **Missing hulls in Top Hulls**: after fleet composition is built, a second pass credits the best non-pod lost ship for any pilot whose `flying_ship_type_id` was resolved to a capsule — Retrievers, Covetors etc. now appear
- **Battle location map**: removed the standalone full-width section; map is now a compact 260px inline element on the right of the theater header bar; bumped cache version to `v2` to force regeneration with 1-hop gate neighbours fetched via neo4j `CONNECTS_TO` relationships

## Test plan

- [ ] Open a theater where the opponent only lost ships + pods — verify final blows show 0 for the opponent (self-destruct pods excluded) and correct count for friendlies
- [ ] Open a theater with a miner/industrial victim — verify participant row shows the miner ship (Retriever/Covetor/Orca), not a Capsule, as the primary ship
- [ ] Verify Top Hulls section lists the actual miner ships, not capsules
- [ ] Open any single-system theater — verify the header bar contains a compact map on the right with the battle system at centre and adjacent gate systems around it (no more giant empty canvas)

https://claude.ai/code/session_01KLhUnxt6n7DFadBNbjjbyK