### PR TITLE
Deduplicate corridor systems while preserving order

### DIFF
--- a/python/orchestrator/jobs/compute_threat_corridors.py
+++ b/python/orchestrator/jobs/compute_threat_corridors.py
@@ -435,6 +435,14 @@ def run_compute_threat_corridors(
         seen_hashes: set[str] = set()
 
         for corridor_systems in raw_corridors:
+            # Deduplicate while preserving order (graph traversals can revisit nodes)
+            seen_sids: set[int] = set()
+            deduped: list[int] = []
+            for sid in corridor_systems:
+                if sid not in seen_sids:
+                    seen_sids.add(sid)
+                    deduped.append(sid)
+            corridor_systems = deduped
             if len(corridor_systems) < 2:
                 continue
             ch = _corridor_hash(corridor_systems)


### PR DESCRIPTION
## Summary
Added deduplication logic to the threat corridor computation to handle cases where graph traversals revisit the same nodes, ensuring each system appears only once in a corridor while maintaining traversal order.

## Key Changes
- Added deduplication step in `run_compute_threat_corridors()` that preserves insertion order
- Uses a set to track seen system IDs for O(1) lookup while building a deduplicated list
- Deduplication occurs before the length check, ensuring corridors with duplicate systems are properly filtered

## Implementation Details
The deduplication uses a standard two-variable pattern (seen set + result list) to maintain order while removing duplicates. This is necessary because graph traversal algorithms can revisit nodes, potentially creating duplicate entries in the corridor_systems list that should be consolidated before further processing.

https://claude.ai/code/session_01DPxJt5Vt3Z1bijg72BcUEp