### PR TITLE
Optimize compute_signals query with subqueries and database index

### DIFF
--- a/database/migrations/20260331_fix_compute_signals_snapshot_index.sql
+++ b/database/migrations/20260331_fix_compute_signals_snapshot_index.sql
@@ -1,0 +1,10 @@
+-- Add index to market_order_snapshots_summary to support the compute_signals query.
+-- The query filters by (source_type, observed_at) and groups by type_id; all existing
+-- indexes lead with (source_type, source_id, ...) which forces a full scan over all
+-- source_ids for every type_id join, causing the query to run for hours.
+
+ALTER TABLE market_order_snapshots_summary
+    ADD KEY idx_snapshot_summary_source_at_type (source_type, observed_at, type_id);
+
+ALTER TABLE market_order_snapshots_summary_p
+    ADD KEY idx_snapshot_summary_source_at_type (source_type, observed_at, type_id);

--- a/python/orchestrator/jobs/compute_signals.py
+++ b/python/orchestrator/jobs/compute_signals.py
@@ -65,8 +65,8 @@ def run_compute_signals(db: SupplyCoreDb, influx_raw: dict[str, Any] | None = No
             MAX(bai.profit_score) AS profit_score,
             MAX(CASE WHEN rit.type_name IS NULL OR rit.type_name = '' THEN CONCAT('Type #', bai.type_id) ELSE rit.type_name END) AS type_name,
             MAX(COALESCE(bai.quantity, 0)) AS planner_qty,
-            MAX(COALESCE(mh.best_sell_price, mh.best_buy_price, 0)) AS hub_price,
-            MAX(COALESCE(asrc.best_sell_price, asrc.best_buy_price, 0)) AS alliance_price,
+            MAX(COALESCE(mh.hub_price, 0)) AS hub_price,
+            MAX(COALESCE(asrc.alliance_price, 0)) AS alliance_price,
             MAX(COALESCE(asrc.total_sell_volume, 0)) AS alliance_volume,
             MAX(COALESCE(ids.dependency_score, 0.0)) AS dependency_score,
             MAX(COALESCE(ids.doctrine_count, 0)) AS doctrine_count,
@@ -74,8 +74,23 @@ def run_compute_signals(db: SupplyCoreDb, influx_raw: dict[str, Any] | None = No
         FROM buy_all_items bai
         INNER JOIN buy_all_summary bas ON bas.id = bai.summary_id
         LEFT JOIN ref_item_types rit ON rit.type_id = bai.type_id
-        LEFT JOIN market_order_snapshots_summary mh ON mh.type_id = bai.type_id AND mh.source_type = 'market_hub'
-        LEFT JOIN market_order_snapshots_summary asrc ON asrc.type_id = bai.type_id AND asrc.source_type = 'alliance_structure'
+        LEFT JOIN (
+            SELECT type_id,
+                   MAX(COALESCE(best_sell_price, best_buy_price, 0)) AS hub_price
+            FROM market_order_snapshots_summary
+            WHERE source_type = 'market_hub'
+              AND observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 24 HOUR)
+            GROUP BY type_id
+        ) mh ON mh.type_id = bai.type_id
+        LEFT JOIN (
+            SELECT type_id,
+                   MAX(COALESCE(best_sell_price, best_buy_price, 0)) AS alliance_price,
+                   MAX(COALESCE(total_sell_volume, 0)) AS total_sell_volume
+            FROM market_order_snapshots_summary
+            WHERE source_type = 'alliance_structure'
+              AND observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 24 HOUR)
+            GROUP BY type_id
+        ) asrc ON asrc.type_id = bai.type_id
         LEFT JOIN item_dependency_score ids ON ids.type_id = bai.type_id
         WHERE bas.computed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 24 HOUR)
         GROUP BY bai.type_id


### PR DESCRIPTION
## Summary
This PR optimizes the `compute_signals` job query to improve performance by refactoring market price lookups into subqueries and adding a supporting database index.

## Key Changes
- **Refactored market price joins**: Converted direct table joins on `market_order_snapshots_summary` into subqueries that pre-filter by `source_type` and `observed_at` (last 24 hours), then aggregate prices and volumes by `type_id`. This eliminates redundant row processing and moves filtering closer to the data source.
- **Simplified column selection**: Changed from selecting `best_sell_price` and `best_buy_price` separately with inline COALESCE logic to selecting pre-computed `hub_price` and `alliance_price` columns from the subqueries.
- **Added database index**: Created `idx_snapshot_summary_source_at_type` on both `market_order_snapshots_summary` and its partitioned variant `market_order_snapshots_summary_p` with columns `(source_type, observed_at, type_id)` to support the new query pattern and avoid full table scans.

## Implementation Details
The subqueries now handle the aggregation logic that was previously done in the outer SELECT, allowing the database optimizer to use the new index to efficiently filter snapshots by source type and recency before grouping by type_id. This should significantly reduce query execution time from hours to seconds by avoiding full scans over all source_ids for each type_id lookup.

https://claude.ai/code/session_01X7L5mjBwazW7pZeTSBmL3F