### PR TITLE
Fix killmail total count query to use proper result handling

### DIFF
--- a/bin/python_scheduler_bridge.php
+++ b/bin/python_scheduler_bridge.php
@@ -149,7 +149,8 @@ try {
             'SELECT killmail_id, killmail_hash FROM killmail_events WHERE zkb_total_value IS NULL ORDER BY killmail_id ASC LIMIT ? OFFSET ?',
             [$limit, $offset]
         );
-        $total = (int) db_select_value('SELECT COUNT(*) FROM killmail_events WHERE zkb_total_value IS NULL');
+        $totalRow = db_select_one('SELECT COUNT(*) AS total FROM killmail_events WHERE zkb_total_value IS NULL');
+        $total = (int) ($totalRow['total'] ?? 0);
         python_scheduler_bridge_output(['ok' => true, 'rows' => $rows, 'total' => $total]);
     }
 


### PR DESCRIPTION
## Summary
Updated the killmail events total count query to use `db_select_one()` instead of `db_select_value()` for more robust result handling with proper null safety.

## Key Changes
- Changed from `db_select_value()` to `db_select_one()` for fetching the COUNT query result
- Updated the SQL query to use an alias (`AS total`) for the COUNT result
- Added null-safe access with a fallback to 0: `(int) ($totalRow['total'] ?? 0)`

## Implementation Details
This change improves the reliability of the total count retrieval by:
- Using the more appropriate `db_select_one()` method that returns a full row array
- Providing explicit null handling to prevent potential errors if the query returns unexpected results
- Maintaining backward compatibility by casting the result to an integer with a safe default value

https://claude.ai/code/session_01S5GaqyXa2qB8BnUgVfAgJd