### PR TITLE
Support corporation grouping in theater intelligence view

### DIFF
--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -243,8 +243,14 @@ if ($viewSnapshot !== null && !$pendingLock) {
             continue;
         }
         arsort($alliances);
-        $preferredAllianceId = (int) array_key_first($alliances);
-        $preferredName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $preferredAllianceId, '', 'Alliance');
+        $preferredKey = (string) array_key_first($alliances);
+        if (str_starts_with($preferredKey, 'c:')) {
+            $preferredId = (int) substr($preferredKey, 2);
+            $preferredName = killmail_entity_preferred_name($resolvedEntities, 'corporation', $preferredId, '', 'Corporation');
+        } else {
+            $preferredId = (int) substr($preferredKey, 2);
+            $preferredName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $preferredId, '', 'Alliance');
+        }
         $otherCount = count($alliances) - 1;
         $sideLabels[$side] = $preferredName . ($otherCount > 0 ? " +{$otherCount}" : '');
     }
@@ -257,9 +263,17 @@ if ($viewSnapshot !== null && !$pendingLock) {
     ];
     $opponentAlliances = $sideAlliancesByPilots['opponent'];
     arsort($opponentAlliances);
-    foreach ($opponentAlliances as $aid => $pilots) {
-        $name = killmail_entity_preferred_name($resolvedEntities, 'alliance', (int) $aid, '', 'Alliance');
-        $entry = ['alliance_id' => (int) $aid, 'name' => $name, 'pilots' => $pilots];
+    foreach ($opponentAlliances as $groupKey => $pilots) {
+        $groupKey = (string) $groupKey;
+        if (str_starts_with($groupKey, 'c:')) {
+            $entityId = (int) substr($groupKey, 2);
+            $name = killmail_entity_preferred_name($resolvedEntities, 'corporation', $entityId, '', 'Corporation');
+            $entry = ['alliance_id' => 0, 'corporation_id' => $entityId, 'name' => $name, 'pilots' => $pilots];
+        } else {
+            $entityId = (int) substr($groupKey, 2);
+            $name = killmail_entity_preferred_name($resolvedEntities, 'alliance', $entityId, '', 'Alliance');
+            $entry = ['alliance_id' => $entityId, 'name' => $name, 'pilots' => $pilots];
+        }
         $opponentModel['opponents'][] = $entry;
         if ($opponentModel['primary_opponent'] === null) {
             $opponentModel['primary_opponent'] = $entry;


### PR DESCRIPTION
## Summary
Updated the theater intelligence view to support grouping participants by both alliances and corporations, not just alliances. The code now handles entity keys with prefixes to distinguish between corporation (`c:`) and alliance entries.

## Key Changes
- Modified alliance grouping logic to parse entity keys with type prefixes (`c:` for corporation, `a:` for alliance)
- Updated preferred entity selection to correctly identify and display either the preferred corporation or alliance based on the key prefix
- Enhanced opponent grouping to support both corporations and alliances, adding `corporation_id` field to entries when applicable
- Changed entity ID extraction to use `substr()` with the appropriate offset based on the key prefix

## Implementation Details
- Entity keys are now stored as strings with format `{type}:{id}` where type is either `c` (corporation) or `a` (alliance)
- When building opponent entries, corporations are marked with `alliance_id: 0` and include a `corporation_id` field
- Alliance entries maintain the existing structure with `alliance_id` set to the actual alliance ID
- The preferred entity name is determined by checking the key prefix and calling the appropriate entity lookup function

https://claude.ai/code/session_01F9ANXS2WszoXMP7P2dWJjE