### PR TITLE
Deduplicate overlapping alliances in co-present and enemies lists

### DIFF
--- a/python/orchestrator/jobs/compute_alliance_dossiers.py
+++ b/python/orchestrator/jobs/compute_alliance_dossiers.py
@@ -651,6 +651,19 @@ def run_compute_alliance_dossiers(
                 if enemies:
                     logger.info("alliance %d: enemies from SQL fallback (%d results)", aid, len(enemies))
 
+            # Deduplicate: if an alliance appears in both co-present and
+            # enemies, keep it only in the list where the count is higher.
+            co_map = {cp["alliance_id"]: cp.get("shared_battles") or cp.get("count", 0) for cp in co_present}
+            en_map = {en["alliance_id"]: en.get("engagements") or en.get("count", 0) for en in enemies}
+            overlap = set(co_map) & set(en_map)
+            if overlap:
+                logger.info("alliance %d: %d overlapping alliances in co-present/enemies, deduplicating", aid, len(overlap))
+                for oid in overlap:
+                    if en_map[oid] >= co_map[oid]:
+                        co_present = [cp for cp in co_present if cp["alliance_id"] != oid]
+                    else:
+                        enemies = [en for en in enemies if en["alliance_id"] != oid]
+
             for cp in co_present:
                 all_ally_ids.add(cp["alliance_id"])
             for en in enemies:


### PR DESCRIPTION
## Summary
Added deduplication logic to handle cases where an alliance appears in both the co-present and enemies lists for a given alliance. When overlap is detected, the alliance is kept only in the list where it has the higher engagement count.

## Changes
- Added deduplication logic after fetching co-present and enemies data
- Creates maps of alliance IDs to their respective counts (shared_battles/engagements)
- Identifies overlapping alliances between the two lists
- Removes overlapping alliances from the list with the lower count, keeping them only in the list with higher engagement
- Logs deduplication activity for debugging and monitoring purposes

## Implementation Details
- Uses set intersection to efficiently find overlapping alliance IDs
- Handles both primary count fields (shared_battles, engagements) and fallback count field
- Preserves data integrity by keeping the most significant relationship (higher count) for each overlapping alliance
- Includes informational logging to track deduplication operations

https://claude.ai/code/session_01SpFPvZ9FajMd5DDDMtFUVw