### PR TITLE
Add backlog overview and job run summaries to log viewer

### DIFF
--- a/public/log-viewer/index.php
+++ b/public/log-viewer/index.php
@@ -20,6 +20,7 @@ $neverRan = $pageData['never_ran'];
 $logFiles = $pageData['log_files'];
 $kpi = $pageData['kpi'];
 $recentRuns = $pageData['recent_runs'];
+$backlog = $pageData['backlog'];
 
 // Determine page freshness from data
 $pageFreshness = [];
@@ -83,6 +84,70 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
     </article>
 </section>
 <!-- ui-section:log-viewer-kpi:end -->
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     Backlog Overview — real-time queue depth and overdue jobs
+     ══════════════════════════════════════════════════════════════════════════ -->
+<!-- ui-section:log-viewer-backlog:start -->
+<section class="mt-8" data-ui-section="log-viewer-backlog">
+    <h2 class="section-title mb-4">Backlog Overview</h2>
+    <div class="grid gap-4 sm:grid-cols-3 mb-6">
+        <article class="kpi-card">
+            <p class="eyebrow">Queued</p>
+            <p class="mt-3 metric-value text-[2rem] <?= $backlog['queue']['queued'] > 0 ? 'text-sky-100' : 'text-slate-400' ?>"><?= $backlog['queue']['queued'] ?></p>
+            <p class="mt-2 text-sm text-slate-300">Jobs waiting to be picked up by a worker.</p>
+        </article>
+        <article class="kpi-card">
+            <p class="eyebrow">Running</p>
+            <p class="mt-3 metric-value text-[2rem] <?= $backlog['queue']['running'] > 0 ? 'text-emerald-100' : 'text-slate-400' ?>"><?= $backlog['queue']['running'] ?></p>
+            <p class="mt-2 text-sm text-slate-300">Jobs currently executing across all workers.</p>
+        </article>
+        <article class="kpi-card">
+            <p class="eyebrow">Retry</p>
+            <p class="mt-3 metric-value text-[2rem] <?= $backlog['queue']['retry'] > 0 ? 'text-amber-100' : 'text-slate-400' ?>"><?= $backlog['queue']['retry'] ?></p>
+            <p class="mt-2 text-sm text-slate-300">Jobs waiting to retry after a transient failure.</p>
+        </article>
+    </div>
+    <?php if ($backlog['overdue_jobs'] !== []): ?>
+    <div class="rounded-2xl border border-amber-400/20 bg-amber-500/6 p-1">
+        <div class="table-shell overflow-x-auto">
+            <table class="table-ui w-full">
+                <thead>
+                    <tr>
+                        <th class="text-left">Job</th>
+                        <th class="text-left">Last run</th>
+                        <th class="text-right">Overdue by</th>
+                        <th class="text-left">Interval</th>
+                        <th class="text-left">Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($backlog['overdue_jobs'] as $oj): ?>
+                        <?php
+                        $overdueBy = $oj['last_run_at']
+                            ? max(0, time() - strtotime((string) $oj['last_run_at']) - (int) $oj['interval_seconds'])
+                            : null;
+                        ?>
+                        <tr>
+                            <td>
+                                <p class="font-medium text-white"><?= htmlspecialchars($oj['label'], ENT_QUOTES) ?></p>
+                                <p class="mt-0.5 text-xs text-slate-400"><?= htmlspecialchars($oj['job_key'], ENT_QUOTES) ?></p>
+                            </td>
+                            <td class="text-slate-300"><?= htmlspecialchars($oj['last_run_relative'], ENT_QUOTES) ?></td>
+                            <td class="text-right font-semibold text-amber-200"><?= $overdueBy !== null ? htmlspecialchars(human_duration_seconds((float) $overdueBy), ENT_QUOTES) : 'Never ran' ?></td>
+                            <td class="text-slate-300"><?= $oj['interval_seconds'] > 0 ? htmlspecialchars(human_duration_seconds((float) $oj['interval_seconds']), ENT_QUOTES) : '-' ?></td>
+                            <td>
+                                <span class="badge <?= htmlspecialchars($oj['health_tone'], ENT_QUOTES) ?>"><?= htmlspecialchars($oj['health_label'], ENT_QUOTES) ?></span>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <?php endif; ?>
+</section>
+<!-- ui-section:log-viewer-backlog:end -->
 
 <!-- ═══════════════════════════════════════════════════════════════════════════
      External Services — compact inline cards
@@ -265,6 +330,8 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                                     <p class="text-xs text-slate-400"><?= $job['recent_deferral_count'] ?> deferral(s)</p>
                                 <?php elseif ($job['last_planner_reason']): ?>
                                     <p class="truncate text-xs text-slate-400" title="<?= htmlspecialchars($job['last_planner_reason'], ENT_QUOTES) ?>"><?= htmlspecialchars($job['last_planner_reason'], ENT_QUOTES) ?></p>
+                                <?php elseif ($job['last_run_summary']): ?>
+                                    <p class="truncate text-xs text-slate-400" title="<?= htmlspecialchars($job['last_run_summary'], ENT_QUOTES) ?>"><?= htmlspecialchars($job['last_run_summary'], ENT_QUOTES) ?></p>
                                 <?php else: ?>
                                     <span class="text-xs text-slate-500">-</span>
                                 <?php endif; ?>
@@ -326,7 +393,7 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                         <th class="text-right">Duration</th>
                         <th class="text-right" title="written rows / source rows read">Written / Read</th>
                         <th class="text-right">Recent OK</th>
-                        <th class="text-left">Error</th>
+                        <th class="text-left">Summary / Error</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -377,7 +444,13 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                                     <span class="text-xs text-slate-500">-</span>
                                 <?php endif; ?>
                             </td>
-                            <td class="max-w-xs truncate text-xs text-rose-200" title="<?= htmlspecialchars((string) ($run['error_message'] ?? ''), ENT_QUOTES) ?>"><?= htmlspecialchars((string) ($run['error_message'] ?? ''), ENT_QUOTES) ?></td>
+                            <td class="max-w-xs">
+                                <?php if (!empty($run['error_message'])): ?>
+                                    <p class="truncate text-xs text-rose-200" title="<?= htmlspecialchars((string) $run['error_message'], ENT_QUOTES) ?>"><?= htmlspecialchars((string) $run['error_message'], ENT_QUOTES) ?></p>
+                                <?php elseif (!empty($run['summary'])): ?>
+                                    <p class="truncate text-xs text-slate-400" title="<?= htmlspecialchars((string) $run['summary'], ENT_QUOTES) ?>"><?= htmlspecialchars((string) $run['summary'], ENT_QUOTES) ?></p>
+                                <?php endif; ?>
+                            </td>
                         </tr>
                     <?php endforeach; ?>
                 </tbody>

--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -659,11 +659,11 @@ class SupplyCoreDb:
             )
         return bumped
 
-    def insert_sync_run(self, *, dataset_key: str, rows_seen: int, rows_written: int, status: str, error: str | None = None) -> int:
+    def insert_sync_run(self, *, dataset_key: str, rows_seen: int, rows_written: int, status: str, error: str | None = None, summary: str | None = None) -> int:
         return self.insert(
-            """INSERT INTO sync_runs (dataset_key, run_mode, run_status, started_at, finished_at, cursor_start, cursor_end, source_rows, written_rows, error_message)
-               VALUES (%s, 'incremental', %s, UTC_TIMESTAMP(), UTC_TIMESTAMP(), NULL, NULL, %s, %s, %s)""",
-            (dataset_key[:190], status[:20], max(0, rows_seen), max(0, rows_written), error[:500] if error else None),
+            """INSERT INTO sync_runs (dataset_key, run_mode, run_status, started_at, finished_at, cursor_start, cursor_end, source_rows, written_rows, error_message, summary)
+               VALUES (%s, 'incremental', %s, UTC_TIMESTAMP(), UTC_TIMESTAMP(), NULL, NULL, %s, %s, %s, %s)""",
+            (dataset_key[:190], status[:20], max(0, rows_seen), max(0, rows_written), error[:500] if error else None, summary[:500] if summary else None),
         )
 
     def insert_scheduler_job_event(self, *, job_key: str, event_type: str, payload_json: str, duration_seconds: float) -> int:
@@ -681,6 +681,7 @@ class SupplyCoreDb:
         event_type: str = "completion",
         pressure_state: str = "healthy",
         failure_message: str | None = None,
+        last_run_summary: str | None = None,
     ) -> int:
         """Mirror the PHP ``db_scheduler_job_current_status_upsert`` so that
         Python-executed jobs are visible in the log-viewer and settings pages.
@@ -695,14 +696,14 @@ class SupplyCoreDb:
                     job_key, dataset_key, latest_status, latest_event_type,
                     last_started_at, last_finished_at,
                     last_success_at, last_failure_at, last_failure_message,
-                    current_pressure_state, last_event_at
+                    current_pressure_state, last_event_at, last_run_summary
                 ) VALUES (
                     %s, %s, %s, %s,
                     {now_sql}, {now_sql},
                     {"" + now_sql if is_success else "NULL"},
                     {"" + now_sql if is_failure else "NULL"},
                     %s,
-                    %s, {now_sql}
+                    %s, {now_sql}, %s
                 )
                 ON DUPLICATE KEY UPDATE
                     latest_status = VALUES(latest_status),
@@ -716,7 +717,8 @@ class SupplyCoreDb:
                         ELSE last_failure_message
                     END,
                     current_pressure_state = COALESCE(VALUES(current_pressure_state), current_pressure_state),
-                    last_event_at = VALUES(last_event_at)""",
+                    last_event_at = VALUES(last_event_at),
+                    last_run_summary = COALESCE(VALUES(last_run_summary), last_run_summary)""",
             (
                 job_key[:190],
                 f"scheduler.job.{job_key[:170]}",
@@ -724,6 +726,7 @@ class SupplyCoreDb:
                 event_type[:50],
                 failure_message[:500] if failure_message else None,
                 pressure_state[:32],
+                last_run_summary[:500] if last_run_summary else None,
             ),
         )
 

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -142,6 +142,7 @@ def _finalize_job(db: SupplyCoreDb, job_key: str, result: dict[str, Any], logger
     rows_written = max(0, int(result.get("rows_written") or 0))
     duration_ms = max(0, int(result.get("duration_ms") or 0))
     error_text = str(result.get("error_text") or result.get("error") or result.get("summary") or "") if status == "failed" else None
+    summary = str(result.get("summary") or "")[:500] or None
 
     dataset_key = f"scheduler.job.{job_key}"
     try:
@@ -163,6 +164,7 @@ def _finalize_job(db: SupplyCoreDb, job_key: str, result: dict[str, Any], logger
             rows_written=rows_written,
             status=status,
             error=error_text,
+            summary=summary,
         )
     except Exception as exc:
         logger.warning("sync_run insert failed", payload={"event": "worker_pool.finalize.sync_run_error", "job_key": job_key, "error": str(exc)})
@@ -203,6 +205,7 @@ def _finalize_job(db: SupplyCoreDb, job_key: str, result: dict[str, Any], logger
             status=status,
             event_type="finished" if status != "failed" else "failure",
             failure_message=error_text,
+            last_run_summary=summary,
         )
     except Exception as exc:
         logger.warning("scheduler_job_current_status upsert failed", payload={"event": "worker_pool.finalize.current_status_error", "job_key": job_key, "error": str(exc)})
@@ -253,7 +256,7 @@ def _finalize_job(db: SupplyCoreDb, job_key: str, result: dict[str, Any], logger
             job_key=job_key,
             job_status=status,
             domains_json=json_dumps_safe(["scheduler"]),
-            ui_sections_json=json_dumps_safe(["log-viewer-kpi", "log-viewer-jobs", "log-viewer-runs"]),
+            ui_sections_json=json_dumps_safe(["log-viewer-kpi", "log-viewer-jobs", "log-viewer-runs", "log-viewer-backlog"]),
         )
         db.bump_ui_refresh_section_versions(
             version_keys=["log_viewer_version"],

--- a/src/db.php
+++ b/src/db.php
@@ -8151,6 +8151,9 @@ function db_sync_schedule_registry_columns_ensure(): void
     db_ensure_table_index('sync_schedules', 'idx_sync_schedules_due_lookup', 'INDEX idx_sync_schedules_due_lookup (enabled, current_state, next_due_at, locked_until, id)');
     db_ensure_table_index('sync_schedules', 'idx_sync_schedules_backfill_lookup', 'INDEX idx_sync_schedules_backfill_lookup (enabled, allow_backfill, current_state, degraded_until, locked_until, next_due_at, last_finished_at, id)');
     db_ensure_table_index('sync_schedules', 'idx_sync_schedules_running_lookup', 'INDEX idx_sync_schedules_running_lookup (enabled, current_state, locked_until, last_started_at, id)');
+    db_ensure_table_column('sync_runs', 'summary', 'VARCHAR(500) DEFAULT NULL');
+    db_ensure_table_column('scheduler_job_current_status', 'last_run_summary', 'VARCHAR(500) DEFAULT NULL');
+
     db_ensure_table_index('sync_runs', 'idx_sync_runs_created_at', 'INDEX idx_sync_runs_created_at (created_at)');
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -30479,7 +30479,8 @@ function log_viewer_page_data(): array
                 cs.current_pressure_state, cs.recent_timeout_count,
                 cs.recent_lock_conflict_count, cs.recent_deferral_count,
                 cs.recent_skip_count, cs.last_planner_decision_type,
-                cs.last_planner_reason_text
+                cs.last_planner_reason_text,
+                cs.last_run_summary
          FROM sync_schedules s
          LEFT JOIN scheduler_job_current_status cs ON cs.job_key = s.job_key
          ORDER BY s.job_key"
@@ -30490,7 +30491,7 @@ function log_viewer_page_data(): array
     // unique job, plus any currently running or failed runs for context.
     $recentRunsRaw = db_select(
         "SELECT r.dataset_key, r.run_status, r.started_at, r.finished_at,
-                r.source_rows, r.written_rows, r.error_message,
+                r.source_rows, r.written_rows, r.error_message, r.summary,
                 TIMESTAMPDIFF(SECOND, r.started_at, COALESCE(r.finished_at, NOW())) AS duration_seconds
          FROM sync_runs r
          ORDER BY r.started_at DESC
@@ -30713,6 +30714,7 @@ function log_viewer_page_data(): array
             'recent_deferral_count' => (int) ($s['recent_deferral_count'] ?? 0),
             'recent_skip_count' => (int) ($s['recent_skip_count'] ?? 0),
             'last_planner_reason' => $s['last_planner_reason_text'] ?? null,
+            'last_run_summary' => $s['last_run_summary'] ?? null,
             'timeout_seconds' => $meta['timeout_seconds'] ?? $defaultTimeout,
         ];
     }
@@ -30755,6 +30757,7 @@ function log_viewer_page_data(): array
             'recent_deferral_count' => 0,
             'recent_skip_count' => 0,
             'last_planner_reason' => 'No schedule row — job exists in registry but has not been provisioned into sync_schedules yet.',
+            'last_run_summary' => null,
             'timeout_seconds' => $regMeta['timeout_seconds'] ?? $defaultTimeout,
         ];
     }
@@ -30793,6 +30796,33 @@ function log_viewer_page_data(): array
         usort($logFiles, fn (array $a, array $b) => ($b['size_bytes'] ?? 0) <=> ($a['size_bytes'] ?? 0));
     }
 
+    // ── Worker job queue depth (backlog) ─────────────────────────────────
+    $workerQueueRaw = db_select(
+        "SELECT status, queue_name, COUNT(*) AS cnt
+         FROM worker_jobs
+         WHERE status IN ('queued', 'running', 'retry')
+         GROUP BY status, queue_name"
+    );
+    $backlogQueue = ['queued' => 0, 'running' => 0, 'retry' => 0, 'total' => 0];
+    $backlogByQueue = [];
+    foreach ($workerQueueRaw as $row) {
+        $s = $row['status'];
+        $q = $row['queue_name'] ?? 'default';
+        $cnt = (int) $row['cnt'];
+        $backlogQueue[$s] = ($backlogQueue[$s] ?? 0) + $cnt;
+        $backlogQueue['total'] += $cnt;
+        $backlogByQueue[$q][$s] = $cnt;
+    }
+
+    // ── Overdue job details ───────────────────────────────────────────
+    $overdueJobs = array_filter($jobs, fn (array $j) => $j['overdue'] && $j['health'] !== 'disabled');
+    usort($overdueJobs, function (array $a, array $b) {
+        $aAge = $a['last_run_at'] ? (time() - strtotime((string) $a['last_run_at'])) : PHP_INT_MAX;
+        $bAge = $b['last_run_at'] ? (time() - strtotime((string) $b['last_run_at'])) : PHP_INT_MAX;
+        return $bAge <=> $aAge;
+    });
+    $overdueJobsList = array_values($overdueJobs);
+
     return [
         'jobs' => $jobs,
         'recent_runs' => $recentRuns,
@@ -30807,6 +30837,11 @@ function log_viewer_page_data(): array
             'total_never_ran' => $totalNeverRan,
             'total_overdue' => $totalOverdue,
             'total_healthy' => $totalHealthy,
+        ],
+        'backlog' => [
+            'queue' => $backlogQueue,
+            'by_queue' => $backlogByQueue,
+            'overdue_jobs' => $overdueJobsList,
         ],
     ];
 }


### PR DESCRIPTION
## Summary
This PR enhances the log viewer dashboard with real-time queue depth monitoring and improves job run visibility by displaying execution summaries alongside error messages.

## Key Changes

- **Backlog Overview Section**: Added a new "Backlog Overview" UI section displaying:
  - Real-time queue depth metrics (queued, running, retry job counts)
  - Table of overdue jobs with last run time, overdue duration, and health status
  - Color-coded metrics for visual status indication

- **Job Run Summary Support**: Extended database schema and data flow to capture and display job execution summaries:
  - Added `summary` column to `sync_runs` table
  - Added `last_run_summary` column to `scheduler_job_current_status` table
  - Updated recent runs display to show summaries when error messages are absent
  - Updated job list to display last run summary as fallback context

- **Worker Pool Integration**: Modified Python worker finalization to:
  - Extract and persist job execution summaries from worker results
  - Pass summaries to both sync run and scheduler job status records
  - Trigger UI refresh for backlog section on job completion

- **UI Improvements**:
  - Renamed "Error" column header to "Summary / Error" in recent runs table
  - Added conditional rendering to display summaries in slate-400 color vs errors in rose-200
  - Improved job context display in job list with summary fallback

## Implementation Details

- Backlog data is aggregated from `worker_jobs` table grouped by status and queue
- Overdue jobs are filtered from the main jobs list and sorted by age (most recent first)
- Summary field is truncated to 500 characters at database and application layers
- UI sections are properly marked with data attributes for targeted refresh

https://claude.ai/code/session_01H2bw89Gq1sGMfbR1J1UnVc