### PR TITLE
Add execute_many method to Database class for batch operations

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -73,6 +73,12 @@ class SupplyCoreDb:
                 return int(cursor.execute(sql))
             return int(cursor.execute(sql, params))
 
+    def execute_many(self, sql: str, params_seq: Sequence[Sequence[Any]]) -> int:
+        with self.cursor() as (connection, cursor):
+            cursor.executemany(sql, params_seq)
+            connection.commit()
+            return int(cursor.rowcount)
+
     def insert(self, sql: str, params: Sequence[Any] | None = None) -> int:
         with self.cursor() as (connection, cursor):
             if params is None:


### PR DESCRIPTION
## Summary
Added a new `execute_many` method to the Database class to support batch database operations using SQLite's `executemany` functionality.

## Key Changes
- Added `execute_many(sql: str, params_seq: Sequence[Sequence[Any]]) -> int` method to the Database class
- The method accepts SQL and a sequence of parameter sequences for batch execution
- Returns the row count affected by the batch operation
- Properly handles connection management and commits the transaction

## Implementation Details
- Follows the same pattern as the existing `execute` method with proper context manager usage
- Uses `cursor.executemany()` for efficient batch operations
- Automatically commits the transaction after execution
- Returns `cursor.rowcount` as an integer to indicate the number of affected rows

https://claude.ai/code/session_01JaLBRjMdt1951ijssA96tU