### PR TITLE
Add consumption-based buy quantity predictions using killmail burn-rate data

### DIFF
--- a/database/migrations/20260410_item_criticality_consumption_columns.sql
+++ b/database/migrations/20260410_item_criticality_consumption_columns.sql
@@ -1,0 +1,6 @@
+-- Add consumption tracking columns to item_criticality_index for burn-rate
+-- driven buy-all quantity predictions.
+
+ALTER TABLE item_criticality_index
+    ADD COLUMN consumption_30d       DECIMAL(14,2)  DEFAULT NULL AFTER stock_days_remaining,
+    ADD COLUMN avg_daily_consumption DECIMAL(12,4)  DEFAULT NULL AFTER consumption_30d;

--- a/public/buy-all/index.php
+++ b/public/buy-all/index.php
@@ -245,7 +245,16 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 </td>
                                 <td class="px-4 py-3 align-top">
                                     <p class="font-semibold text-white"><?= htmlspecialchars((string) ($item['final_planner_quantity'] ?? $item['quantity'] ?? 0), ENT_QUOTES) ?></p>
-                                    <p class="mt-1 text-xs text-slate-500">Short by <?= htmlspecialchars((string) ($item['exact_deficit_quantity'] ?? 0), ENT_QUOTES) ?> · target <?= htmlspecialchars((string) ($item['operational_recommended_quantity'] ?? 0), ENT_QUOTES) ?></p>
+                                    <?php
+                                        $hasConsumptionData = ($item['avg_daily_consumption'] ?? null) !== null && (float) ($item['avg_daily_consumption'] ?? 0) > 0.0;
+                                        $stockDays = ($item['stock_days_remaining'] ?? null) !== null ? (float) $item['stock_days_remaining'] : null;
+                                    ?>
+                                    <?php if ($hasConsumptionData): ?>
+                                        <p class="mt-1 text-xs <?= $stockDays !== null && $stockDays < 7 ? 'text-rose-300' : ($stockDays !== null && $stockDays < 14 ? 'text-amber-300' : 'text-slate-500') ?>">Burns <?= htmlspecialchars(number_format((float) ($item['avg_daily_consumption'] ?? 0), 1), ENT_QUOTES) ?>/day · <?= $stockDays !== null ? htmlspecialchars(number_format($stockDays, 0), ENT_QUOTES) . 'd remaining' : 'no stock data' ?></p>
+                                        <p class="mt-1 text-xs text-slate-500"><?= htmlspecialchars(number_format((float) ($item['consumption_30d'] ?? 0), 0), ENT_QUOTES) ?> lost in 30d · <?= htmlspecialchars((string) ($item['runway_days_target'] ?? 30), ENT_QUOTES) ?>d runway target</p>
+                                    <?php else: ?>
+                                        <p class="mt-1 text-xs text-slate-500">Short by <?= htmlspecialchars((string) ($item['exact_deficit_quantity'] ?? 0), ENT_QUOTES) ?> · target <?= htmlspecialchars((string) ($item['operational_recommended_quantity'] ?? 0), ENT_QUOTES) ?></p>
+                                    <?php endif; ?>
                                     <p class="mt-1 text-xs <?= !empty($item['hub_capped']) ? 'text-amber-300' : 'text-slate-500' ?>">Hub <?= htmlspecialchars(number_format((int) ($item['hub_available_quantity'] ?? 0)), ENT_QUOTES) ?> avail · <?= htmlspecialchars(number_format((float) ($item['hub_pct_of_stock'] ?? 0), 0), ENT_QUOTES) ?>% of stock<?= !empty($item['hub_capped']) ? ' · capped from ' . htmlspecialchars(number_format((int) ($item['uncapped_planner_quantity'] ?? 0)), ENT_QUOTES) : '' ?></p>
                                 </td>
                                 <td class="px-4 py-3 align-top">
@@ -282,6 +291,9 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                         <summary class="cursor-pointer list-none text-xs font-medium text-slate-100">More detail</summary>
                                         <div class="mt-2 space-y-2">
                                             <p class="text-xs text-slate-500">Reason code <?= htmlspecialchars((string) ($item['reason_code'] ?? ''), ENT_QUOTES) ?> · necessity <?= htmlspecialchars(number_format((float) ($item['necessity_score'] ?? 0.0), 1), ENT_QUOTES) ?> · profit <?= htmlspecialchars(number_format((float) ($item['profit_score'] ?? 0.0), 1), ENT_QUOTES) ?> · blended <?= htmlspecialchars(number_format((float) ($item['blended_score'] ?? 0.0), 1), ENT_QUOTES) ?></p>
+                                            <?php if (($item['avg_daily_consumption'] ?? null) !== null && (float) ($item['avg_daily_consumption'] ?? 0) > 0.0): ?>
+                                                <p class="text-xs text-cyan-200/85">Consumption: <?= htmlspecialchars(number_format((float) ($item['consumption_30d'] ?? 0), 0), ENT_QUOTES) ?> lost in 30d · <?= htmlspecialchars(number_format((float) ($item['avg_daily_consumption'] ?? 0), 1), ENT_QUOTES) ?>/day avg · stock <?= ($item['stock_days_remaining'] ?? null) !== null ? htmlspecialchars(number_format((float) $item['stock_days_remaining'], 1), ENT_QUOTES) . 'd' : 'N/A' ?> · consumption qty <?= htmlspecialchars((string) ($item['consumption_recommended_quantity'] ?? 0), ENT_QUOTES) ?> · doctrine qty <?= htmlspecialchars((string) ($item['operational_recommended_quantity'] ?? 0), ENT_QUOTES) ?></p>
+                                            <?php endif; ?>
                                             <?php foreach ($affectedFits as $affectedFit): ?>
                                                 <div class="rounded-lg border border-white/8 bg-white/[0.03] px-3 py-2">
                                                     <p class="text-xs font-semibold text-slate-100"><?= htmlspecialchars((string) ($affectedFit['fit_name'] ?? 'Doctrine fit'), ENT_QUOTES) ?></p>

--- a/python/orchestrator/jobs/compute_buy_all.py
+++ b/python/orchestrator/jobs/compute_buy_all.py
@@ -164,7 +164,10 @@ def _load_market_rows(db: SupplyCoreDb, limit: int = 600) -> list[dict[str, Any]
             COALESCE(ici.trend_score, 0.0) AS trend_score,
             COALESCE(ici.market_stress_score, 0.0) AS market_stress_score,
             COALESCE(ici.trend_regime, 'stable') AS trend_regime,
-            COALESCE(ici.substitute_count, 0) AS substitute_count
+            COALESCE(ici.substitute_count, 0) AS substitute_count,
+            ici.consumption_30d,
+            ici.avg_daily_consumption,
+            ici.stock_days_remaining
         FROM hub_snapshot ref
         LEFT JOIN alliance_snapshot alliance ON alliance.type_id = ref.type_id
         LEFT JOIN ref_item_types rit ON rit.type_id = ref.type_id
@@ -185,8 +188,24 @@ def _ranked_items(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             continue
         buy_price = to_decimal(row.get("buy_price"))
         sell_price = to_decimal(row.get("sell_price"))
-        quantity = max(1, int(to_decimal(row.get("reference_total_sell_volume")) * Decimal("0.06")))
-        quantity = min(500, quantity)
+        alliance_stock = max(0, int(row.get("alliance_total_sell_volume") or 0))
+        avg_daily = float(row.get("avg_daily_consumption") or 0)
+        consumption_30d_val = row.get("consumption_30d")
+        stock_days_val = row.get("stock_days_remaining")
+        runway_days = 30
+
+        # Consumption-based prediction: buy enough for the target runway minus current stock.
+        if avg_daily > 0:
+            runway_demand = int(Decimal(str(avg_daily * runway_days)).to_integral_value(rounding=ROUND_HALF_UP))
+            consumption_qty = max(0, runway_demand - alliance_stock)
+        else:
+            consumption_qty = 0
+
+        # Legacy economic fallback: 6% of hub volume.
+        economic_qty = max(1, int(to_decimal(row.get("reference_total_sell_volume")) * Decimal("0.06")))
+        economic_qty = min(500, economic_qty)
+
+        quantity = max(consumption_qty, economic_qty)
         dependency_score = to_decimal(row.get("dependency_score"))
         doctrine_count = max(0, int(row.get("doctrine_count") or 0))
         dependency_fit_count = max(0, int(row.get("dependency_fit_count") or 0))
@@ -273,6 +292,11 @@ def _ranked_items(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "market_stress_score": market_stress_score.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP),
                 "trend_regime": trend_regime,
                 "substitute_count": substitute_count,
+                "consumption_30d": float(consumption_30d_val) if consumption_30d_val is not None else None,
+                "avg_daily_consumption": avg_daily if avg_daily > 0 else None,
+                "stock_days_remaining": float(stock_days_val) if stock_days_val is not None else None,
+                "consumption_recommended_quantity": consumption_qty,
+                "runway_days_target": runway_days,
                 "reason_text": graph_reason,
                 "reason_theme": "Graph dependency priority" if dependency_score > DECIMAL_ZERO else "Market-only priority",
             }

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -1558,6 +1558,7 @@ def _compute_market_stress(
         # Stock days remaining: alliance stock / avg daily consumption
         consumption_30d = data.get("consumption_30d") or 0
         avg_daily_consumption = consumption_30d / 30.0 if consumption_30d > 0 else 0
+        data["avg_daily_consumption"] = avg_daily_consumption
         if avg_daily_consumption > 0:
             data["stock_days_remaining"] = alliance_volume / avg_daily_consumption
 
@@ -1656,6 +1657,8 @@ def _persist_criticality_index(db: SupplyCoreDb, item_data: dict[int, dict[str, 
             d.get("market_spread_pct"),
             d.get("liquidity_score"),
             d.get("stock_days_remaining"),
+            d.get("consumption_30d"),
+            d.get("avg_daily_consumption"),
             d.get("market_stress_score", 0),
             d.get("data_freshness_hrs"),
             d.get("coverage_ratio"),
@@ -1679,13 +1682,14 @@ def _persist_criticality_index(db: SupplyCoreDb, item_data: dict[int, dict[str, 
                     price_velocity, volume_velocity, price_volatility,
                     trend_regime, trend_score,
                     market_spread_pct, liquidity_score, stock_days_remaining,
+                    consumption_30d, avg_daily_consumption,
                     market_stress_score,
                     data_freshness_hrs, coverage_ratio, confidence_score,
                     priority_index, priority_rank, computed_at
                 ) VALUES (
                     %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
                     %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                    %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                    %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
                 )""",
                 chunk,
             )

--- a/src/db.php
+++ b/src/db.php
@@ -16605,7 +16605,10 @@ function db_item_graph_intelligence_by_type_ids(array $typeIds): array
             COALESCE(ici.priority_index, 0.0) AS priority_index,
             COALESCE(ici.spof_flag, 0) AS spof_flag,
             COALESCE(ici.trend_score, 0.0) AS trend_score,
-            COALESCE(ici.substitute_count, 0) AS substitute_count
+            COALESCE(ici.substitute_count, 0) AS substitute_count,
+            ici.consumption_30d,
+            ici.avg_daily_consumption,
+            ici.stock_days_remaining
          FROM item_dependency_score ids
          LEFT JOIN item_criticality_index ici ON ici.type_id = ids.type_id
          WHERE ids.type_id IN ({$placeholders})
@@ -16619,7 +16622,10 @@ function db_item_graph_intelligence_by_type_ids(array $typeIds): array
             COALESCE(ici2.priority_index, 0.0) AS priority_index,
             COALESCE(ici2.spof_flag, 0) AS spof_flag,
             COALESCE(ici2.trend_score, 0.0) AS trend_score,
-            COALESCE(ici2.substitute_count, 0) AS substitute_count
+            COALESCE(ici2.substitute_count, 0) AS substitute_count,
+            ici2.consumption_30d,
+            ici2.avg_daily_consumption,
+            ici2.stock_days_remaining
          FROM item_criticality_index ici2
          WHERE ici2.type_id IN ({$placeholders})
            AND ici2.type_id NOT IN (SELECT type_id FROM item_dependency_score WHERE type_id IN ({$placeholders}))",

--- a/src/functions.php
+++ b/src/functions.php
@@ -28185,6 +28185,18 @@ function buy_all_hauling_cost_per_m3(): float
     return 250.0;
 }
 
+/**
+ * Target runway in days for consumption-based buy quantity predictions.
+ *
+ * When an item has killmail-derived burn-rate data the planner recommends
+ * enough units to cover this many days of expected consumption beyond the
+ * current stock level.
+ */
+function buy_all_runway_days(): int
+{
+    return 30;
+}
+
 function buy_all_page_item_type_limit(): int
 {
     return 100;
@@ -28624,6 +28636,17 @@ function buy_all_reason_meta(array $candidate): array
             'code' => 'exact_doctrine_deficit',
             'text' => 'Exact doctrine deficit for ' . doctrine_format_quantity($exactDeficitFitCount) . ' ' . $hullClassLabel . ' fits.',
             'theme' => 'Exact doctrine deficit',
+        ];
+    }
+    $consumptionQty = max(0, (int) ($candidate['consumption_recommended_quantity'] ?? 0));
+    $avgDaily = ($candidate['avg_daily_consumption'] ?? null) !== null ? (float) $candidate['avg_daily_consumption'] : null;
+    $stockDays = ($candidate['stock_days_remaining'] ?? null) !== null ? (float) $candidate['stock_days_remaining'] : null;
+    if ($consumptionQty > 0 && $avgDaily !== null && $avgDaily > 0.0) {
+        $daysLabel = $stockDays !== null ? number_format($stockDays, 0) . 'd remaining' : 'low stock';
+        return [
+            'code' => 'consumption_runway_prediction',
+            'text' => 'Burns ' . number_format($avgDaily, 1) . '/day (' . $daysLabel . '); buying ' . doctrine_format_quantity($consumptionQty) . ' for ' . (int) ($candidate['runway_days_target'] ?? 30) . '-day runway.',
+            'theme' => 'Consumption runway prediction',
         ];
     }
     if ((bool) ($candidate['missing_in_alliance'] ?? false) && (($candidate['net_profit_total'] ?? null) !== null) && (float) ($candidate['net_profit_total'] ?? 0.0) > 0.0) {
@@ -29069,16 +29092,41 @@ function buy_all_planner_data_uncached(array $query = []): array
         $blockedFitImpact = max(0, (int) ($demand['deterministic_blocked_fits'] ?? 0));
         $targetReadyFits = max(0, (int) ($demand['target_ready_fits'] ?? 0));
         $activityPressureModifier = max(1.0, (float) ($demand['activity_pressure_modifier'] ?? 1.0));
+
+        // -----------------------------------------------------------------
+        // Consumption-based prediction: use killmail burn-rate data to
+        // calculate how many units we need to sustain a target runway.
+        // -----------------------------------------------------------------
+        $consumption30d = ($graphIntel['consumption_30d'] ?? null) !== null ? (float) $graphIntel['consumption_30d'] : null;
+        $avgDailyConsumption = ($graphIntel['avg_daily_consumption'] ?? null) !== null ? (float) $graphIntel['avg_daily_consumption'] : null;
+        $stockDaysRemaining = ($graphIntel['stock_days_remaining'] ?? null) !== null ? (float) $graphIntel['stock_days_remaining'] : null;
+        $runwayDays = buy_all_runway_days();
+        $consumptionRecommendedQuantity = 0;
+
+        if ($avgDailyConsumption !== null && $avgDailyConsumption > 0.0) {
+            // Units needed to cover the full runway from zero, minus what we already have.
+            $runwayDemand = (int) ceil($avgDailyConsumption * $runwayDays);
+            $consumptionRecommendedQuantity = max(0, $runwayDemand - $localQty);
+        }
+
+        // Legacy doctrine-deficit operational recommendation (kept as a floor).
         $operationalBuffer = $exactDeficitQuantity > 0
             ? (int) ceil($exactDeficitQuantity * max(0.0, min(0.35, $activityPressureModifier - 1.0)))
             : 0;
         $operationalRecommendedQuantity = $exactDeficitQuantity > 0
             ? ($exactDeficitQuantity + $operationalBuffer)
             : ($blockedFitImpact > 0 ? (int) max(1, ceil(((int) ($demand['required_quantity_total'] ?? 0) / max(1, (int) ($demand['valid_fits_count'] ?? 1))) * $blockedFitImpact)) : 0);
+
         $economicRecommendedQuantity = buy_all_round_quantity(max(0, $economicRecommendedQuantity));
         $operationalRecommendedQuantity = buy_all_round_quantity(max(0, $operationalRecommendedQuantity));
-        $finalPlannerQuantity = max($operationalRecommendedQuantity, $economicRecommendedQuantity);
-        if ($blockedFitImpact <= 0 && $exactDeficitQuantity <= 0 && $economicRecommendedQuantity <= 0 && !((bool) ($market['missing_in_alliance'] ?? false))) {
+        $consumptionRecommendedQuantity = buy_all_round_quantity(max(0, $consumptionRecommendedQuantity));
+
+        // The final quantity is the largest of the three signals:
+        // 1. Consumption-based runway prediction (preferred when burn-rate data exists)
+        // 2. Doctrine-deficit operational recommendation (hard floor for doctrine readiness)
+        // 3. Economic / seed recommendation (market opportunity)
+        $finalPlannerQuantity = max($consumptionRecommendedQuantity, $operationalRecommendedQuantity, $economicRecommendedQuantity);
+        if ($blockedFitImpact <= 0 && $exactDeficitQuantity <= 0 && $economicRecommendedQuantity <= 0 && $consumptionRecommendedQuantity <= 0 && !((bool) ($market['missing_in_alliance'] ?? false))) {
             $finalPlannerQuantity = 0;
         }
         if ($unitVolume >= 50000.0 && $finalPlannerQuantity > 5) {
@@ -29204,6 +29252,7 @@ function buy_all_planner_data_uncached(array $query = []): array
             'quantity' => $finalPlannerQuantity,
             'exact_deficit_quantity' => $exactDeficitQuantity,
             'operational_recommended_quantity' => $operationalRecommendedQuantity,
+            'consumption_recommended_quantity' => $consumptionRecommendedQuantity,
             'economic_recommended_quantity' => $economicRecommendedQuantity,
             'final_planner_quantity' => $finalPlannerQuantity,
             'buy_price' => $buyPrice,
@@ -29265,6 +29314,10 @@ function buy_all_planner_data_uncached(array $query = []): array
             'spof_flag' => (bool) (int) ($graphIntel['spof_flag'] ?? 0),
             'trend_score' => round(max(0.0, (float) ($graphIntel['trend_score'] ?? 0.0)), 4),
             'substitute_count' => max(0, (int) ($graphIntel['substitute_count'] ?? 0)),
+            'consumption_30d' => $consumption30d,
+            'avg_daily_consumption' => $avgDailyConsumption,
+            'stock_days_remaining' => $stockDaysRemaining,
+            'runway_days_target' => $runwayDays,
         ];
         $reason = buy_all_reason_meta($candidate);
         $candidate['reason_code'] = $reason['code'];


### PR DESCRIPTION
## Summary
This PR introduces consumption-based buy quantity predictions to the buy-all planner, leveraging killmail-derived burn-rate data to recommend stock levels that sustain a configurable target runway (default 30 days). When consumption data is available, it becomes the primary signal for purchase recommendations, with doctrine-deficit and economic recommendations serving as fallback floors.

## Key Changes

- **New configuration function** `buy_all_runway_days()` to set the target runway days (default 30)

- **Consumption prediction logic** in `buy_all_planner_data_uncached()`:
  - Calculates runway demand as `avg_daily_consumption × runway_days`
  - Recommends quantity as `max(0, runway_demand - current_stock)`
  - Blends three signals: consumption-based (preferred), operational/doctrine (floor), and economic (fallback)

- **Database schema** migration adds three columns to `item_criticality_index`:
  - `consumption_30d`: 30-day consumption total
  - `avg_daily_consumption`: calculated daily burn rate
  - `stock_days_remaining`: days of stock at current consumption rate

- **Data pipeline updates** in `graph_pipeline.py`:
  - Computes `avg_daily_consumption` from 30-day consumption data
  - Persists consumption metrics to the criticality index table

- **Python orchestrator** (`compute_buy_all.py`):
  - Loads consumption data from database
  - Calculates consumption-based quantity alongside legacy economic quantity (6% of hub volume)
  - Uses max of both signals for final recommendation

- **UI enhancements** in buy-all display:
  - Shows burn rate and stock days remaining with color-coded urgency (red <7d, amber <14d)
  - Displays 30-day consumption loss and runway target
  - Adds detailed consumption breakdown in expanded details section
  - Conditionally shows consumption metrics when burn-rate data is available

- **Reason metadata** adds new `consumption_runway_prediction` reason code with detailed explanation of burn rate and runway calculation

## Implementation Details

The consumption-based prediction integrates seamlessly with existing recommendation logic:
- When killmail data provides burn rates, consumption becomes the primary driver
- Doctrine-deficit recommendations remain as a hard floor for operational readiness
- Economic recommendations provide a fallback for items without consumption data
- The final quantity is `max(consumption_qty, operational_qty, economic_qty)` with appropriate filtering

All consumption-related fields are nullable to maintain backward compatibility with items lacking killmail data.

https://claude.ai/code/session_01NNQuJuo8wdGBhLdtPXWyMK