### PR TITLE
Enrich community page with named callouts and role badges

### DIFF
--- a/public/battle-intelligence/community.php
+++ b/public/battle-intelligence/community.php
@@ -24,10 +24,24 @@ $communityLabel = $topMemberName !== '' ? $topMemberName . "'s cluster" : 'Commu
 
 $title = $communityLabel;
 
-$memberCount  = count($members);
-$bridgeCount  = count(array_filter($members, static fn(array $m): bool => (bool) ($m['is_bridge'] ?? false)));
-$avgPagerank  = $memberCount > 0 ? array_sum(array_column($members, 'pagerank_score')) / $memberCount : 0.0;
-$maxPagerank  = $memberCount > 0 ? max(array_column($members, 'pagerank_score')) : 0.0;
+$memberCount = count($members);
+$bridges     = array_filter($members, static fn(array $m): bool => (bool) ($m['is_bridge'] ?? false));
+$bridgeCount = count($bridges);
+
+// Fetch counterintel suspicion scores for all community members
+$charIds = array_map(static fn(array $m): int => (int) ($m['character_id'] ?? 0), $members);
+$counterintel = db_counterintel_scores_for_characters($charIds);
+
+// Identify flagged members (any non-zero review_priority_score)
+$flaggedMembers = [];
+foreach ($members as $m) {
+    $cid = (int) ($m['character_id'] ?? 0);
+    $score = (float) ($counterintel[$cid]['review_priority_score'] ?? 0);
+    if ($score > 0) {
+        $flaggedMembers[] = array_merge($m, ['priority_score' => $score, 'percentile_rank' => (float) ($counterintel[$cid]['percentile_rank'] ?? 0)]);
+    }
+}
+usort($flaggedMembers, static fn(array $a, array $b): int => $b['priority_score'] <=> $a['priority_score']);
 
 include __DIR__ . '/../../src/views/partials/header.php';
 ?>
@@ -36,44 +50,66 @@ include __DIR__ . '/../../src/views/partials/header.php';
         <div>
             <p class="text-xs uppercase tracking-[0.16em] text-muted">Battle intelligence &rsaquo; Community</p>
             <h1 class="mt-1 text-2xl font-semibold text-slate-50"><?= htmlspecialchars($communityLabel, ENT_QUOTES) ?></h1>
-            <p class="mt-2 text-xs text-muted">Community ID #<?= $communityId ?> &middot; label-propagation detection</p>
+            <p class="mt-2 text-xs text-muted">Community #<?= $communityId ?> &middot; <?= $memberCount ?> members detected via label-propagation</p>
         </div>
         <a href="/battle-intelligence/" class="btn-secondary">&larr; Back to leaderboard</a>
     </div>
 
-    <div class="mt-5 grid gap-3 md:grid-cols-4">
-        <div class="surface-tertiary">
-            <p class="text-xs text-muted">Members</p>
-            <p class="mt-1 text-xl text-slate-100"><?= $memberCount ?></p>
-        </div>
-        <div class="surface-tertiary">
-            <p class="text-xs text-muted" title="Characters that act as connectors between otherwise separate groups — high risk for intel relay">Bridges</p>
-            <p class="mt-1 text-xl <?= $bridgeCount > 0 ? 'text-amber-400' : 'text-slate-100' ?>"><?= $bridgeCount ?></p>
-        </div>
-        <div class="surface-tertiary">
-            <p class="text-xs text-muted" title="Average PageRank — how interconnected members are on average">Avg influence</p>
-            <p class="mt-1 text-xl text-slate-100"><?= number_format($avgPagerank, 4) ?></p>
-        </div>
-        <div class="surface-tertiary">
-            <p class="text-xs text-muted" title="PageRank of the most central member in this community">Top influence</p>
-            <p class="mt-1 text-xl text-slate-100"><?= number_format($maxPagerank, 4) ?></p>
+    <?php if ($flaggedMembers !== []): ?>
+    <div class="mt-5 surface-tertiary">
+        <p class="text-xs uppercase tracking-[0.16em] text-red-400">Flagged members</p>
+        <p class="mt-1 text-xs text-muted"><?= count($flaggedMembers) ?> member<?= count($flaggedMembers) !== 1 ? 's' : '' ?> in this cluster also appear on the suspicion leaderboard.</p>
+        <div class="mt-3 flex flex-col gap-2">
+            <?php foreach ($flaggedMembers as $fm): ?>
+                <?php
+                $fmScore = (float) $fm['priority_score'];
+                if ($fmScore > 0.15) { $fmLabel = 'CRITICAL'; $fmClass = 'bg-red-900/60 text-red-300 border border-red-800/50'; }
+                elseif ($fmScore > 0.05) { $fmLabel = 'HIGH'; $fmClass = 'bg-orange-900/60 text-orange-300 border border-orange-800/50'; }
+                elseif ($fmScore > 0.01) { $fmLabel = 'ELEVATED'; $fmClass = 'bg-amber-900/60 text-amber-300 border border-amber-800/50'; }
+                else { $fmLabel = 'WATCH'; $fmClass = 'bg-yellow-900/60 text-yellow-400 border border-yellow-800/50'; }
+                $fmPct = (float) $fm['percentile_rank'] * 100;
+                ?>
+                <div class="flex items-center gap-3">
+                    <span class="inline-flex items-center rounded px-2 py-0.5 text-xs font-medium <?= $fmClass ?>"><?= $fmLabel ?></span>
+                    <a class="text-accent hover:underline" href="/battle-intelligence/character.php?character_id=<?= urlencode((string) ((int) $fm['character_id'])) ?>"><?= htmlspecialchars((string) $fm['character_name'], ENT_QUOTES) ?></a>
+                    <span class="text-xs text-muted"><?= number_format($fmPct, 1) ?>% percentile</span>
+                </div>
+            <?php endforeach; ?>
         </div>
     </div>
+    <?php endif; ?>
 
-    <div class="mt-5 table-shell">
+    <?php if ($bridgeCount > 0): ?>
+    <div class="mt-4 surface-tertiary">
+        <p class="text-xs uppercase tracking-[0.16em] text-amber-400">Bridge characters</p>
+        <p class="mt-1 text-xs text-muted">These <?= $bridgeCount ?> character<?= $bridgeCount !== 1 ? 's connect' : ' connects' ?> otherwise separate groups in the network &mdash; they may relay intel between sides or act as cross-corp intermediaries.</p>
+        <div class="mt-3 flex flex-wrap gap-2">
+            <?php foreach ($bridges as $bridge): ?>
+                <a class="inline-flex items-center gap-1.5 rounded-full bg-amber-900/40 border border-amber-800/40 px-3 py-1 text-sm text-amber-200 hover:bg-amber-900/60 transition-colors"
+                   href="/battle-intelligence/character.php?character_id=<?= urlencode((string) ((int) ($bridge['character_id'] ?? 0))) ?>">
+                    <?= htmlspecialchars((string) ($bridge['character_name'] ?? 'Unknown'), ENT_QUOTES) ?>
+                    <span class="text-[10px] text-amber-400/60"><?= (int) ($bridge['degree_centrality'] ?? 0) ?> connections</span>
+                </a>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <?php endif; ?>
+
+    <h2 class="mt-6 text-lg font-semibold text-slate-100">All members</h2>
+    <p class="mt-1 text-xs text-muted">Sorted by influence (most central first). Click any name to see their full intelligence profile.</p>
+    <div class="mt-3 table-shell">
         <table class="table-ui">
             <thead>
             <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
                 <th class="px-3 py-2 text-left">Character</th>
-                <th class="px-3 py-2 text-right" title="PageRank score — higher means more central and influential within this community">Influence</th>
-                <th class="px-3 py-2 text-right" title="How many shortest paths between other members pass through this character — high values suggest an intel relay role">Betweenness</th>
+                <th class="px-3 py-2 text-left">Role</th>
                 <th class="px-3 py-2 text-right" title="Number of direct connections to other characters in the graph">Connections</th>
-                <th class="px-3 py-2 text-right" title="Bridge characters connect otherwise separate groups — elevated cross-side risk">Bridge</th>
+                <th class="px-3 py-2 text-right" title="Suspicion status from the counterintel pipeline — only shown if this character has been scored">Suspicion</th>
                 <th class="px-3 py-2 text-right">Inspect</th>
             </tr>
             </thead>
             <tbody>
-            <?php foreach ($members as $member): ?>
+            <?php foreach ($members as $idx => $member): ?>
                 <?php
                 $pagerank    = (float) ($member['pagerank_score'] ?? 0);
                 $betweenness = (float) ($member['betweenness_centrality'] ?? 0);
@@ -82,19 +118,47 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 $charId      = (int)   ($member['character_id'] ?? 0);
                 $charName    = (string) ($member['character_name'] ?? 'Unknown');
 
-                $pagerankClass   = $pagerank >= 1.5 ? 'text-orange-400 font-semibold' : ($pagerank >= 1.1 ? 'text-amber-400' : 'text-slate-300');
-                $betweennessDisp = $betweenness > 0 ? number_format($betweenness, 4) : '<span class="text-muted">—</span>';
+                // Determine role badges
+                $roles = [];
+                if ($idx === 0) {
+                    $roles[] = ['label' => 'Leader', 'class' => 'bg-sky-900/60 text-sky-300 border border-sky-800/50'];
+                } elseif ($pagerank >= 1.3) {
+                    $roles[] = ['label' => 'Key member', 'class' => 'bg-indigo-900/60 text-indigo-300 border border-indigo-800/50'];
+                }
+                if ($isBridge) {
+                    $roles[] = ['label' => 'Bridge', 'class' => 'bg-amber-900/60 text-amber-300 border border-amber-800/50'];
+                }
+                if ($betweenness > 0.01) {
+                    $roles[] = ['label' => 'Relay', 'class' => 'bg-purple-900/60 text-purple-300 border border-purple-800/50'];
+                }
+
+                // Suspicion from counterintel
+                $ciScore = (float) ($counterintel[$charId]['review_priority_score'] ?? 0);
+                if ($ciScore > 0.15) { $ciLabel = 'CRITICAL'; $ciClass = 'text-red-400'; }
+                elseif ($ciScore > 0.05) { $ciLabel = 'HIGH'; $ciClass = 'text-orange-400'; }
+                elseif ($ciScore > 0.01) { $ciLabel = 'ELEVATED'; $ciClass = 'text-amber-400'; }
+                elseif ($ciScore > 0) { $ciLabel = 'WATCH'; $ciClass = 'text-yellow-400'; }
+                else { $ciLabel = null; $ciClass = ''; }
                 ?>
                 <tr class="border-b border-border/50">
                     <td class="px-3 py-2 text-slate-100"><?= htmlspecialchars($charName, ENT_QUOTES) ?></td>
-                    <td class="px-3 py-2 text-right"><span class="<?= $pagerankClass ?>"><?= number_format($pagerank, 4) ?></span></td>
-                    <td class="px-3 py-2 text-right"><?= $betweennessDisp ?></td>
+                    <td class="px-3 py-2">
+                        <?php if ($roles !== []): ?>
+                            <div class="flex flex-wrap gap-1">
+                                <?php foreach ($roles as $role): ?>
+                                    <span class="inline-block rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wider font-medium <?= $role['class'] ?>"><?= $role['label'] ?></span>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php else: ?>
+                            <span class="text-muted text-xs">Member</span>
+                        <?php endif; ?>
+                    </td>
                     <td class="px-3 py-2 text-right"><?= $degree ?></td>
                     <td class="px-3 py-2 text-right">
-                        <?php if ($isBridge): ?>
-                            <span class="inline-block rounded-full bg-amber-900/60 border border-amber-800/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-amber-300">Yes</span>
+                        <?php if ($ciLabel !== null): ?>
+                            <span class="text-xs font-medium <?= $ciClass ?>"><?= $ciLabel ?></span>
                         <?php else: ?>
-                            <span class="text-muted">—</span>
+                            <span class="text-muted text-xs">—</span>
                         <?php endif; ?>
                     </td>
                     <td class="px-3 py-2 text-right">

--- a/src/db.php
+++ b/src/db.php
@@ -15548,6 +15548,28 @@ function db_graph_community_overview(int $limit = 30): array
     );
 }
 
+function db_counterintel_scores_for_characters(array $characterIds): array
+{
+    $ids = array_map('intval', array_filter($characterIds, static fn($id): bool => ((int) $id) > 0));
+    if ($ids === []) {
+        return [];
+    }
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+
+    $rows = db_select(
+        'SELECT ccs.character_id, ccs.review_priority_score, ccs.percentile_rank, ccs.confidence_score
+         FROM character_counterintel_scores ccs
+         WHERE ccs.character_id IN (' . $placeholders . ')',
+        $ids
+    );
+
+    $indexed = [];
+    foreach ($rows as $r) {
+        $indexed[(int) $r['character_id']] = $r;
+    }
+    return $indexed;
+}
+
 // ---------------------------------------------------------------------------
 // Theater intelligence
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Replace the raw-numbers community table with a human-friendly layout:

- Flagged members section: cross-references counterintel scores and calls out community members on the suspicion leaderboard by name, with priority badges (CRITICAL/HIGH/ELEVATED/WATCH)
- Bridge characters section: lists every bridge by name as clickable pills with connection counts, explains what bridges are
- Member table: replaces PageRank/betweenness columns with readable role badges (Leader, Key member, Bridge, Relay) and a Suspicion column showing counterintel status
- New db helper db_counterintel_scores_for_characters() to batch-fetch suspicion scores for a set of character IDs

https://claude.ai/code/session_016skUJx1EWAjCXZwc5MBsER