### PR TITLE
Clear job error state on success and add error field to result

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -752,6 +752,7 @@ class SupplyCoreDb:
                     last_failure_at = COALESCE(VALUES(last_failure_at), last_failure_at),
                     last_failure_message = CASE
                         WHEN VALUES(last_failure_at) IS NOT NULL THEN VALUES(last_failure_message)
+                        WHEN VALUES(last_success_at) IS NOT NULL THEN NULL
                         ELSE last_failure_message
                     END,
                     current_pressure_state = COALESCE(VALUES(current_pressure_state), current_pressure_state),
@@ -774,9 +775,10 @@ class SupplyCoreDb:
                SET last_status = %s,
                    last_run_at = UTC_TIMESTAMP(),
                    last_finished_at = UTC_TIMESTAMP(),
-                   locked_until = NULL
+                   locked_until = NULL,
+                   last_error = CASE WHEN %s = 'success' THEN NULL ELSE last_error END
                WHERE job_key = %s AND execution_mode = 'python'""",
-            (status[:20], job_key[:120]),
+            (status[:20], status[:20], job_key[:120]),
         )
 
     def advance_next_due_at(self, job_key: str) -> int:

--- a/python/orchestrator/job_result.py
+++ b/python/orchestrator/job_result.py
@@ -302,6 +302,7 @@ class JobResult:
             "checkpoint_after": self.checkpoint_after,
             "has_more": self.has_more,
             "error_text": self.error_text,
+            "error": self.error_text,
             "warnings": list(self.warnings),
             "meta": dict(self.meta),
         })


### PR DESCRIPTION
## Summary
This PR improves job status tracking by clearing error messages when jobs succeed and adds an `error` field to job result serialization for better API consistency.

## Key Changes
- **Clear error state on success**: Modified `update_sync_schedule_status()` to set `last_error` to NULL when a job completes with 'success' status, ensuring error messages don't persist after successful runs
- **Clear failure message on success**: Updated `upsert_scheduler_job_current_status()` to clear `last_failure_message` when `last_success_at` is updated, maintaining consistency in failure tracking
- **Add error field to job results**: Added `error` field to `JobResult.to_dict()` that mirrors the existing `error_text` field for improved API compatibility and consistency

## Implementation Details
- The error clearing logic uses CASE statements to conditionally update fields based on job status
- The new `error` field in job results provides an alias to `error_text` without duplicating the underlying data
- Changes maintain backward compatibility by keeping the existing `error_text` field intact

https://claude.ai/code/session_01E23SbLQdar32L5Ak1zXA9Q