### PR TITLE
Fix recurring job dependency blocking by using last_finished_at

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -454,11 +454,21 @@ class SupplyCoreDb:
         Used by the scheduling graph to determine whether upstream dependencies
         are satisfied — if a dependency completed recently, the downstream job
         can proceed even if the dependency isn't currently due.
+
+        NOTE: We intentionally do NOT filter on ``status = 'completed'``.
+        Recurring jobs share a single ``unique_key`` row.  The moment a job
+        finishes and the scheduler re-queues it, ``status`` flips back to
+        ``'queued'``, removing the row from a ``status='completed'`` query.
+        This would cause every downstream job to appear permanently blocked.
+        Instead we use ``last_finished_at`` (preserved across re-queues) and
+        ``last_error IS NULL`` (cleared by complete_worker_job) to identify
+        jobs that last ran successfully, regardless of their current status.
         """
         rows = self.fetch_all(
             """SELECT DISTINCT job_key FROM worker_jobs
-               WHERE status = 'completed'
-                 AND last_finished_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL %s SECOND)""",
+               WHERE last_finished_at IS NOT NULL
+                 AND last_finished_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL %s SECOND)
+                 AND last_error IS NULL""",
             (max(60, within_seconds),),
         )
         return {str(r["job_key"]) for r in rows if r.get("job_key")}


### PR DESCRIPTION
## Summary
Fixed an issue where recurring jobs would permanently block downstream dependencies after being re-queued by the scheduler. The problem was that the dependency check was filtering on `status = 'completed'`, which would flip back to `'queued'` immediately after a recurring job is re-scheduled.

## Changes
- Modified `get_recently_completed_job_keys()` to use `last_finished_at` and `last_error IS NULL` instead of `status = 'completed'` for identifying successfully completed jobs
- These fields persist across job re-queues, ensuring recurring jobs don't appear permanently blocked to downstream tasks
- Added detailed documentation explaining why this approach is necessary for recurring job handling

## Implementation Details
The query now identifies recently completed jobs by checking:
1. `last_finished_at IS NOT NULL` - job has finished at least once
2. `last_finished_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL %s SECOND)` - finished within the specified timeframe
3. `last_error IS NULL` - last execution was successful (cleared by `complete_worker_job`)

This approach correctly handles recurring jobs that are immediately re-queued after completion, allowing their downstream dependencies to proceed without being permanently blocked.

https://claude.ai/code/session_01MA4UtCxuUM5k6hWL7UxUbr