### PR TITLE
Add last_run_summary column to scheduler job status table

### DIFF
--- a/database/migrations/20260331_add_last_run_summary_to_scheduler_job_current_status.sql
+++ b/database/migrations/20260331_add_last_run_summary_to_scheduler_job_current_status.sql
@@ -1,0 +1,6 @@
+-- Add last_run_summary column to scheduler_job_current_status
+-- This column stores a short human-readable summary of the most recent job run,
+-- used by the log viewer page to display per-job status at a glance.
+
+ALTER TABLE scheduler_job_current_status
+    ADD COLUMN IF NOT EXISTS last_run_summary VARCHAR(500) DEFAULT NULL;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1024,6 +1024,7 @@ CREATE TABLE IF NOT EXISTS scheduler_job_current_status (
     last_planner_reason_text VARCHAR(500) DEFAULT NULL,
     last_planner_decided_at DATETIME DEFAULT NULL,
     last_event_at DATETIME DEFAULT NULL,
+    last_run_summary VARCHAR(500) DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     KEY idx_scheduler_job_current_status_dataset (dataset_key),


### PR DESCRIPTION
## Summary
This PR adds a new `last_run_summary` column to the `scheduler_job_current_status` table to store human-readable summaries of the most recent job runs.

## Changes
- Added `last_run_summary` VARCHAR(500) column to `scheduler_job_current_status` table
- Created migration file to add the column with `IF NOT EXISTS` clause for safe deployment
- Updated schema.sql to reflect the new column definition

## Implementation Details
- The column stores short text summaries (max 500 characters) of job execution results
- Defaults to NULL to maintain backward compatibility
- Intended to be used by the log viewer page to display per-job status information at a glance
- Migration uses `IF NOT EXISTS` to safely handle environments at different schema versions

https://claude.ai/code/session_01Dh7Yh9XKTz4R8u8XB4t518