### PR TITLE
Add killmail edge projection to Neo4j graph sync

### DIFF
--- a/python/orchestrator/jobs/__init__.py
+++ b/python/orchestrator/jobs/__init__.py
@@ -12,6 +12,7 @@ from .graph_pipeline import (
     run_compute_graph_prune,
     run_compute_graph_topology_metrics,
     run_compute_graph_sync_killmail_entities,
+    run_compute_graph_sync_killmail_edges,
 )
 from .graph_universe_sync import run_graph_universe_sync
 from .battle_intelligence import (

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -2074,7 +2074,8 @@ def run_compute_graph_sync_killmail_entities(
             MERGE (km:Killmail {killmail_id: toInteger(row.killmail_id)})
               SET km.killed_at = row.killed_at,
                   km.total_value = toFloat(row.total_value),
-                  km.victim_ship_type_id = toInteger(row.victim_ship_type_id)
+                  km.victim_ship_type_id = toInteger(row.victim_ship_type_id),
+                  km.battle_id = row.battle_id
             WITH km, row
             MERGE (sys:System {system_id: toInteger(row.solar_system_id)})
             MERGE (km)-[:OCCURRED_IN]->(sys)
@@ -2107,6 +2108,157 @@ def run_compute_graph_sync_killmail_entities(
     return JobResult.success(
         job_key=job_name,
         summary=f"Projected {rows_written} killmails into Neo4j.",
+        rows_processed=rows_processed,
+        rows_written=rows_written,
+        duration_ms=duration_ms,
+    ).to_dict()
+
+
+# ── Killmail attacker/victim edge projection ─────────────────────────────────
+
+_KM_ATTACKER_EDGE_CURSOR_KEY = "graph_sync_killmail_attacker_edges_cursor"
+_KM_VICTIM_EDGE_CURSOR_KEY = "graph_sync_killmail_victim_edges_cursor"
+_KM_EDGE_BATCH = 2000
+
+
+def run_compute_graph_sync_killmail_edges(
+    db: SupplyCoreDb,
+    neo4j_raw: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Sync ATTACKED_ON and VICTIM_OF edges from killmail_attackers/killmail_events into Neo4j.
+
+    Only processes killmails that belong to a battle (battle_id IS NOT NULL).
+    Characters and Killmail nodes must already exist (written by
+    compute_graph_sync_battle_intelligence and compute_graph_sync_killmail_entities).
+    These edges are required by the alliance dossier co-presence and enemy queries.
+    """
+    started = time.perf_counter()
+    job_name = "compute_graph_sync_killmail_edges"
+
+    config = Neo4jConfig.from_runtime(neo4j_raw or {})
+    if not config.enabled:
+        return JobResult.skipped(job_key=job_name, reason="neo4j disabled").to_dict()
+
+    client = Neo4jClient(config)
+    batch_size = _coerce_batch_size((neo4j_raw or {}).get("batch_size"), fallback=_KM_EDGE_BATCH)
+    rows_processed = 0
+    rows_written = 0
+
+    # ── Attacker edges (ATTACKED_ON) ─────────────────────────────────────────
+    cursor_row = db.fetch_one(
+        "SELECT last_cursor FROM sync_state WHERE dataset_key = %s",
+        (_KM_ATTACKER_EDGE_CURSOR_KEY,),
+    )
+    last_attacker_cursor = int(cursor_row["last_cursor"]) if cursor_row and cursor_row.get("last_cursor") else 0
+    new_attacker_cursor = last_attacker_cursor
+
+    while True:
+        batch = db.fetch_all(
+            """
+            SELECT ka.character_id, ke.killmail_id
+            FROM killmail_attackers ka
+            INNER JOIN killmail_events ke ON ke.sequence_id = ka.sequence_id
+            WHERE ka.character_id IS NOT NULL AND ka.character_id > 0
+              AND ke.battle_id IS NOT NULL
+              AND ke.killmail_id > %s
+            ORDER BY ke.killmail_id ASC
+            LIMIT %s
+            """,
+            (new_attacker_cursor, batch_size),
+        )
+        if not batch:
+            break
+
+        rows_processed += len(batch)
+        neo4j_rows = [
+            {"character_id": int(r["character_id"]), "killmail_id": int(r["killmail_id"])}
+            for r in batch
+        ]
+
+        client.query(
+            """
+            UNWIND $rows AS row
+            MATCH (c:Character {character_id: toInteger(row.character_id)})
+            MATCH (km:Killmail {killmail_id: toInteger(row.killmail_id)})
+            MERGE (c)-[:ATTACKED_ON]->(km)
+            """,
+            {"rows": neo4j_rows},
+        )
+        rows_written += len(neo4j_rows)
+        new_attacker_cursor = int(batch[-1]["killmail_id"])
+
+    if new_attacker_cursor > last_attacker_cursor:
+        db.execute(
+            """
+            INSERT INTO sync_state (dataset_key, last_cursor, last_row_count, last_success_at, status)
+            VALUES (%s, %s, %s, UTC_TIMESTAMP(), 'success')
+            ON DUPLICATE KEY UPDATE last_cursor = VALUES(last_cursor),
+                                    last_row_count = VALUES(last_row_count),
+                                    last_success_at = VALUES(last_success_at),
+                                    status = 'success'
+            """,
+            (_KM_ATTACKER_EDGE_CURSOR_KEY, str(new_attacker_cursor), rows_written),
+        )
+
+    # ── Victim edges (VICTIM_OF) ──────────────────────────────────────────────
+    cursor_row = db.fetch_one(
+        "SELECT last_cursor FROM sync_state WHERE dataset_key = %s",
+        (_KM_VICTIM_EDGE_CURSOR_KEY,),
+    )
+    last_victim_cursor = int(cursor_row["last_cursor"]) if cursor_row and cursor_row.get("last_cursor") else 0
+    new_victim_cursor = last_victim_cursor
+
+    while True:
+        batch = db.fetch_all(
+            """
+            SELECT ke.victim_character_id AS character_id, ke.killmail_id
+            FROM killmail_events ke
+            WHERE ke.victim_character_id IS NOT NULL AND ke.victim_character_id > 0
+              AND ke.battle_id IS NOT NULL
+              AND ke.killmail_id > %s
+            ORDER BY ke.killmail_id ASC
+            LIMIT %s
+            """,
+            (new_victim_cursor, batch_size),
+        )
+        if not batch:
+            break
+
+        rows_processed += len(batch)
+        neo4j_rows = [
+            {"character_id": int(r["character_id"]), "killmail_id": int(r["killmail_id"])}
+            for r in batch
+        ]
+
+        client.query(
+            """
+            UNWIND $rows AS row
+            MATCH (c:Character {character_id: toInteger(row.character_id)})
+            MATCH (km:Killmail {killmail_id: toInteger(row.killmail_id)})
+            MERGE (c)-[:VICTIM_OF]->(km)
+            """,
+            {"rows": neo4j_rows},
+        )
+        rows_written += len(neo4j_rows)
+        new_victim_cursor = int(batch[-1]["killmail_id"])
+
+    if new_victim_cursor > last_victim_cursor:
+        db.execute(
+            """
+            INSERT INTO sync_state (dataset_key, last_cursor, last_row_count, last_success_at, status)
+            VALUES (%s, %s, %s, UTC_TIMESTAMP(), 'success')
+            ON DUPLICATE KEY UPDATE last_cursor = VALUES(last_cursor),
+                                    last_row_count = VALUES(last_row_count),
+                                    last_success_at = VALUES(last_success_at),
+                                    status = 'success'
+            """,
+            (_KM_VICTIM_EDGE_CURSOR_KEY, str(new_victim_cursor), rows_written),
+        )
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    return JobResult.success(
+        job_key=job_name,
+        summary=f"Synced {rows_written} killmail edges (ATTACKED_ON + VICTIM_OF) into Neo4j.",
         rows_processed=rows_processed,
         rows_written=rows_written,
         duration_ms=duration_ms,

--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -122,6 +122,9 @@ def parse_args() -> argparse.Namespace:
     graph_killmails = subparsers.add_parser("compute-graph-sync-killmail-entities", help="Project killmail events as nodes into Neo4j")
     graph_killmails.add_argument("--app-root", default=resolve_app_root(__file__))
     graph_killmails.add_argument("--verbose", action="store_true")
+    graph_killmail_edges = subparsers.add_parser("compute-graph-sync-killmail-edges", help="Sync ATTACKED_ON and VICTIM_OF edges from battle killmails into Neo4j")
+    graph_killmail_edges.add_argument("--app-root", default=resolve_app_root(__file__))
+    graph_killmail_edges.add_argument("--verbose", action="store_true")
     compute_graph_sync = subparsers.add_parser("compute-graph-sync", help="Incrementally sync doctrine-fit-item graph into Neo4j")
     compute_graph_sync.add_argument("--app-root", default=resolve_app_root(__file__))
     compute_graph_sync.add_argument("--verbose", action="store_true")
@@ -318,6 +321,16 @@ def main() -> int:
         db = SupplyCoreDb(config.raw.get("db", {}))
         from .jobs.graph_pipeline import run_compute_graph_sync_killmail_entities
         result = run_compute_graph_sync_killmail_entities(db, neo4j_runtime(config.raw))
+        print(result)
+        return 0
+    if command == "compute-graph-sync-killmail-edges":
+        app_root = Path(args.app_root).resolve()
+        config = load_php_runtime_config(app_root)
+        configure_logging(verbose=args.verbose, log_file=config.log_file)
+        from .db import SupplyCoreDb
+        db = SupplyCoreDb(config.raw.get("db", {}))
+        from .jobs.graph_pipeline import run_compute_graph_sync_killmail_edges
+        result = run_compute_graph_sync_killmail_edges(db, neo4j_runtime(config.raw))
         print(result)
         return 0
     if command == "compute-graph-sync":

--- a/python/orchestrator/processor_registry.py
+++ b/python/orchestrator/processor_registry.py
@@ -60,7 +60,7 @@ from .jobs.theater_graph_integration import run_theater_graph_integration
 from .jobs.theater_suspicion import run_theater_suspicion
 from .jobs.compute_economic_warfare import run_compute_economic_warfare
 from .jobs.graph_universe_sync import run_graph_universe_sync
-from .jobs.graph_pipeline import run_compute_graph_sync_killmail_entities, run_graph_model_audit
+from .jobs.graph_pipeline import run_compute_graph_sync_killmail_entities, run_compute_graph_sync_killmail_edges, run_graph_model_audit
 from .jobs.compute_alliance_dossiers import run_compute_alliance_dossiers
 from .jobs.compute_threat_corridors import run_compute_threat_corridors
 from .jobs.cache_expiry_cleanup_sync import run_cache_expiry_cleanup_sync
@@ -111,6 +111,7 @@ PYTHON_COMPUTE_PROCESSOR_JOB_KEYS: set[str] = {
     "compute_economic_warfare",
     "graph_universe_sync",
     "compute_graph_sync_killmail_entities",
+    "compute_graph_sync_killmail_edges",
     "compute_alliance_dossiers",
     "compute_threat_corridors",
     "graph_model_audit",
@@ -204,6 +205,7 @@ _PROCESSOR_DISPATCH: dict[str, tuple] = {
     # Universe graph
     "graph_universe_sync": (run_graph_universe_sync, lambda db, cfg: (db, neo4j_runtime(cfg))),
     "compute_graph_sync_killmail_entities": (run_compute_graph_sync_killmail_entities, lambda db, cfg: (db, neo4j_runtime(cfg))),
+    "compute_graph_sync_killmail_edges": (run_compute_graph_sync_killmail_edges, lambda db, cfg: (db, neo4j_runtime(cfg))),
     # Theater intelligence
     "theater_clustering": (run_theater_clustering, lambda db, cfg: (db, battle_runtime(cfg), neo4j_runtime(cfg))),
     "theater_analysis": (run_theater_analysis, lambda db, cfg: (db, battle_runtime(cfg))),

--- a/scripts/reset_and_rebuild.sh
+++ b/scripts/reset_and_rebuild.sh
@@ -326,6 +326,7 @@ run_job "graph_universe_sync" "Graph Universe Sync"
 run_job_until_done "compute_graph_sync" "Graph Entity Sync"
 run_job_until_done "compute_graph_sync_battle_intelligence" "Graph Battle Intelligence"
 run_job "compute_graph_sync_killmail_entities" "Graph Killmail Entities"
+run_job "compute_graph_sync_killmail_edges" "Graph Killmail Edges"
 run_job_until_done "compute_graph_sync_doctrine_dependency" "Graph Doctrine Dependencies"
 
 echo ""


### PR DESCRIPTION
## Summary
This PR adds a new job to sync killmail attacker and victim relationship edges into Neo4j, enabling alliance dossier co-presence and enemy queries.

## Key Changes
- **New job function**: `run_compute_graph_sync_killmail_edges()` in `graph_pipeline.py`
  - Syncs `ATTACKED_ON` edges from killmail_attackers to killmail_events
  - Syncs `VICTIM_OF` edges from killmail_events victim_character_id
  - Only processes killmails with a battle_id (battle-associated kills)
  - Uses incremental cursor-based processing with configurable batch size (default 2000)
  - Maintains separate sync state cursors for attacker and victim edges

- **Killmail entity enhancement**: Added `battle_id` field to Killmail nodes during sync
  - Allows filtering edges to only battle-associated killmails

- **CLI and registry integration**:
  - Added `compute-graph-sync-killmail-edges` command to main.py
  - Registered job in processor_registry.py and jobs/__init__.py
  - Added to reset_and_rebuild.sh script

## Implementation Details
- Edges are created via `MERGE` operations to ensure idempotency
- Requires Character and Killmail nodes to already exist (created by prior sync jobs)
- Uses separate cursor tracking for attacker and victim edges to allow independent progress
- Batch processing with cursor-based pagination for efficient incremental syncs
- Returns JobResult with rows_processed, rows_written, and duration metrics

https://claude.ai/code/session_01ES389A2WFLsk1sG6MV7qJ7