### PR TITLE
Migrate character enrichment from EveWho to ESI API

### DIFF
--- a/python/orchestrator/jobs/evewho_alliance_member_sync.py
+++ b/python/orchestrator/jobs/evewho_alliance_member_sync.py
@@ -311,7 +311,40 @@ def _apply_depart_events(
 
 
 # ---------------------------------------------------------------------------
-# Character enrichment (Phase 2) — reused from original implementation
+# ESI character history helper
+# ---------------------------------------------------------------------------
+
+def _compute_end_dates(esi_history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Compute end_date for each ESI corporation history entry.
+
+    ESI returns history entries without end_date.  The end_date of entry N is
+    the start_date of the chronologically next entry.  The most recent entry
+    (last in chronological order) has no end_date.
+    """
+    if not esi_history:
+        return []
+    # Sort ascending by record_id (canonical ordering per ESI spec)
+    sorted_history = sorted(esi_history, key=lambda h: int(h.get("record_id") or 0))
+    result: list[dict[str, Any]] = []
+    for i, entry in enumerate(sorted_history):
+        corp_id = int(entry.get("corporation_id") or 0)
+        if corp_id <= 0:
+            continue
+        start_date = str(entry.get("start_date") or "").strip()
+        end_date: str | None = None
+        if i + 1 < len(sorted_history):
+            end_date = str(sorted_history[i + 1].get("start_date") or "").strip() or None
+        result.append({
+            "corporation_id": corp_id,
+            "start_date": start_date,
+            "end_date": end_date,
+            "is_deleted": bool(entry.get("is_deleted", False)),
+        })
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Character enrichment (Phase 2)
 # ---------------------------------------------------------------------------
 
 def _enrich_character_to_neo4j(
@@ -750,25 +783,28 @@ def run_evewho_alliance_member_sync(
                     break
 
                 try:
-                    _, char_payload = adapter.fetch_character(char_id)
+                    # Fetch character info from ESI
+                    info_resp = esi.get(f"/characters/{char_id}/")
                     api_calls += 1
 
-                    if not char_payload:
-                        _mark_enrichment_failed(db, char_id, "Empty response from EveWho")
+                    if not info_resp.ok or not isinstance(info_resp.body, dict):
+                        _mark_enrichment_failed(db, char_id, f"ESI character info failed (status {info_resp.status_code})")
                         continue
 
-                    # Extract info
-                    info_list = char_payload.get("info")
-                    if isinstance(info_list, list) and info_list:
-                        info = info_list[0]
-                    elif isinstance(char_payload.get("character_id"), int):
-                        info = char_payload
+                    esi_info = info_resp.body
+                    info = {
+                        "name": esi_info.get("name") or "",
+                        "sec_status": esi_info.get("security_status") or 0.0,
+                        "corporation_id": esi_info.get("corporation_id") or 0,
+                        "alliance_id": esi_info.get("alliance_id") or 0,
+                    }
+
+                    # Fetch corporation history from ESI
+                    hist_resp = esi.get(f"/characters/{char_id}/corporationhistory")
+                    api_calls += 1
+                    if hist_resp.ok and isinstance(hist_resp.body, list):
+                        history = _compute_end_dates(hist_resp.body)
                     else:
-                        _mark_enrichment_failed(db, char_id, "No info in response")
-                        continue
-
-                    history = char_payload.get("history") or char_payload.get("corporation_history") or []
-                    if not isinstance(history, list):
                         history = []
 
                     _enrich_character_to_neo4j(neo4j, char_id, info, history)

--- a/python/orchestrator/jobs/evewho_enrichment_sync.py
+++ b/python/orchestrator/jobs/evewho_enrichment_sync.py
@@ -1,9 +1,9 @@
-"""EveWho Neo4j Enrichment Sync — batch-enriches characters from EveWho into Neo4j.
+"""ESI Neo4j Enrichment Sync — batch-enriches characters from ESI into Neo4j.
 
 This job processes the enrichment_queue table in bounded batches:
 
 1. Claims a batch of pending characters (highest priority first)
-2. Fetches corp history from EveWho via the adapter layer
+2. Fetches character info and corp history from ESI
 3. Upserts Character, Corporation, Alliance nodes and MEMBER_OF relationships
    into Neo4j
 4. Updates queue status and sync_state cursor
@@ -18,10 +18,9 @@ from datetime import UTC, datetime
 from typing import Any
 
 from ..db import SupplyCoreDb
-from ..evewho_adapter import EveWhoAdapter
+from ..esi_client import EsiClient
 from ..job_result import JobResult
 from ..job_utils import finish_job_run, start_job_run
-from ..json_utils import json_dumps_safe
 from ..neo4j import Neo4jClient, Neo4jConfig, Neo4jError
 
 JOB_KEY = "evewho_enrichment_sync"
@@ -98,6 +97,35 @@ def _mark_failed(db: SupplyCoreDb, character_id: int, error: str) -> None:
         (MAX_ATTEMPTS, str(error)[:500], character_id),
     )
 
+
+
+def _compute_end_dates(esi_history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Compute end_date for each ESI corporation history entry.
+
+    ESI returns history entries without end_date.  The end_date of entry N is
+    the start_date of the chronologically next entry.  The most recent entry
+    (last in chronological order) has no end_date.
+    """
+    if not esi_history:
+        return []
+    # Sort ascending by record_id (canonical ordering per ESI spec)
+    sorted_history = sorted(esi_history, key=lambda h: int(h.get("record_id") or 0))
+    result: list[dict[str, Any]] = []
+    for i, entry in enumerate(sorted_history):
+        corp_id = int(entry.get("corporation_id") or 0)
+        if corp_id <= 0:
+            continue
+        start_date = str(entry.get("start_date") or "").strip()
+        end_date: str | None = None
+        if i + 1 < len(sorted_history):
+            end_date = str(sorted_history[i + 1].get("start_date") or "").strip() or None
+        result.append({
+            "corporation_id": corp_id,
+            "start_date": start_date,
+            "end_date": end_date,
+            "is_deleted": bool(entry.get("is_deleted", False)),
+        })
+    return result
 
 
 def _enrich_character_to_neo4j(
@@ -203,7 +231,7 @@ def _enrich_character_to_neo4j(
 def _process_batch(
     db: SupplyCoreDb,
     neo4j: Neo4jClient,
-    adapter: EveWhoAdapter,
+    esi: EsiClient,
     batch: list[dict[str, Any]],
 ) -> tuple[int, int]:
     """Process a single batch. Returns (processed, written)."""
@@ -215,24 +243,25 @@ def _process_batch(
         processed += 1
 
         try:
-            # Fetch from EveWho
-            _, payload = adapter.fetch_character(character_id)
-            if not payload:
-                _mark_failed(db, character_id, "EveWho returned empty/null response")
+            # Fetch character info from ESI
+            info_resp = esi.get(f"/characters/{character_id}/")
+            if not info_resp.ok or not isinstance(info_resp.body, dict):
+                _mark_failed(db, character_id, f"ESI character info failed (status {info_resp.status_code})")
                 continue
 
-            # Extract info — EveWho returns {info: [{...}], history: [{...}]}
-            info_list = payload.get("info")
-            if isinstance(info_list, list) and info_list:
-                info = info_list[0]
-            elif isinstance(payload.get("character_id"), int):
-                info = payload
+            esi_info = info_resp.body
+            info = {
+                "name": esi_info.get("name") or "",
+                "sec_status": esi_info.get("security_status") or 0.0,
+                "corporation_id": esi_info.get("corporation_id") or 0,
+                "alliance_id": esi_info.get("alliance_id") or 0,
+            }
+
+            # Fetch corporation history from ESI
+            hist_resp = esi.get(f"/characters/{character_id}/corporationhistory")
+            if hist_resp.ok and isinstance(hist_resp.body, list):
+                history = _compute_end_dates(hist_resp.body)
             else:
-                _mark_failed(db, character_id, "No character info in EveWho response")
-                continue
-
-            history = payload.get("history") or payload.get("corporation_history") or []
-            if not isinstance(history, list):
                 history = []
 
             # Write to Neo4j
@@ -273,8 +302,7 @@ def run_evewho_enrichment_sync(
             return JobResult.skipped(job_key=JOB_KEY, reason="neo4j-disabled").to_dict()
 
         neo4j = Neo4jClient(neo4j_config)
-        rate_limit = max(1, int(runtime.get("evewho_rate_limit_requests") or 0)) if runtime.get("evewho_rate_limit_requests") else None
-        adapter = EveWhoAdapter(user_agent, rate_limit_requests=rate_limit) if rate_limit else EveWhoAdapter(user_agent)
+        esi = EsiClient(user_agent=user_agent)
 
         batch_count = 0
         exhausted = False
@@ -285,7 +313,7 @@ def run_evewho_enrichment_sync(
                 break
 
             batch_count += 1
-            processed, written = _process_batch(db, neo4j, adapter, batch)
+            processed, written = _process_batch(db, neo4j, esi, batch)
             rows_processed += processed
             rows_written += written
 


### PR DESCRIPTION
## Summary
Migrate character enrichment jobs from the EveWho adapter to direct ESI API calls. This change replaces the EveWho data source with official ESI endpoints for fetching character information and corporation history.

## Key Changes

- **Replaced EveWho adapter with ESI client**: Updated `evewho_enrichment_sync.py` and `evewho_alliance_member_sync.py` to use `EsiClient` instead of `EveWhoAdapter`
- **Direct ESI endpoint calls**: Character info now fetched from `/characters/{id}/` and corporation history from `/characters/{id}/corporationhistory`
- **Added `_compute_end_dates()` helper**: New utility function to compute end dates for corporation history entries, since ESI returns history without explicit end dates. The end date of entry N is derived from the start date of the next chronological entry
- **Simplified character info extraction**: Replaced complex EveWho response parsing logic with direct mapping from ESI response fields (`name`, `security_status`, `corporation_id`, `alliance_id`)
- **Removed EveWho rate limiting**: Eliminated rate limit configuration that was specific to EveWho adapter
- **Removed unused imports**: Cleaned up `json_utils` import that is no longer needed

## Implementation Details

- The `_compute_end_dates()` function is duplicated in both job files to maintain independence between the two enrichment processes
- ESI history entries are sorted by `record_id` to ensure canonical ordering per ESI specification
- Invalid corporation IDs (≤ 0) are filtered out during history processing
- Error handling updated to report ESI HTTP status codes instead of generic EveWho errors
- The most recent corporation history entry correctly has no end date (as per ESI behavior)

https://claude.ai/code/session_01DD1dKK2BZXAm5smuAWKHqC