### PR TITLE
Fix market hub sync to use source_id for all location filters

### DIFF
--- a/python/orchestrator/jobs/market_hub_current_sync.py
+++ b/python/orchestrator/jobs/market_hub_current_sync.py
@@ -45,7 +45,7 @@ def _processor(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None) -> di
             continue
         orders: list[dict[str, object]] = []
         resolved_region_id = region_id
-        filter_location_id: int | None = source_id if source_kind == "player_structure" else None
+        filter_location_id: int | None = source_id
         structure_orders_mode = False
 
         try:


### PR DESCRIPTION
## Summary
Updated the market hub current sync processor to use `source_id` for filtering location IDs regardless of the source kind, removing the conditional logic that previously only applied the filter for player structures.

## Changes
- Modified `filter_location_id` assignment to always use `source_id` instead of conditionally setting it based on `source_kind == "player_structure"`
- This ensures consistent location filtering behavior across all source types in the market hub synchronization process

## Implementation Details
The change simplifies the filtering logic by removing the ternary condition that was restricting location ID filtering to only player structures. Now all source types will have their `source_id` applied as the `filter_location_id`, which should improve consistency in how market orders are filtered and processed during synchronization.

https://claude.ai/code/session_017vFYkDGJssLyMS4wn6iJFE