### PR TITLE
Fix missing item prices and align quantity/price columns

### DIFF
--- a/public/api/killmail-summary.php
+++ b/public/api/killmail-summary.php
@@ -65,18 +65,25 @@ $data = supplycore_cache_aside('killmail_summary', [$sequenceId], supplycore_cac
     if ($allTypeIds !== []) {
         $typeIdList = array_keys($allTypeIds);
         $placeholders = implode(',', array_fill(0, count($typeIdList), '?'));
+        // Get the latest avg_price per type_id using a correlated subquery
         $priceRows = db_select(
-            "SELECT type_id, avg_price
-             FROM market_item_price_1d
-             WHERE type_id IN ({$placeholders})
-             ORDER BY bucket_start DESC
-             LIMIT " . count($typeIdList),
+            "SELECT p.type_id, p.avg_price
+             FROM market_item_price_1d p
+             INNER JOIN (
+                 SELECT type_id, MAX(bucket_start) AS max_bucket
+                 FROM market_item_price_1d
+                 WHERE type_id IN ({$placeholders})
+                   AND avg_price IS NOT NULL
+                   AND avg_price > 0
+                 GROUP BY type_id
+             ) latest ON latest.type_id = p.type_id AND latest.max_bucket = p.bucket_start",
             $typeIdList
         );
         foreach ($priceRows as $pr) {
             $tid = (int) ($pr['type_id'] ?? 0);
-            if ($tid > 0 && !isset($priceMap[$tid])) {
-                $priceMap[$tid] = (float) ($pr['avg_price'] ?? 0);
+            $price = (float) ($pr['avg_price'] ?? 0);
+            if ($tid > 0 && $price > 0) {
+                $priceMap[$tid] = $price;
             }
         }
     }

--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -1057,17 +1057,15 @@ function _render_structure_row(array $sk, array $resolvedEntities, array $shipTy
                 html += '<div class="px-3 pb-2 space-y-1">';
                 for (var ii = 0; ii < group.rows.length; ii++) {
                     var item = group.rows[ii];
-                    html += '<div style="display:flex;align-items:center;gap:0.375rem;padding:0.25rem 0;">';
+                    html += '<div style="display:grid;grid-template-columns:1.25rem 1fr 3rem 3.5rem;align-items:center;gap:0.375rem;padding:0.2rem 0;font-size:0.75rem;">';
                     if (item.type_id > 0) {
-                        html += '<img style="width:1.25rem;height:1.25rem;flex-shrink:0;background:rgba(0,0,0,0.3);padding:1px;border-radius:0.25rem;" src="https://images.evetech.net/types/' + item.type_id + '/icon?size=32" loading="lazy">';
+                        html += '<img style="width:1.25rem;height:1.25rem;background:rgba(0,0,0,0.3);padding:1px;border-radius:0.25rem;" src="https://images.evetech.net/types/' + item.type_id + '/icon?size=32" loading="lazy">';
+                    } else {
+                        html += '<span></span>';
                     }
-                    html += '<span style="font-size:0.75rem;color:#e2e8f0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;min-width:0;">' + esc(item.name) + '</span>';
-                    if (item.quantity > 1) {
-                        html += '<span style="font-size:0.625rem;color:#64748b;flex-shrink:0;white-space:nowrap;min-width:2rem;text-align:right;">&times;' + item.quantity.toLocaleString() + '</span>';
-                    }
-                    if (item.total_price != null) {
-                        html += '<span style="font-size:0.625rem;color:rgba(234,179,8,0.7);flex-shrink:0;white-space:nowrap;min-width:3rem;text-align:right;">' + fmtIsk(item.total_price) + '</span>';
-                    }
+                    html += '<span style="color:#e2e8f0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + esc(item.name) + '</span>';
+                    html += '<span style="font-size:0.625rem;color:#64748b;text-align:right;white-space:nowrap;">' + (item.quantity > 1 ? '&times;' + item.quantity.toLocaleString() : '') + '</span>';
+                    html += '<span style="font-size:0.625rem;color:rgba(234,179,8,0.7);text-align:right;white-space:nowrap;">' + (item.total_price != null ? fmtIsk(item.total_price) : '') + '</span>';
                     html += '</div>';
                 }
                 html += '</div></details>';


### PR DESCRIPTION
## Summary

- **Fixed missing prices** — the query used `ORDER BY bucket_start DESC LIMIT N` which only returned prices for whichever type_ids happened to have the most recent bucket. Now uses a `GROUP BY` subquery to get the latest price **per type_id**, so ammo, charges, and other items all show prices.
- **Aligned item layout** — switched from flexbox to CSS grid with fixed columns (`icon | name | qty | price`) so quantity and price always sit in clean, aligned columns regardless of content length.

## Test plan

- [ ] Items that previously showed no price (e.g. Nova Rage Rocket ×1,000) now show a price
- [ ] Quantity and price columns are aligned across all rows — no overlapping
- [ ] Items with no market data still show cleanly (empty price column)
- [ ] Group summary badges still show item count and total value

https://claude.ai/code/session_01AKWBJHoF7cLdXCHJBo4mPb