### PR TITLE
Add loop runner: tier-by-tier job execution replacing worker pool

### DIFF
--- a/ops/systemd/supplycore-loop-runner.service
+++ b/ops/systemd/supplycore-loop-runner.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=SupplyCore loop runner (tier-by-tier job execution)
+After=network.target mariadb.service
+Wants=network.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+WorkingDirectory=/var/www/SupplyCore
+EnvironmentFile=-/etc/default/supplycore-worker
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --max-parallel 6 --fast-pause 5 --background-pause 30
+Restart=always
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=120
+MemoryMax=2G
+StandardOutput=append:/var/www/SupplyCore/storage/logs/worker.log
+StandardError=append:/var/www/SupplyCore/storage/logs/worker.log
+
+[Install]
+WantedBy=multi-user.target

--- a/python/orchestrator/loop_runner.py
+++ b/python/orchestrator/loop_runner.py
@@ -1,0 +1,525 @@
+"""Simple tier-by-tier loop runner.
+
+Replaces the database-queue-backed worker pool with a straightforward approach:
+
+  1. Compute execution tiers from the job dependency graph.
+  2. For each tier, run all jobs in parallel (respecting concurrency groups).
+  3. Wait for every job in the tier to finish before starting the next tier.
+  4. When all tiers are done, start over immediately.
+
+Two loops run concurrently inside the same process:
+
+  - **Fast loop**: jobs with ``opportunistic_background=False``.  These are the
+    critical, frequent jobs (syncs, dashboards, compute).  A full cycle typically
+    completes in a few minutes.
+  - **Background loop**: jobs with ``opportunistic_background=True``.  These are
+    slow, occasional jobs (historical backfills, forecasting, pruning).  They run
+    independently so they never block the fast loop.
+
+One process, one systemd service, no database queuing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import socket
+import time
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed, Future
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .config import load_php_runtime_config, resolve_app_root
+from .db import SupplyCoreDb
+from .job_result import JobResult
+from .json_utils import json_dumps_safe, make_json_safe
+from .logging_utils import LoggerAdapter, configure_logging
+from .processor_registry import audit_enabled_python_jobs, run_registered_processor
+from .scheduling_graph import build_graph, _topological_tiers
+from .worker_registry import WORKER_JOB_DEFINITIONS
+from .worker_runtime import resident_memory_bytes, utc_now_iso
+
+
+# Re-use the UI refresh mapping and finalize logic from worker_pool.
+from .worker_pool import _finalize_job, _UI_REFRESH_JOB_MAP
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@dataclass(slots=True)
+class JobOutcome:
+    """Result of running a single job inside the loop."""
+    job_key: str
+    status: str           # "success", "failed", "skipped"
+    duration_seconds: float
+    error: str | None = None
+    result: dict[str, Any] = field(default_factory=dict)
+
+
+def _run_single_job(
+    job_key: str,
+    db: SupplyCoreDb,
+    raw_config: dict[str, Any],
+    logger: LoggerAdapter,
+    timeout_seconds: int,
+) -> JobOutcome:
+    """Execute one job synchronously and return its outcome."""
+    started = time.monotonic()
+    try:
+        result = run_registered_processor(job_key, db, raw_config)
+        elapsed = time.monotonic() - started
+        result = make_json_safe(result)
+
+        # Back-fill timing if the processor didn't provide it.
+        if not result.get("duration_ms"):
+            result["duration_ms"] = int(elapsed * 1000)
+        if not result.get("started_at"):
+            result["started_at"] = utc_now_iso()
+        if not result.get("finished_at"):
+            result["finished_at"] = utc_now_iso()
+        result.setdefault("meta", {})
+        result["meta"]["execution_language"] = "python"
+        result["meta"]["runner"] = "loop_runner"
+
+        status = str(result.get("status") or "success")
+
+        _finalize_job(db, job_key, result, logger)
+
+        return JobOutcome(
+            job_key=job_key,
+            status=status,
+            duration_seconds=elapsed,
+            result=result,
+        )
+    except Exception as exc:
+        elapsed = time.monotonic() - started
+        fail_result = JobResult.failed(
+            job_key=job_key,
+            error=exc,
+            meta={"execution_language": "python", "runner": "loop_runner"},
+        ).to_dict()
+
+        _finalize_job(db, job_key, fail_result, logger)
+
+        return JobOutcome(
+            job_key=job_key,
+            status="failed",
+            duration_seconds=elapsed,
+            error=str(exc),
+            result=fail_result,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tier execution
+# ---------------------------------------------------------------------------
+
+def _split_tier_by_concurrency(
+    tier_jobs: list[str],
+    graph_nodes: dict,
+) -> tuple[list[str], dict[str, list[str]]]:
+    """Split a tier into independent jobs and concurrency-grouped jobs.
+
+    Returns:
+        (independent_jobs, grouped_jobs) where grouped_jobs maps
+        concurrency_group -> [job_key, ...] (must run sequentially within group).
+    """
+    independent: list[str] = []
+    groups: dict[str, list[str]] = {}
+
+    for job_key in tier_jobs:
+        node = graph_nodes.get(job_key)
+        cg = node.concurrency_group if node else ""
+        if not cg:
+            independent.append(job_key)
+        else:
+            groups.setdefault(cg, []).append(job_key)
+
+    return independent, groups
+
+
+def _run_concurrency_group(
+    group_jobs: list[str],
+    db: SupplyCoreDb,
+    raw_config: dict[str, Any],
+    logger: LoggerAdapter,
+    definitions: dict[str, dict[str, Any]],
+    shutdown_event: threading.Event,
+) -> list[JobOutcome]:
+    """Run jobs in a concurrency group sequentially."""
+    outcomes: list[JobOutcome] = []
+    for job_key in group_jobs:
+        if shutdown_event.is_set():
+            break
+        timeout = int(definitions.get(job_key, {}).get("timeout_seconds", 300))
+        outcome = _run_single_job(job_key, db, raw_config, logger, timeout)
+        outcomes.append(outcome)
+        logger.info(
+            f"job finished: {job_key}",
+            payload={
+                "event": "loop_runner.job_finished",
+                "job_key": job_key,
+                "status": outcome.status,
+                "duration_seconds": round(outcome.duration_seconds, 1),
+                "error": outcome.error,
+            },
+        )
+    return outcomes
+
+
+def run_tier(
+    tier_index: int,
+    tier_jobs: list[str],
+    db: SupplyCoreDb,
+    raw_config: dict[str, Any],
+    logger: LoggerAdapter,
+    definitions: dict[str, dict[str, Any]],
+    graph_nodes: dict,
+    max_parallel: int,
+    shutdown_event: threading.Event,
+) -> list[JobOutcome]:
+    """Run all jobs in a single tier, respecting concurrency groups.
+
+    Independent jobs run in parallel.  Jobs sharing a concurrency group run
+    sequentially within that group, but different groups run in parallel with
+    each other and with independent jobs.
+    """
+    if not tier_jobs or shutdown_event.is_set():
+        return []
+
+    independent, groups = _split_tier_by_concurrency(tier_jobs, graph_nodes)
+
+    logger.info(
+        f"tier {tier_index}: {len(tier_jobs)} jobs "
+        f"({len(independent)} independent, {len(groups)} concurrency groups)",
+        payload={
+            "event": "loop_runner.tier_start",
+            "tier": tier_index,
+            "total_jobs": len(tier_jobs),
+            "independent_count": len(independent),
+            "concurrency_groups": {k: v for k, v in groups.items()},
+        },
+    )
+
+    all_outcomes: list[JobOutcome] = []
+    futures: list[Future] = []
+
+    with ThreadPoolExecutor(max_workers=max_parallel) as pool:
+        # Submit each independent job as its own task.
+        for job_key in independent:
+            if shutdown_event.is_set():
+                break
+            timeout = int(definitions.get(job_key, {}).get("timeout_seconds", 300))
+            fut = pool.submit(_run_single_job, job_key, db, raw_config, logger, timeout)
+            fut.job_key = job_key  # type: ignore[attr-defined]
+            futures.append(fut)
+
+        # Submit each concurrency group as a single sequential task.
+        for group_name, group_jobs in groups.items():
+            if shutdown_event.is_set():
+                break
+            fut = pool.submit(
+                _run_concurrency_group,
+                group_jobs, db, raw_config, logger, definitions, shutdown_event,
+            )
+            fut.job_key = f"[group:{group_name}]"  # type: ignore[attr-defined]
+            futures.append(fut)
+
+        # Wait for everything in this tier.
+        for fut in as_completed(futures):
+            try:
+                result = fut.result()
+                if isinstance(result, list):
+                    # Concurrency group returned a list of outcomes
+                    all_outcomes.extend(result)
+                elif isinstance(result, JobOutcome):
+                    all_outcomes.append(result)
+                    logger.info(
+                        f"job finished: {result.job_key}",
+                        payload={
+                            "event": "loop_runner.job_finished",
+                            "job_key": result.job_key,
+                            "status": result.status,
+                            "duration_seconds": round(result.duration_seconds, 1),
+                            "error": result.error,
+                        },
+                    )
+            except Exception as exc:
+                job_label = getattr(fut, "job_key", "unknown")
+                logger.warning(
+                    f"unexpected error in tier {tier_index}",
+                    payload={
+                        "event": "loop_runner.tier_error",
+                        "tier": tier_index,
+                        "job": job_label,
+                        "error": str(exc),
+                    },
+                )
+
+    return all_outcomes
+
+
+# ---------------------------------------------------------------------------
+# Main loops
+# ---------------------------------------------------------------------------
+
+def _select_jobs(
+    definitions: dict[str, dict[str, Any]],
+    background: bool,
+) -> dict[str, dict[str, Any]]:
+    """Filter job definitions to either the fast loop or background loop."""
+    return {
+        key: defn
+        for key, defn in definitions.items()
+        if bool(defn.get("opportunistic_background", False)) == background
+    }
+
+
+def _run_loop(
+    loop_name: str,
+    definitions: dict[str, dict[str, Any]],
+    db: SupplyCoreDb,
+    raw_config: dict[str, Any],
+    logger: LoggerAdapter,
+    max_parallel: int,
+    shutdown_event: threading.Event,
+    pause_between_cycles: float,
+    run_once: bool = False,
+) -> None:
+    """Run the tier-by-tier loop continuously (or once)."""
+    graph_nodes = build_graph(definitions)
+    tiers, _tier_map = _topological_tiers(graph_nodes)
+    cycle = 0
+
+    logger.info(
+        f"{loop_name}: computed {len(tiers)} tiers from {len(definitions)} jobs",
+        payload={
+            "event": "loop_runner.graph_computed",
+            "loop": loop_name,
+            "total_jobs": len(definitions),
+            "total_tiers": len(tiers),
+            "tiers": {i: jobs for i, jobs in enumerate(tiers)},
+        },
+    )
+
+    while not shutdown_event.is_set():
+        cycle += 1
+        cycle_start = time.monotonic()
+        logger.info(
+            f"{loop_name}: cycle {cycle} starting",
+            payload={"event": "loop_runner.cycle_start", "loop": loop_name, "cycle": cycle},
+        )
+
+        total_success = 0
+        total_failed = 0
+        total_skipped = 0
+
+        for tier_idx, tier_jobs in enumerate(tiers):
+            if shutdown_event.is_set():
+                break
+
+            outcomes = run_tier(
+                tier_index=tier_idx,
+                tier_jobs=tier_jobs,
+                db=db,
+                raw_config=raw_config,
+                logger=logger,
+                definitions=definitions,
+                graph_nodes=graph_nodes,
+                max_parallel=max_parallel,
+                shutdown_event=shutdown_event,
+            )
+
+            for o in outcomes:
+                if o.status == "failed":
+                    total_failed += 1
+                elif o.status == "skipped":
+                    total_skipped += 1
+                else:
+                    total_success += 1
+
+        cycle_elapsed = time.monotonic() - cycle_start
+        logger.info(
+            f"{loop_name}: cycle {cycle} finished in {cycle_elapsed:.1f}s "
+            f"({total_success} ok, {total_failed} failed, {total_skipped} skipped)",
+            payload={
+                "event": "loop_runner.cycle_end",
+                "loop": loop_name,
+                "cycle": cycle,
+                "duration_seconds": round(cycle_elapsed, 1),
+                "success": total_success,
+                "failed": total_failed,
+                "skipped": total_skipped,
+            },
+        )
+
+        if run_once:
+            break
+
+        # Brief pause between cycles to avoid hot-looping if everything is instant.
+        if not shutdown_event.is_set() and pause_between_cycles > 0:
+            shutdown_event.wait(timeout=pause_between_cycles)
+
+
+# ---------------------------------------------------------------------------
+# State file for external monitoring
+# ---------------------------------------------------------------------------
+
+def _write_state_file(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json_dumps_safe(payload, indent=2) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Simple tier-by-tier loop runner")
+    parser.add_argument("--app-root", default=resolve_app_root(__file__))
+    parser.add_argument("--max-parallel", type=int, default=6,
+                        help="Max concurrent jobs per tier (default: 6)")
+    parser.add_argument("--fast-pause", type=float, default=5.0,
+                        help="Seconds to pause between fast-loop cycles (default: 5)")
+    parser.add_argument("--background-pause", type=float, default=30.0,
+                        help="Seconds to pause between background-loop cycles (default: 30)")
+    parser.add_argument("--once", action="store_true",
+                        help="Run one cycle of each loop and exit")
+    parser.add_argument("--fast-only", action="store_true",
+                        help="Only run the fast loop (skip background jobs)")
+    parser.add_argument("--background-only", action="store_true",
+                        help="Only run the background loop (skip fast jobs)")
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    app_root = Path(args.app_root).resolve()
+    raw_config = load_php_runtime_config(app_root).raw
+    worker_settings = dict(raw_config.get("workers") or {})
+
+    log_file = Path(worker_settings.get("worker_log_file", app_root / "storage/logs/worker.log"))
+    logger = configure_logging(verbose=args.verbose, log_file=log_file)
+    worker_id = f"loop-{socket.gethostname()}-{os.getpid()}"
+
+    db = SupplyCoreDb(dict(raw_config.get("db") or {}))
+
+    # Audit: make sure all registered jobs have Python processors bound.
+    audit = audit_enabled_python_jobs(db)
+    if audit["issues"]:
+        for issue in audit["issues"]:
+            logger.error(
+                "python processor binding audit failure",
+                payload={"event": "loop_runner.binding_audit.failed", "issue": issue},
+            )
+        return 1
+
+    state_file = Path(worker_settings.get("pool_state_file", app_root / "storage/run/loop-runner-heartbeat.json"))
+
+    shutdown_event = threading.Event()
+
+    def _handle_signal(signum: int, _frame: Any) -> None:
+        sig_name = signal.Signals(signum).name
+        logger.info(
+            f"received {sig_name}, shutting down gracefully",
+            payload={"event": "loop_runner.shutdown", "signal": sig_name},
+        )
+        shutdown_event.set()
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    logger.info(
+        f"loop runner starting (worker_id={worker_id}, max_parallel={args.max_parallel})",
+        payload={
+            "event": "loop_runner.start",
+            "worker_id": worker_id,
+            "max_parallel": args.max_parallel,
+            "fast_pause": args.fast_pause,
+            "background_pause": args.background_pause,
+            "fast_only": args.fast_only,
+            "background_only": args.background_only,
+        },
+    )
+
+    _write_state_file(state_file, {
+        "ts": utc_now_iso(),
+        "worker_id": worker_id,
+        "status": "starting",
+        "max_parallel": args.max_parallel,
+    })
+
+    fast_defs = _select_jobs(WORKER_JOB_DEFINITIONS, background=False)
+    bg_defs = _select_jobs(WORKER_JOB_DEFINITIONS, background=True)
+
+    logger.info(
+        f"job split: {len(fast_defs)} fast-loop jobs, {len(bg_defs)} background jobs",
+        payload={
+            "event": "loop_runner.job_split",
+            "fast_jobs": sorted(fast_defs.keys()),
+            "background_jobs": sorted(bg_defs.keys()),
+        },
+    )
+
+    threads: list[threading.Thread] = []
+
+    if not args.background_only and fast_defs:
+        fast_thread = threading.Thread(
+            target=_run_loop,
+            args=("fast", fast_defs, db, raw_config, logger,
+                  args.max_parallel, shutdown_event, args.fast_pause, args.once),
+            name="fast-loop",
+            daemon=True,
+        )
+        threads.append(fast_thread)
+
+    if not args.fast_only and bg_defs:
+        bg_thread = threading.Thread(
+            target=_run_loop,
+            args=("background", bg_defs, db, raw_config, logger,
+                  args.max_parallel, shutdown_event, args.background_pause, args.once),
+            name="background-loop",
+            daemon=True,
+        )
+        threads.append(bg_thread)
+
+    for t in threads:
+        t.start()
+
+    # Write periodic heartbeat while running.
+    try:
+        while not shutdown_event.is_set() and any(t.is_alive() for t in threads):
+            _write_state_file(state_file, {
+                "ts": utc_now_iso(),
+                "worker_id": worker_id,
+                "status": "running",
+                "max_parallel": args.max_parallel,
+                "memory_usage_bytes": resident_memory_bytes(),
+                "threads": [t.name for t in threads if t.is_alive()],
+            })
+            shutdown_event.wait(timeout=15)
+    except KeyboardInterrupt:
+        shutdown_event.set()
+
+    # Wait for loops to finish.
+    for t in threads:
+        t.join(timeout=30)
+
+    _write_state_file(state_file, {
+        "ts": utc_now_iso(),
+        "worker_id": worker_id,
+        "status": "stopped",
+    })
+
+    logger.info("loop runner stopped", payload={"event": "loop_runner.stopped", "worker_id": worker_id})
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -32,6 +32,7 @@ from .jobs.battle_intelligence import (
 )
 from .logging_utils import configure_logging
 from .rebuild_data_model import main as run_rebuild_data_model
+from .loop_runner import main as run_loop_runner
 from .supervisor import run_supervisor
 from .worker_pool import main as run_worker_pool
 from .zkill_worker import main as run_zkill_worker
@@ -58,6 +59,16 @@ def parse_args() -> argparse.Namespace:
     worker_pool.add_argument("--execution-modes", default="python,php")
     worker_pool.add_argument("--once", action="store_true")
     worker_pool.add_argument("--verbose", action="store_true")
+
+    loop_runner = subparsers.add_parser("loop-runner", help="Simple tier-by-tier loop runner (replaces worker-pool)")
+    loop_runner.add_argument("--app-root", default=resolve_app_root(__file__))
+    loop_runner.add_argument("--max-parallel", type=int, default=6, help="Max concurrent jobs per tier (default: 6)")
+    loop_runner.add_argument("--fast-pause", type=float, default=5.0, help="Seconds to pause between fast-loop cycles (default: 5)")
+    loop_runner.add_argument("--background-pause", type=float, default=30.0, help="Seconds to pause between background-loop cycles (default: 30)")
+    loop_runner.add_argument("--once", action="store_true", help="Run one cycle and exit")
+    loop_runner.add_argument("--fast-only", action="store_true", help="Only run fast loop")
+    loop_runner.add_argument("--background-only", action="store_true", help="Only run background loop")
+    loop_runner.add_argument("--verbose", action="store_true")
 
     zkill = subparsers.add_parser("zkill-worker", help="Run the dedicated zKill continuous worker")
     zkill.add_argument("--app-root", default=resolve_app_root(__file__))
@@ -220,6 +231,17 @@ def main() -> int:
             "--workload-classes", args.workload_classes,
             "--execution-modes", args.execution_modes,
             *( ["--once"] if args.once else [] ),
+            *( ["--verbose"] if args.verbose else [] ),
+        ])
+    if command == "loop-runner":
+        return run_loop_runner([
+            "--app-root", args.app_root,
+            "--max-parallel", str(args.max_parallel),
+            "--fast-pause", str(args.fast_pause),
+            "--background-pause", str(args.background_pause),
+            *( ["--once"] if args.once else [] ),
+            *( ["--fast-only"] if args.fast_only else [] ),
+            *( ["--background-only"] if args.background_only else [] ),
             *( ["--verbose"] if args.verbose else [] ),
         ])
     if command == "zkill-worker":

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -23,6 +23,11 @@ STALE_UNITS=(
   supplycore-php-compute-worker@.service
   supplycore-orchestrator.service
   supplycore-worker@.service
+  # Legacy queue-based workers — replaced by supplycore-loop-runner.service
+  supplycore-sync-worker.service
+  supplycore-sync-worker@.service
+  supplycore-compute-worker.service
+  supplycore-compute-worker@.service
 )
 
 # ---------------------------------------------------------------------------
@@ -350,8 +355,22 @@ if [[ ${CONFIGURE_LOCAL_PHP} == true ]]; then
   DB_PASSWORD=$(prompt_secret "Database password" true)
 fi
 
-SYNC_COUNT=$(prompt_number "How many sync workers should be enabled?" "1")
-COMPUTE_COUNT=$(prompt_number "How many compute workers should be enabled?" "1")
+INSTALL_LOOP_RUNNER=true
+if ! prompt_yes_no "Install the loop runner (replaces separate sync/compute workers)?" "Y"; then
+  INSTALL_LOOP_RUNNER=false
+fi
+LOOP_RUNNER_MAX_PARALLEL=6
+if [[ ${INSTALL_LOOP_RUNNER} == true ]]; then
+  LOOP_RUNNER_MAX_PARALLEL=$(prompt_number "Max parallel jobs per tier for the loop runner?" "6")
+fi
+
+# Legacy worker counts — only used if loop runner is NOT installed.
+SYNC_COUNT=0
+COMPUTE_COUNT=0
+if [[ ${INSTALL_LOOP_RUNNER} == false ]]; then
+  SYNC_COUNT=$(prompt_number "How many sync workers should be enabled?" "1")
+  COMPUTE_COUNT=$(prompt_number "How many compute workers should be enabled?" "1")
+fi
 INSTALL_ZKILL=false
 if prompt_yes_no "Install and enable the dedicated zKill worker?" "Y"; then
   INSTALL_ZKILL=true
@@ -426,6 +445,7 @@ fi
 
 "${VENV_PATH}/bin/python" -m pip install --upgrade pip
 "${VENV_PATH}/bin/python" -m pip install --upgrade "${APP_ROOT}/python"
+"${VENV_PATH}/bin/python" -m orchestrator loop-runner --help >/dev/null
 "${VENV_PATH}/bin/python" -m orchestrator worker-pool --help >/dev/null
 "${VENV_PATH}/bin/python" -m orchestrator zkill-worker --help >/dev/null
 "${VENV_PATH}/bin/python" -m orchestrator evewho-alliance-runner --help >/dev/null
@@ -444,6 +464,12 @@ else
 fi
 
 # ===========================  Render and install units  ====================
+
+render_unit "${REPO_ROOT}/ops/systemd/supplycore-loop-runner.service" "${SYSTEMD_DIR}/supplycore-loop-runner.service"
+# Patch max-parallel if the user chose a non-default value.
+if [[ ${INSTALL_LOOP_RUNNER} == true && ${LOOP_RUNNER_MAX_PARALLEL} -ne 6 ]]; then
+  sed -i "s|--max-parallel 6|--max-parallel ${LOOP_RUNNER_MAX_PARALLEL}|" "${SYSTEMD_DIR}/supplycore-loop-runner.service"
+fi
 
 render_unit "${REPO_ROOT}/ops/systemd/supplycore-sync-worker.service" "${SYSTEMD_DIR}/supplycore-sync-worker.service"
 render_unit "${REPO_ROOT}/ops/systemd/supplycore-compute-worker.service" "${SYSTEMD_DIR}/supplycore-compute-worker.service"
@@ -465,20 +491,25 @@ fi
 # ===========================  Enable and start  ===========================
 
 services_to_enable=()
-if (( SYNC_COUNT == 1 )); then
-  services_to_enable+=("supplycore-sync-worker.service")
-elif (( SYNC_COUNT > 1 )); then
-  for ((i = 1; i <= SYNC_COUNT; i++)); do
-    services_to_enable+=("supplycore-sync-worker@${i}.service")
-  done
-fi
 
-if (( COMPUTE_COUNT == 1 )); then
-  services_to_enable+=("supplycore-compute-worker.service")
-elif (( COMPUTE_COUNT > 1 )); then
-  for ((i = 1; i <= COMPUTE_COUNT; i++)); do
-    services_to_enable+=("supplycore-compute-worker@${i}.service")
-  done
+if [[ ${INSTALL_LOOP_RUNNER} == true ]]; then
+  services_to_enable+=("supplycore-loop-runner.service")
+else
+  if (( SYNC_COUNT == 1 )); then
+    services_to_enable+=("supplycore-sync-worker.service")
+  elif (( SYNC_COUNT > 1 )); then
+    for ((i = 1; i <= SYNC_COUNT; i++)); do
+      services_to_enable+=("supplycore-sync-worker@${i}.service")
+    done
+  fi
+
+  if (( COMPUTE_COUNT == 1 )); then
+    services_to_enable+=("supplycore-compute-worker.service")
+  elif (( COMPUTE_COUNT > 1 )); then
+    for ((i = 1; i <= COMPUTE_COUNT; i++)); do
+      services_to_enable+=("supplycore-compute-worker@${i}.service")
+    done
+  fi
 fi
 
 if [[ ${INSTALL_ZKILL} == true ]]; then
@@ -507,19 +538,23 @@ if [[ -f ${LOCAL_CONFIG_PATH} ]]; then
 fi
 echo
 echo "Active services:"
-if (( SYNC_COUNT == 1 )); then
-  echo "  systemctl status supplycore-sync-worker.service"
-elif (( SYNC_COUNT > 1 )); then
-  for ((i = 1; i <= SYNC_COUNT; i++)); do
-    echo "  systemctl status supplycore-sync-worker@${i}.service"
-  done
-fi
-if (( COMPUTE_COUNT == 1 )); then
-  echo "  systemctl status supplycore-compute-worker.service"
-elif (( COMPUTE_COUNT > 1 )); then
-  for ((i = 1; i <= COMPUTE_COUNT; i++)); do
-    echo "  systemctl status supplycore-compute-worker@${i}.service"
-  done
+if [[ ${INSTALL_LOOP_RUNNER} == true ]]; then
+  echo "  systemctl status supplycore-loop-runner.service"
+else
+  if (( SYNC_COUNT == 1 )); then
+    echo "  systemctl status supplycore-sync-worker.service"
+  elif (( SYNC_COUNT > 1 )); then
+    for ((i = 1; i <= SYNC_COUNT; i++)); do
+      echo "  systemctl status supplycore-sync-worker@${i}.service"
+    done
+  fi
+  if (( COMPUTE_COUNT == 1 )); then
+    echo "  systemctl status supplycore-compute-worker.service"
+  elif (( COMPUTE_COUNT > 1 )); then
+    for ((i = 1; i <= COMPUTE_COUNT; i++)); do
+      echo "  systemctl status supplycore-compute-worker@${i}.service"
+    done
+  fi
 fi
 if [[ ${INSTALL_ZKILL} == true ]]; then
   echo "  systemctl status supplycore-zkill.service"


### PR DESCRIPTION
## Summary

Introduces a new `loop_runner` module that replaces the database-queue-backed worker pool with a simpler, in-process tier-by-tier job execution model. Jobs are organized into dependency tiers and executed in parallel within each tier, with two independent loops (fast and background) running concurrently in separate threads.

## Key Changes

- **New `loop_runner.py` module** (525 lines):
  - Computes execution tiers from job dependency graph using topological sort
  - Executes all jobs in a tier in parallel (respecting concurrency groups)
  - Waits for tier completion before starting the next tier
  - Runs two concurrent loops: fast loop (critical jobs) and background loop (slow/occasional jobs)
  - Respects concurrency groups by running grouped jobs sequentially within their group while allowing parallel execution across groups
  - Includes graceful shutdown handling via SIGTERM/SIGINT
  - Writes periodic heartbeat state files for external monitoring

- **Installation script updates** (`scripts/install-services.sh`):
  - Adds prompt to choose between loop runner and legacy worker pool during installation
  - Configurable `--max-parallel` parameter for loop runner
  - Marks legacy sync/compute worker units as stale for cleanup
  - Conditionally enables either loop runner or legacy workers based on user choice
  - Validates loop runner installation with `--help` check

- **New systemd service** (`ops/systemd/supplycore-loop-runner.service`):
  - Single service unit for the loop runner (replaces multiple worker units)
  - Configurable `--max-parallel` parameter (default: 6)
  - Configurable pause intervals between cycles (fast: 5s, background: 30s)
  - Memory limit of 2GB
  - Automatic restart on failure

- **CLI integration** (`python/orchestrator/main.py`):
  - Adds `loop-runner` subcommand with options for `--max-parallel`, `--fast-pause`, `--background-pause`, `--once`, `--fast-only`, `--background-only`, and `--verbose`

## Implementation Details

- Jobs are split into fast-loop (non-background) and background-loop (opportunistic_background=True) based on job definitions
- Independent jobs within a tier use ThreadPoolExecutor for parallel execution
- Concurrency groups are submitted as single sequential tasks to the executor, allowing different groups to run in parallel
- Job outcomes are tracked with status, duration, and error information
- Finalization logic (database updates, UI refresh) is reused from the existing worker pool
- State file updates every 15 seconds with worker ID, status, memory usage, and active threads

https://claude.ai/code/session_01AJ5g13ezFdfzH8kA4jJ15C