### PR TITLE
Fix Neo4j arg mismatches, motif data loss, and add Pipeline Observatory

### DIFF
--- a/public/pipeline/index.php
+++ b/public/pipeline/index.php
@@ -73,7 +73,8 @@ $stages = [
         'health' => $stageHealth['resolution'] ?? ['total_jobs' => 0, 'succeeded' => 0, 'failed' => 0, 'pct' => 0, 'last_success' => null],
         'metrics' => [
             ['label' => 'Unique characters', 'value' => _po_fmt($kpis['unique_characters'])],
-            ['label' => 'Entities resolved', 'value' => _po_fmt($kpis['entities_resolved'])],
+            ['label' => 'Characters resolved', 'value' => _po_fmt($kpis['characters_resolved'])],
+            ['label' => 'All entities',      'value' => _po_fmt($kpis['entities_resolved'])],
             ['label' => 'Coverage',          'value' => $kpis['entity_coverage'] . '%'],
             ['label' => 'Alliance histories', 'value' => _po_fmt($kpis['alliance_histories'])],
         ],
@@ -259,7 +260,7 @@ $overallPct = $stageCount > 0 ? round($overallPct / $stageCount) : 0;
         $coverageCards = [
             [
                 'label'   => 'Entity Resolution',
-                'detail'  => _po_fmt($kpis['entities_resolved']) . ' of ' . _po_fmt($kpis['unique_characters']) . ' characters',
+                'detail'  => _po_fmt($kpis['characters_resolved']) . ' of ' . _po_fmt($kpis['unique_characters']) . ' characters',
                 'pct'     => $kpis['entity_coverage'],
             ],
             [

--- a/src/db.php
+++ b/src/db.php
@@ -16730,13 +16730,14 @@ function db_pipeline_observatory_data(): array
 
     // ── Stage 2: Entity resolution ───────────────────────────────────────────
     $entitiesResolved   = (int) (db_select_one("SELECT COUNT(*) AS cnt FROM entity_metadata_cache") ?? [])['cnt'] ?? 0;
+    $charactersResolved = (int) (db_select_one("SELECT COUNT(*) AS cnt FROM entity_metadata_cache WHERE entity_type = 'character'") ?? [])['cnt'] ?? 0;
     $allianceHistories  = (int) (db_select_one("SELECT COUNT(DISTINCT character_id) AS cnt FROM character_alliance_history") ?? [])['cnt'] ?? 0;
 
     // Unique characters across killmails (attackers + victims)
     $uniqueCharacters = (int) (db_select_one(
         "SELECT COUNT(DISTINCT character_id) AS cnt FROM killmail_attackers WHERE character_id IS NOT NULL AND character_id > 0"
     ) ?? [])['cnt'] ?? 0;
-    $entityCoverage = $uniqueCharacters > 0 ? min(100, round($entitiesResolved / $uniqueCharacters * 100, 1)) : 0;
+    $entityCoverage = $uniqueCharacters > 0 ? min(100, round($charactersResolved / $uniqueCharacters * 100, 1)) : 0;
 
     // ── Stage 3: Graph enrichment ────────────────────────────────────────────
     $communities       = (int) (db_select_one("SELECT COUNT(DISTINCT community_id) AS cnt FROM graph_community_assignments") ?? [])['cnt'] ?? 0;
@@ -16848,6 +16849,7 @@ function db_pipeline_observatory_data(): array
             'market_orders'     => $marketOrders,
             'unique_characters' => $uniqueCharacters,
             'entities_resolved' => $entitiesResolved,
+            'characters_resolved' => $charactersResolved,
             'entity_coverage'   => $entityCoverage,
             'alliance_histories' => $allianceHistories,
             'communities'       => $communities,


### PR DESCRIPTION
## Summary

- **Fix neo4j_raw arg mismatch in `compute_alliance_dossiers` and `compute_threat_corridors`** — both had `(db, runtime, neo4j_raw)` signatures but the registry lambdas passed `neo4j_runtime(cfg)` as the second positional arg, so it landed in `runtime` and `neo4j_raw` was always `None`. This caused both jobs to silently fall back to SQL-only paths instead of using Neo4j graph queries.
- **Fix silent data loss in `graph_motif_detection_sync`** — a bare `except Exception` swallowed all Neo4j errors per-detector. If some detectors failed and others succeeded, the table was truncated and rewritten with partial data while the job reported success. Now catches only `(Neo4jError, OSError)`, logs failures, and returns `JobResult.failed` without touching existing data.
- **Add Pipeline Observatory page** (`/pipeline`) — end-to-end view of all 5 pipeline stages (Collection, Entity Resolution, Graph Enrichment, Intelligence, Analytics) with hero KPIs, progress bars, data coverage matrix, and recent job activity table. No new tables or migrations needed.
- **Fix suspicion coverage query** — the observatory was reading `character_counterintel_scores` (74 rows from the counterintel pipeline) instead of `character_suspicion_scores` (2,578 rows from the v2 scoring pipeline).

## Test plan

- [ ] Verify alliance dossier page shows "Co-Present Alliances via neo4j" and "Primary Enemies via neo4j" instead of "via sql"
- [ ] Verify threat corridors page populates from Neo4j graph data
- [ ] Run `graph_motif_detection_sync` and confirm it reports failure (not success) when Neo4j is unreachable
- [ ] Visit `/pipeline` and confirm all 5 stages render with correct counts and progress bars
- [ ] Confirm suspicion coverage shows ~71% (2,578/3,604) not 2%

https://claude.ai/code/session_012dqj1VuLmfosEvsekXuXD2