### PR TITLE
Add killmail zKillboard metadata repair job

### DIFF
--- a/bin/python_scheduler_bridge.php
+++ b/bin/python_scheduler_bridge.php
@@ -134,6 +134,25 @@ try {
         python_scheduler_bridge_output(['ok' => true, 'result' => $result]);
     }
 
+    if ($action === 'repair-killmail-zkb') {
+        $input = python_scheduler_bridge_read_stdin_json();
+        $updates = (array) ($input['updates'] ?? []);
+        $result = python_bridge_repair_killmail_zkb($updates);
+        python_scheduler_bridge_output(['ok' => true, 'result' => $result]);
+    }
+
+    if ($action === 'killmails-missing-zkb') {
+        $input = python_scheduler_bridge_read_stdin_json();
+        $limit = max(1, min(1000, (int) ($input['limit'] ?? 500)));
+        $offset = max(0, (int) ($input['offset'] ?? 0));
+        $rows = db_select_all(
+            'SELECT killmail_id, killmail_hash FROM killmail_events WHERE zkb_total_value IS NULL ORDER BY killmail_id ASC LIMIT ? OFFSET ?',
+            [$limit, $offset]
+        );
+        $total = (int) db_select_value('SELECT COUNT(*) FROM killmail_events WHERE zkb_total_value IS NULL');
+        python_scheduler_bridge_output(['ok' => true, 'rows' => $rows, 'total' => $total]);
+    }
+
     if ($action === 'worker-runtime-config') {
         $runtime = orchestrator_runtime_config_export();
         python_scheduler_bridge_output([

--- a/python/orchestrator/jobs/killmail_full_history_backfill.py
+++ b/python/orchestrator/jobs/killmail_full_history_backfill.py
@@ -88,8 +88,48 @@ def _fetch_daily_dump(day: date, user_agent: str, max_retries: int = 3) -> dict[
     return {}
 
 
-def _fetch_esi_killmail(killmail_id: int, killmail_hash: str, esi_client: EsiClient, gateway: Any = None) -> dict[str, Any] | None:
-    """Fetch a single killmail from ESI and wrap in R2Z2-compatible format."""
+_ZKB_API_BASE = "https://zkillboard.com/api"
+
+
+def _fetch_zkb_metadata(killmail_id: int, user_agent: str) -> dict[str, Any]:
+    """Fetch zkb metadata (totalValue, points, etc.) for a single killmail from zKillboard API.
+
+    Returns the zkb dict, or empty dict on failure.
+    """
+    url = f"{_ZKB_API_BASE}/killID/{killmail_id}/"
+    status, body = _http_get(url, user_agent)
+    if status != 200 or not body.strip():
+        return {}
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
+        return data[0].get("zkb") or {}
+    return {}
+
+
+def _fetch_zkb_metadata_batch(killmail_ids: list[int], user_agent: str) -> dict[int, dict[str, Any]]:
+    """Fetch zkb metadata for a batch of killmail IDs from zKillboard API.
+
+    Returns {killmail_id: zkb_dict} for successfully fetched killmails.
+    Rate-limits requests to be polite to the zKB API (~1 req/sec).
+    """
+    result: dict[int, dict[str, Any]] = {}
+    for km_id in killmail_ids:
+        zkb = _fetch_zkb_metadata(km_id, user_agent)
+        if zkb:
+            result[km_id] = zkb
+        time.sleep(1)  # Be polite to zKB API
+    return result
+
+
+def _fetch_esi_killmail(killmail_id: int, killmail_hash: str, esi_client: EsiClient, gateway: Any = None, zkb_data: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    """Fetch a single killmail from ESI and wrap in R2Z2-compatible format.
+
+    *zkb_data*, when provided, is the full zKillboard metadata dict
+    (totalValue, points, npc, etc.) to include in the payload.
+    """
     path = f"/latest/killmails/{killmail_id}/{killmail_hash}/"
     if gateway is not None:
         resp = gateway.get(path, route_template="/latest/killmails/{killmail_id}/{killmail_hash}/")
@@ -116,7 +156,7 @@ def _fetch_esi_killmail(killmail_id: int, killmail_hash: str, esi_client: EsiCli
         "killmail_id": killmail_id,
         "hash": killmail_hash,
         "esi": body,
-        "zkb": {},
+        "zkb": zkb_data if zkb_data else {},
         "sequence_id": killmail_id,
         "requested_sequence_id": killmail_id,
         "uploaded_at": int(time.time()),
@@ -235,8 +275,13 @@ def run_killmail_full_history_backfill(context: Any) -> dict[str, Any]:
             batch_pairs = kill_pairs[batch_start:batch_start + batch_size]
             payloads = []
 
+            # Pre-fetch zkb metadata for the batch from zKillboard API
+            batch_km_ids = [km_id for km_id, _ in batch_pairs]
+            zkb_batch = _fetch_zkb_metadata_batch(batch_km_ids, user_agent)
+
             for km_id, km_hash in batch_pairs:
-                payload = _fetch_esi_killmail(km_id, km_hash, esi_client, gateway=gateway)
+                zkb_data = zkb_batch.get(km_id) or {}
+                payload = _fetch_esi_killmail(km_id, km_hash, esi_client, gateway=gateway, zkb_data=zkb_data)
                 if payload is not None:
                     payloads.append(payload)
                     day_esi_fetched += 1

--- a/python/orchestrator/jobs/killmail_history_backfill.py
+++ b/python/orchestrator/jobs/killmail_history_backfill.py
@@ -84,13 +84,16 @@ def _fetch_zkb_page(entity_type: str, entity_id: int, year: int, month: int, pag
     return data
 
 
-def _fetch_esi_killmail(killmail_id: int, killmail_hash: str, esi_client: EsiClient, gateway: Any = None) -> dict[str, Any] | None:
+def _fetch_esi_killmail(killmail_id: int, killmail_hash: str, esi_client: EsiClient, gateway: Any = None, zkb_data: dict[str, Any] | None = None) -> dict[str, Any] | None:
     """Fetch a single killmail from ESI and wrap in R2Z2-compatible format.
 
     When *gateway* is provided, the request goes through the ESI compliance
     gateway for Expires-gating, conditional request handling, and distributed
     rate-limit coordination.  The gateway caches response bodies in Redis,
     so Expires-gated hits return the payload directly.
+
+    *zkb_data*, when provided, is the full zKillboard metadata dict
+    (totalValue, points, npc, etc.) to include in the payload.
     """
     path = f"/latest/killmails/{killmail_id}/{killmail_hash}/"
     if gateway is not None:
@@ -118,7 +121,7 @@ def _fetch_esi_killmail(killmail_id: int, killmail_hash: str, esi_client: EsiCli
         "killmail_id": killmail_id,
         "hash": killmail_hash,
         "esi": body,
-        "zkb": {},
+        "zkb": zkb_data if zkb_data else {},
         "sequence_id": killmail_id,
         "requested_sequence_id": killmail_id,
         "uploaded_at": int(time.time()),
@@ -132,14 +135,17 @@ def _collect_entity_kills(
     months: list[int],
     user_agent: str,
     endpoint: str = "losses",
-) -> dict[int, str]:
-    """Collect all {killmail_id: hash} pairs for an entity across months.
+) -> dict[int, dict[str, Any]]:
+    """Collect all {killmail_id: {hash, zkb}} dicts for an entity across months.
 
     Paginates through all pages for each month. ``endpoint`` can be
     ``"losses"`` (default — fetches entity deaths) or ``"kills"``
     (fetches entity kills of others).
+
+    Returns a mapping of killmail_id → {"hash": str, "zkb": dict} where
+    ``zkb`` contains the full zKillboard metadata (totalValue, points, etc.).
     """
-    collected: dict[int, str] = {}
+    collected: dict[int, dict[str, Any]] = {}
 
     for month in months:
         page = 1
@@ -155,7 +161,7 @@ def _collect_entity_kills(
                 zkb = entry.get("zkb") or {}
                 km_hash = str(zkb.get("hash", ""))
                 if km_id > 0 and km_hash:
-                    collected[km_id] = km_hash
+                    collected[km_id] = {"hash": km_hash, "zkb": zkb}
 
             logger.info("zKB fetch: got %d results, total collected=%d", len(results), len(collected))
 
@@ -284,7 +290,7 @@ def run_killmail_history_backfill(context: Any) -> dict[str, Any]:
         except Exception:
             pass
 
-    new_kills = {km_id: km_hash for km_id, km_hash in all_kills.items() if km_id not in existing_ids}
+    new_kills = {km_id: km_info for km_id, km_info in all_kills.items() if km_id not in existing_ids}
     total_skipped_existing = total_killmails_seen - len(new_kills)
     logger.info("Dedup: %d already in DB, %d new killmails to fetch from ESI", total_skipped_existing, len(new_kills))
 
@@ -320,8 +326,10 @@ def run_killmail_history_backfill(context: Any) -> dict[str, Any]:
         batch_pairs = kill_pairs[batch_start:batch_start + batch_size]
         payloads = []
 
-        for km_id, km_hash in batch_pairs:
-            payload = _fetch_esi_killmail(km_id, km_hash, esi_client, gateway=_bf_gateway)
+        for km_id, km_info in batch_pairs:
+            km_hash = km_info["hash"]
+            zkb_data = km_info.get("zkb") or {}
+            payload = _fetch_esi_killmail(km_id, km_hash, esi_client, gateway=_bf_gateway, zkb_data=zkb_data)
             if payload is not None:
                 payloads.append(payload)
                 total_esi_fetched += 1

--- a/python/orchestrator/jobs/killmail_zkb_repair.py
+++ b/python/orchestrator/jobs/killmail_zkb_repair.py
@@ -1,0 +1,172 @@
+"""Repair killmails with missing zKillboard metadata (totalValue, points, etc.).
+
+Finds killmail_events rows where zkb_total_value IS NULL, fetches the zkb
+metadata from the zKillboard API, and updates the rows via the PHP bridge.
+
+Usage (via worker job system or direct):
+    python -m orchestrator.jobs.killmail_zkb_repair
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+from ..bridge import PhpBridge
+from ..http_client import ipv4_opener
+from ..worker_runtime import utc_now_iso
+
+logger = logging.getLogger("supplycore.killmail_zkb_repair")
+
+_ZKB_API_BASE = "https://zkillboard.com/api"
+BATCH_SIZE = 500
+ZKB_REQUEST_DELAY = 1.0  # seconds between zKB API requests
+
+
+def _http_get(url: str, user_agent: str, timeout: int = 30) -> tuple[int, str]:
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": user_agent,
+    }
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with ipv4_opener.open(request, timeout=timeout) as response:
+            status = int(getattr(response, "status", response.getcode()))
+            body = response.read()
+            if isinstance(body, bytes):
+                body = body.decode("utf-8", errors="replace")
+            return status, body
+    except urllib.error.HTTPError as error:
+        return int(error.code), ""
+    except (urllib.error.URLError, OSError, TimeoutError) as error:
+        logger.warning("HTTP request failed for %s: %s", url, error)
+        return 0, ""
+
+
+def _fetch_zkb_metadata(killmail_id: int, user_agent: str) -> dict[str, Any]:
+    """Fetch zkb metadata for a single killmail from zKillboard API."""
+    url = f"{_ZKB_API_BASE}/killID/{killmail_id}/"
+    status, body = _http_get(url, user_agent)
+    if status != 200 or not body.strip():
+        return {}
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
+        return data[0].get("zkb") or {}
+    return {}
+
+
+def run_killmail_zkb_repair(context: Any) -> dict[str, Any]:
+    """Repair killmails with missing zkb metadata."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    bridge = PhpBridge(context.php_binary, context.app_root)
+    user_agent = "SupplyCore killmail-zkb-repair/1.0"
+
+    started_at = utc_now_iso()
+    total_found = 0
+    total_fetched = 0
+    total_updated = 0
+    total_failed = 0
+    total_zkb_empty = 0
+
+    offset = 0
+    while True:
+        # Get batch of killmails missing zkb data
+        try:
+            response = bridge.call(
+                "killmails-missing-zkb",
+                payload={"limit": BATCH_SIZE, "offset": 0},  # Always offset=0 since repaired rows disappear from query
+            )
+        except Exception as e:
+            logger.error("Failed to fetch killmails missing zkb: %s", e)
+            break
+
+        rows = response.get("rows") or []
+        total_remaining = int(response.get("total") or 0)
+
+        if not rows:
+            logger.info("No more killmails with missing zkb data.")
+            break
+
+        total_found += len(rows)
+        logger.info("Found %d killmails missing zkb data (%d remaining total)", len(rows), total_remaining)
+
+        # Fetch zkb metadata from zKillboard and prepare updates
+        updates = []
+        for row in rows:
+            km_id = int(row.get("killmail_id") or 0)
+            if km_id <= 0:
+                continue
+
+            zkb = _fetch_zkb_metadata(km_id, user_agent)
+            total_fetched += 1
+
+            if zkb and zkb.get("totalValue") is not None:
+                updates.append({"killmail_id": km_id, "zkb": zkb})
+            else:
+                total_zkb_empty += 1
+
+            time.sleep(ZKB_REQUEST_DELAY)
+
+        # Send updates to PHP bridge
+        if updates:
+            try:
+                result = bridge.call(
+                    "repair-killmail-zkb",
+                    payload={"updates": updates},
+                )
+                batch_result = result.get("result") or {}
+                total_updated += int(batch_result.get("updated") or 0)
+                total_failed += int(batch_result.get("failed") or 0)
+                logger.info("Repair batch: updated=%d failed=%d", batch_result.get("updated", 0), batch_result.get("failed", 0))
+            except Exception as e:
+                logger.error("Failed to send repair batch: %s", e)
+                total_failed += len(updates)
+
+        # Progress update
+        try:
+            bridge.call("update-setting", payload={
+                "key": "killmail_zkb_repair_progress",
+                "value": json.dumps({
+                    "found": total_found,
+                    "fetched": total_fetched,
+                    "updated": total_updated,
+                    "failed": total_failed,
+                    "zkb_empty": total_zkb_empty,
+                    "remaining": total_remaining - len(rows),
+                    "updated_at": utc_now_iso(),
+                }),
+            })
+        except Exception:
+            pass
+
+        # Safety: if we processed a batch but updated nothing, we're stuck
+        if not updates and total_zkb_empty >= len(rows):
+            logger.warning("Entire batch had no zkb data from zKillboard; stopping to avoid infinite loop.")
+            break
+
+    # Clear progress
+    try:
+        bridge.call("update-setting", payload={
+            "key": "killmail_zkb_repair_progress",
+            "value": "",
+        })
+    except Exception:
+        pass
+
+    return {
+        "status": "success",
+        "started_at": started_at,
+        "finished_at": utc_now_iso(),
+        "total_found": total_found,
+        "total_fetched": total_fetched,
+        "total_updated": total_updated,
+        "total_failed": total_failed,
+        "total_zkb_empty": total_zkb_empty,
+    }

--- a/src/functions.php
+++ b/src/functions.php
@@ -15578,6 +15578,68 @@ function python_bridge_process_killmail_batch(array $payloads, bool $skipEntityF
     ];
 }
 
+function python_bridge_repair_killmail_zkb(array $updates): array
+{
+    $updated = 0;
+    $failed = 0;
+
+    foreach ($updates as $entry) {
+        $killmailId = (int) ($entry['killmail_id'] ?? 0);
+        $zkb = is_array($entry['zkb'] ?? null) ? $entry['zkb'] : [];
+
+        if ($killmailId <= 0 || $zkb === []) {
+            $failed++;
+            continue;
+        }
+
+        $totalValue = isset($zkb['totalValue']) && is_numeric($zkb['totalValue']) ? (float) $zkb['totalValue'] : null;
+        $fittedValue = isset($zkb['fittedValue']) && is_numeric($zkb['fittedValue']) ? (float) $zkb['fittedValue'] : null;
+        $droppedValue = isset($zkb['droppedValue']) && is_numeric($zkb['droppedValue']) ? (float) $zkb['droppedValue'] : null;
+        $destroyedValue = isset($zkb['destroyedValue']) && is_numeric($zkb['destroyedValue']) ? (float) $zkb['destroyedValue'] : null;
+        $points = isset($zkb['points']) && is_numeric($zkb['points']) ? (int) $zkb['points'] : null;
+        $npc = isset($zkb['npc']) ? (!empty($zkb['npc']) ? 1 : 0) : null;
+        $solo = isset($zkb['solo']) ? (!empty($zkb['solo']) ? 1 : 0) : null;
+        $awox = isset($zkb['awox']) ? (!empty($zkb['awox']) ? 1 : 0) : null;
+
+        if ($totalValue === null) {
+            $failed++;
+            continue;
+        }
+
+        try {
+            db_execute(
+                'UPDATE killmail_events SET
+                    zkb_total_value = ?,
+                    zkb_fitted_value = COALESCE(?, zkb_fitted_value),
+                    zkb_dropped_value = COALESCE(?, zkb_dropped_value),
+                    zkb_destroyed_value = COALESCE(?, zkb_destroyed_value),
+                    zkb_points = COALESCE(?, zkb_points),
+                    zkb_npc = COALESCE(?, zkb_npc),
+                    zkb_solo = COALESCE(?, zkb_solo),
+                    zkb_awox = COALESCE(?, zkb_awox)
+                 WHERE killmail_id = ? AND zkb_total_value IS NULL',
+                [$totalValue, $fittedValue, $droppedValue, $destroyedValue, $points, $npc, $solo, $awox, $killmailId]
+            );
+
+            // Also update the stored zkb_json in killmail_event_payloads
+            $zkbJson = json_encode($zkb, JSON_UNESCAPED_SLASHES);
+            db_execute(
+                'UPDATE killmail_event_payloads p
+                 INNER JOIN killmail_events e ON e.sequence_id = p.sequence_id
+                 SET p.zkb_json = ?
+                 WHERE e.killmail_id = ? AND (p.zkb_json IS NULL OR p.zkb_json = \'{}\' OR p.zkb_json = \'\')',
+                [$zkbJson, $killmailId]
+            );
+
+            $updated++;
+        } catch (Throwable $e) {
+            $failed++;
+        }
+    }
+
+    return ['updated' => $updated, 'failed' => $failed];
+}
+
 function python_bridge_run_job_handler(string $jobKey, string $reason = 'python-fallback'): array
 {
     $definitions = scheduler_job_definitions();


### PR DESCRIPTION
## Summary
Adds a new job to repair killmails with missing zKillboard metadata (totalValue, points, etc.) by fetching from the zKillboard API and updating the database. Also enhances existing killmail backfill jobs to pre-fetch and include zkb metadata during ESI ingestion.

## Key Changes

- **New repair job** (`killmail_zkb_repair.py`): Finds killmail_events rows where `zkb_total_value IS NULL`, fetches metadata from zKillboard API, and updates via PHP bridge with rate-limiting (1 req/sec)

- **PHP bridge functions**:
  - `python_bridge_repair_killmail_zkb()`: Updates killmail_events and killmail_event_payloads with zkb metadata (totalValue, fittedValue, points, npc, solo, awox flags)
  - `killmails-missing-zkb` action: Queries for killmails missing zkb data with pagination support
  - `repair-killmail-zkb` action: Processes batch updates from Python

- **Enhanced backfill jobs**:
  - `killmail_history_backfill.py`: Modified `_collect_entity_kills()` to return full zkb metadata dict alongside hash; passes zkb_data to `_fetch_esi_killmail()`
  - `killmail_full_history_backfill.py`: Added `_fetch_zkb_metadata()` and `_fetch_zkb_metadata_batch()` helpers; pre-fetches zkb metadata for daily dump batches before ESI ingestion

- **Repair job features**:
  - Batch processing (500 killmails per batch)
  - Progress tracking via settings table
  - Graceful handling of empty zkb responses from API
  - Infinite loop prevention when entire batch has no zkb data
  - Comprehensive logging and error handling

## Implementation Details

- Uses existing `ipv4_opener` HTTP client for zKillboard API requests
- Respects rate limits with configurable delays between requests
- Updates only rows where `zkb_total_value IS NULL` to avoid re-processing
- Uses `COALESCE()` in SQL to preserve existing values while filling nulls
- Returns detailed statistics (found, fetched, updated, failed, zkb_empty counts)

https://claude.ai/code/session_0179v6DfMTh8n4ZswzcBkuDh