### PR TITLE
Fix MySQL ON DUPLICATE KEY UPDATE clauses to use VALUES()

### DIFF
--- a/python/orchestrator/jobs/battle_type_classification.py
+++ b/python/orchestrator/jobs/battle_type_classification.py
@@ -214,8 +214,6 @@ def run_battle_type_classification(
                 insert_rows.append((
                     bid, battle_type, confidence,
                     json_dumps_safe(features), computed_at,
-                    battle_type, confidence,
-                    json_dumps_safe(features), computed_at,
                 ))
 
             rows_processed += len(battles)
@@ -227,8 +225,8 @@ def run_battle_type_classification(
                         (battle_id, battle_type, confidence, features_json, computed_at)
                     VALUES (%s, %s, %s, %s, %s)
                     ON DUPLICATE KEY UPDATE
-                        battle_type = %s, confidence = %s,
-                        features_json = %s, computed_at = %s
+                        battle_type = VALUES(battle_type), confidence = VALUES(confidence),
+                        features_json = VALUES(features_json), computed_at = VALUES(computed_at)
                     """,
                     insert_rows,
                 )

--- a/python/orchestrator/jobs/escalation_detection.py
+++ b/python/orchestrator/jobs/escalation_detection.py
@@ -226,8 +226,6 @@ def run_escalation_detection(
                 seq_rows.append((
                     sid, bid, ordinal, int(b["system_id"]),
                     pc, cc, isk, b["started_at"], computed_at,
-                    ordinal, int(b["system_id"]), pc, cc, isk,
-                    b["started_at"], computed_at,
                 ))
 
             # Determine primary aggressor/defender from largest battle
@@ -247,10 +245,6 @@ def run_escalation_detection(
                 len(chain), peak_participants, peak_capitals, total_isk,
                 grade, aggressor_aid, defender_aid,
                 chain[0]["started_at"], chain[-1]["started_at"], computed_at,
-                region_id, constellation_id,
-                len(chain), peak_participants, peak_capitals, total_isk,
-                grade, aggressor_aid, defender_aid,
-                chain[0]["started_at"], chain[-1]["started_at"], computed_at,
             ))
 
         if seq_rows:
@@ -262,9 +256,11 @@ def run_escalation_detection(
                      started_at, computed_at)
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON DUPLICATE KEY UPDATE
-                    ordinal = %s, system_id = %s, participant_count = %s,
-                    capital_count = %s, isk_destroyed = %s,
-                    started_at = %s, computed_at = %s
+                    ordinal = VALUES(ordinal), system_id = VALUES(system_id),
+                    participant_count = VALUES(participant_count),
+                    capital_count = VALUES(capital_count),
+                    isk_destroyed = VALUES(isk_destroyed),
+                    started_at = VALUES(started_at), computed_at = VALUES(computed_at)
                 """,
                 seq_rows,
             )
@@ -281,11 +277,15 @@ def run_escalation_detection(
                      first_battle_at, last_battle_at, computed_at)
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON DUPLICATE KEY UPDATE
-                    region_id = %s, constellation_id = %s,
-                    battle_count = %s, peak_participants = %s, peak_capitals = %s,
-                    total_isk_destroyed = %s, escalation_grade = %s,
-                    primary_aggressor_alliance_id = %s, primary_defender_alliance_id = %s,
-                    first_battle_at = %s, last_battle_at = %s, computed_at = %s
+                    region_id = VALUES(region_id), constellation_id = VALUES(constellation_id),
+                    battle_count = VALUES(battle_count), peak_participants = VALUES(peak_participants),
+                    peak_capitals = VALUES(peak_capitals),
+                    total_isk_destroyed = VALUES(total_isk_destroyed),
+                    escalation_grade = VALUES(escalation_grade),
+                    primary_aggressor_alliance_id = VALUES(primary_aggressor_alliance_id),
+                    primary_defender_alliance_id = VALUES(primary_defender_alliance_id),
+                    first_battle_at = VALUES(first_battle_at), last_battle_at = VALUES(last_battle_at),
+                    computed_at = VALUES(computed_at)
                 """,
                 summary_rows,
             )

--- a/python/orchestrator/jobs/jump_bridge_sync.py
+++ b/python/orchestrator/jobs/jump_bridge_sync.py
@@ -147,7 +147,6 @@ def import_jb_list_to_db(
         owner = r.get("owner", "")
         insert_rows.append((
             from_id, to_id, None, owner, source, 1, imported_at,
-            None, owner, source, 1, imported_at,
         ))
 
     if insert_rows:
@@ -158,8 +157,10 @@ def import_jb_list_to_db(
                  owner_name, source, is_active, imported_at)
             VALUES (%s, %s, %s, %s, %s, %s, %s)
             ON DUPLICATE KEY UPDATE
-                owner_alliance_id = %s, owner_name = %s,
-                source = %s, is_active = %s, imported_at = %s
+                owner_alliance_id = VALUES(owner_alliance_id),
+                owner_name = VALUES(owner_name),
+                source = VALUES(source), is_active = VALUES(is_active),
+                imported_at = VALUES(imported_at)
             """,
             insert_rows,
         )

--- a/python/orchestrator/jobs/pre_op_join_detection.py
+++ b/python/orchestrator/jobs/pre_op_join_detection.py
@@ -146,11 +146,6 @@ def run_pre_op_join_detection(
                 evidence_text,
                 json_dumps_safe(payload),
                 computed_at,
-                # ON DUPLICATE KEY UPDATE values:
-                float(days_after), float(PRE_OP_WINDOW_DAYS),
-                float(PRE_OP_WINDOW_DAYS - days_after),
-                z_score, z_score, None, confidence,
-                evidence_text, json_dumps_safe(payload), computed_at,
             ))
 
         if insert_rows:
@@ -164,11 +159,15 @@ def run_pre_op_join_detection(
                      computed_at)
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON DUPLICATE KEY UPDATE
-                    evidence_value = %s, expected_value = %s,
-                    deviation_value = %s, z_score = %s, mad_score = %s,
-                    cohort_percentile = %s, confidence_flag = %s,
-                    evidence_text = %s, evidence_payload_json = %s,
-                    computed_at = %s
+                    evidence_value = VALUES(evidence_value),
+                    expected_value = VALUES(expected_value),
+                    deviation_value = VALUES(deviation_value),
+                    z_score = VALUES(z_score), mad_score = VALUES(mad_score),
+                    cohort_percentile = VALUES(cohort_percentile),
+                    confidence_flag = VALUES(confidence_flag),
+                    evidence_text = VALUES(evidence_text),
+                    evidence_payload_json = VALUES(evidence_payload_json),
+                    computed_at = VALUES(computed_at)
                 """,
                 insert_rows,
             )

--- a/python/orchestrator/jobs/shell_corp_detection.py
+++ b/python/orchestrator/jobs/shell_corp_detection.py
@@ -230,9 +230,6 @@ def run_shell_corp_detection(
                     cid, aid, member_count, age_days,
                     round(turnover, 4), km_count, unique_members, avg_tenure,
                     shell_s, json_dumps_safe(flags), computed_at,
-                    aid, member_count, age_days,
-                    round(turnover, 4), km_count, unique_members, avg_tenure,
-                    shell_s, json_dumps_safe(flags), computed_at,
                 ))
 
         rows_processed = len(corp_data)
@@ -246,10 +243,13 @@ def run_shell_corp_detection(
                      avg_member_tenure_days, shell_score, flags_json, computed_at)
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON DUPLICATE KEY UPDATE
-                    alliance_id = %s, member_count = %s, age_days = %s,
-                    turnover_ratio_90d = %s, killmail_count_90d = %s,
-                    unique_members_90d = %s, avg_member_tenure_days = %s,
-                    shell_score = %s, flags_json = %s, computed_at = %s
+                    alliance_id = VALUES(alliance_id), member_count = VALUES(member_count),
+                    age_days = VALUES(age_days), turnover_ratio_90d = VALUES(turnover_ratio_90d),
+                    killmail_count_90d = VALUES(killmail_count_90d),
+                    unique_members_90d = VALUES(unique_members_90d),
+                    avg_member_tenure_days = VALUES(avg_member_tenure_days),
+                    shell_score = VALUES(shell_score), flags_json = VALUES(flags_json),
+                    computed_at = VALUES(computed_at)
                 """,
                 insert_rows,
             )

--- a/python/orchestrator/jobs/staging_system_detection.py
+++ b/python/orchestrator/jobs/staging_system_detection.py
@@ -200,9 +200,6 @@ def run_staging_system_detection(
                     len(pilots), len(nearby_battles),
                     round(avg_jump, 2), 0,  # pre_battle_appearances placeholder
                     json_dumps_safe(features), computed_at,
-                    staging_score, len(pilots), len(nearby_battles),
-                    round(avg_jump, 2), 0,
-                    json_dumps_safe(features), computed_at,
                 ))
 
         if insert_rows:
@@ -214,10 +211,13 @@ def run_staging_system_detection(
                      pre_battle_appearances, features_json, computed_at)
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON DUPLICATE KEY UPDATE
-                    staging_score = %s, unique_pilots_7d = %s,
-                    battles_within_2j = %s, avg_jump_to_battle = %s,
-                    pre_battle_appearances = %s,
-                    features_json = %s, computed_at = %s
+                    staging_score = VALUES(staging_score),
+                    unique_pilots_7d = VALUES(unique_pilots_7d),
+                    battles_within_2j = VALUES(battles_within_2j),
+                    avg_jump_to_battle = VALUES(avg_jump_to_battle),
+                    pre_battle_appearances = VALUES(pre_battle_appearances),
+                    features_json = VALUES(features_json),
+                    computed_at = VALUES(computed_at)
                 """,
                 insert_rows,
             )


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in multiple job files where `ON DUPLICATE KEY UPDATE` clauses were incorrectly duplicating parameter values in the tuple instead of using MySQL's `VALUES()` function to reference the inserted values.

## Problem
The original code was appending duplicate values to the insert tuples for the `ON DUPLICATE KEY UPDATE` clause:
```python
insert_rows.append((
    col1, col2, col3,  # INSERT values
    col1, col2, col3,  # Duplicate values for UPDATE (WRONG)
))
```

This approach:
- Doubles the number of parameters in each tuple unnecessarily
- Makes the code harder to maintain and understand
- Relies on manual duplication which is error-prone

## Solution
Updated all affected files to use MySQL's `VALUES()` function in the `ON DUPLICATE KEY UPDATE` clause:
```python
insert_rows.append((
    col1, col2, col3,  # INSERT values only
))
# In SQL:
# ON DUPLICATE KEY UPDATE col1 = VALUES(col1), col2 = VALUES(col2), ...
```

## Files Modified
- `python/orchestrator/jobs/escalation_detection.py`
- `python/orchestrator/jobs/pre_op_join_detection.py`
- `python/orchestrator/jobs/shell_corp_detection.py`
- `python/orchestrator/jobs/staging_system_detection.py`
- `python/orchestrator/jobs/jump_bridge_sync.py`
- `python/orchestrator/jobs/battle_type_classification.py`

## Key Changes
- Removed duplicate parameter values from all insert tuple constructions
- Updated all `ON DUPLICATE KEY UPDATE` clauses to use `VALUES(column_name)` syntax
- Improved code clarity and maintainability across all affected detection jobs

https://claude.ai/code/session_011a3AipBScgQ76E2HkJvQ2q