### PR TITLE
Fix loss count accuracy by including corp-only player losses

### DIFF
--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -527,6 +527,33 @@ if (
     }
 }
 
+// ── Loss-count correction: count ALL killmail victims, including corp-only ───
+// The alliance_summary only tracks losses for victims WITH an alliance.
+// Victims without an alliance (corp-only players) were silently dropped,
+// causing opposition losses to be understated.  Query killmail_events directly
+// for accurate totals.
+$rawLossesByVictimAlliance = db_theater_losses_by_victim_alliance($theaterId);
+if ($rawLossesByVictimAlliance !== []) {
+    $correctedLosses = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
+    $correctedIskLost = ['friendly' => 0.0, 'opponent' => 0.0, 'third_party' => 0.0];
+    foreach ($rawLossesByVictimAlliance as $row) {
+        $side = $classifyAlliance((int) ($row['victim_alliance_id'] ?? 0));
+        $correctedLosses[$side] += (int) ($row['losses'] ?? 0);
+        $correctedIskLost[$side] += (float) ($row['isk_lost'] ?? 0);
+    }
+    foreach (['friendly', 'opponent', 'third_party'] as $side) {
+        if (isset($sidePanels[$side]) && $correctedLosses[$side] >= ($sidePanels[$side]['losses'] ?? 0)) {
+            $sidePanels[$side]['losses'] = $correctedLosses[$side];
+            $sidePanels[$side]['isk_lost'] = $correctedIskLost[$side];
+            // Recompute efficiency with corrected ISK
+            $totalIsk = ($sidePanels[$side]['isk_killed'] ?? 0) + $correctedIskLost[$side];
+            $sidePanels[$side]['efficiency'] = $totalIsk > 0
+                ? ($sidePanels[$side]['isk_killed'] ?? 0) / $totalIsk
+                : 0.0;
+        }
+    }
+}
+
 include __DIR__ . '/../../src/views/partials/header.php';
 
 // ── Render partials ────────────────────────────────────────────────────

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -423,9 +423,12 @@ def _compute_alliance_summary(
         final_blow = int(km.get("attacker_final_blow") or 0)
 
         # Record loss for victim alliance (once per killmail)
-        if victim_alliance > 0 and km_id not in seen_loss_km:
+        # When the victim has no alliance (corp-only), group under alliance_id = 0
+        # so losses are still counted (they'll be classified as third_party).
+        if km_id not in seen_loss_km:
             seen_loss_km.add(km_id)
-            entry = alliance_stats.setdefault(victim_alliance, _empty_alliance_stats(victim_alliance))
+            loss_key = victim_alliance if victim_alliance > 0 else 0
+            entry = alliance_stats.setdefault(loss_key, _empty_alliance_stats(loss_key))
             entry["total_losses"] += 1
             entry["total_isk_lost"] += isk
 

--- a/src/db.php
+++ b/src/db.php
@@ -15874,6 +15874,30 @@ function db_theater_final_blows_by_side(string $theaterId): array
     return $result;
 }
 
+/**
+ * Count losses per victim alliance directly from killmail_events.
+ *
+ * Unlike the alliance_summary (which misses victims without an alliance),
+ * this query counts ALL killmails in the theater grouped by victim_alliance_id
+ * so the caller can classify each group with its own closure.
+ *
+ * @return list<array{victim_alliance_id: int, losses: int, isk_lost: float}>
+ */
+function db_theater_losses_by_victim_alliance(string $theaterId): array
+{
+    return db_select(
+        "SELECT
+            COALESCE(ke.victim_alliance_id, 0) AS victim_alliance_id,
+            COUNT(DISTINCT ke.killmail_id) AS losses,
+            COALESCE(SUM(ke.zkb_total_value), 0) AS isk_lost
+         FROM killmail_events ke
+         INNER JOIN theater_battles tb ON tb.battle_id = ke.battle_id
+         WHERE tb.theater_id = ?
+         GROUP BY ke.victim_alliance_id",
+        [$theaterId]
+    );
+}
+
 function db_theater_notable_kills(string $theaterId, int $limit = 10): array
 {
     return db_select(


### PR DESCRIPTION
## Summary
This PR fixes an undercount of losses in theater battle statistics by ensuring that killmails involving victims without an alliance (corp-only players) are properly included in loss totals. Previously, these losses were silently dropped from the alliance_summary, causing opposition losses to be understated.

## Key Changes

- **PHP view layer** (`public/theater-intelligence/view.php`):
  - Added loss-count correction logic that queries killmail_events directly for accurate loss totals
  - Corrects loss counts and ISK lost for all sides (friendly, opponent, third_party)
  - Recalculates combat efficiency metrics using the corrected ISK values

- **Database layer** (`src/db.php`):
  - Added new `db_theater_losses_by_victim_alliance()` function that counts ALL killmails grouped by victim alliance ID
  - Unlike alliance_summary, this query includes victims without an alliance (grouped under alliance_id = 0)
  - Returns loss count and total ISK lost per victim alliance for flexible classification

- **Python orchestrator** (`python/orchestrator/jobs/theater_analysis.py`):
  - Modified `_compute_alliance_summary()` to include corp-only player losses (alliance_id = 0)
  - Changed condition from `if victim_alliance > 0` to always record losses, grouping corp-only losses under alliance_id = 0
  - These losses are then classified as third_party by the caller's classification logic

## Implementation Details

The fix uses a two-pronged approach:
1. The Python orchestrator now captures corp-only losses during initial alliance summary computation
2. The PHP view applies an additional correction by querying killmail_events directly, ensuring accuracy even if the orchestrator data is incomplete
3. The correction only updates loss counts if the corrected value is greater than or equal to the existing value, preserving data integrity
4. Combat efficiency is recalculated using the corrected ISK values to maintain statistical consistency

https://claude.ai/code/session_01K3EUvS2um7PMWQBY6rdsQ3