### PR TITLE
Refactor cursor parsing to use helper function

### DIFF
--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -2032,7 +2032,7 @@ def run_compute_graph_sync_killmail_entities(
         "SELECT last_cursor FROM sync_state WHERE dataset_key = %s",
         (_KILLMAIL_CURSOR_KEY,),
     )
-    last_cursor = int(cursor_row["last_cursor"]) if cursor_row and cursor_row.get("last_cursor") else 0
+    last_cursor = _parse_int_cursor(cursor_row["last_cursor"]) if cursor_row else 0
 
     rows_processed = 0
     rows_written = 0
@@ -2149,7 +2149,7 @@ def run_compute_graph_sync_killmail_edges(
         "SELECT last_cursor FROM sync_state WHERE dataset_key = %s",
         (_KM_ATTACKER_EDGE_CURSOR_KEY,),
     )
-    last_attacker_cursor = int(cursor_row["last_cursor"]) if cursor_row and cursor_row.get("last_cursor") else 0
+    last_attacker_cursor = _parse_int_cursor(cursor_row["last_cursor"]) if cursor_row else 0
     new_attacker_cursor = last_attacker_cursor
 
     while True:
@@ -2205,7 +2205,7 @@ def run_compute_graph_sync_killmail_edges(
         "SELECT last_cursor FROM sync_state WHERE dataset_key = %s",
         (_KM_VICTIM_EDGE_CURSOR_KEY,),
     )
-    last_victim_cursor = int(cursor_row["last_cursor"]) if cursor_row and cursor_row.get("last_cursor") else 0
+    last_victim_cursor = _parse_int_cursor(cursor_row["last_cursor"]) if cursor_row else 0
     new_victim_cursor = last_victim_cursor
 
     while True:


### PR DESCRIPTION
## Summary
Refactored cursor value parsing in the killmail synchronization functions to use a dedicated helper function (`_parse_int_cursor`) instead of inline conditional logic. This improves code maintainability and reduces duplication.

## Key Changes
- Replaced inline `int(cursor_row["last_cursor"]) if cursor_row and cursor_row.get("last_cursor") else 0` logic with calls to `_parse_int_cursor(cursor_row["last_cursor"]) if cursor_row else 0`
- Applied the refactoring to three cursor initialization locations:
  - `run_compute_graph_sync_killmail_entities`: `last_cursor` variable
  - `run_compute_graph_sync_killmail_edges`: `last_attacker_cursor` variable
  - `run_compute_graph_sync_killmail_edges`: `last_victim_cursor` variable

## Implementation Details
The refactoring simplifies the null-checking logic by delegating integer parsing to a helper function. The outer `if cursor_row` check ensures the cursor row exists before attempting to parse its value, while the helper function handles the actual conversion and any edge cases related to parsing the cursor value.

https://claude.ai/code/session_01LiqxoWKUnaA3UBSfhpoSQ1