### PR TITLE
Add structure kill tracking and display in theater analysis

### DIFF
--- a/database/migrations/20260408_theater_structure_kills.sql
+++ b/database/migrations/20260408_theater_structure_kills.sql
@@ -1,0 +1,18 @@
+-- Theater structure kills — tracks player-owned structure losses within a theater.
+-- Structures have no victim character, so they cannot be stored in theater_participants
+-- (which has a character_id PK component).  This table stores one row per
+-- structure killmail and feeds the structure rows in the Participants table UI.
+
+CREATE TABLE IF NOT EXISTS theater_structure_kills (
+    theater_id            CHAR(64)        NOT NULL,
+    killmail_id           BIGINT UNSIGNED NOT NULL,
+    victim_corporation_id BIGINT UNSIGNED DEFAULT NULL,
+    victim_alliance_id    BIGINT UNSIGNED DEFAULT NULL,
+    victim_ship_type_id   INT UNSIGNED    NOT NULL DEFAULT 0,
+    isk_lost              DECIMAL(20,2)   NOT NULL DEFAULT 0,
+    side                  VARCHAR(80)     NOT NULL DEFAULT 'third_party',
+    killed_at             DATETIME        DEFAULT NULL,
+    PRIMARY KEY (theater_id, killmail_id),
+    KEY idx_theater_structure_kills_side (theater_id, side),
+    KEY idx_theater_structure_kills_alliance (theater_id, victim_alliance_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -21,6 +21,22 @@ foreach ($participantsAll as $p) {
     }
 }
 
+// Split structure kills by owning alliance side
+$friendlyStructureKills = [];
+$enemyStructureKills = [];
+$thirdPartyStructureKills = [];
+$structureKills = $structureKills ?? [];
+foreach ($structureKills as $sk) {
+    $skSide = $classifyAlliance((int) ($sk['victim_alliance_id'] ?? 0));
+    if ($skSide === 'friendly') {
+        $friendlyStructureKills[] = $sk;
+    } elseif ($skSide === 'opponent') {
+        $enemyStructureKills[] = $sk;
+    } else {
+        $thirdPartyStructureKills[] = $sk;
+    }
+}
+
 // When a specific filter is active, show single filtered list
 $showSideBySide = ($sideFilter === null && !$suspiciousOnly);
 $filteredList = $showSideBySide ? [] : $participants;
@@ -102,7 +118,8 @@ function _render_participant_row(array $p, array $resolvedEntities, array $shipT
         $decoded = json_decode($lostJson, true);
         if (is_array($decoded)) $lostDetail = $decoded;
     }
-    // Filter out pods
+    // Filter out pods (for ship display), and separately collect pod losses for the indicator
+    $_podIds = [670, 33328];
     $lostDisplay = array_values(array_filter($lostDetail, static fn(array $e): bool => !in_array((int) ($e['ship_type_id'] ?? 0), [670, 33328], true)));
     if ($lostDisplay !== []) {
         usort($lostDisplay, static fn(array $a, array $b): int => (float) ($b['isk_lost'] ?? 0) <=> (float) ($a['isk_lost'] ?? 0));
@@ -112,6 +129,16 @@ function _render_participant_row(array $p, array $resolvedEntities, array $shipT
         $lostShipCount = 0;
         foreach ($lostDisplay as $entry) {
             $lostShipCount += (int) ($entry['count'] ?? 1);
+        }
+    }
+
+    // ── Capsule (pod) losses — shown as a secondary indicator ──
+    $podIsk = 0.0;
+    $wasPodded = false;
+    foreach ($lostDetail as $_pe) {
+        if (in_array((int) ($_pe['ship_type_id'] ?? 0), [670, 33328], true)) {
+            $podIsk += (float) ($_pe['isk_lost'] ?? 0);
+            $wasPodded = true;
         }
     }
 
@@ -219,6 +246,12 @@ function _render_participant_row(array $p, array $resolvedEntities, array $shipT
                         <span class="text-[10px] text-red-500/60">&darr; lost<?= $lostShipCount > 1 ? ' &times;' . $lostShipCount : '' ?></span>
                     </div>
                 <?php endif; ?>
+                <?php if ($wasPodded): ?>
+                    <div class="flex items-center gap-1 opacity-80" title="Capsule also destroyed">
+                        <img class="w-3 h-3 flex-shrink-0 opacity-50" src="https://images.evetech.net/types/670/icon?size=32" loading="lazy">
+                        <span class="text-[10px] text-orange-400/80">+ Pod<?= $podIsk > 0 ? ' (' . supplycore_format_isk($podIsk) . ')' : '' ?></span>
+                    </div>
+                <?php endif; ?>
             </div>
         </td>
         <td class="px-2 py-1.5">
@@ -259,6 +292,81 @@ function _fmt_damage(float $v): string {
     if ($v >= 1e3) return number_format($v / 1e3, 0) . 'k';
     return number_format($v, 0);
 }
+
+/**
+ * Render a single structure-kill row for the participant table.
+ * Structures have no pilot character, K/D, or damage — only an owning
+ * corp/alliance, hull type, and ISK lost.
+ */
+function _render_structure_row(array $sk, array $resolvedEntities, array $shipTypeNames): string {
+    $allianceId = (int) ($sk['victim_alliance_id'] ?? 0);
+    $corpId     = (int) ($sk['victim_corporation_id'] ?? 0);
+    $shipTypeId = (int) ($sk['victim_ship_type_id'] ?? 0);
+    $iskLost    = (float) ($sk['isk_lost'] ?? 0);
+    $shipName   = $shipTypeId > 0
+        ? (string) ($shipTypeNames[$shipTypeId] ?? ('Structure #' . $shipTypeId))
+        : 'Unknown Structure';
+
+    // Prefer corp name, fall back to alliance name
+    $orgName = '';
+    if ($corpId > 0) {
+        $orgName = killmail_entity_preferred_name($resolvedEntities, 'corporation', $corpId, (string) ($sk['corporation_name'] ?? ''), 'Corp');
+    }
+    if (($orgName === '' || str_starts_with($orgName, 'Corp #')) && $allianceId > 0) {
+        $orgName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $allianceId, (string) ($sk['alliance_name'] ?? ''), 'Alliance');
+    }
+    if ($orgName === '') {
+        $orgName = 'Unknown';
+    }
+
+    ob_start();
+    ?>
+    <tr class="border-b border-border/50 hover:bg-slate-800/40 transition-colors border-l-2 border-l-orange-500/40 bg-orange-950/5"
+        data-deaths="1"
+        data-kills="0"
+        data-kd="0.0000"
+        data-role-rank="99"
+        data-hull="zzz-structure"
+        data-damage="0"
+        data-isk="<?= $iskLost ?>">
+        <td class="px-2 py-1.5">
+            <div class="flex items-center gap-1.5">
+                <span class="text-orange-500/70 text-sm leading-none flex-shrink-0" title="Structure">&#x1F3DB;</span>
+                <span class="text-xs text-slate-400 truncate max-w-[8rem]" title="<?= htmlspecialchars($orgName, ENT_QUOTES) ?>">
+                    <?= htmlspecialchars($orgName, ENT_QUOTES) ?>
+                </span>
+                <span class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-orange-950 ring-1 ring-orange-500/60 text-[8px] text-orange-400 flex-shrink-0" title="Structure destroyed">&#x2715;</span>
+            </div>
+        </td>
+        <td class="px-2 py-1.5">
+            <div class="flex items-center gap-1">
+                <?php if ($shipTypeId > 0): ?>
+                    <img class="w-4 h-4 flex-shrink-0" src="https://images.evetech.net/types/<?= $shipTypeId ?>/icon?size=32" loading="lazy">
+                <?php endif; ?>
+                <span class="text-[11px] text-orange-300/80 truncate max-w-[6rem]"><?= htmlspecialchars($shipName, ENT_QUOTES) ?></span>
+            </div>
+        </td>
+        <td class="px-2 py-1.5">
+            <span class="inline-flex items-center rounded-full px-[6px] py-[4px] text-[8px] font-semibold uppercase tracking-[0.12em] leading-none bg-orange-950/60 border border-orange-500/30 text-orange-400">
+                Structure
+            </span>
+        </td>
+        <td class="px-2 py-1.5 text-right text-xs text-slate-600">&mdash;</td>
+        <td class="px-2 py-1.5 text-right text-xs text-slate-600">&mdash;</td>
+        <td class="px-2 py-1.5 text-right">
+            <?php if ($iskLost > 0): ?>
+                <span class="text-xs text-red-400"><?= supplycore_format_isk($iskLost) ?></span>
+            <?php else: ?>
+                <span class="text-xs text-slate-600">&mdash;</span>
+            <?php endif; ?>
+        </td>
+        <td class="px-2 py-1.5 text-right">
+            <span class="text-xs text-slate-600">&mdash;</span>
+        </td>
+    </tr>
+    <?php
+    return ob_get_clean();
+}
 ?>
 <section class="surface-primary mt-4">
     <div class="flex items-center justify-between gap-4">
@@ -282,8 +390,8 @@ function _fmt_damage(float $v): string {
             $enemyLabel .= ' + Third Party';
         }
         $panelSets = [
-            ['label' => $sideLabels['friendly'] ?? 'Friendlies', 'side' => 'friendly', 'rows' => $friendlyParticipants, 'colorClass' => 'text-blue-300', 'borderClass' => 'border-blue-500/30', 'badgeClass' => 'bg-green-950 text-green-400 ring-1 ring-green-600/60', 'badgeLabel' => 'Friendly'],
-            ['label' => $enemyLabel, 'side' => 'opponent', 'rows' => $enemyCombinedParticipants, 'colorClass' => 'text-red-300', 'borderClass' => 'border-red-500/30', 'badgeClass' => 'bg-red-950 text-red-400 ring-1 ring-red-600/60', 'badgeLabel' => 'Opponent'],
+            ['label' => $sideLabels['friendly'] ?? 'Friendlies', 'side' => 'friendly', 'rows' => $friendlyParticipants, 'structure_kills' => $friendlyStructureKills, 'colorClass' => 'text-blue-300', 'borderClass' => 'border-blue-500/30', 'badgeClass' => 'bg-green-950 text-green-400 ring-1 ring-green-600/60', 'badgeLabel' => 'Friendly'],
+            ['label' => $enemyLabel, 'side' => 'opponent', 'rows' => $enemyCombinedParticipants, 'structure_kills' => array_merge($enemyStructureKills, $thirdPartyStructureKills), 'colorClass' => 'text-red-300', 'borderClass' => 'border-red-500/30', 'badgeClass' => 'bg-red-950 text-red-400 ring-1 ring-red-600/60', 'badgeLabel' => 'Opponent'],
         ];
         foreach ($panelSets as $panel):
             // Max damage for this panel
@@ -299,7 +407,7 @@ function _fmt_damage(float $v): string {
                     <?= htmlspecialchars($panel['label'], ENT_QUOTES) ?>
                     <span class="<?= $panel['badgeClass'] ?> text-[10px] rounded px-1.5 py-0.5 ml-1.5"><?= $panel['badgeLabel'] ?></span>
                     <span class="text-muted font-normal text-xs ml-1" data-panel-count>
-                        (<?= count($panel['rows']) ?>)
+                        (<?= count($panel['rows']) + count($panel['structure_kills'] ?? []) ?>)
                     </span>
                 </h3>
             </div>
@@ -329,11 +437,14 @@ function _fmt_damage(float $v): string {
                         </tr>
                     </thead>
                     <tbody class="sc-tbody">
-                        <?php if ($panel['rows'] === []): ?>
+                        <?php if ($panel['rows'] === [] && ($panel['structure_kills'] ?? []) === []): ?>
                             <tr><td colspan="7" class="px-2 py-4 text-sm text-muted text-center">No participants.</td></tr>
                         <?php else: ?>
                             <?php foreach ($panel['rows'] as $p): ?>
                                 <?= _render_participant_row($p, $resolvedEntities, $shipTypeNames, $panelMaxDmg, $hasMonitorOrFlagShips) ?>
+                            <?php endforeach; ?>
+                            <?php foreach (($panel['structure_kills'] ?? []) as $sk): ?>
+                                <?= _render_structure_row($sk, $resolvedEntities, $shipTypeNames) ?>
                             <?php endforeach; ?>
                         <?php endif; ?>
                     </tbody>
@@ -567,6 +678,22 @@ function _fmt_damage(float $v): string {
                                             <span class="text-[10px] text-red-500/60">&darr; lost<?= $lostShipCount2 > 1 ? ' &times;' . $lostShipCount2 : '' ?></span>
                                         </div>
                                     <?php endif; ?>
+                                    <?php
+                                        $podIsk2 = 0.0;
+                                        $wasPodded2 = false;
+                                        foreach ($lostDetail2 as $_pe2) {
+                                            if (in_array((int) ($_pe2['ship_type_id'] ?? 0), [670, 33328], true)) {
+                                                $podIsk2 += (float) ($_pe2['isk_lost'] ?? 0);
+                                                $wasPodded2 = true;
+                                            }
+                                        }
+                                    ?>
+                                    <?php if ($wasPodded2): ?>
+                                        <div class="flex items-center gap-1 opacity-80" title="Capsule also destroyed">
+                                            <img class="w-3 h-3 flex-shrink-0 opacity-50" src="https://images.evetech.net/types/670/icon?size=32" loading="lazy">
+                                            <span class="text-[10px] text-orange-400/80">+ Pod<?= $podIsk2 > 0 ? ' (' . supplycore_format_isk($podIsk2) . ')' : '' ?></span>
+                                        </div>
+                                    <?php endif; ?>
                                 </div>
                             </td>
                             <td class="px-3 py-2">
@@ -597,6 +724,72 @@ function _fmt_damage(float $v): string {
                             <td class="px-3 py-2 text-right">
                                 <a class="text-accent text-sm" href="/battle-intelligence/character.php?character_id=<?= (int) ($p['character_id'] ?? 0) ?>">Intel</a>
                             </td>
+                        </tr>
+                    <?php endforeach; ?>
+                    <?php
+                        // Structure rows in single-column view — filter by side if active
+                        $filteredStructures = array_values(array_filter(
+                            $structureKills,
+                            static function (array $sk) use ($sideFilter, $classifyAlliance): bool {
+                                if ($sideFilter === null) return true;
+                                return $classifyAlliance((int) ($sk['victim_alliance_id'] ?? 0)) === $sideFilter;
+                            }
+                        ));
+                    ?>
+                    <?php foreach ($filteredStructures as $sk): ?>
+                        <?php
+                            $skAllianceId = (int) ($sk['victim_alliance_id'] ?? 0);
+                            $skCorpId     = (int) ($sk['victim_corporation_id'] ?? 0);
+                            $skShipTypeId = (int) ($sk['victim_ship_type_id'] ?? 0);
+                            $skIskLost    = (float) ($sk['isk_lost'] ?? 0);
+                            $skShipName   = $skShipTypeId > 0 ? (string) ($shipTypeNames[$skShipTypeId] ?? 'Structure #' . $skShipTypeId) : 'Unknown Structure';
+                            $skSide       = $classifyAlliance($skAllianceId);
+                            $skSideClass  = $sideColorClass[$skSide] ?? 'text-slate-300';
+                            $skOrgName    = '';
+                            if ($skCorpId > 0) {
+                                $skOrgName = killmail_entity_preferred_name($resolvedEntities, 'corporation', $skCorpId, (string) ($sk['corporation_name'] ?? ''), 'Corp');
+                            }
+                            if (($skOrgName === '' || str_starts_with($skOrgName, 'Corp #')) && $skAllianceId > 0) {
+                                $skOrgName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $skAllianceId, (string) ($sk['alliance_name'] ?? ''), 'Alliance');
+                            }
+                            if ($skOrgName === '') $skOrgName = 'Unknown';
+                        ?>
+                        <tr class="border-b border-border/50 border-l-2 border-l-orange-500/40 bg-orange-950/5">
+                            <td class="px-3 py-2">
+                                <div class="flex items-center gap-1.5">
+                                    <span class="text-orange-500/70 text-sm leading-none flex-shrink-0" title="Structure">&#x1F3DB;</span>
+                                    <span class="text-sm text-slate-400 truncate" title="<?= htmlspecialchars($skOrgName, ENT_QUOTES) ?>"><?= htmlspecialchars($skOrgName, ENT_QUOTES) ?></span>
+                                    <span class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-orange-950 ring-1 ring-orange-500/60 text-[8px] text-orange-400 flex-shrink-0" title="Structure destroyed">&#x2715;</span>
+                                    <span class="inline-block rounded-full px-1.5 py-0.5 text-[9px] uppercase tracking-wider ml-1 <?= $sideBgClass[$skSide] ?? 'bg-slate-700' ?> <?= $skSideClass ?>">
+                                        <?= htmlspecialchars($sideLabels[$skSide] ?? $skSide, ENT_QUOTES) ?>
+                                    </span>
+                                </div>
+                            </td>
+                            <td class="px-3 py-2 text-slate-300 text-xs">
+                                <div class="flex items-center gap-1.5">
+                                    <?php if ($skAllianceId > 0): ?>
+                                        <img src="https://images.evetech.net/alliances/<?= $skAllianceId ?>/logo?size=64" alt="" class="w-5 h-5" loading="lazy">
+                                        <span class="text-slate-100"><?= htmlspecialchars($skOrgName, ENT_QUOTES) ?></span>
+                                    <?php endif; ?>
+                                </div>
+                            </td>
+                            <td class="px-3 py-2">
+                                <div class="flex items-center gap-1">
+                                    <?php if ($skShipTypeId > 0): ?>
+                                        <img class="w-4 h-4" src="https://images.evetech.net/types/<?= $skShipTypeId ?>/icon?size=32" loading="lazy">
+                                    <?php endif; ?>
+                                    <span class="text-[11px] text-orange-300/80 truncate max-w-[8rem]"><?= htmlspecialchars($skShipName, ENT_QUOTES) ?></span>
+                                </div>
+                            </td>
+                            <td class="px-3 py-2">
+                                <span class="inline-flex items-center rounded-full px-[6px] py-[4px] text-[8px] font-semibold uppercase tracking-[0.12em] leading-none bg-orange-950/60 border border-orange-500/30 text-orange-400">Structure</span>
+                            </td>
+                            <td class="px-3 py-2 text-right text-xs text-slate-600">&mdash;</td>
+                            <td class="px-3 py-2 text-right text-xs text-slate-600">&mdash;</td>
+                            <td class="px-3 py-2 text-right text-xs text-slate-600">&mdash;</td>
+                            <td class="px-3 py-2 text-right text-xs <?= $skIskLost > 0 ? 'text-red-300' : 'text-slate-500' ?>"><?= $skIskLost > 0 ? supplycore_format_isk($skIskLost) : '&mdash;' ?></td>
+                            <td class="px-3 py-2 text-right text-xs text-slate-600">&mdash;</td>
+                            <td class="px-3 py-2 text-right text-xs text-slate-600">&mdash;</td>
                         </tr>
                     <?php endforeach; ?>
                 <?php endif; ?>

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -45,6 +45,7 @@ if ($viewSnapshot !== null && !$pendingLock) {
     $turningPoints = (array) ($viewSnapshot['turning_points'] ?? []);
     $participantsAll = (array) ($viewSnapshot['participants'] ?? []);
     $graphParticipants = (array) ($viewSnapshot['graph_participants'] ?? []);
+    $structureKills = (array) ($viewSnapshot['structure_kills'] ?? []);
     $resolvedEntities = (array) ($viewSnapshot['resolved_entities'] ?? []);
     $shipTypeNames = (array) ($viewSnapshot['ship_type_names'] ?? []);
     $trackedAllianceIds = (array) ($viewSnapshot['tracked_alliance_ids'] ?? []);
@@ -122,6 +123,7 @@ if ($viewSnapshot !== null && !$pendingLock) {
     $turningPoints = db_theater_turning_points($theaterId);
     $participantsAll = db_theater_participants($theaterId, null, false, 1000);
     $graphParticipants = db_theater_graph_participants($theaterId);
+    $structureKills = db_theater_structure_kills($theaterId);
 
     $sideFilter = isset($_GET['side']) ? (string) $_GET['side'] : null;
     $suspiciousOnly = isset($_GET['suspicious']) && $_GET['suspicious'] === '1';
@@ -152,6 +154,14 @@ if ($viewSnapshot !== null && !$pendingLock) {
     foreach ($graphParticipants as $row) {
         if (($id = (int) ($row['character_id'] ?? 0)) > 0) {
             $entityRequests['character'][$id] = $id;
+        }
+    }
+    foreach ($structureKills as $row) {
+        if (($id = (int) ($row['victim_alliance_id'] ?? 0)) > 0) {
+            $entityRequests['alliance'][$id] = $id;
+        }
+        if (($id = (int) ($row['victim_corporation_id'] ?? 0)) > 0) {
+            $entityRequests['corporation'][$id] = $id;
         }
     }
     foreach ($entityRequests as $type => $ids) {
@@ -438,6 +448,12 @@ if ($viewSnapshot !== null && !$pendingLock) {
             }
         }
     }
+    // Collect structure ship type IDs so they resolve in the participant table
+    foreach ($structureKills as $sk) {
+        $stid = (int) ($sk['victim_ship_type_id'] ?? 0);
+        if ($stid > 0) $allShipTypeIds[$stid] = true;
+    }
+
     $shipTypeNames = !empty($allShipTypeIds) ? db_market_orders_current_compact_type_names(array_keys($allShipTypeIds)) : [];
 
     // Fill ship names for any extra top-hull entries added from lost-ship fallback
@@ -473,6 +489,7 @@ if ($viewSnapshot !== null && !$pendingLock) {
             'turning_points' => $turningPoints,
             'participants' => $participantsAll,
             'graph_participants' => $graphParticipants,
+            'structure_kills' => $structureKills,
             'resolved_entities' => $resolvedEntities,
             'ship_type_names' => $shipTypeNames,
             'tracked_alliance_ids' => $trackedAllianceIds,

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -123,6 +123,7 @@ def _load_killmails_for_battles(db: SupplyCoreDb, battle_ids: list[str]) -> list
                 ke.victim_alliance_id,
                 ke.victim_ship_type_id,
                 COALESCE(ke.zkb_total_value, 0) AS total_value,
+                COALESCE(ke.zkb_npc, 0) AS zkb_npc,
                 ka.character_id AS attacker_character_id,
                 ka.corporation_id AS attacker_corporation_id,
                 ka.alliance_id AS attacker_alliance_id,
@@ -653,6 +654,63 @@ def _compute_participants(
     return result
 
 
+# ── Structure kill detection ───────────────────────────────────────────────
+
+def _compute_structure_kills(
+    killmails: list[dict[str, Any]],
+    side_configuration: dict[str, set[int]],
+    theater_id: str,
+) -> list[dict[str, Any]]:
+    """Detect player-owned structure killmails (victim has no character, but has alliance).
+
+    Structures cannot appear in theater_participants (character_id PK), so they
+    are stored separately in theater_structure_kills.  A killmail is classified
+    as a structure kill when:
+      - victim_character_id == 0  (no pilot — only structures/deployables have this)
+      - victim_alliance_id > 0    (player-owned — filters out NPC entities)
+      - zkb_npc == 0              (sanity guard: not flagged as an NPC engagement)
+    """
+    seen: set[int] = set()
+    result: list[dict[str, Any]] = []
+
+    for km in killmails:
+        km_id = int(km.get("killmail_id") or 0)
+        if km_id <= 0 or km_id in seen:
+            continue
+
+        victim_char = int(km.get("victim_character_id") or 0)
+        victim_alliance = int(km.get("victim_alliance_id") or 0)
+        zkb_npc = int(km.get("zkb_npc") or 0)
+
+        # Only player-owned structures: no pilot, has an owning alliance, not NPC
+        if victim_char != 0 or victim_alliance <= 0 or zkb_npc:
+            continue
+
+        seen.add(km_id)
+
+        victim_corp = int(km.get("victim_corporation_id") or 0)
+        side = _classify_alliance(victim_alliance, victim_corp, side_configuration)
+        isk = float(km.get("total_value") or 0)
+        km_time = km.get("killmail_time")
+        if isinstance(km_time, datetime):
+            killed_at = km_time.strftime("%Y-%m-%d %H:%M:%S")
+        else:
+            killed_at = str(km_time) if km_time else None
+
+        result.append({
+            "theater_id": theater_id,
+            "killmail_id": km_id,
+            "victim_corporation_id": victim_corp if victim_corp > 0 else None,
+            "victim_alliance_id": victim_alliance,
+            "victim_ship_type_id": int(km.get("victim_ship_type_id") or 0),
+            "isk_lost": isk,
+            "side": side,
+            "killed_at": killed_at,
+        })
+
+    return result
+
+
 # ── Side composition computation ──────────────────────────────────────────
 
 def _compute_side_composition(
@@ -841,6 +899,7 @@ def _flush_analysis(
     computed_at: str,
     battle_ids: list[str],
     side_composition_rows: list[dict[str, Any]] | None = None,
+    structure_kill_rows: list[dict[str, Any]] | None = None,
 ) -> int:
     """Write analysis results for one theater. Returns rows written."""
     rows_written = 0
@@ -850,6 +909,7 @@ def _flush_analysis(
         cursor.execute("DELETE FROM theater_timeline WHERE theater_id = %s", (theater_id,))
         cursor.execute("DELETE FROM theater_alliance_summary WHERE theater_id = %s", (theater_id,))
         cursor.execute("DELETE FROM theater_participants WHERE theater_id = %s", (theater_id,))
+        cursor.execute("DELETE FROM theater_structure_kills WHERE theater_id = %s", (theater_id,))
 
         # Clean turning points for battles in this theater
         if battle_ids:
@@ -978,6 +1038,27 @@ def _flush_analysis(
             )
             rows_written += len(side_composition_rows)
 
+        # Structure kills
+        if structure_kill_rows:
+            cursor.executemany(
+                """
+                INSERT INTO theater_structure_kills (
+                    theater_id, killmail_id, victim_corporation_id, victim_alliance_id,
+                    victim_ship_type_id, isk_lost, side, killed_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                [
+                    (
+                        s["theater_id"], s["killmail_id"],
+                        s["victim_corporation_id"], s["victim_alliance_id"],
+                        s["victim_ship_type_id"], s["isk_lost"],
+                        s["side"], s["killed_at"],
+                    )
+                    for s in structure_kill_rows
+                ],
+            )
+            rows_written += len(structure_kill_rows)
+
         # Update theater aggregates
         cursor.execute(
             """
@@ -1069,6 +1150,9 @@ def run_theater_analysis(
             # Compute participant stats
             participant_stats = _compute_participants(killmails, bp_rows, char_sides, theater_id, ship_group_map)
 
+            # Detect structure kills (player-owned structures with no victim character)
+            structure_kills = _compute_structure_kills(killmails, side_configuration, theater_id)
+
             # Compute side composition features for force-normalization
             side_composition = _compute_side_composition(bp_rows, char_sides, ship_group_map, theater_id)
 
@@ -1084,7 +1168,7 @@ def run_theater_analysis(
                 written = _flush_analysis(
                     db, theater_id, timeline, alliance_summary, participant_stats,
                     turning_points, total_kills, total_isk, anomaly_score, computed_at,
-                    battle_ids, side_composition,
+                    battle_ids, side_composition, structure_kills,
                 )
                 rows_written += written
 
@@ -1093,6 +1177,7 @@ def run_theater_analysis(
                 "theater_id": theater_id,
                 "kills": total_kills,
                 "participants": len(participant_stats),
+                "structure_kills": len(structure_kills),
                 "alliances": len(alliance_summary),
                 "timeline_buckets": len(timeline),
                 "turning_points": len(turning_points),

--- a/src/db.php
+++ b/src/db.php
@@ -15649,6 +15649,23 @@ function db_theater_participants(string $theaterId, ?string $sideFilter = null, 
     return db_select($sql, $params);
 }
 
+function db_theater_structure_kills(string $theaterId): array
+{
+    return db_select(
+        'SELECT tsk.*,
+                COALESCE(emc_a.entity_name, CONCAT("Alliance #", tsk.victim_alliance_id)) AS alliance_name,
+                COALESCE(emc_c.entity_name, CONCAT("Corp #", tsk.victim_corporation_id)) AS corporation_name
+         FROM theater_structure_kills tsk
+         LEFT JOIN entity_metadata_cache emc_a
+              ON emc_a.entity_type = "alliance" AND emc_a.entity_id = tsk.victim_alliance_id
+         LEFT JOIN entity_metadata_cache emc_c
+              ON emc_c.entity_type = "corporation" AND emc_c.entity_id = tsk.victim_corporation_id
+         WHERE tsk.theater_id = ?
+         ORDER BY tsk.isk_lost DESC',
+        [$theaterId]
+    );
+}
+
 function db_theater_suspicion_summary(string $theaterId): ?array
 {
     return db_select_one(


### PR DESCRIPTION
## Summary
This PR adds comprehensive tracking and visualization of player-owned structure losses within theater analysis. Structures are now detected, stored separately, and displayed alongside participant data in the theater intelligence UI.

## Key Changes

### Backend (Python/Database)
- **Structure kill detection** (`_compute_structure_kills`): New function that identifies player-owned structure killmails by filtering for kills with no victim character but with an owning alliance, excluding NPC entities
- **Database schema**: New `theater_structure_kills` table to store structure losses separately (since structures have no character_id and cannot use the `theater_participants` table with its character-based primary key)
- **Data pipeline**: Integrated structure kill computation into `run_theater_analysis` workflow and added `zkb_npc` field to killmail queries for NPC filtering
- **Flush logic**: Updated `_flush_analysis` to persist structure kill rows to the database

### Frontend (PHP/UI)
- **Structure kill grouping**: Split structure kills by alliance side (friendly/enemy/third-party) to display in appropriate participant panels
- **Structure row rendering** (`_render_structure_row`): New function that renders structure losses as table rows with organization name, hull type, ISK lost, and visual indicators
- **Pod loss tracking**: Enhanced participant rows to separately track and display capsule (pod) losses with ISK value as a secondary indicator
- **Dual-view support**: Structure kills are displayed in both side-by-side panel view and single-column filtered view, respecting side filters
- **Participant count**: Updated panel headers to include structure kill counts in the total participant count

### Data Access
- **New query function** (`db_theater_structure_kills`): Retrieves structure kills with resolved alliance and corporation names from entity metadata cache
- **Entity resolution**: Extended entity request collection to include alliances and corporations from structure kill data

## Implementation Details
- Structures are visually distinguished with an orange color scheme (vs. blue for friendly, red for opponent participants)
- Structure rows display organization name, hull type, and ISK lost but omit K/D, damage, and other pilot-specific metrics
- Pod losses are now tracked separately from ship losses and displayed with a capsule icon and ISK value
- The implementation maintains consistency with existing participant filtering and sorting logic
- Structure kills are properly classified by side using the same alliance classification system as participants

https://claude.ai/code/session_01QmW3rXNzhcxUga1JzD281S