### PR TITLE
Support corp-only entities in theater alliance summaries

### DIFF
--- a/database/migrations/20260409_theater_alliance_summary_corporation.sql
+++ b/database/migrations/20260409_theater_alliance_summary_corporation.sql
@@ -1,0 +1,8 @@
+-- Add corporation_id to theater_alliance_summary so that corp-only entities
+-- (NPC corps / allianceless player corps) get their own row instead of being
+-- lumped under alliance_id = 0.
+
+ALTER TABLE theater_alliance_summary
+    ADD COLUMN corporation_id BIGINT UNSIGNED NOT NULL DEFAULT 0 AFTER alliance_id,
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (theater_id, alliance_id, corporation_id);

--- a/public/theater-intelligence/partials/_alliance_summary.php
+++ b/public/theater-intelligence/partials/_alliance_summary.php
@@ -19,17 +19,25 @@
             <tbody>
                 <?php foreach ($allianceSummary as $a): ?>
                     <?php
-                        $aSide = $classifyAlliance((int) ($a['alliance_id'] ?? 0));
+                        $aAllianceId = (int) ($a['alliance_id'] ?? 0);
+                        $aCorporationId = (int) ($a['corporation_id'] ?? 0);
+                        $aSide = $classifyAlliance($aAllianceId, $aCorporationId);
                         $eff = (float) ($a['efficiency'] ?? 0);
                         $effClass = $eff >= 0.6 ? 'text-green-400' : ($eff >= 0.4 ? 'text-yellow-400' : 'text-red-400');
                         $aSideColor = $sideColorClass[$aSide] ?? 'text-slate-300';
                         $aSideBg = $sideBgClass[$aSide] ?? 'bg-slate-700';
                         $isTracked = $aSide === 'friendly';
                         $isOpponent = $aSide === 'opponent';
+                        // Resolve name: use corporation for corp-only entries
+                        if ($aAllianceId > 0) {
+                            $aDisplayName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $aAllianceId, (string) ($a['alliance_name'] ?? ''), 'Alliance');
+                        } else {
+                            $aDisplayName = killmail_entity_preferred_name($resolvedEntities, 'corporation', $aCorporationId, (string) ($a['alliance_name'] ?? ''), 'Corporation');
+                        }
                     ?>
                     <tr class="border-b border-border/50">
                         <td class="px-3 py-2 text-slate-100">
-                            <?= htmlspecialchars(killmail_entity_preferred_name($resolvedEntities, 'alliance', (int) ($a['alliance_id'] ?? 0), (string) ($a['alliance_name'] ?? ''), 'Alliance'), ENT_QUOTES) ?>
+                            <?= htmlspecialchars($aDisplayName, ENT_QUOTES) ?>
                             <?php if ($isTracked): ?>
                                 <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Friendly</span>
                             <?php elseif ($isOpponent): ?>

--- a/public/theater-intelligence/partials/_battle_report.php
+++ b/public/theater-intelligence/partials/_battle_report.php
@@ -65,9 +65,12 @@
                     <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2">Alliances</p>
                     <?php foreach ($panelAlliances as $allianceRow): ?>
                         <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                        <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
                         <div class="flex items-center gap-2.5 px-4 py-2">
                             <?php if ($allianceId > 0): ?>
                                 <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                            <?php elseif ($corporationId > 0): ?>
+                                <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
                             <?php endif; ?>
                             <span class="text-xs text-slate-200 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
                             <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
@@ -139,9 +142,12 @@
                     <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2">Opponent Alliances</p>
                     <?php foreach ($opponentAlliances as $allianceRow): ?>
                         <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                        <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
                         <div class="flex items-center gap-2.5 px-4 py-2">
                             <?php if ($allianceId > 0): ?>
                                 <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                            <?php elseif ($corporationId > 0): ?>
+                                <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
                             <?php endif; ?>
                             <span class="text-xs text-slate-200 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
                             <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
@@ -156,9 +162,12 @@
                     <p class="text-[10px] uppercase tracking-wider text-slate-400 px-4 py-2">Third Party</p>
                     <?php foreach ($tpAlliances as $allianceRow): ?>
                         <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                        <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
                         <div class="flex items-center gap-2.5 px-4 py-2">
                             <?php if ($allianceId > 0): ?>
                                 <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                            <?php elseif ($corporationId > 0): ?>
+                                <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
                             <?php endif; ?>
                             <span class="text-xs text-slate-400 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
                             <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>

--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -11,7 +11,7 @@ $friendlyParticipants = [];
 $enemyParticipants = [];
 $thirdPartyParticipants = [];
 foreach ($participantsAll as $p) {
-    $pSide = $classifyAlliance((int) ($p['alliance_id'] ?? 0));
+    $pSide = $classifyAlliance((int) ($p['alliance_id'] ?? 0), (int) ($p['corporation_id'] ?? 0));
     if ($pSide === 'friendly') {
         $friendlyParticipants[] = $p;
     } elseif ($pSide === 'opponent') {
@@ -27,7 +27,7 @@ $enemyStructureKills = [];
 $thirdPartyStructureKills = [];
 $structureKills = $structureKills ?? [];
 foreach ($structureKills as $sk) {
-    $skSide = $classifyAlliance((int) ($sk['victim_alliance_id'] ?? 0));
+    $skSide = $classifyAlliance((int) ($sk['victim_alliance_id'] ?? 0), (int) ($sk['victim_corporation_id'] ?? 0));
     if ($skSide === 'friendly') {
         $friendlyStructureKills[] = $sk;
     } elseif ($skSide === 'opponent') {
@@ -551,7 +551,7 @@ function _render_structure_row(array $sk, array $resolvedEntities, array $shipTy
                 <?php else: ?>
                     <?php foreach ($filteredList as $p): ?>
                         <?php
-                            $pSide = $classifyAlliance((int) ($p['alliance_id'] ?? 0));
+                            $pSide = $classifyAlliance((int) ($p['alliance_id'] ?? 0), (int) ($p['corporation_id'] ?? 0));
                             $pSideClass = $sideColorClass[$pSide] ?? 'text-slate-300';
                             $pSusp = (float) ($p['suspicion_score'] ?? 0);
                             $isSusp = (int) ($p['is_suspicious'] ?? 0);
@@ -732,7 +732,7 @@ function _render_structure_row(array $sk, array $resolvedEntities, array $shipTy
                             $structureKills,
                             static function (array $sk) use ($sideFilter, $classifyAlliance): bool {
                                 if ($sideFilter === null) return true;
-                                return $classifyAlliance((int) ($sk['victim_alliance_id'] ?? 0)) === $sideFilter;
+                                return $classifyAlliance((int) ($sk['victim_alliance_id'] ?? 0), (int) ($sk['victim_corporation_id'] ?? 0)) === $sideFilter;
                             }
                         ));
                     ?>
@@ -743,7 +743,7 @@ function _render_structure_row(array $sk, array $resolvedEntities, array $shipTy
                             $skShipTypeId = (int) ($sk['victim_ship_type_id'] ?? 0);
                             $skIskLost    = (float) ($sk['isk_lost'] ?? 0);
                             $skShipName   = $skShipTypeId > 0 ? (string) ($shipTypeNames[$skShipTypeId] ?? 'Structure #' . $skShipTypeId) : 'Unknown Structure';
-                            $skSide       = $classifyAlliance($skAllianceId);
+                            $skSide       = $classifyAlliance($skAllianceId, $skCorpId);
                             $skSideClass  = $sideColorClass[$skSide] ?? 'text-slate-300';
                             $skOrgName    = '';
                             if ($skCorpId > 0) {

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -63,12 +63,21 @@ if ($viewSnapshot !== null && !$pendingLock) {
     $reportedKillTotal = (int) ($viewSnapshot['reported_kill_total'] ?? 0);
     $observedKillTotal = (int) ($viewSnapshot['observed_kill_total'] ?? 0);
 
-    // Reconstruct classify closure from saved alliance IDs
-    $classifyAlliance = static function (int $allianceId) use ($trackedAllianceIds, $opponentAllianceIds): string {
+    $trackedCorporationIds = (array) ($viewSnapshot['tracked_corporation_ids'] ?? []);
+    $opponentCorporationIds = (array) ($viewSnapshot['opponent_corporation_ids'] ?? []);
+
+    // Reconstruct classify closure from saved alliance/corporation IDs
+    $classifyAlliance = static function (int $allianceId, int $corporationId = 0) use ($trackedAllianceIds, $opponentAllianceIds, $trackedCorporationIds, $opponentCorporationIds): string {
         if ($allianceId > 0 && in_array($allianceId, $trackedAllianceIds, true)) {
             return 'friendly';
         }
+        if ($corporationId > 0 && in_array($corporationId, $trackedCorporationIds, true)) {
+            return 'friendly';
+        }
         if ($allianceId > 0 && in_array($allianceId, $opponentAllianceIds, true)) {
+            return 'opponent';
+        }
+        if ($corporationId > 0 && in_array($corporationId, $opponentCorporationIds, true)) {
             return 'opponent';
         }
         return 'third_party';
@@ -93,7 +102,8 @@ if ($viewSnapshot !== null && !$pendingLock) {
             $participantsAll,
             static function (array $participant) use ($sideFilter, $suspiciousOnly, $classifyAlliance): bool {
                 $allianceId = (int) ($participant['alliance_id'] ?? 0);
-                $displaySide = $classifyAlliance($allianceId);
+                $corporationId = (int) ($participant['corporation_id'] ?? 0);
+                $displaySide = $classifyAlliance($allianceId, $corporationId);
                 if ($sideFilter !== null && $displaySide !== $sideFilter) {
                     return false;
                 }
@@ -139,6 +149,9 @@ if ($viewSnapshot !== null && !$pendingLock) {
         if (($id = (int) ($row['alliance_id'] ?? 0)) > 0) {
             $entityRequests['alliance'][$id] = $id;
         }
+        if (($id = (int) ($row['corporation_id'] ?? 0)) > 0) {
+            $entityRequests['corporation'][$id] = $id;
+        }
     }
     foreach ($participantsAll as $row) {
         if (($id = (int) ($row['character_id'] ?? 0)) > 0) {
@@ -169,7 +182,7 @@ if ($viewSnapshot !== null && !$pendingLock) {
     }
     $resolvedEntities = killmail_entity_resolve_batch($entityRequests, false);
 
-    // ── Classify alliances from user settings (friendly/opponent/third_party) ──
+    // ── Classify alliances/corporations from user settings (friendly/opponent/third_party) ──
     $trackedAlliances = db_killmail_tracked_alliances_active();
     $trackedAllianceIds = array_map('intval', array_column($trackedAlliances, 'alliance_id'));
     $trackedAllianceIds = array_values(array_unique($trackedAllianceIds));
@@ -178,11 +191,25 @@ if ($viewSnapshot !== null && !$pendingLock) {
     $opponentAllianceIds = array_map('intval', array_column($opponentAlliances, 'alliance_id'));
     $opponentAllianceIds = array_values(array_unique($opponentAllianceIds));
 
-    $classifyAlliance = static function (int $allianceId) use ($trackedAllianceIds, $opponentAllianceIds): string {
+    $trackedCorporations = db_killmail_tracked_corporations_active();
+    $trackedCorporationIds = array_map('intval', array_column($trackedCorporations, 'corporation_id'));
+    $trackedCorporationIds = array_values(array_unique($trackedCorporationIds));
+
+    $opponentCorporations = db_killmail_opponent_corporations_active();
+    $opponentCorporationIds = array_map('intval', array_column($opponentCorporations, 'corporation_id'));
+    $opponentCorporationIds = array_values(array_unique($opponentCorporationIds));
+
+    $classifyAlliance = static function (int $allianceId, int $corporationId = 0) use ($trackedAllianceIds, $opponentAllianceIds, $trackedCorporationIds, $opponentCorporationIds): string {
         if ($allianceId > 0 && in_array($allianceId, $trackedAllianceIds, true)) {
             return 'friendly';
         }
+        if ($corporationId > 0 && in_array($corporationId, $trackedCorporationIds, true)) {
+            return 'friendly';
+        }
         if ($allianceId > 0 && in_array($allianceId, $opponentAllianceIds, true)) {
+            return 'opponent';
+        }
+        if ($corporationId > 0 && in_array($corporationId, $opponentCorporationIds, true)) {
             return 'opponent';
         }
         return 'third_party';
@@ -197,13 +224,16 @@ if ($viewSnapshot !== null && !$pendingLock) {
         'third_party' => 'Third Party',
     ];
 
-    // Build friendly/opponent lists from actual alliance names
+    // Build friendly/opponent lists from actual alliance/corporation names
     $sideAlliancesByPilots = ['friendly' => [], 'opponent' => [], 'third_party' => []];
     foreach ($allianceSummary as $a) {
         $aid = (int) ($a['alliance_id'] ?? 0);
+        $corpId = (int) ($a['corporation_id'] ?? 0);
         $pilots = (int) ($a['participant_count'] ?? 0);
-        $classification = $classifyAlliance($aid);
-        $sideAlliancesByPilots[$classification][$aid] = ($sideAlliancesByPilots[$classification][$aid] ?? 0) + $pilots;
+        $classification = $classifyAlliance($aid, $corpId);
+        // Use a composite key to distinguish corp-only entries from alliance entries
+        $groupKey = $aid > 0 ? "a:{$aid}" : "c:{$corpId}";
+        $sideAlliancesByPilots[$classification][$groupKey] = ($sideAlliancesByPilots[$classification][$groupKey] ?? 0) + $pilots;
     }
 
     // Generate smart opponent labels supporting multiple hostile alliances
@@ -257,7 +287,8 @@ if ($viewSnapshot !== null && !$pendingLock) {
             $participantsAll,
             static function (array $participant) use ($sideFilter, $suspiciousOnly, $classifyAlliance): bool {
                 $allianceId = (int) ($participant['alliance_id'] ?? 0);
-                $displaySide = $classifyAlliance($allianceId);
+                $corporationId = (int) ($participant['corporation_id'] ?? 0);
+                $displaySide = $classifyAlliance($allianceId, $corporationId);
                 if ($sideFilter !== null && $displaySide !== $sideFilter) {
                     return false;
                 }
@@ -304,7 +335,7 @@ if ($viewSnapshot !== null && !$pendingLock) {
     $participantKillTotalsBySide = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
     foreach ($participantsAll as $row) {
         $kills = (int) ($row['kills'] ?? 0);
-        $side = $classifyAlliance((int) ($row['alliance_id'] ?? 0));
+        $side = $classifyAlliance((int) ($row['alliance_id'] ?? 0), (int) ($row['corporation_id'] ?? 0));
         $participantKillTotal += $kills;
         if (isset($participantKillTotalsBySide[$side])) {
             $participantKillTotalsBySide[$side] += $kills;
@@ -332,16 +363,25 @@ if ($viewSnapshot !== null && !$pendingLock) {
         'third_party' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => []],
     ];
     foreach ($allianceSummary as $a) {
-        $side = $classifyAlliance((int) ($a['alliance_id'] ?? 0));
+        $aid = (int) ($a['alliance_id'] ?? 0);
+        $corpId = (int) ($a['corporation_id'] ?? 0);
+        $side = $classifyAlliance($aid, $corpId);
         if (!isset($sidePanels[$side])) continue;
         $sidePanels[$side]['pilots'] += (int) ($a['participant_count'] ?? 0);
         $sidePanels[$side]['kills'] += (int) ($a['total_kills'] ?? 0);
         $sidePanels[$side]['losses'] += (int) ($a['total_losses'] ?? 0);
         $sidePanels[$side]['isk_killed'] += (float) ($a['total_isk_killed'] ?? 0);
         $sidePanels[$side]['isk_lost'] += (float) ($a['total_isk_lost'] ?? 0);
+        // For corp-only entries, resolve as corporation; otherwise as alliance
+        if ($aid > 0) {
+            $entryName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $aid, (string) ($a['alliance_name'] ?? ''), 'Alliance');
+        } else {
+            $entryName = killmail_entity_preferred_name($resolvedEntities, 'corporation', $corpId, (string) ($a['alliance_name'] ?? ''), 'Corporation');
+        }
         $sidePanels[$side]['alliances'][] = [
-            'alliance_id' => (int) ($a['alliance_id'] ?? 0),
-            'name' => killmail_entity_preferred_name($resolvedEntities, 'alliance', (int) ($a['alliance_id'] ?? 0), (string) ($a['alliance_name'] ?? ''), 'Alliance'),
+            'alliance_id' => $aid,
+            'corporation_id' => $corpId,
+            'name' => $entryName,
             'pilots' => (int) ($a['participant_count'] ?? 0),
         ];
     }
@@ -389,7 +429,7 @@ if ($viewSnapshot !== null && !$pendingLock) {
         if ($_flyId > 0 && !in_array($_flyId, $_podTypeIdsFC, true)) {
             continue; // already counted by fleet composition query
         }
-        $_pSide = $classifyAlliance((int) ($_p['alliance_id'] ?? 0));
+        $_pSide = $classifyAlliance((int) ($_p['alliance_id'] ?? 0), (int) ($_p['corporation_id'] ?? 0));
         if (!isset($sidePanels[$_pSide])) continue;
         // Find the best non-pod lost ship for this pilot
         $_lostJson = $_p['ships_lost_detail'] ?? null;
@@ -494,6 +534,8 @@ if ($viewSnapshot !== null && !$pendingLock) {
             'ship_type_names' => $shipTypeNames,
             'tracked_alliance_ids' => $trackedAllianceIds,
             'opponent_alliance_ids' => $opponentAllianceIds,
+            'tracked_corporation_ids' => $trackedCorporationIds,
+            'opponent_corporation_ids' => $opponentCorporationIds,
             'side_labels' => $sideLabels,
             'side_alliances_by_pilots' => $sideAlliancesByPilots,
             'opponent_model' => $opponentModel,
@@ -537,7 +579,7 @@ if ($rawLossesByVictimAlliance !== []) {
     $correctedLosses = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
     $correctedIskLost = ['friendly' => 0.0, 'opponent' => 0.0, 'third_party' => 0.0];
     foreach ($rawLossesByVictimAlliance as $row) {
-        $side = $classifyAlliance((int) ($row['victim_alliance_id'] ?? 0));
+        $side = $classifyAlliance((int) ($row['victim_alliance_id'] ?? 0), (int) ($row['victim_corporation_id'] ?? 0));
         $correctedLosses[$side] += (int) ($row['losses'] ?? 0);
         $correctedIskLost[$side] += (float) ($row['isk_lost'] ?? 0);
     }

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -383,77 +383,83 @@ def _compute_alliance_summary(
     side_configuration: dict[str, set[int]],
     char_sides: dict[int, str],
 ) -> list[dict[str, Any]]:
-    """Compute per-alliance summary across the theater."""
-    # alliance_id → accumulated stats
-    alliance_stats: dict[int, dict[str, Any]] = {}
+    """Compute per-alliance (or per-corporation for allianceless entities) summary.
 
-    # Get alliance names from participants
-    alliance_names: dict[int, str] = {}
+    Grouping key is (alliance_id, corporation_id):
+      - Entities WITH an alliance  → (alliance_id, 0)
+      - Entities WITHOUT an alliance → (0, corporation_id)
+    This ensures NPC-corp / allianceless-corp pilots get their own row
+    instead of being lumped under a single alliance_id=0 bucket.
+    """
+    # (alliance_id, corporation_id) → accumulated stats
+    group_stats: dict[tuple[int, int], dict[str, Any]] = {}
 
-    # Track which characters belong to which alliance
-    char_alliance: dict[int, int] = {}
+    def _group_key_for(alliance_id: int, corporation_id: int) -> tuple[int, int]:
+        if alliance_id > 0:
+            return (alliance_id, 0)
+        if corporation_id > 0:
+            return (0, corporation_id)
+        return (0, 0)
+
+    def _get_entry(key: tuple[int, int]) -> dict[str, Any]:
+        return group_stats.setdefault(key, _empty_alliance_stats(key[0], key[1]))
+
+    # Count participants per group
+    group_participants: dict[tuple[int, int], set[int]] = defaultdict(set)
     for p in bp_rows:
         aid = int(p.get("alliance_id") or 0)
+        corp_id = int(p.get("corporation_id") or 0)
         cid = int(p.get("character_id") or 0)
-        if cid > 0 and aid > 0:
-            char_alliance[cid] = aid
-
-    # Count participants per alliance
-    alliance_participants: dict[int, set[int]] = defaultdict(set)
-    for p in bp_rows:
-        aid = int(p.get("alliance_id") or 0)
-        cid = int(p.get("character_id") or 0)
-        if aid > 0 and cid > 0:
-            alliance_participants[aid].add(cid)
+        if cid > 0 and (aid > 0 or corp_id > 0):
+            gk = _group_key_for(aid, corp_id)
+            group_participants[gk].add(cid)
 
     # Process killmails for kills/losses/damage — deduplicate by killmail_id
     # since rows are expanded per-attacker from the LEFT JOIN.
     seen_loss_km: set[int] = set()
-    seen_kill_km: set[tuple[int, int]] = set()  # (killmail_id, alliance_id)
-    seen_final_blow_km: set[int] = set()  # killmail_ids where final blow ISK was credited
+    seen_kill_km: set[tuple[int, tuple[int, int]]] = set()
+    seen_final_blow_km: set[int] = set()
     for km in killmails:
         km_id = int(km.get("killmail_id") or 0)
-        victim_id = int(km.get("victim_character_id") or 0)
         victim_alliance = int(km.get("victim_alliance_id") or 0)
+        victim_corp = int(km.get("victim_corporation_id") or 0)
         isk = float(km.get("total_value") or 0)
 
-        attacker_id = int(km.get("attacker_character_id") or 0)
         attacker_alliance = int(km.get("attacker_alliance_id") or 0)
+        attacker_corp = int(km.get("attacker_corporation_id") or 0)
         attacker_damage = float(km.get("attacker_damage_done") or 0)
         final_blow = int(km.get("attacker_final_blow") or 0)
 
-        # Record loss for victim alliance (once per killmail)
-        # When the victim has no alliance (corp-only), group under alliance_id = 0
-        # so losses are still counted (they'll be classified as third_party).
+        # Record loss for victim group (once per killmail)
         if km_id not in seen_loss_km:
             seen_loss_km.add(km_id)
-            loss_key = victim_alliance if victim_alliance > 0 else 0
-            entry = alliance_stats.setdefault(loss_key, _empty_alliance_stats(loss_key))
+            loss_key = _group_key_for(victim_alliance, victim_corp)
+            entry = _get_entry(loss_key)
             entry["total_losses"] += 1
             entry["total_isk_lost"] += isk
 
-        # Record kill involvement for attacker alliance (once per killmail per alliance)
-        if attacker_alliance > 0:
-            entry = alliance_stats.setdefault(attacker_alliance, _empty_alliance_stats(attacker_alliance))
+        # Record kill involvement for attacker group (once per killmail per group)
+        atk_key = _group_key_for(attacker_alliance, attacker_corp)
+        if atk_key != (0, 0):
+            entry = _get_entry(atk_key)
             entry["total_damage"] += attacker_damage
-            kill_key = (km_id, attacker_alliance)
+            kill_key = (km_id, atk_key)
             if kill_key not in seen_kill_km:
                 seen_kill_km.add(kill_key)
                 entry["total_kills"] += 1
 
-        # ISK killed credited to the final-blow alliance only (no double-counting)
-        if final_blow and attacker_alliance > 0 and km_id not in seen_final_blow_km:
+        # ISK killed credited to the final-blow group only (no double-counting)
+        if final_blow and atk_key != (0, 0) and km_id not in seen_final_blow_km:
             seen_final_blow_km.add(km_id)
-            entry = alliance_stats.setdefault(attacker_alliance, _empty_alliance_stats(attacker_alliance))
+            entry = _get_entry(atk_key)
             entry["total_isk_killed"] += isk
 
     # Finalize
     result: list[dict[str, Any]] = []
-    for aid, stats in alliance_stats.items():
-        stats["participant_count"] = len(alliance_participants.get(aid, set()))
-        # Classify alliance directly from user settings
-        stats["side"] = _classify_alliance(aid, 0, side_configuration)
-        # Efficiency
+    for gk, stats in group_stats.items():
+        aid, corp_id = gk
+        stats["participant_count"] = len(group_participants.get(gk, set()))
+        stats["side"] = _classify_alliance(aid, corp_id, side_configuration)
         total_isk = stats["total_isk_killed"] + stats["total_isk_lost"]
         stats["efficiency"] = round(_safe_div(stats["total_isk_killed"], total_isk, 0.0), 4)
         result.append(stats)
@@ -461,9 +467,10 @@ def _compute_alliance_summary(
     return result
 
 
-def _empty_alliance_stats(alliance_id: int) -> dict[str, Any]:
+def _empty_alliance_stats(alliance_id: int, corporation_id: int = 0) -> dict[str, Any]:
     return {
         "alliance_id": alliance_id,
+        "corporation_id": corporation_id,
         "alliance_name": None,
         "side": "third_party",
         "participant_count": 0,
@@ -946,14 +953,15 @@ def _flush_analysis(
             cursor.executemany(
                 """
                 INSERT INTO theater_alliance_summary (
-                    theater_id, alliance_id, alliance_name, side,
+                    theater_id, alliance_id, corporation_id, alliance_name, side,
                     participant_count, total_kills, total_losses,
                     total_damage, total_isk_lost, total_isk_killed, efficiency
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 [
                     (
-                        theater_id, a["alliance_id"], a["alliance_name"], a["side"],
+                        theater_id, a["alliance_id"], a.get("corporation_id", 0),
+                        a["alliance_name"], a["side"],
                         a["participant_count"], a["total_kills"], a["total_losses"],
                         a["total_damage"], a["total_isk_lost"], a["total_isk_killed"],
                         a["efficiency"],

--- a/src/db.php
+++ b/src/db.php
@@ -15673,10 +15673,18 @@ function db_theater_alliance_summary(string $theaterId): array
 {
     return db_select(
         'SELECT tas.*,
-                COALESCE(emc.entity_name, tas.alliance_name, CONCAT("Alliance #", tas.alliance_id)) AS alliance_name
+                CASE
+                    WHEN tas.alliance_id > 0
+                        THEN COALESCE(emc_a.entity_name, tas.alliance_name, CONCAT("Alliance #", tas.alliance_id))
+                    WHEN tas.corporation_id > 0
+                        THEN COALESCE(emc_c.entity_name, CONCAT("Corporation #", tas.corporation_id))
+                    ELSE COALESCE(tas.alliance_name, "Unknown")
+                END AS alliance_name
          FROM theater_alliance_summary tas
-         LEFT JOIN entity_metadata_cache emc
-              ON emc.entity_type = "alliance" AND emc.entity_id = tas.alliance_id
+         LEFT JOIN entity_metadata_cache emc_a
+              ON emc_a.entity_type = "alliance" AND emc_a.entity_id = tas.alliance_id AND tas.alliance_id > 0
+         LEFT JOIN entity_metadata_cache emc_c
+              ON emc_c.entity_type = "corporation" AND emc_c.entity_id = tas.corporation_id AND tas.corporation_id > 0
          WHERE tas.theater_id = ?
          ORDER BY tas.total_isk_killed DESC',
         [$theaterId]
@@ -15785,11 +15793,19 @@ function db_theater_side_labels(array $theaterIds): array
     }
     $placeholders = implode(',', array_fill(0, count($theaterIds), '?'));
     $rows = db_select(
-        "SELECT tas.theater_id, tas.alliance_id, tas.side, tas.participant_count,
-                COALESCE(emc.entity_name, tas.alliance_name, CONCAT('Alliance #', tas.alliance_id)) AS alliance_name
+        "SELECT tas.theater_id, tas.alliance_id, tas.corporation_id, tas.side, tas.participant_count,
+                CASE
+                    WHEN tas.alliance_id > 0
+                        THEN COALESCE(emc_a.entity_name, tas.alliance_name, CONCAT('Alliance #', tas.alliance_id))
+                    WHEN tas.corporation_id > 0
+                        THEN COALESCE(emc_c.entity_name, CONCAT('Corporation #', tas.corporation_id))
+                    ELSE COALESCE(tas.alliance_name, 'Unknown')
+                END AS alliance_name
          FROM theater_alliance_summary tas
-         LEFT JOIN entity_metadata_cache emc
-              ON emc.entity_type = 'alliance' AND emc.entity_id = tas.alliance_id
+         LEFT JOIN entity_metadata_cache emc_a
+              ON emc_a.entity_type = 'alliance' AND emc_a.entity_id = tas.alliance_id AND tas.alliance_id > 0
+         LEFT JOIN entity_metadata_cache emc_c
+              ON emc_c.entity_type = 'corporation' AND emc_c.entity_id = tas.corporation_id AND tas.corporation_id > 0
          WHERE tas.theater_id IN ({$placeholders})
          ORDER BY tas.participant_count DESC",
         $theaterIds
@@ -15861,7 +15877,8 @@ function db_theater_fleet_composition(string $theaterId): array
          LEFT JOIN ref_item_groups rig ON rig.group_id = rit.group_id
          LEFT JOIN theater_alliance_summary tas
               ON tas.theater_id = tp.theater_id
-              AND tas.alliance_id = tp.alliance_id
+              AND tas.alliance_id = COALESCE(tp.alliance_id, 0)
+              AND tas.corporation_id = CASE WHEN COALESCE(tp.alliance_id, 0) > 0 THEN 0 ELSE COALESCE(tp.corporation_id, 0) END
          WHERE tp.theater_id = ?
            AND tp.flying_ship_type_id IS NOT NULL
            AND tp.flying_ship_type_id > 0
@@ -15886,7 +15903,8 @@ function db_theater_final_blows_by_side(string $theaterId): array
          INNER JOIN theater_battles tb ON tb.battle_id = ke.battle_id
          LEFT JOIN theater_alliance_summary tas
               ON tas.theater_id = tb.theater_id
-              AND tas.alliance_id = ka.alliance_id
+              AND tas.alliance_id = COALESCE(ka.alliance_id, 0)
+              AND tas.corporation_id = CASE WHEN COALESCE(ka.alliance_id, 0) > 0 THEN 0 ELSE COALESCE(ka.corporation_id, 0) END
          WHERE tb.theater_id = ?
            AND ka.final_blow = 1
            AND (ka.character_id IS NULL OR ka.character_id != ke.victim_character_id)
@@ -15917,12 +15935,13 @@ function db_theater_losses_by_victim_alliance(string $theaterId): array
     return db_select(
         "SELECT
             COALESCE(ke.victim_alliance_id, 0) AS victim_alliance_id,
+            COALESCE(ke.victim_corporation_id, 0) AS victim_corporation_id,
             COUNT(DISTINCT ke.killmail_id) AS losses,
             COALESCE(SUM(ke.zkb_total_value), 0) AS isk_lost
          FROM killmail_events ke
          INNER JOIN theater_battles tb ON tb.battle_id = ke.battle_id
          WHERE tb.theater_id = ?
-         GROUP BY ke.victim_alliance_id",
+         GROUP BY ke.victim_alliance_id, ke.victim_corporation_id",
         [$theaterId]
     );
 }
@@ -15951,7 +15970,8 @@ function db_theater_notable_kills(string $theaterId, int $limit = 10): array
          LEFT JOIN ref_item_groups rig ON rig.group_id = rit.group_id
          LEFT JOIN theater_alliance_summary tas
               ON tas.theater_id = tb.theater_id
-              AND tas.alliance_id = ke.victim_alliance_id
+              AND tas.alliance_id = COALESCE(ke.victim_alliance_id, 0)
+              AND tas.corporation_id = CASE WHEN COALESCE(ke.victim_alliance_id, 0) > 0 THEN 0 ELSE COALESCE(ke.victim_corporation_id, 0) END
          WHERE tb.theater_id = ?
            AND ke.zkb_total_value IS NOT NULL
          ORDER BY ke.zkb_total_value DESC


### PR DESCRIPTION
## Summary
This PR extends theater alliance summary tracking to properly handle entities without alliances (NPC corporations and allianceless player corporations). Previously, all such entities were lumped under a single `alliance_id = 0` bucket. Now they get individual rows keyed by their corporation ID.

## Key Changes

- **Grouping Logic**: Changed from alliance-only grouping to a composite `(alliance_id, corporation_id)` key:
  - Entities WITH an alliance → `(alliance_id, 0)`
  - Entities WITHOUT an alliance → `(0, corporation_id)`
  - This ensures corp-only pilots get their own summary row instead of being aggregated

- **Database Schema**: Added `corporation_id` column to `theater_alliance_summary` table and updated the primary key to `(theater_id, alliance_id, corporation_id)`

- **Classification**: Extended `_classify_alliance()` function to accept both alliance and corporation IDs, allowing tracked/opponent corporations to be classified independently of alliances

- **Data Processing**:
  - Updated killmail processing to track both victim and attacker corporation IDs
  - Modified participant counting and statistics accumulation to use the new composite grouping key
  - Updated all database queries to properly join on both alliance and corporation IDs

- **UI/Display**:
  - Updated alliance summary views to resolve corporation names when displaying corp-only entries
  - Added corporation logo display in battle report panels for corp-only entities
  - Extended side panel logic to distinguish between alliance and corporation entries
  - Updated entity resolution to fetch both alliance and corporation metadata

- **Configuration**: Added support for tracked and opponent corporation lists in view snapshots, enabling corporation-level classification alongside alliance-level classification

## Implementation Details

The grouping key function ensures consistent bucketing:
- If `alliance_id > 0`, use `(alliance_id, 0)` regardless of corporation
- Otherwise, if `corporation_id > 0`, use `(0, corporation_id)`
- Fallback to `(0, 0)` for completely unaffiliated entities

All database queries were updated to properly match on the composite key, and display logic now conditionally resolves entity names as either alliances or corporations based on which ID is populated.

https://claude.ai/code/session_01TMfPdPW5PV2RC72YjZ5K5C