### PR TITLE
Fix theater intelligence side classification logic

### DIFF
--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -70,9 +70,6 @@ if ($viewSnapshot !== null && !$pendingLock) {
         if ($allianceId > 0 && in_array($allianceId, $opponentAllianceIds, true)) {
             return 'opponent';
         }
-        if ($allianceId > 0) {
-            return 'opponent';
-        }
         return 'third_party';
     };
 
@@ -176,9 +173,6 @@ if ($viewSnapshot !== null && !$pendingLock) {
             return 'friendly';
         }
         if ($allianceId > 0 && in_array($allianceId, $opponentAllianceIds, true)) {
-            return 'opponent';
-        }
-        if ($allianceId > 0) {
             return 'opponent';
         }
         return 'third_party';

--- a/src/db.php
+++ b/src/db.php
@@ -15798,8 +15798,8 @@ function db_theater_final_blows_by_side(string $theaterId): array
     $rows = db_select(
         "SELECT
             CASE
-                WHEN tas.side = 'side_a' THEN 'friendly'
-                WHEN tas.side = 'side_b' THEN 'opponent'
+                WHEN tas.side = 'friendly' THEN 'friendly'
+                WHEN tas.side = 'opponent' THEN 'opponent'
                 ELSE 'third_party'
             END AS side,
             COUNT(*) AS final_blows


### PR DESCRIPTION
## Summary
This PR fixes incorrect side classification logic in the theater intelligence feature that was causing all non-opponent alliances to be misclassified as opponents.

## Key Changes
- **Removed redundant fallback logic** in `public/theater-intelligence/view.php`: Deleted two instances of a catch-all condition (`if ($allianceId > 0) return 'opponent'`) that was incorrectly classifying any alliance with a positive ID as an opponent, regardless of whether it was actually in the opponent list.

- **Fixed database query mapping** in `src/db.php`: Updated the CASE statement in `db_theater_final_blows_by_side()` to correctly map database side values (`'friendly'` and `'opponent'`) instead of the incorrect legacy values (`'side_a'` and `'side_b'`).

## Implementation Details
The bug was in the classification closure used in two places within the view file. The logic flow was:
1. Check if alliance is in opponent list → classify as 'opponent' ✓
2. Check if alliance ID > 0 → classify as 'opponent' ✗ (this was wrong)
3. Otherwise → classify as 'third_party'

Step 2 was a catch-all that contradicted the intended logic. Removing it allows alliances that aren't explicitly in the opponent list to be correctly classified as 'third_party'. The database query fix ensures the source data uses the correct side identifiers.

https://claude.ai/code/session_01GMGUSVUmitMto712SjNKt6