### PR TITLE
Replace db_select_all() calls with db_select()

### DIFF
--- a/bin/python_scheduler_bridge.php
+++ b/bin/python_scheduler_bridge.php
@@ -145,7 +145,7 @@ try {
         $input = python_scheduler_bridge_read_stdin_json();
         $limit = max(1, min(1000, (int) ($input['limit'] ?? 500)));
         $offset = max(0, (int) ($input['offset'] ?? 0));
-        $rows = db_select_all(
+        $rows = db_select(
             'SELECT killmail_id, killmail_hash FROM killmail_events WHERE zkb_total_value IS NULL ORDER BY killmail_id ASC LIMIT ? OFFSET ?',
             [$limit, $offset]
         );

--- a/src/db.php
+++ b/src/db.php
@@ -14696,7 +14696,7 @@ function db_signals_recent(int $limit = 200): array
 
 function db_theater_side_composition(string $theaterId): array
 {
-    return db_select_all(
+    return db_select(
         'SELECT * FROM theater_side_composition WHERE theater_id = ? ORDER BY side ASC',
         [$theaterId]
     );


### PR DESCRIPTION
## Summary
This PR updates two database query calls to use `db_select()` instead of `db_select_all()`, standardizing the database access pattern across the codebase.

## Key Changes
- **bin/python_scheduler_bridge.php**: Changed `db_select_all()` to `db_select()` when fetching killmail events with pagination
- **src/db.php**: Changed `db_select_all()` to `db_select()` in the `db_theater_side_composition()` function

## Implementation Details
Both functions are querying for multiple rows and the change suggests that `db_select()` is the preferred method for retrieving result sets, replacing the previous `db_select_all()` calls. This appears to be a refactoring to consolidate on a single database query interface.

https://claude.ai/code/session_01Cfx16UnzcogvAuesqjFNSh