### PR TITLE
Add has_more flag to re-queue jobs with remaining work

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -738,6 +738,19 @@ class SupplyCoreDb:
             (status[:20], job_key[:120]),
         )
 
+    def advance_next_due_at(self, job_key: str) -> int:
+        """Reset next_due_at to now so a job with remaining work is re-queued immediately.
+
+        Called after a successful run that returned has_more=True — the job hit its
+        max_batches limit but still has items in the queue.  Setting next_due_at to
+        UTC_TIMESTAMP() makes queue_due_recurring_jobs pick it up on the very next
+        poll cycle instead of waiting for the full scheduled interval.
+        """
+        return self.execute(
+            "UPDATE sync_schedules SET next_due_at = UTC_TIMESTAMP() WHERE job_key = %s AND enabled = 1",
+            (job_key[:120],),
+        )
+
     def refresh_market_order_current_projection(self, *, source_type: str) -> dict[str, int]:
         rows_processed = self.fetch_scalar(
             "SELECT COUNT(*) AS c FROM market_orders_current WHERE source_type = %s",

--- a/python/orchestrator/job_result.py
+++ b/python/orchestrator/job_result.py
@@ -95,6 +95,7 @@ class JobResult:
     batches_completed: int = 0
     checkpoint_before: str | None = None
     checkpoint_after: str | None = None
+    has_more: bool = False
     error_text: str | None = None
     warnings: list[str] = field(default_factory=list)
     meta: dict[str, Any] = field(default_factory=dict)
@@ -152,12 +153,18 @@ class JobResult:
             "status", "summary", "started_at", "finished_at", "duration_ms",
             "rows_seen", "rows_processed", "rows_written", "rows_skipped",
             "rows_failed", "batches_completed", "checkpoint_before",
-            "checkpoint_after", "error_text", "error", "warnings", "meta",
+            "checkpoint_after", "has_more", "error_text", "error", "warnings", "meta",
             "computed_at",
         }
         for key, value in safe.items():
             if key not in _CANONICAL_KEYS and key not in raw_meta:
                 raw_meta[key] = value
+
+        # has_more may be set at top level or inside meta (graph_pipeline sets it in meta).
+        has_more = bool(
+            raw.get("has_more")
+            or (raw.get("meta") or {}).get("has_more")
+        )
 
         return cls(
             status=status,
@@ -173,6 +180,7 @@ class JobResult:
             batches_completed=_safe_int(raw.get("batches_completed")),
             checkpoint_before=raw.get("checkpoint_before"),
             checkpoint_after=raw.get("checkpoint_after"),
+            has_more=has_more,
             error_text=error_text,
             warnings=warnings,
             meta=raw_meta,
@@ -191,6 +199,7 @@ class JobResult:
         duration_ms: int = 0,
         meta: dict[str, Any] | None = None,
         warnings: list[str] | None = None,
+        has_more: bool = False,
         **kwargs: Any,
     ) -> JobResult:
         """Convenience builder for a successful result."""
@@ -209,6 +218,7 @@ class JobResult:
             batches_completed=kwargs.get("batches_completed", 0),
             checkpoint_before=kwargs.get("checkpoint_before"),
             checkpoint_after=kwargs.get("checkpoint_after"),
+            has_more=has_more,
             error_text=None,
             warnings=warnings or [],
             meta={
@@ -290,6 +300,7 @@ class JobResult:
             "batches_completed": self.batches_completed,
             "checkpoint_before": self.checkpoint_before,
             "checkpoint_after": self.checkpoint_after,
+            "has_more": self.has_more,
             "error_text": self.error_text,
             "warnings": list(self.warnings),
             "meta": dict(self.meta),

--- a/python/orchestrator/jobs/character_feature_windows.py
+++ b/python/orchestrator/jobs/character_feature_windows.py
@@ -471,6 +471,9 @@ def run_compute_character_feature_windows(
 
             _sync_state_upsert(db, DATASET_KEY, last_battle_id, "success", rows_written)
 
+        # has_more is true when we hit the batch cap without draining the cursor.
+        has_more = batch_count == max_batches
+
         duration_ms = int((time.perf_counter() - started) * 1000)
         result = JobResult.success(
             job_key=lock_key,
@@ -479,6 +482,7 @@ def run_compute_character_feature_windows(
             rows_written=0 if dry_run else rows_written,
             duration_ms=duration_ms,
             batches_completed=batch_count,
+            has_more=has_more,
             meta={
                 "computed_at": computed_at,
                 "cursor": last_battle_id,

--- a/python/orchestrator/jobs/character_movement_footprints.py
+++ b/python/orchestrator/jobs/character_movement_footprints.py
@@ -752,6 +752,8 @@ def run_compute_character_movement_footprints(
             # Also update cohort z-scores on the footprint rows
             _update_cohort_scores(db, all_evidence)
 
+        has_more = batch_count == max_batches
+
         duration_ms = int((time.perf_counter() - started) * 1000)
         result = JobResult.success(
             job_key=lock_key,
@@ -760,6 +762,7 @@ def run_compute_character_movement_footprints(
             rows_written=0 if dry_run else rows_written,
             duration_ms=duration_ms,
             batches_completed=batch_count,
+            has_more=has_more,
             meta={
                 "computed_at": computed_at,
                 "cursor": last_battle_id,

--- a/python/orchestrator/jobs/copresence_edges.py
+++ b/python/orchestrator/jobs/copresence_edges.py
@@ -606,6 +606,10 @@ def run_compute_copresence_edges(
 
             _sync_state_upsert(db, DATASET_KEY, last_battle_id, "success", rows_written)
 
+        # has_more is true when we hit the batch cap (cursor-based: hitting the cap
+        # means the cursor advanced on every iteration so more battles likely remain).
+        has_more = batch_count == max_batches
+
         if not all_character_ids:
             duration_ms = int((time.perf_counter() - started) * 1000)
             result = JobResult.success(
@@ -613,6 +617,7 @@ def run_compute_copresence_edges(
                 summary="No characters to process.",
                 rows_processed=0,
                 rows_written=0,
+                has_more=has_more,
                 duration_ms=duration_ms,
             ).to_dict()
             finish_job_run(db, job, status="success", rows_processed=0, rows_written=0, meta=result)
@@ -768,6 +773,7 @@ def run_compute_copresence_edges(
             rows_written=rows_written + signals_written,
             duration_ms=duration_ms,
             batches_completed=batch_count,
+            has_more=has_more,
             meta={
                 "computed_at": computed_at,
                 "cursor": last_battle_id,

--- a/python/orchestrator/jobs/counterintel_pipeline.py
+++ b/python/orchestrator/jobs/counterintel_pipeline.py
@@ -1156,6 +1156,8 @@ def run_compute_counterintel_pipeline(
             rows_written += len(hull_rows) + len(overperformance_rows) + len(feature_rows) + len(score_rows) + len(evidence_rows) + org_written
             _sync_state_upsert(db, COUNTERINTEL_DATASET_KEY, last_battle_id, "success", rows_written)
 
+        has_more = batch_count == max_batches
+
         duration_ms = int((time.perf_counter() - started) * 1000)
         result = JobResult.success(
             job_key=lock_key,
@@ -1164,6 +1166,7 @@ def run_compute_counterintel_pipeline(
             rows_written=0 if dry_run else rows_written,
             duration_ms=duration_ms,
             batches_completed=batch_count,
+            has_more=has_more,
             meta={
                 "computed_at": computed_at,
                 "rows_would_write": rows_written if dry_run else rows_written,

--- a/python/orchestrator/jobs/evewho_enrichment_sync.py
+++ b/python/orchestrator/jobs/evewho_enrichment_sync.py
@@ -277,15 +277,20 @@ def run_evewho_enrichment_sync(
         adapter = EveWhoAdapter(user_agent, rate_limit_requests=rate_limit) if rate_limit else EveWhoAdapter(user_agent)
 
         batch_count = 0
+        exhausted = False
         while batch_count < max_batches:
             batch = _claim_batch(db, batch_size)
             if not batch:
+                exhausted = True
                 break
 
             batch_count += 1
             processed, written = _process_batch(db, neo4j, adapter, batch)
             rows_processed += processed
             rows_written += written
+
+        # has_more is true when we hit the batch cap without emptying the queue.
+        has_more = not exhausted and batch_count == max_batches
 
         # Update sync state cursor with progress
         _sync_state_upsert(db, str(rows_written), "success", rows_written)
@@ -300,12 +305,14 @@ def run_evewho_enrichment_sync(
                 "batches": batch_count,
                 "batch_size": batch_size,
                 "duration_ms": duration_ms,
+                "has_more": has_more,
             },
         )
         return JobResult.success(
             job_key=JOB_KEY,
             rows_seen=rows_processed,
             rows_written=rows_written,
+            has_more=has_more,
             summary=f"Enriched {rows_written}/{rows_processed} characters in {batch_count} batch(es), {duration_ms}ms",
         ).to_dict()
 

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -166,6 +166,9 @@ def _job_payload(job_name: str, started_at: float, status: str, **kwargs: Any) -
     rows_processed = int(kwargs.pop("rows_processed", 0))
     rows_written = int(kwargs.pop("rows_written", 0))
     error_text = str(kwargs.pop("error_text", "")) or None
+    # Pop has_more before building graph_meta so it surfaces as a canonical
+    # top-level field rather than being buried inside meta.
+    has_more = bool(kwargs.pop("has_more", False))
 
     graph_meta = {
         "nodes_created": int(kwargs.pop("nodes_created", 0)),
@@ -198,6 +201,7 @@ def _job_payload(job_name: str, started_at: float, status: str, **kwargs: Any) -
         rows_written=rows_written,
         rows_seen=rows_processed,
         duration_ms=duration_ms,
+        has_more=has_more,
         meta=graph_meta,
     ).to_dict()
 

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -207,6 +207,23 @@ def _finalize_job(db: SupplyCoreDb, job_key: str, result: dict[str, Any], logger
     except Exception as exc:
         logger.warning("scheduler_job_current_status upsert failed", payload={"event": "worker_pool.finalize.current_status_error", "job_key": job_key, "error": str(exc)})
 
+    # If the job processed a full set of batches and still has items queued,
+    # advance next_due_at to now so the job is re-queued immediately on the
+    # next scheduler poll instead of waiting for the full schedule interval.
+    has_more = bool(result.get("has_more"))
+    if has_more and status == "success":
+        try:
+            db.advance_next_due_at(job_key)
+            logger.info(
+                "has_more: advancing next_due_at to drain remaining queue",
+                payload={"event": "worker_pool.finalize.has_more_requeue", "job_key": job_key},
+            )
+        except Exception as exc:
+            logger.warning(
+                "has_more: advance_next_due_at failed",
+                payload={"event": "worker_pool.finalize.has_more_requeue_error", "job_key": job_key, "error": str(exc)},
+            )
+
     mapping = _UI_REFRESH_JOB_MAP.get(job_key)
     if mapping and status in ("success", "skipped"):
         try:


### PR DESCRIPTION
## Summary
This PR implements a mechanism to immediately re-queue jobs that have remaining work in their queue after hitting their batch processing limit. When a job completes successfully but still has items queued (`has_more=True`), the scheduler will pick it up on the next poll cycle instead of waiting for the full schedule interval.

## Key Changes

- **JobResult enhancement**: Added `has_more` field to the `JobResult` dataclass to track whether a job has remaining work after hitting its batch limit. The field can be set at the top level or within metadata (for compatibility with graph_pipeline).

- **Worker pool finalization**: Added logic in `_finalize_job()` to detect when a job has `has_more=True` and call `db.advance_next_due_at()` to reset the job's `next_due_at` timestamp to the current time, ensuring immediate re-queuing.

- **Database support**: Implemented `advance_next_due_at()` method in `SupplyCoreDb` to update the `next_due_at` column to `UTC_TIMESTAMP()` for enabled jobs, allowing the scheduler to pick them up immediately.

- **Job implementations**: Updated all batch-processing jobs to calculate and report `has_more`:
  - `evewho_enrichment_sync`: Tracks whether the queue was exhausted or batch limit was hit
  - `copresence_edges`: Sets `has_more` when batch count equals max_batches
  - `character_feature_windows`: Sets `has_more` when batch count equals max_batches
  - `character_movement_footprints`: Sets `has_more` when batch count equals max_batches
  - `counterintel_pipeline`: Sets `has_more` when batch count equals max_batches
  - `graph_pipeline`: Extracts `has_more` from kwargs to surface it as a top-level field

## Implementation Details

- The `has_more` flag is only acted upon when a job completes with `status="success"`, preventing unnecessary re-queuing of failed jobs.
- Error handling is in place for both the database update and the finalization logic, with appropriate warning logs if re-queuing fails.
- The implementation supports both top-level and metadata-nested `has_more` values for flexibility across different job types.

https://claude.ai/code/session_01D34eCDZXW9vjZgdtSeaoCK