### PR TITLE
Add job finalization via PHP bridge for Python scheduler

### DIFF
--- a/bin/python_scheduler_bridge.php
+++ b/bin/python_scheduler_bridge.php
@@ -221,6 +221,23 @@ try {
         python_scheduler_bridge_output(['ok' => true, 'result' => $result]);
     }
 
+    if ($action === 'finalize-job-by-key') {
+        $jobKey = trim((string) ($options['job-key'] ?? ''));
+        if ($jobKey === '') {
+            throw new InvalidArgumentException('Argument --job-key is required for finalize-job-by-key.');
+        }
+
+        $rows = db_sync_schedule_fetch_by_job_keys([$jobKey]);
+        $job = is_array($rows) && count($rows) > 0 ? $rows[0] : null;
+        if (!is_array($job)) {
+            throw new RuntimeException('No scheduler job found for job key ' . $jobKey . '.');
+        }
+
+        $input = python_scheduler_bridge_read_stdin_json();
+        $result = scheduler_finalize_python_job_result($job, $input);
+        python_scheduler_bridge_output(['ok' => true, 'result' => $result]);
+    }
+
     if ($action === 'sync-run-start') {
         $input = python_scheduler_bridge_read_stdin_json();
         $datasetKey = trim((string) ($input['dataset_key'] ?? ''));

--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -424,6 +424,7 @@ def main() -> int:
         config = load_php_runtime_config(app_root)
         configure_logging(verbose=args.verbose, log_file=config.log_file)
         from .db import SupplyCoreDb
+        from .bridge import PhpBridge
         db = SupplyCoreDb(config.raw.get("db", {}))
         job_key = str(args.job_key).strip()
         if job_key not in PYTHON_PROCESSOR_JOB_KEYS:
@@ -432,16 +433,16 @@ def main() -> int:
         started_at = time.monotonic()
         try:
             result = run_registered_processor(job_key, db, config.raw, verbose=getattr(args, "verbose", False))
-            _print_cli_result(job_key, started_at, result)
-            return 1 if str(result.get("status") or "success").lower() == "failed" else 0
         except Exception as exc:
             import traceback
-            _print_cli_result(
-                job_key,
-                started_at,
-                {"status": "failed", "error_text": f"{type(exc).__name__}: {exc}", "traceback": traceback.format_exc(), "rows_processed": 0, "rows_written": 0},
-            )
-            return 1
+            result = {"status": "failed", "error_text": f"{type(exc).__name__}: {exc}", "traceback": traceback.format_exc(), "rows_processed": 0, "rows_written": 0}
+        _print_cli_result(job_key, started_at, result)
+        try:
+            bridge = PhpBridge(config.php_binary, app_root)
+            bridge.call("finalize-job-by-key", args=[f"--job-key={job_key}"], payload=result)
+        except Exception:
+            pass
+        return 1 if str(result.get("status") or "success").lower() == "failed" else 0
 
     if command in {
         "compute-battle-rollups",


### PR DESCRIPTION
## Summary
This PR adds a new mechanism to finalize Python scheduler jobs through a PHP bridge, ensuring job results are properly persisted regardless of execution outcome.

## Key Changes
- **PHP Bridge**: Added new `finalize-job-by-key` action in `python_scheduler_bridge.php` that:
  - Accepts a job key via `--job-key` argument
  - Fetches the corresponding scheduler job from the database
  - Reads job result data from stdin (JSON format)
  - Calls `scheduler_finalize_python_job_result()` to persist the result

- **Python Orchestrator**: Refactored `run_registered_processor()` command in `main.py` to:
  - Consolidate result handling for both success and failure paths
  - Always call `_print_cli_result()` regardless of execution outcome
  - Invoke the PHP bridge's `finalize-job-by-key` action with the job result
  - Gracefully handle bridge communication failures (non-blocking)
  - Return appropriate exit code based on final result status

## Implementation Details
- The PHP bridge call is wrapped in a try-except block to prevent bridge communication errors from affecting the overall job completion status
- Job result data (including error details and traceback on failure) is passed to the PHP layer for proper finalization
- The refactoring eliminates code duplication in error handling while maintaining the same exit code behavior

https://claude.ai/code/session_01ECkq8ma8d8L2wvTUnSdEG7