### PR TITLE
Update database table and snapshot key references

### DIFF
--- a/python/orchestrator/jobs/compute_buy_all.py
+++ b/python/orchestrator/jobs/compute_buy_all.py
@@ -293,7 +293,7 @@ def _ranked_items(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def _freshness_card(db: SupplyCoreDb, source_type: str, label: str) -> dict[str, Any]:
     """Build a freshness card for a given market snapshot source type."""
     row = db.fetch_one(
-        "SELECT MAX(observed_at) AS latest FROM market_order_snapshots_summary WHERE source_type = %s",
+        "SELECT MAX(observed_at) AS latest FROM market_order_current_projection WHERE source_type = %s",
         (source_type,),
     )
     latest = row.get("latest") if row else None
@@ -325,7 +325,7 @@ def _doctrine_freshness(db: SupplyCoreDb) -> dict[str, Any]:
     """Build a freshness card for the doctrine intelligence dataset."""
     row = db.fetch_one(
         "SELECT MAX(updated_at) AS latest FROM intelligence_snapshots WHERE snapshot_key = %s",
-        ("doctrine_fit_intelligence",),
+        ("doctrine_fit_db_state",),
     )
     latest = row.get("latest") if row else None
     if latest is None:


### PR DESCRIPTION
## Summary
This PR updates two database query references in the compute_buy_all module to use the correct table and snapshot key names.

## Key Changes
- Updated `_freshness_card()` to query `market_order_current_projection` instead of `market_order_snapshots_summary` table
- Updated `_doctrine_freshness()` to use `doctrine_fit_db_state` instead of `doctrine_fit_intelligence` as the snapshot key

## Details
These changes correct the data source references used for freshness card generation in the orchestrator's buy-all computation logic. The updates ensure that the freshness checks are querying the appropriate tables and using the correct snapshot identifiers for market order and doctrine intelligence data.

https://claude.ai/code/session_01XqrWMYVbsS8xxmjqhSzP8L