### PR TITLE
Ensure UTC timezone awareness for datetime objects from DB

### DIFF
--- a/python/orchestrator/jobs/copresence_edges.py
+++ b/python/orchestrator/jobs/copresence_edges.py
@@ -68,6 +68,15 @@ def _safe_div(num: float, den: float, default: float = 0.0) -> float:
     return num / den if den > 0 else default
 
 
+def _ensure_utc(dt: datetime | None) -> datetime | None:
+    """Ensure a datetime is timezone-aware (UTC).  DB drivers often return naive datetimes."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
 # ---------------------------------------------------------------------------
 # Sync-state helpers
 # ---------------------------------------------------------------------------
@@ -226,7 +235,7 @@ def _generate_battle_edges(
         if len(chars) < 2:
             continue
 
-        battle_time = chars[0].get("started_at")
+        battle_time = _ensure_utc(chars[0].get("started_at"))
         system_id = int(chars[0].get("system_id") or 0) or None
 
         for wlabel, wdelta in window_defs:
@@ -273,6 +282,7 @@ def _generate_system_time_edges(
     for p in participations:
         sid = int(p.get("system_id") or 0)
         if sid > 0 and p.get("started_at"):
+            p["started_at"] = _ensure_utc(p["started_at"])
             system_events[sid].append(p)
 
     proximity = timedelta(hours=SYSTEM_TIME_PROXIMITY_HOURS)


### PR DESCRIPTION
## Summary
Add timezone normalization for datetime objects retrieved from the database to prevent issues with naive datetime comparisons and operations.

## Key Changes
- Added `_ensure_utc()` helper function to convert naive datetimes to UTC-aware datetimes, addressing the common issue where database drivers return timezone-naive datetime objects
- Applied timezone normalization in `_generate_battle_edges()` when extracting `started_at` from battle character data
- Applied timezone normalization in `_generate_system_time_edges()` when processing participation records before adding them to system events

## Implementation Details
The new `_ensure_utc()` function:
- Returns `None` if the input datetime is `None`
- Adds UTC timezone info to naive datetimes using `replace(tzinfo=UTC)`
- Passes through datetimes that are already timezone-aware
- Ensures consistent datetime handling across the codebase without requiring changes to database query logic

https://claude.ai/code/session_01QXNkCmAY2b7yEtbWnfeBPw