### PR TITLE
Handle duplicate order IDs from ESI API and ignore duplicate inserts

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -1036,6 +1036,17 @@ class SupplyCoreDb:
                 )
             )
 
+        # Deduplicate by order_id; the ESI API occasionally returns the same
+        # order_id twice for a source, which would violate unique_source_order_current.
+        seen_order_ids: set[int] = set()
+        deduped_orders: list[tuple[Any, ...]] = []
+        for row_tuple in safe_orders:
+            oid = row_tuple[3]
+            if oid not in seen_order_ids:
+                seen_order_ids.add(oid)
+                deduped_orders.append(row_tuple)
+        safe_orders = deduped_orders
+
         with self.transaction() as (_, cursor):
             cursor.execute(
                 "DELETE FROM market_orders_current WHERE source_type = %s AND source_id = %s",

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -1005,7 +1005,7 @@ def _upsert_table(db: SupplyCoreDb, table_name: str, columns: str, placeholders:
     for offset in range(0, len(rows), batch_size):
         chunk = rows[offset : offset + batch_size]
         with db.transaction() as (_, cursor):
-            cursor.executemany(f"INSERT INTO {table_name} ({columns}) VALUES ({placeholders})", chunk)
+            cursor.executemany(f"INSERT IGNORE INTO {table_name} ({columns}) VALUES ({placeholders})", chunk)
 
 
 def _ensure_doctrine_dependency_depth_schema(db: SupplyCoreDb) -> None:


### PR DESCRIPTION
## Summary
This PR addresses two data integrity issues: duplicate order IDs returned by the ESI API and duplicate key constraint violations during batch inserts.

## Key Changes
- **Deduplication in `replace_market_orders_for_source`**: Added logic to deduplicate orders by `order_id` before inserting into the database. The ESI API occasionally returns the same `order_id` twice for a source, which would violate the `unique_source_order_current` constraint.
- **INSERT IGNORE in `_upsert_table`**: Changed `INSERT INTO` to `INSERT IGNORE INTO` in the graph pipeline to gracefully handle duplicate key violations during batch inserts instead of failing.

## Implementation Details
- The deduplication uses a set to track seen order IDs and filters the orders list in-place, maintaining order while removing duplicates.
- The `INSERT IGNORE` approach allows the batch insert to continue even when duplicate keys are encountered, silently skipping conflicting rows.

https://claude.ai/code/session_01KUS3o7TnVnbBhE8L1NH5UD