### PR TITLE
Fix theater killmail popout: clickable lost ships for all theaters

### DIFF
--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -90,7 +90,7 @@ foreach ($allForMax as $p) {
  * Render a single participant row for the side-by-side table.
  * Extracted to avoid duplicating HTML across both panels.
  */
-function _render_participant_row(array $p, array $resolvedEntities, array $shipTypeNames, float $maxDmgForPanel, bool $hasMonitorOrFlagShips): string {
+function _render_participant_row(array $p, array $resolvedEntities, array $shipTypeNames, float $maxDmgForPanel, bool $hasMonitorOrFlagShips, array $victimKmLookup = []): string {
     $isSusp = (int) ($p['is_suspicious'] ?? 0);
     $charName = killmail_entity_preferred_name($resolvedEntities, 'character', (int) ($p['character_id'] ?? 0), (string) ($p['character_name'] ?? ''), 'Character');
     $fleetRole = (string) ($p['role_proxy'] ?? 'mainline_dps');
@@ -234,15 +234,22 @@ function _render_participant_row(array $p, array $resolvedEntities, array $shipT
                     </div>
                 <?php endif; ?>
                 <?php
-                    // Extract killmail sequence IDs for clickable lost-ship links
-                    $lostKillmailIds = [];
-                    foreach ($lostDisplay as $ld) {
-                        foreach ((array) ($ld['killmail_ids'] ?? []) as $kmRef) {
-                            $seqId = (int) ($kmRef['sequence_id'] ?? 0);
-                            if ($seqId > 0) $lostKillmailIds[] = $seqId;
+                    // Resolve sequence_id for clickable lost-ship link.
+                    // Primary: battle-based lookup from view.php (works for all theaters).
+                    // Fallback: killmail_ids embedded in ships_lost_detail JSON (new data only).
+                    $charId = (int) ($p['character_id'] ?? 0);
+                    $firstLostSeqId = 0;
+                    if ($lostShipId > 0 && $charId > 0 && isset($victimKmLookup[$charId][$lostShipId])) {
+                        $firstLostSeqId = $victimKmLookup[$charId][$lostShipId];
+                    }
+                    if ($firstLostSeqId === 0) {
+                        foreach ($lostDisplay as $ld) {
+                            foreach ((array) ($ld['killmail_ids'] ?? []) as $kmRef) {
+                                $seqId = (int) ($kmRef['sequence_id'] ?? 0);
+                                if ($seqId > 0) { $firstLostSeqId = $seqId; break 2; }
+                            }
                         }
                     }
-                    $firstLostSeqId = $lostKillmailIds[0] ?? 0;
                 ?>
                 <?php if ($lostShipId > 0 && !$lostSameAsFlying): ?>
                     <div class="flex items-center gap-1 <?= $firstLostSeqId > 0 ? 'cursor-pointer hover:brightness-125 transition-all' : '' ?>"<?= $firstLostSeqId > 0 ? ' data-km-seq="' . $firstLostSeqId . '" onclick="window._scKmModal(' . $firstLostSeqId . ')"' : '' ?>>
@@ -309,12 +316,17 @@ function _fmt_damage(float $v): string {
  * Structures have no pilot character, K/D, or damage — only an owning
  * corp/alliance, hull type, and ISK lost.
  */
-function _render_structure_row(array $sk, array $resolvedEntities, array $shipTypeNames): string {
+function _render_structure_row(array $sk, array $resolvedEntities, array $shipTypeNames, array $killmailSeqLookup = []): string {
     $allianceId = (int) ($sk['victim_alliance_id'] ?? 0);
     $corpId     = (int) ($sk['victim_corporation_id'] ?? 0);
     $shipTypeId = (int) ($sk['victim_ship_type_id'] ?? 0);
     $iskLost    = (float) ($sk['isk_lost'] ?? 0);
+    $skKmId     = (int) ($sk['killmail_id'] ?? 0);
     $skSeqId    = (int) ($sk['sequence_id'] ?? 0);
+    // Fallback: use the battle-based lookup if the JOIN didn't resolve sequence_id
+    if ($skSeqId === 0 && $skKmId > 0 && isset($killmailSeqLookup[$skKmId])) {
+        $skSeqId = $killmailSeqLookup[$skKmId];
+    }
     $shipName   = $shipTypeId > 0
         ? (string) ($shipTypeNames[$shipTypeId] ?? ('Structure #' . $shipTypeId))
         : 'Unknown Structure';
@@ -453,10 +465,10 @@ function _render_structure_row(array $sk, array $resolvedEntities, array $shipTy
                             <tr><td colspan="7" class="px-2 py-4 text-sm text-muted text-center">No participants.</td></tr>
                         <?php else: ?>
                             <?php foreach ($panel['rows'] as $p): ?>
-                                <?= _render_participant_row($p, $resolvedEntities, $shipTypeNames, $panelMaxDmg, $hasMonitorOrFlagShips) ?>
+                                <?= _render_participant_row($p, $resolvedEntities, $shipTypeNames, $panelMaxDmg, $hasMonitorOrFlagShips, $victimKmLookup ?? []) ?>
                             <?php endforeach; ?>
                             <?php foreach (($panel['structure_kills'] ?? []) as $sk): ?>
-                                <?= _render_structure_row($sk, $resolvedEntities, $shipTypeNames) ?>
+                                <?= _render_structure_row($sk, $resolvedEntities, $shipTypeNames, $killmailSeqLookup ?? []) ?>
                             <?php endforeach; ?>
                         <?php endif; ?>
                     </tbody>
@@ -678,14 +690,20 @@ function _render_structure_row(array $sk, array $resolvedEntities, array $shipTy
                                         </div>
                                     <?php endif; ?>
                                     <?php
-                                        $lostKillmailIds2 = [];
-                                        foreach ($lostDisplay2 as $ld2) {
-                                            foreach ((array) ($ld2['killmail_ids'] ?? []) as $kmRef2) {
-                                                $seqId2 = (int) ($kmRef2['sequence_id'] ?? 0);
-                                                if ($seqId2 > 0) $lostKillmailIds2[] = $seqId2;
+                                        // Resolve sequence_id for clickable lost-ship link.
+                                        $charId2 = (int) ($p['character_id'] ?? 0);
+                                        $firstLostSeqId2 = 0;
+                                        if ($lostShipId2 > 0 && $charId2 > 0 && isset($victimKmLookup[$charId2][$lostShipId2])) {
+                                            $firstLostSeqId2 = $victimKmLookup[$charId2][$lostShipId2];
+                                        }
+                                        if ($firstLostSeqId2 === 0) {
+                                            foreach ($lostDisplay2 as $ld2) {
+                                                foreach ((array) ($ld2['killmail_ids'] ?? []) as $kmRef2) {
+                                                    $seqId2 = (int) ($kmRef2['sequence_id'] ?? 0);
+                                                    if ($seqId2 > 0) { $firstLostSeqId2 = $seqId2; break 2; }
+                                                }
                                             }
                                         }
-                                        $firstLostSeqId2 = $lostKillmailIds2[0] ?? 0;
                                     ?>
                                     <?php if ($lostShipId2 > 0 && !$lostSameAsFlying2): ?>
                                         <div class="flex items-center gap-1 <?= $firstLostSeqId2 > 0 ? 'cursor-pointer hover:brightness-125 transition-all' : '' ?>"<?= $firstLostSeqId2 > 0 ? ' data-km-seq="' . $firstLostSeqId2 . '" onclick="window._scKmModal(' . $firstLostSeqId2 . ')"' : '' ?>>
@@ -764,7 +782,11 @@ function _render_structure_row(array $sk, array $resolvedEntities, array $shipTy
                             $skCorpId     = (int) ($sk['victim_corporation_id'] ?? 0);
                             $skShipTypeId = (int) ($sk['victim_ship_type_id'] ?? 0);
                             $skIskLost    = (float) ($sk['isk_lost'] ?? 0);
+                            $skKmId3      = (int) ($sk['killmail_id'] ?? 0);
                             $skSeqId3     = (int) ($sk['sequence_id'] ?? 0);
+                            if ($skSeqId3 === 0 && $skKmId3 > 0 && isset($killmailSeqLookup[$skKmId3])) {
+                                $skSeqId3 = $killmailSeqLookup[$skKmId3];
+                            }
                             $skShipName   = $skShipTypeId > 0 ? (string) ($shipTypeNames[$skShipTypeId] ?? 'Structure #' . $skShipTypeId) : 'Unknown Structure';
                             $skSide       = $classifyAlliance($skAllianceId, $skCorpId);
                             $skSideClass  = $sideColorClass[$skSide] ?? 'text-slate-300';

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -659,6 +659,31 @@ include __DIR__ . '/partials/_ai_briefing.php';
 include __DIR__ . '/partials/_battles.php';
 include __DIR__ . '/partials/_timeline.php';
 include __DIR__ . '/partials/_alliance_summary.php';
+// ── Build killmail lookup for clickable lost-ship links ──────────────
+// This runs a lightweight query against killmail_events for the theater's
+// battles so every participant's lost ship can link to its killmail detail,
+// regardless of whether ships_lost_detail JSON has been updated with
+// killmail_ids by the analysis pipeline.
+$theaterBattleIds = array_map(static fn(array $b): string => (string) ($b['battle_id'] ?? ''), $battles);
+$theaterBattleIds = array_filter($theaterBattleIds, static fn(string $id): bool => $id !== '');
+$victimKillmailRows = $theaterBattleIds !== [] ? db_theater_victim_killmails_by_battles($theaterBattleIds) : [];
+// character_id → [ship_type_id → sequence_id] (first match wins)
+$victimKmLookup = [];
+// killmail_id → sequence_id (for structure kills)
+$killmailSeqLookup = [];
+foreach ($victimKillmailRows as $vkr) {
+    $cid = (int) ($vkr['victim_character_id'] ?? 0);
+    $stid = (int) ($vkr['victim_ship_type_id'] ?? 0);
+    $seq = (int) ($vkr['sequence_id'] ?? 0);
+    $kmId = (int) ($vkr['killmail_id'] ?? 0);
+    if ($cid > 0 && $stid > 0 && $seq > 0 && !isset($victimKmLookup[$cid][$stid])) {
+        $victimKmLookup[$cid][$stid] = $seq;
+    }
+    if ($kmId > 0 && $seq > 0) {
+        $killmailSeqLookup[$kmId] = $seq;
+    }
+}
+
 include __DIR__ . '/partials/_participants.php';
 include __DIR__ . '/partials/_suspicion.php';
 

--- a/src/db.php
+++ b/src/db.php
@@ -15843,6 +15843,30 @@ function db_theater_structure_kills(string $theaterId): array
     );
 }
 
+/**
+ * Look up all victim killmails for the given battle IDs.
+ * Returns rows with sequence_id, killmail_id, victim_character_id, victim_ship_type_id
+ * so the theater participants view can link lost ships to killmail details.
+ */
+function db_theater_victim_killmails_by_battles(array $battleIds): array
+{
+    if ($battleIds === []) {
+        return [];
+    }
+
+    $placeholders = implode(',', array_fill(0, count($battleIds), '?'));
+
+    return db_select(
+        "SELECT ke.sequence_id, ke.killmail_id, ke.victim_character_id, ke.victim_ship_type_id
+         FROM killmail_events ke
+         WHERE ke.battle_id IN ({$placeholders})
+           AND ke.victim_character_id IS NOT NULL
+           AND ke.victim_character_id > 0
+         ORDER BY ke.sequence_id ASC",
+        array_values($battleIds)
+    );
+}
+
 function db_theater_suspicion_summary(string $theaterId): ?array
 {
     return db_select_one(


### PR DESCRIPTION
## Summary

- **Adds killmail detail popout modal** to the theater intelligence participants table — clicking a lost ship (or structure) opens a slide-over panel with ship render, victim info, value, attackers, fitted modules, and links to full detail / zKillboard
- **Fixes clickability for all theaters** — the initial implementation stored killmail IDs in the `ships_lost_detail` JSON (only populated after Python re-analysis), so existing/snapshot-locked theaters had no clickable links. Now resolves `sequence_id` at render time by querying `killmail_events` directly using the theater's battle IDs
- **Includes modules & cargo** in the popout as collapsible groups (fitted / destroyed / dropped) with item icons and quantities

### Key changes

| File | What |
|---|---|
| `src/db.php` | New `db_theater_victim_killmails_by_battles()` query; JOIN on structure kills for `sequence_id` |
| `public/theater-intelligence/view.php` | Builds `$victimKmLookup` and `$killmailSeqLookup` maps before rendering participants |
| `public/theater-intelligence/partials/_participants.php` | Clickable lost-ship cells using lookup maps, modal HTML/JS with modules section |
| `public/api/killmail-summary.php` | New lightweight API endpoint returning killmail data for the modal |
| `python/orchestrator/jobs/theater_analysis.py` | Includes `sequence_id` + `killmail_ids` in `ships_lost_detail` JSON for future data |

## Test plan

- [ ] Open a theater intelligence view with known losses — lost ships should show underlined text and be clickable
- [ ] Click a lost ship — slide-over panel should appear with ship render, victim, value, attackers, and modules
- [ ] Verify modules section shows fitted/destroyed/dropped groups with correct items
- [ ] Press Escape or click backdrop to dismiss — theater view should remain intact
- [ ] Test on a snapshot-locked theater — lost ships should still be clickable
- [ ] Test structure kill rows — structure names should also be clickable where killmail data exists
- [ ] Verify "Full detail" link navigates to killmail-intelligence view
- [ ] Verify "zKillboard" link opens correct external URL

https://claude.ai/code/session_01AKWBJHoF7cLdXCHJBo4mPb