### PR TITLE
Remove stock freshness calculation and standardize snapshot keys

### DIFF
--- a/python/orchestrator/jobs/compute_buy_all.py
+++ b/python/orchestrator/jobs/compute_buy_all.py
@@ -325,7 +325,7 @@ def _doctrine_freshness(db: SupplyCoreDb) -> dict[str, Any]:
     """Build a freshness card for the doctrine intelligence dataset."""
     row = db.fetch_one(
         "SELECT MAX(updated_at) AS latest FROM intelligence_snapshots WHERE snapshot_key = %s",
-        ("doctrine_fit_db_state",),
+        ("doctrine_fit_intelligence",),
     )
     latest = row.get("latest") if row else None
     if latest is None:

--- a/python/orchestrator/jobs/doctrine_intelligence_sync.py
+++ b/python/orchestrator/jobs/doctrine_intelligence_sync.py
@@ -99,11 +99,12 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         "rows_written": rows_written,
     }
     db.upsert_intelligence_snapshot(
-        snapshot_key="doctrine_fit_db_state",
+        snapshot_key="doctrine_fit_intelligence",
         payload_json=json_dumps_safe(snapshot_payload),
         metadata_json=json_dumps_safe({
             "source": "doctrine_item_stock_1d+doctrine_fit_activity_1d",
             "reason": "scheduler:python",
+            "refresh_interval_seconds": 900,
             "fit_count": len(fit_summaries),
         }),
         expires_seconds=900,
@@ -114,7 +115,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         "rows_written": rows_written,
         "warnings": [] if rows_processed > 0 else ["No active doctrine fits found while building doctrine intelligence."],
         "summary": f"Updated doctrine intelligence stock/activity rows ({rows_written} upserts).",
-        "meta": {"bucket_start": "CURDATE", "snapshot_key": "doctrine_fit_db_state"},
+        "meta": {"bucket_start": "CURDATE", "snapshot_key": "doctrine_fit_intelligence"},
     }
 
 

--- a/python/orchestrator/jobs/market_comparison_summary_sync.py
+++ b/python/orchestrator/jobs/market_comparison_summary_sync.py
@@ -139,6 +139,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
         metadata_json=json_dumps_safe({
             "source": "market_order_current_projection",
             "reason": "scheduler:python",
+            "refresh_interval_seconds": 900,
             "row_count": len(evaluated),
             "alliance_structure_id": alliance_structure_id,
             "reference_source_id": reference_source_id,

--- a/src/functions.php
+++ b/src/functions.php
@@ -29329,20 +29329,6 @@ function buy_all_planner_data_uncached(array $query = []): array
     $hubFreshness = supplycore_page_freshness_view_model((array) ($marketOutcomes['_freshness'] ?? []));
     $doctrineFreshness = supplycore_page_freshness_view_model((array) ($doctrineSnapshot['_freshness'] ?? []));
     $stockFreshness = $hubFreshness;
-    if ($marketRows !== []) {
-        $timestamps = array_values(array_filter(array_map(static fn (array $row): ?string => isset($row['alliance_last_observed_at']) ? (string) $row['alliance_last_observed_at'] : null, $marketRows)));
-        rsort($timestamps);
-        $latestStock = $timestamps[0] ?? null;
-        $stockFreshness = [
-            'state' => $latestStock !== null && (time() - (strtotime($latestStock) ?: 0)) <= supplycore_summary_stale_after_seconds() ? 'fresh' : 'stale',
-            'label' => $latestStock !== null && (time() - (strtotime($latestStock) ?: 0)) <= supplycore_summary_stale_after_seconds() ? 'Fresh' : 'Stale',
-            'computed_at' => supplycore_format_datetime($latestStock),
-            'computed_relative' => supplycore_relative_datetime($latestStock),
-            'tone' => $latestStock !== null && (time() - (strtotime($latestStock) ?: 0)) <= supplycore_summary_stale_after_seconds() ? 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100' : 'border-amber-400/20 bg-amber-500/10 text-amber-100',
-            'message' => 'Alliance stock freshness for the current planner inputs.',
-            'reason' => '',
-        ];
-    }
 
     $result = [
         'request' => $request,


### PR DESCRIPTION
## Summary
This PR removes redundant stock freshness calculation logic from the planner data function and standardizes snapshot key naming across the doctrine intelligence sync pipeline.

## Key Changes

- **Removed stock freshness override logic** from `buy_all_planner_data_uncached()` in `src/functions.php`
  - Deleted 14 lines that computed alliance stock freshness based on `alliance_last_observed_at` timestamps
  - Stock freshness now defaults to `$hubFreshness` instead of being recalculated from market rows

- **Standardized snapshot key naming** across Python orchestrator jobs
  - Renamed `doctrine_fit_db_state` → `doctrine_fit_intelligence` in:
    - `doctrine_intelligence_sync.py` (snapshot key and metadata)
    - `compute_buy_all.py` (database query)
  - Updated corresponding metadata references in job summaries

- **Added refresh interval metadata** to snapshot configurations
  - Added `"refresh_interval_seconds": 900` to both:
    - `doctrine_intelligence_sync.py` metadata
    - `market_comparison_summary_sync.py` metadata
  - Provides explicit refresh interval documentation in snapshot metadata

## Implementation Details

The removal of the stock freshness calculation simplifies the planner data logic by eliminating a conditional override that was computing freshness from market row timestamps. The standardized snapshot key naming improves consistency and clarity across the intelligence pipeline. The added refresh interval metadata makes the snapshot update cadence explicit and queryable.

https://claude.ai/code/session_0179qr9xr6D4C6AbqPsTkPzT