### PR TITLE
Fix SDE stargate import: parse nested destination object

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -18209,11 +18209,18 @@ function static_data_extract_reference_rows_from_jsonl_archive(string $archivePa
             }
 
             if ($targetKey === 'stargates') {
-                // Handle stargates.jsonl format (stargateID, destinationStargateID, etc.)
+                // Handle stargates.jsonl / mapStargates.jsonl formats
                 $stargateId = (int) static_data_record_value($row, ['stargateID', 'stargate_id', '_key']);
                 $systemId = (int) static_data_record_value($row, ['solarSystemID', 'system_id'], 0);
                 $destStargateId = (int) static_data_record_value($row, ['destinationStargateID', 'destination_stargate_id', 'dest_stargate_id'], 0);
                 $destSystemId = (int) static_data_record_value($row, ['destinationSystemID', 'destination_system_id', 'dest_system_id'], 0);
+                // CCP SDE nested format: {"destination": {"solarSystemID": ..., "stargateID": ...}}
+                if ($destSystemId <= 0 && isset($row['destination']) && is_array($row['destination'])) {
+                    $destSystemId = (int) ($row['destination']['solarSystemID'] ?? $row['destination']['system_id'] ?? 0);
+                    if ($destStargateId <= 0) {
+                        $destStargateId = (int) ($row['destination']['stargateID'] ?? $row['destination']['stargate_id'] ?? 0);
+                    }
+                }
                 // Handle mapsolarsystemjumps.jsonl format (fromSolarSystemID / toSolarSystemID)
                 if ($stargateId <= 0 && $systemId <= 0) {
                     $systemId = (int) static_data_record_value($row, ['fromSolarSystemID', 'fromRegionID'], 0);


### PR DESCRIPTION
## Summary

The CCP SDE `mapStargates.jsonl` nests destination data inside an object:

```json
{"_key": 50000001, "destination": {"solarSystemID": 30000778, "stargateID": 50000482}, "solarSystemID": 30000777}
```

The parser only looked for flat fields (`destinationSystemID`, `destinationStargateID`), so `destSystemId` was always 0 and the `if ($systemId > 0 && $destSystemId > 0)` guard rejected every row — leaving `ref_stargates` empty.

Now extracts from `row['destination']['solarSystemID']` and `row['destination']['stargateID']` when the flat fields are missing.

## Post-merge

```bash
php bin/static_data_import.php --mode=full --force
# verify: mysql supplycore -e "SELECT COUNT(*) FROM ref_stargates;"
python3 python/orchestrator/jobs/graph_universe_sync.py
```

https://claude.ai/code/session_0171GfzsZwWv6ym3RrMJotRH