### PR TITLE
Refactor battle report panels to support 3-column layout with third party

### DIFF
--- a/public-proxy/partials/_battle_report.php
+++ b/public-proxy/partials/_battle_report.php
@@ -4,195 +4,141 @@
     $enemyPanel = $sidePanels['opponent'] ?? [];
     $thirdPartyPanel = $sidePanels['third_party'] ?? [];
 
-    $enemyCombinedIskLost = ($enemyPanel['isk_lost'] ?? 0) + ($thirdPartyPanel['isk_lost'] ?? 0);
-    $enemyCombinedIskKilled = ($enemyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_killed'] ?? 0);
-    $enemyCombinedPilots = ($enemyPanel['pilots'] ?? 0) + ($thirdPartyPanel['pilots'] ?? 0);
-    $enemyCombinedLosses = ($enemyPanel['losses'] ?? 0) + ($thirdPartyPanel['losses'] ?? 0);
-    $enemyCombinedTotalIsk = $enemyCombinedIskKilled + $enemyCombinedIskLost;
-    $enemyCombinedEfficiency = $enemyCombinedTotalIsk > 0 ? $enemyCombinedIskKilled / $enemyCombinedTotalIsk : 0.0;
+    $hasOpponent = ($enemyPanel['pilots'] ?? 0) > 0;
+    $hasThirdParty = ($thirdPartyPanel['pilots'] ?? 0) > 0;
+    $isThreeColumn = $hasOpponent && $hasThirdParty;
 
+    $ourTotalIsk = ($ourPanel['isk_killed'] ?? 0) + ($ourPanel['isk_lost'] ?? 0);
+    $ourEfficiency = $ourTotalIsk > 0 ? ($ourPanel['isk_killed'] ?? 0) / $ourTotalIsk : 0.0;
+
+    $enemyTotalIsk = ($enemyPanel['isk_killed'] ?? 0) + ($enemyPanel['isk_lost'] ?? 0);
+    $enemyEfficiency = $enemyTotalIsk > 0 ? ($enemyPanel['isk_killed'] ?? 0) / $enemyTotalIsk : 0.0;
+
+    $tpTotalIsk = ($thirdPartyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_lost'] ?? 0);
+    $tpEfficiency = $tpTotalIsk > 0 ? ($thirdPartyPanel['isk_killed'] ?? 0) / $tpTotalIsk : 0.0;
+
+    $enemyCombinedIskLost = ($enemyPanel['isk_lost'] ?? 0) + ($thirdPartyPanel['isk_lost'] ?? 0);
     $totalIskBothSides = ($ourPanel['isk_lost'] ?? 0) + $enemyCombinedIskLost;
     $ourBarPct = $totalIskBothSides > 0 ? ($enemyCombinedIskLost / $totalIskBothSides) * 100 : 50;
-    $enemyBarPct = 100 - $ourBarPct;
+
+    if ($isThreeColumn) {
+        $totalIskDestAll = ($ourPanel['isk_killed'] ?? 0) + ($enemyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_killed'] ?? 0);
+        $ourBarPct = $totalIskDestAll > 0 ? (($ourPanel['isk_killed'] ?? 0) / $totalIskDestAll) * 100 : 33.3;
+        $enemyBarPct = $totalIskDestAll > 0 ? (($enemyPanel['isk_killed'] ?? 0) / $totalIskDestAll) * 100 : 33.3;
+        $tpBarPct = 100 - $ourBarPct - $enemyBarPct;
+    } else {
+        $enemyBarPct = 100 - $ourBarPct;
+        $enemyEfficiency = $hasOpponent ? $enemyEfficiency : $tpEfficiency;
+    }
+
+    $gridCols = $isThreeColumn ? 'md:grid-cols-3' : 'md:grid-cols-2';
 ?>
 <section class="surface-primary mt-4">
     <!-- Efficiency Bar -->
     <div class="flex items-center gap-3 mb-3">
-        <span class="text-xs font-semibold text-blue-300"><?= number_format(($ourPanel['efficiency'] ?? 0) * 100, 1) ?>%</span>
+        <span class="text-xs font-semibold text-blue-300"><?= number_format($ourEfficiency * 100, 1) ?>%</span>
         <div class="flex-1 h-3 rounded-full overflow-hidden bg-slate-800 flex shadow-inner">
             <div class="bg-blue-500 h-full transition-all" style="width: <?= number_format($ourBarPct, 1) ?>%"></div>
             <div class="bg-red-500 h-full transition-all" style="width: <?= number_format($enemyBarPct, 1) ?>%"></div>
+            <?php if ($isThreeColumn): ?>
+                <div class="bg-amber-500 h-full transition-all" style="width: <?= number_format($tpBarPct, 1) ?>%"></div>
+            <?php endif; ?>
         </div>
-        <span class="text-xs font-semibold text-red-300"><?= number_format($enemyCombinedEfficiency * 100, 1) ?>%</span>
+        <?php if ($isThreeColumn): ?>
+            <span class="text-xs font-semibold text-red-300"><?= number_format($enemyEfficiency * 100, 1) ?>%</span>
+            <span class="text-xs font-semibold text-amber-300"><?= number_format($tpEfficiency * 100, 1) ?>%</span>
+        <?php else: ?>
+            <span class="text-xs font-semibold text-red-300"><?= number_format($enemyEfficiency * 100, 1) ?>%</span>
+        <?php endif; ?>
     </div>
 
-    <!-- Two-column side comparison -->
-    <div class="grid gap-4 md:grid-cols-2">
+    <!-- Dynamic column layout -->
+    <div class="grid gap-4 <?= $gridCols ?>">
         <!-- Friendly panel -->
-        <div class="coalition-panel rounded-lg overflow-hidden border border-blue-500/25">
-            <div class="bg-blue-900/40 px-4 py-3 flex items-center justify-between border-b border-blue-500/20">
-                <h3 class="text-sm font-semibold text-blue-300"><?= proxy_e($sideLabels['friendly'] ?? 'Friendlies') ?></h3>
-                <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Friendly</span>
-            </div>
-            <div class="px-4 pt-3">
-                <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted">Friendly coalition overview</p>
-            </div>
-            <div class="grid grid-cols-2 divide-x divide-y divide-white/5 border-b border-white/5 text-sm">
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">Unique Pilots</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format((int) ($ourPanel['pilots'] ?? 0)) ?></p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">ISK Efficiency</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format(($ourPanel['efficiency'] ?? 0) * 100, 1) ?>%</p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">Final Blows / Losses</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format((int) ($ourPanel['final_blows'] ?? 0)) ?> / <?= number_format((int) ($ourPanel['losses'] ?? 0)) ?></p>
-                    <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($ourPanel['kill_involvements'] ?? 0)) ?></p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">ISK Killed / Lost</p>
-                    <p class="text-slate-100 font-semibold"><?= proxy_format_isk((float) ($ourPanel['isk_killed'] ?? 0)) ?> / <?= proxy_format_isk((float) ($ourPanel['isk_lost'] ?? 0)) ?></p>
-                </div>
-            </div>
+        <?php
+            $_brp_data = $ourPanel;
+            $_brp_label = proxy_e($sideLabels['friendly'] ?? 'Friendlies');
+            $_brp_badge = 'Friendly';
+            $_brp_border = 'border-blue-500/25';
+            $_brp_header_bg = 'bg-blue-900/40';
+            $_brp_header_border = 'border-blue-500/20';
+            $_brp_text = 'text-blue-300';
+            $_brp_badge_bg = 'bg-blue-900/60';
+            $_brp_subtitle = 'Friendly coalition overview';
+            $_brp_alliances_label = 'Alliances';
+            $_brp_alliance_text = 'text-slate-200';
+            $_brp_header_extra = '';
+        ?>
+        <?php include __DIR__ . '/_battle_report_panel.php'; ?>
 
-            <?php $panelAlliances = $ourPanel['alliances'] ?? []; ?>
-            <?php if ($panelAlliances): ?>
-                <div class="divide-y divide-white/5">
-                    <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2">Alliances</p>
-                    <?php foreach ($panelAlliances as $allianceRow): ?>
-                        <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
-                        <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
-                        <div class="flex items-center gap-2.5 px-4 py-2">
-                            <?php if ($allianceId > 0): ?>
-                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php elseif ($corporationId > 0): ?>
-                                <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php endif; ?>
-                            <span class="text-xs text-slate-200 flex-1 truncate"><?= proxy_e((string) ($allianceRow['name'] ?? '')) ?></span>
-                            <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
+        <!-- Opponent panel -->
+        <?php if (!$isThreeColumn): ?>
+            <?php
+                $_brp_data = [
+                    'pilots' => ($enemyPanel['pilots'] ?? 0) + ($thirdPartyPanel['pilots'] ?? 0),
+                    'efficiency' => $enemyEfficiency,
+                    'final_blows' => ($enemyPanel['final_blows'] ?? 0) + ($thirdPartyPanel['final_blows'] ?? 0),
+                    'losses' => ($enemyPanel['losses'] ?? 0) + ($thirdPartyPanel['losses'] ?? 0),
+                    'kill_involvements' => ($enemyPanel['kill_involvements'] ?? 0) + ($thirdPartyPanel['kill_involvements'] ?? 0),
+                    'isk_killed' => ($enemyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_killed'] ?? 0),
+                    'isk_lost' => ($enemyPanel['isk_lost'] ?? 0) + ($thirdPartyPanel['isk_lost'] ?? 0),
+                    'alliances' => $enemyPanel['alliances'] ?? [],
+                    'ships' => (static function() use ($enemyPanel, $thirdPartyPanel) {
+                        $merged = array_merge($enemyPanel['ships'] ?? [], $thirdPartyPanel['ships'] ?? []);
+                        usort($merged, static fn(array $l, array $r): int => ($r['pilots'] ?? 0) <=> ($l['pilots'] ?? 0));
+                        return array_slice($merged, 0, 12);
+                    })(),
+                ];
+                $_brp_label = proxy_e($sideLabels['opponent'] ?? 'Opposition');
+                $_brp_badge = 'Hostile';
+                $_brp_border = 'border-red-500/25';
+                $_brp_header_bg = 'bg-red-900/40';
+                $_brp_header_border = 'border-red-500/20';
+                $_brp_text = 'text-red-300';
+                $_brp_badge_bg = 'bg-red-900/60';
+                $_brp_subtitle = 'Opposition coalition overview';
+                $_brp_alliances_label = 'Opponent Alliances';
+                $_brp_alliance_text = 'text-slate-200';
+                $_brp_header_extra = $hasThirdParty ? '<span class="text-slate-400 text-xs font-normal ml-1">+ Third Party</span>' : '';
+                $_brp_tp_alliances = $thirdPartyPanel['alliances'] ?? [];
+            ?>
+            <?php include __DIR__ . '/_battle_report_panel_merged.php'; ?>
+        <?php else: ?>
+            <?php
+                $_brp_data = $enemyPanel;
+                $_brp_label = proxy_e($sideLabels['opponent'] ?? 'Opposition');
+                $_brp_badge = 'Hostile';
+                $_brp_border = 'border-red-500/25';
+                $_brp_header_bg = 'bg-red-900/40';
+                $_brp_header_border = 'border-red-500/20';
+                $_brp_text = 'text-red-300';
+                $_brp_badge_bg = 'bg-red-900/60';
+                $_brp_subtitle = 'Opposition coalition overview';
+                $_brp_alliances_label = 'Opponent Alliances';
+                $_brp_alliance_text = 'text-slate-200';
+                $_brp_header_extra = '';
+            ?>
+            <?php include __DIR__ . '/_battle_report_panel.php'; ?>
+        <?php endif; ?>
 
-            <?php $panelShips = $ourPanel['ships'] ?? []; ?>
-            <?php if ($panelShips): ?>
-                <div class="mt-3 border-t border-slate-700/50 px-4 py-2">
-                    <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
-                    <div class="flex flex-wrap gap-2">
-                        <?php foreach (array_slice($panelShips, 0, 12) as $ship): ?>
-                            <div class="flex flex-col items-center gap-1 bg-slate-800/50 border border-white/6 rounded-md px-2 py-2 min-w-[72px]">
-                                <?php if (($ship['type_id'] ?? 0) > 0): ?>
-                                    <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/render?size=64" alt="" class="w-12 h-12 object-contain" loading="lazy">
-                                <?php endif; ?>
-                                <span class="text-[11px] text-slate-300 text-center leading-tight max-w-[68px] truncate"><?= proxy_e((string) ($ship['name'] ?? '')) ?></span>
-                                <span class="text-[10px] text-slate-500 font-semibold">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
-                            </div>
-                        <?php endforeach; ?>
-                        <?php if (count($panelShips) > 12): ?>
-                            <span class="text-[10px] text-muted self-center">+<?= count($panelShips) - 12 ?> more</span>
-                        <?php endif; ?>
-                    </div>
-                </div>
-            <?php endif; ?>
-        </div>
-
-        <!-- Opposition + Third Party panel -->
-        <div class="coalition-panel rounded-lg overflow-hidden border border-red-500/25">
-            <div class="bg-red-900/40 px-4 py-3 flex items-center justify-between border-b border-red-500/20">
-                <h3 class="text-sm font-semibold text-red-300">
-                    <?= proxy_e($sideLabels['opponent'] ?? 'Opposition') ?>
-                    <?php if (($thirdPartyPanel['pilots'] ?? 0) > 0): ?>
-                        <span class="text-slate-400 text-xs font-normal ml-1">+ Third Party</span>
-                    <?php endif; ?>
-                </h3>
-                <span class="text-[10px] uppercase tracking-wider bg-red-900/60 text-red-300 rounded-full px-1.5 py-0.5 ml-1">Hostile</span>
-            </div>
-            <div class="px-4 pt-3">
-                <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted">Opposition coalition overview</p>
-            </div>
-            <div class="grid grid-cols-2 divide-x divide-y divide-white/5 border-b border-white/5 text-sm">
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">Unique Pilots</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format($enemyCombinedPilots) ?></p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">ISK Efficiency</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format($enemyCombinedEfficiency * 100, 1) ?>%</p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">Final Blows / Losses</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format((int) ($enemyPanel['final_blows'] ?? 0) + (int) ($thirdPartyPanel['final_blows'] ?? 0)) ?> / <?= number_format($enemyCombinedLosses) ?></p>
-                    <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($enemyPanel['kill_involvements'] ?? 0) + (int) ($thirdPartyPanel['kill_involvements'] ?? 0)) ?></p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">ISK Killed / Lost</p>
-                    <p class="text-slate-100 font-semibold"><?= proxy_format_isk($enemyCombinedIskKilled) ?> / <?= proxy_format_isk($enemyCombinedIskLost) ?></p>
-                </div>
-            </div>
-
-            <?php $opponentAlliances = $enemyPanel['alliances'] ?? []; ?>
-            <?php if ($opponentAlliances): ?>
-                <div class="divide-y divide-white/5">
-                    <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2">Opponent Alliances</p>
-                    <?php foreach ($opponentAlliances as $allianceRow): ?>
-                        <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
-                        <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
-                        <div class="flex items-center gap-2.5 px-4 py-2">
-                            <?php if ($allianceId > 0): ?>
-                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php elseif ($corporationId > 0): ?>
-                                <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php endif; ?>
-                            <span class="text-xs text-slate-200 flex-1 truncate"><?= proxy_e((string) ($allianceRow['name'] ?? '')) ?></span>
-                            <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-
-            <?php $tpAlliances = $thirdPartyPanel['alliances'] ?? []; ?>
-            <?php if ($tpAlliances): ?>
-                <div class="divide-y divide-white/5 border-t border-slate-700/50">
-                    <p class="text-[10px] uppercase tracking-wider text-slate-400 px-4 py-2">Third Party</p>
-                    <?php foreach ($tpAlliances as $allianceRow): ?>
-                        <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
-                        <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
-                        <div class="flex items-center gap-2.5 px-4 py-2">
-                            <?php if ($allianceId > 0): ?>
-                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php elseif ($corporationId > 0): ?>
-                                <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php endif; ?>
-                            <span class="text-xs text-slate-400 flex-1 truncate"><?= proxy_e((string) ($allianceRow['name'] ?? '')) ?></span>
-                            <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-
-            <?php $panelShips = array_merge($enemyPanel['ships'] ?? [], $thirdPartyPanel['ships'] ?? []); ?>
-            <?php usort($panelShips, static fn(array $l, array $r): int => ($r['pilots'] ?? 0) <=> ($l['pilots'] ?? 0)); ?>
-            <?php $panelShips = array_slice($panelShips, 0, 12); ?>
-            <?php if ($panelShips): ?>
-                <div class="mt-3 border-t border-slate-700/50 px-4 py-2">
-                    <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
-                    <div class="flex flex-wrap gap-2">
-                        <?php foreach ($panelShips as $ship): ?>
-                            <div class="flex flex-col items-center gap-1 bg-slate-800/50 border border-white/6 rounded-md px-2 py-2 min-w-[72px]">
-                                <?php if (($ship['type_id'] ?? 0) > 0): ?>
-                                    <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/render?size=64" alt="" class="w-12 h-12 object-contain" loading="lazy">
-                                <?php endif; ?>
-                                <span class="text-[11px] text-slate-300 text-center leading-tight max-w-[68px] truncate"><?= proxy_e((string) ($ship['name'] ?? '')) ?></span>
-                                <span class="text-[10px] text-slate-500 font-semibold">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
-                            </div>
-                        <?php endforeach; ?>
-                    </div>
-                </div>
-            <?php endif; ?>
-        </div>
+        <?php if ($isThreeColumn): ?>
+            <!-- Third Party panel -->
+            <?php
+                $_brp_data = $thirdPartyPanel;
+                $_brp_label = proxy_e($sideLabels['third_party'] ?? 'Third Party');
+                $_brp_badge = 'Third Party';
+                $_brp_border = 'border-amber-500/25';
+                $_brp_header_bg = 'bg-amber-900/40';
+                $_brp_header_border = 'border-amber-500/20';
+                $_brp_text = 'text-amber-300';
+                $_brp_badge_bg = 'bg-amber-900/60';
+                $_brp_subtitle = 'Third party overview';
+                $_brp_alliances_label = 'Alliances';
+                $_brp_alliance_text = 'text-slate-200';
+                $_brp_header_extra = '';
+            ?>
+            <?php include __DIR__ . '/_battle_report_panel.php'; ?>
+        <?php endif; ?>
     </div>
 
     <?php if ($dataQualityNotes !== []): ?>

--- a/public-proxy/partials/_battle_report_panel.php
+++ b/public-proxy/partials/_battle_report_panel.php
@@ -1,0 +1,70 @@
+<div class="coalition-panel rounded-lg overflow-hidden border <?= $_brp_border ?>">
+    <div class="<?= $_brp_header_bg ?> px-4 py-3 flex items-center justify-between border-b <?= $_brp_header_border ?>">
+        <h3 class="text-sm font-semibold <?= $_brp_text ?>"><?= $_brp_label ?><?= $_brp_header_extra ?></h3>
+        <span class="text-[10px] uppercase tracking-wider <?= $_brp_badge_bg ?> <?= $_brp_text ?> rounded-full px-1.5 py-0.5 ml-1"><?= $_brp_badge ?></span>
+    </div>
+    <div class="px-4 pt-3">
+        <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted"><?= $_brp_subtitle ?></p>
+    </div>
+
+    <div class="grid grid-cols-2 divide-x divide-y divide-white/5 border-b border-white/5 text-sm">
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">Unique Pilots</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($_brp_data['pilots'] ?? 0)) ?></p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">ISK Efficiency</p>
+            <p class="text-slate-100 font-semibold"><?= number_format(($_brp_data['efficiency'] ?? 0) * 100, 1) ?>%</p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">Final Blows / Losses</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($_brp_data['final_blows'] ?? 0)) ?> / <?= number_format((int) ($_brp_data['losses'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($_brp_data['kill_involvements'] ?? 0)) ?></p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">ISK Killed / Lost</p>
+            <p class="text-slate-100 font-semibold"><?= proxy_format_isk((float) ($_brp_data['isk_killed'] ?? 0)) ?> / <?= proxy_format_isk((float) ($_brp_data['isk_lost'] ?? 0)) ?></p>
+        </div>
+    </div>
+
+    <?php $_panelAlliances = $_brp_data['alliances'] ?? []; ?>
+    <?php if ($_panelAlliances): ?>
+        <div class="divide-y divide-white/5">
+            <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2"><?= $_brp_alliances_label ?></p>
+            <?php foreach ($_panelAlliances as $allianceRow): ?>
+                <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
+                <div class="flex items-center gap-2.5 px-4 py-2">
+                    <?php if ($allianceId > 0): ?>
+                        <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php elseif ($corporationId > 0): ?>
+                        <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php endif; ?>
+                    <span class="text-xs <?= $_brp_alliance_text ?> flex-1 truncate"><?= proxy_e((string) ($allianceRow['name'] ?? '')) ?></span>
+                    <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php $_panelShips = $_brp_data['ships'] ?? []; ?>
+    <?php if ($_panelShips): ?>
+        <div class="mt-3 border-t border-slate-700/50 px-4 py-2">
+            <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
+            <div class="flex flex-wrap gap-2">
+                <?php foreach (array_slice($_panelShips, 0, 12) as $ship): ?>
+                    <div class="flex flex-col items-center gap-1 bg-slate-800/50 border border-white/6 rounded-md px-2 py-2 min-w-[72px]">
+                        <?php if (($ship['type_id'] ?? 0) > 0): ?>
+                            <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/render?size=64" alt="" class="w-12 h-12 object-contain" loading="lazy">
+                        <?php endif; ?>
+                        <span class="text-[11px] text-slate-300 text-center leading-tight max-w-[68px] truncate"><?= proxy_e((string) ($ship['name'] ?? '')) ?></span>
+                        <span class="text-[10px] text-slate-500 font-semibold">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
+                    </div>
+                <?php endforeach; ?>
+                <?php if (count($_panelShips) > 12): ?>
+                    <span class="text-[10px] text-muted self-center">+<?= count($_panelShips) - 12 ?> more</span>
+                <?php endif; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>

--- a/public-proxy/partials/_battle_report_panel_merged.php
+++ b/public-proxy/partials/_battle_report_panel_merged.php
@@ -1,0 +1,86 @@
+<div class="coalition-panel rounded-lg overflow-hidden border <?= $_brp_border ?>">
+    <div class="<?= $_brp_header_bg ?> px-4 py-3 flex items-center justify-between border-b <?= $_brp_header_border ?>">
+        <h3 class="text-sm font-semibold <?= $_brp_text ?>"><?= $_brp_label ?><?= $_brp_header_extra ?></h3>
+        <span class="text-[10px] uppercase tracking-wider <?= $_brp_badge_bg ?> <?= $_brp_text ?> rounded-full px-1.5 py-0.5 ml-1"><?= $_brp_badge ?></span>
+    </div>
+    <div class="px-4 pt-3">
+        <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted"><?= $_brp_subtitle ?></p>
+    </div>
+
+    <div class="grid grid-cols-2 divide-x divide-y divide-white/5 border-b border-white/5 text-sm">
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">Unique Pilots</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($_brp_data['pilots'] ?? 0)) ?></p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">ISK Efficiency</p>
+            <p class="text-slate-100 font-semibold"><?= number_format(($_brp_data['efficiency'] ?? 0) * 100, 1) ?>%</p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">Final Blows / Losses</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($_brp_data['final_blows'] ?? 0)) ?> / <?= number_format((int) ($_brp_data['losses'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($_brp_data['kill_involvements'] ?? 0)) ?></p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">ISK Killed / Lost</p>
+            <p class="text-slate-100 font-semibold"><?= proxy_format_isk((float) ($_brp_data['isk_killed'] ?? 0)) ?> / <?= proxy_format_isk((float) ($_brp_data['isk_lost'] ?? 0)) ?></p>
+        </div>
+    </div>
+
+    <?php $_opAlliances = $_brp_data['alliances'] ?? []; ?>
+    <?php if ($_opAlliances): ?>
+        <div class="divide-y divide-white/5">
+            <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2"><?= $_brp_alliances_label ?></p>
+            <?php foreach ($_opAlliances as $allianceRow): ?>
+                <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
+                <div class="flex items-center gap-2.5 px-4 py-2">
+                    <?php if ($allianceId > 0): ?>
+                        <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php elseif ($corporationId > 0): ?>
+                        <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php endif; ?>
+                    <span class="text-xs text-slate-200 flex-1 truncate"><?= proxy_e((string) ($allianceRow['name'] ?? '')) ?></span>
+                    <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($_brp_tp_alliances)): ?>
+        <div class="divide-y divide-white/5 border-t border-slate-700/50">
+            <p class="text-[10px] uppercase tracking-wider text-slate-400 px-4 py-2">Third Party</p>
+            <?php foreach ($_brp_tp_alliances as $allianceRow): ?>
+                <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
+                <div class="flex items-center gap-2.5 px-4 py-2">
+                    <?php if ($allianceId > 0): ?>
+                        <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php elseif ($corporationId > 0): ?>
+                        <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php endif; ?>
+                    <span class="text-xs text-slate-400 flex-1 truncate"><?= proxy_e((string) ($allianceRow['name'] ?? '')) ?></span>
+                    <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php $_panelShips = $_brp_data['ships'] ?? []; ?>
+    <?php if ($_panelShips): ?>
+        <div class="mt-3 border-t border-slate-700/50 px-4 py-2">
+            <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
+            <div class="flex flex-wrap gap-2">
+                <?php foreach (array_slice($_panelShips, 0, 12) as $ship): ?>
+                    <div class="flex flex-col items-center gap-1 bg-slate-800/50 border border-white/6 rounded-md px-2 py-2 min-w-[72px]">
+                        <?php if (($ship['type_id'] ?? 0) > 0): ?>
+                            <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/render?size=64" alt="" class="w-12 h-12 object-contain" loading="lazy">
+                        <?php endif; ?>
+                        <span class="text-[11px] text-slate-300 text-center leading-tight max-w-[68px] truncate"><?= proxy_e((string) ($ship['name'] ?? '')) ?></span>
+                        <span class="text-[10px] text-slate-500 font-semibold">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>

--- a/public-proxy/partials/_header.php
+++ b/public-proxy/partials/_header.php
@@ -15,7 +15,9 @@
             <span class="text-[10px] uppercase tracking-wider bg-red-900/60 text-red-300 rounded-full px-1.5 py-0.5">Hostile</span>
             <?php $thirdPartyCount = count($sideAlliancesByPilots['third_party'] ?? []); ?>
             <?php if ($thirdPartyCount > 0): ?>
-                <span class="text-slate-400 text-sm">(+<?= $thirdPartyCount ?> unidentified)</span>
+                <span class="text-slate-500">vs</span>
+                <span class="text-amber-300 font-semibold"><?= proxy_e($sideLabels['third_party'] ?? 'Third Party') ?></span>
+                <span class="text-[10px] uppercase tracking-wider bg-amber-900/60 text-amber-300 rounded-full px-1.5 py-0.5">Third Party</span>
             <?php endif; ?>
         </div>
         <div class="mt-2 flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs text-muted">
@@ -23,6 +25,9 @@
             <span><?= proxy_e($theaterStartActual) ?> — <?= proxy_e($theaterEndActual) ?></span>
             <span>Friendly: <?= number_format(count($sideAlliancesByPilots['friendly'] ?? [])) ?> alliances</span>
             <span>Hostile: <?= number_format(count($sideAlliancesByPilots['opponent'] ?? [])) ?> alliances</span>
+            <?php if (count($sideAlliancesByPilots['third_party'] ?? []) > 0): ?>
+                <span>Third Party: <?= number_format(count($sideAlliancesByPilots['third_party'])) ?> alliances</span>
+            <?php endif; ?>
         </div>
     </div>
 

--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -117,7 +117,7 @@ if ($viewSnapshot !== null) {
         $sideAlliancesByPilots['opponent'] = $sideAlliancesByPilots['third_party'];
         $sideAlliancesByPilots['third_party'] = [];
     }
-    foreach (['friendly', 'opponent'] as $side) {
+    foreach (['friendly', 'opponent', 'third_party'] as $side) {
         $alliances = $sideAlliancesByPilots[$side];
         if ($alliances === []) continue;
         arsort($alliances);

--- a/public/theater-intelligence/partials/_battle_report.php
+++ b/public/theater-intelligence/partials/_battle_report.php
@@ -4,198 +4,140 @@
     $enemyPanel = $sidePanels['opponent'] ?? [];
     $thirdPartyPanel = $sidePanels['third_party'] ?? [];
 
-    // Merge third party into enemy side for the overview
-    $enemyCombinedIskLost = ($enemyPanel['isk_lost'] ?? 0) + ($thirdPartyPanel['isk_lost'] ?? 0);
-    $enemyCombinedIskKilled = ($enemyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_killed'] ?? 0);
-    $enemyCombinedPilots = ($enemyPanel['pilots'] ?? 0) + ($thirdPartyPanel['pilots'] ?? 0);
-    $enemyCombinedLosses = ($enemyPanel['losses'] ?? 0) + ($thirdPartyPanel['losses'] ?? 0);
-    $enemyCombinedTotalIsk = $enemyCombinedIskKilled + $enemyCombinedIskLost;
-    $enemyCombinedEfficiency = $enemyCombinedTotalIsk > 0 ? $enemyCombinedIskKilled / $enemyCombinedTotalIsk : 0.0;
+    $hasOpponent = ($enemyPanel['pilots'] ?? 0) > 0;
+    $hasThirdParty = ($thirdPartyPanel['pilots'] ?? 0) > 0;
+    $isThreeColumn = $hasOpponent && $hasThirdParty;
 
+    // Compute per-panel efficiency
+    $ourTotalIsk = ($ourPanel['isk_killed'] ?? 0) + ($ourPanel['isk_lost'] ?? 0);
+    $ourEfficiency = $ourTotalIsk > 0 ? ($ourPanel['isk_killed'] ?? 0) / $ourTotalIsk : 0.0;
+
+    $enemyTotalIsk = ($enemyPanel['isk_killed'] ?? 0) + ($enemyPanel['isk_lost'] ?? 0);
+    $enemyEfficiency = $enemyTotalIsk > 0 ? ($enemyPanel['isk_killed'] ?? 0) / $enemyTotalIsk : 0.0;
+
+    $tpTotalIsk = ($thirdPartyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_lost'] ?? 0);
+    $tpEfficiency = $tpTotalIsk > 0 ? ($thirdPartyPanel['isk_killed'] ?? 0) / $tpTotalIsk : 0.0;
+
+    // Efficiency bar: friendly ISK destroyed vs opponent+third_party ISK destroyed (how much each side lost)
+    $enemyCombinedIskLost = ($enemyPanel['isk_lost'] ?? 0) + ($thirdPartyPanel['isk_lost'] ?? 0);
     $totalIskBothSides = ($ourPanel['isk_lost'] ?? 0) + $enemyCombinedIskLost;
     $ourBarPct = $totalIskBothSides > 0 ? ($enemyCombinedIskLost / $totalIskBothSides) * 100 : 50;
-    $enemyBarPct = 100 - $ourBarPct;
+
+    if ($isThreeColumn) {
+        // 3-segment bar: friendly, opponent, third_party based on ISK destroyed (what they killed)
+        $totalIskDestAll = ($ourPanel['isk_killed'] ?? 0) + ($enemyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_killed'] ?? 0);
+        $ourBarPct = $totalIskDestAll > 0 ? (($ourPanel['isk_killed'] ?? 0) / $totalIskDestAll) * 100 : 33.3;
+        $enemyBarPct = $totalIskDestAll > 0 ? (($enemyPanel['isk_killed'] ?? 0) / $totalIskDestAll) * 100 : 33.3;
+        $tpBarPct = 100 - $ourBarPct - $enemyBarPct;
+    } else {
+        $enemyBarPct = 100 - $ourBarPct;
+        // When no opponent, the "enemy" panel is the promoted third party
+        $enemyEfficiency = $hasOpponent ? $enemyEfficiency : $tpEfficiency;
+    }
+
+    $gridCols = $isThreeColumn ? 'md:grid-cols-3' : 'md:grid-cols-2';
 ?>
 <section class="surface-primary mt-4">
     <!-- Efficiency Bar -->
     <div class="flex items-center gap-3 mb-3">
-        <span class="text-xs font-semibold text-blue-300"><?= number_format(($ourPanel['efficiency'] ?? 0) * 100, 1) ?>%</span>
+        <span class="text-xs font-semibold text-blue-300"><?= number_format($ourEfficiency * 100, 1) ?>%</span>
         <div class="flex-1 h-3 rounded-full overflow-hidden bg-slate-800 flex shadow-inner">
             <div class="bg-blue-500 h-full transition-all" style="width: <?= number_format($ourBarPct, 1) ?>%"></div>
             <div class="bg-red-500 h-full transition-all" style="width: <?= number_format($enemyBarPct, 1) ?>%"></div>
+            <?php if ($isThreeColumn): ?>
+                <div class="bg-amber-500 h-full transition-all" style="width: <?= number_format($tpBarPct, 1) ?>%"></div>
+            <?php endif; ?>
         </div>
-        <span class="text-xs font-semibold text-red-300"><?= number_format($enemyCombinedEfficiency * 100, 1) ?>%</span>
+        <?php if ($isThreeColumn): ?>
+            <span class="text-xs font-semibold text-red-300"><?= number_format($enemyEfficiency * 100, 1) ?>%</span>
+            <span class="text-xs font-semibold text-amber-300"><?= number_format($tpEfficiency * 100, 1) ?>%</span>
+        <?php else: ?>
+            <span class="text-xs font-semibold text-red-300"><?= number_format($enemyEfficiency * 100, 1) ?>%</span>
+        <?php endif; ?>
     </div>
 
-    <!-- Two-column side comparison -->
-    <div class="grid gap-4 md:grid-cols-2">
+    <!-- Dynamic column layout -->
+    <div class="grid gap-4 <?= $gridCols ?>">
         <!-- Friendly panel -->
-        <div class="coalition-panel rounded-lg overflow-hidden border border-blue-500/25">
-            <div class="bg-blue-900/40 px-4 py-3 flex items-center justify-between border-b border-blue-500/20">
-                <h3 class="text-sm font-semibold text-blue-300"><?= htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES) ?></h3>
-                <span class="text-[10px] uppercase tracking-wider bg-blue-900/60 text-blue-300 rounded-full px-1.5 py-0.5 ml-1">Friendly</span>
-            </div>
-            <div class="px-4 pt-3">
-            <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted">Friendly coalition overview</p>
-            </div>
+        <?php
+            $panelData = $ourPanel;
+            $panelLabel = htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES);
+            $panelBadge = 'Friendly';
+            $panelBorderColor = 'border-blue-500/25';
+            $panelHeaderBg = 'bg-blue-900/40';
+            $panelHeaderBorder = 'border-blue-500/20';
+            $panelTextColor = 'text-blue-300';
+            $panelBadgeBg = 'bg-blue-900/60';
+            $panelSubtitle = 'Friendly coalition overview';
+            $panelAlliancesLabel = 'Alliances';
+            $panelAllianceTextColor = 'text-slate-200';
+            $panelHeaderExtra = '';
+        ?>
+        <?php include __DIR__ . '/_battle_report_panel.php'; ?>
 
-            <div class="grid grid-cols-2 divide-x divide-y divide-white/5 border-b border-white/5 text-sm">
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">Unique Pilots</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format((int) ($ourPanel['pilots'] ?? 0)) ?></p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">ISK Efficiency</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format(($ourPanel['efficiency'] ?? 0) * 100, 1) ?>%</p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">Final Blows / Losses</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format((int) ($ourPanel['final_blows'] ?? 0)) ?> / <?= number_format((int) ($ourPanel['losses'] ?? 0)) ?></p>
-                    <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($ourPanel['kill_involvements'] ?? 0)) ?></p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">ISK Killed / Lost</p>
-                    <p class="text-slate-100 font-semibold"><?= supplycore_format_isk((float) ($ourPanel['isk_killed'] ?? 0)) ?> / <?= supplycore_format_isk((float) ($ourPanel['isk_lost'] ?? 0)) ?></p>
-                </div>
-            </div>
+        <!-- Opponent panel -->
+        <?php
+            $panelData = $enemyPanel;
+            $panelLabel = htmlspecialchars($sideLabels['opponent'] ?? 'Opposition', ENT_QUOTES);
+            $panelBadge = 'Hostile';
+            $panelBorderColor = 'border-red-500/25';
+            $panelHeaderBg = 'bg-red-900/40';
+            $panelHeaderBorder = 'border-red-500/20';
+            $panelTextColor = 'text-red-300';
+            $panelBadgeBg = 'bg-red-900/60';
+            $panelSubtitle = 'Opposition coalition overview';
+            $panelAlliancesLabel = 'Opponent Alliances';
+            $panelAllianceTextColor = 'text-slate-200';
+            if (!$isThreeColumn && $hasThirdParty) {
+                $panelHeaderExtra = '<span class="text-slate-400 text-xs font-normal ml-1">+ Third Party</span>';
+            } else {
+                $panelHeaderExtra = '';
+            }
+        ?>
+        <?php if (!$isThreeColumn): ?>
+            <?php
+                // Merge third party into opponent for 2-column display
+                $panelData = [
+                    'pilots' => ($enemyPanel['pilots'] ?? 0) + ($thirdPartyPanel['pilots'] ?? 0),
+                    'efficiency' => $enemyEfficiency,
+                    'final_blows' => ($enemyPanel['final_blows'] ?? 0) + ($thirdPartyPanel['final_blows'] ?? 0),
+                    'losses' => ($enemyPanel['losses'] ?? 0) + ($thirdPartyPanel['losses'] ?? 0),
+                    'kill_involvements' => ($enemyPanel['kill_involvements'] ?? 0) + ($thirdPartyPanel['kill_involvements'] ?? 0),
+                    'isk_killed' => ($enemyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_killed'] ?? 0),
+                    'isk_lost' => ($enemyPanel['isk_lost'] ?? 0) + ($thirdPartyPanel['isk_lost'] ?? 0),
+                    'alliances' => $enemyPanel['alliances'] ?? [],
+                    'ships' => (static function() use ($enemyPanel, $thirdPartyPanel) {
+                        $merged = array_merge($enemyPanel['ships'] ?? [], $thirdPartyPanel['ships'] ?? []);
+                        usort($merged, static fn(array $l, array $r): int => ($r['pilots'] ?? 0) <=> ($l['pilots'] ?? 0));
+                        return array_slice($merged, 0, 12);
+                    })(),
+                ];
+                // Show third party alliances as a sub-section
+                $panelThirdPartyAlliances = $thirdPartyPanel['alliances'] ?? [];
+            ?>
+            <?php include __DIR__ . '/_battle_report_panel_merged.php'; ?>
+        <?php else: ?>
+            <?php include __DIR__ . '/_battle_report_panel.php'; ?>
+        <?php endif; ?>
 
-            <?php $panelAlliances = $ourPanel['alliances'] ?? []; ?>
-            <?php if ($panelAlliances): ?>
-                <div class="divide-y divide-white/5">
-                    <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2">Alliances</p>
-                    <?php foreach ($panelAlliances as $allianceRow): ?>
-                        <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
-                        <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
-                        <div class="flex items-center gap-2.5 px-4 py-2">
-                            <?php if ($allianceId > 0): ?>
-                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php elseif ($corporationId > 0): ?>
-                                <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php endif; ?>
-                            <span class="text-xs text-slate-200 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
-                            <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-
-            <?php $panelShips = $ourPanel['ships'] ?? []; ?>
-            <?php if ($panelShips): ?>
-                <div class="mt-3 border-t border-slate-700/50 px-4 py-2">
-                    <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
-                    <div class="flex flex-wrap gap-2">
-                        <?php foreach (array_slice($panelShips, 0, 12) as $ship): ?>
-                            <div class="flex flex-col items-center gap-1 bg-slate-800/50 border border-white/6 rounded-md px-2 py-2 min-w-[72px]">
-                                <?php if (($ship['type_id'] ?? 0) > 0): ?>
-                                    <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/render?size=64" alt="" class="w-12 h-12 object-contain" loading="lazy">
-                                <?php endif; ?>
-                                <span class="text-[11px] text-slate-300 text-center leading-tight max-w-[68px] truncate"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
-                                <span class="text-[10px] text-slate-500 font-semibold">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
-                            </div>
-                        <?php endforeach; ?>
-                        <?php if (count($panelShips) > 12): ?>
-                            <span class="text-[10px] text-muted self-center">+<?= count($panelShips) - 12 ?> more</span>
-                        <?php endif; ?>
-                    </div>
-                </div>
-            <?php endif; ?>
-        </div>
-
-        <!-- Opposition + Third Party panel -->
-        <div class="coalition-panel rounded-lg overflow-hidden border border-red-500/25">
-            <div class="bg-red-900/40 px-4 py-3 flex items-center justify-between border-b border-red-500/20">
-                <h3 class="text-sm font-semibold text-red-300">
-                    <?= htmlspecialchars($sideLabels['opponent'] ?? 'Opposition', ENT_QUOTES) ?>
-                    <?php if (($thirdPartyPanel['pilots'] ?? 0) > 0): ?>
-                        <span class="text-slate-400 text-xs font-normal ml-1">+ Third Party</span>
-                    <?php endif; ?>
-                </h3>
-                <span class="text-[10px] uppercase tracking-wider bg-red-900/60 text-red-300 rounded-full px-1.5 py-0.5 ml-1">Hostile</span>
-            </div>
-            <div class="px-4 pt-3">
-            <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted">Opposition coalition overview</p>
-            </div>
-
-            <div class="grid grid-cols-2 divide-x divide-y divide-white/5 border-b border-white/5 text-sm">
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">Unique Pilots</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format($enemyCombinedPilots) ?></p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">ISK Efficiency</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format($enemyCombinedEfficiency * 100, 1) ?>%</p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">Final Blows / Losses</p>
-                    <p class="text-slate-100 font-semibold"><?= number_format((int) ($enemyPanel['final_blows'] ?? 0) + (int) ($thirdPartyPanel['final_blows'] ?? 0)) ?> / <?= number_format($enemyCombinedLosses) ?></p>
-                    <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($enemyPanel['kill_involvements'] ?? 0) + (int) ($thirdPartyPanel['kill_involvements'] ?? 0)) ?></p>
-                </div>
-                <div class="px-4 py-3">
-                    <p class="text-xs text-muted">ISK Killed / Lost</p>
-                    <p class="text-slate-100 font-semibold"><?= supplycore_format_isk($enemyCombinedIskKilled) ?> / <?= supplycore_format_isk($enemyCombinedIskLost) ?></p>
-                </div>
-            </div>
-
-            <?php $opponentAlliances = $enemyPanel['alliances'] ?? []; ?>
-            <?php if ($opponentAlliances): ?>
-                <div class="divide-y divide-white/5">
-                    <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2">Opponent Alliances</p>
-                    <?php foreach ($opponentAlliances as $allianceRow): ?>
-                        <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
-                        <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
-                        <div class="flex items-center gap-2.5 px-4 py-2">
-                            <?php if ($allianceId > 0): ?>
-                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php elseif ($corporationId > 0): ?>
-                                <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php endif; ?>
-                            <span class="text-xs text-slate-200 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
-                            <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-
-            <?php $tpAlliances = $thirdPartyPanel['alliances'] ?? []; ?>
-            <?php if ($tpAlliances): ?>
-                <div class="divide-y divide-white/5 border-t border-slate-700/50">
-                    <p class="text-[10px] uppercase tracking-wider text-slate-400 px-4 py-2">Third Party</p>
-                    <?php foreach ($tpAlliances as $allianceRow): ?>
-                        <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
-                        <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
-                        <div class="flex items-center gap-2.5 px-4 py-2">
-                            <?php if ($allianceId > 0): ?>
-                                <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php elseif ($corporationId > 0): ?>
-                                <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
-                            <?php endif; ?>
-                            <span class="text-xs text-slate-400 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
-                            <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-
-            <?php $panelShips = array_merge($enemyPanel['ships'] ?? [], $thirdPartyPanel['ships'] ?? []); ?>
-            <?php usort($panelShips, static fn(array $l, array $r): int => ($r['pilots'] ?? 0) <=> ($l['pilots'] ?? 0)); ?>
-            <?php $panelShips = array_slice($panelShips, 0, 12); ?>
-            <?php if ($panelShips): ?>
-                <div class="mt-3 border-t border-slate-700/50 px-4 py-2">
-                    <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
-                    <div class="flex flex-wrap gap-2">
-                        <?php foreach ($panelShips as $ship): ?>
-                            <div class="flex flex-col items-center gap-1 bg-slate-800/50 border border-white/6 rounded-md px-2 py-2 min-w-[72px]">
-                                <?php if (($ship['type_id'] ?? 0) > 0): ?>
-                                    <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/render?size=64" alt="" class="w-12 h-12 object-contain" loading="lazy">
-                                <?php endif; ?>
-                                <span class="text-[11px] text-slate-300 text-center leading-tight max-w-[68px] truncate"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
-                                <span class="text-[10px] text-slate-500 font-semibold">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
-                            </div>
-                        <?php endforeach; ?>
-                    </div>
-                </div>
-            <?php endif; ?>
-        </div>
+        <?php if ($isThreeColumn): ?>
+            <!-- Third Party panel -->
+            <?php
+                $panelData = $thirdPartyPanel;
+                $panelLabel = htmlspecialchars($sideLabels['third_party'] ?? 'Third Party', ENT_QUOTES);
+                $panelBadge = 'Third Party';
+                $panelBorderColor = 'border-amber-500/25';
+                $panelHeaderBg = 'bg-amber-900/40';
+                $panelHeaderBorder = 'border-amber-500/20';
+                $panelTextColor = 'text-amber-300';
+                $panelBadgeBg = 'bg-amber-900/60';
+                $panelSubtitle = 'Third party overview';
+                $panelAlliancesLabel = 'Alliances';
+                $panelAllianceTextColor = 'text-slate-200';
+                $panelHeaderExtra = '';
+            ?>
+            <?php include __DIR__ . '/_battle_report_panel.php'; ?>
+        <?php endif; ?>
     </div>
 
     <?php if ($dataQualityNotes !== []): ?>

--- a/public/theater-intelligence/partials/_battle_report_panel.php
+++ b/public/theater-intelligence/partials/_battle_report_panel.php
@@ -1,0 +1,70 @@
+<div class="coalition-panel rounded-lg overflow-hidden border <?= $panelBorderColor ?>">
+    <div class="<?= $panelHeaderBg ?> px-4 py-3 flex items-center justify-between border-b <?= $panelHeaderBorder ?>">
+        <h3 class="text-sm font-semibold <?= $panelTextColor ?>"><?= $panelLabel ?><?= $panelHeaderExtra ?></h3>
+        <span class="text-[10px] uppercase tracking-wider <?= $panelBadgeBg ?> <?= $panelTextColor ?> rounded-full px-1.5 py-0.5 ml-1"><?= $panelBadge ?></span>
+    </div>
+    <div class="px-4 pt-3">
+        <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted"><?= $panelSubtitle ?></p>
+    </div>
+
+    <div class="grid grid-cols-2 divide-x divide-y divide-white/5 border-b border-white/5 text-sm">
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">Unique Pilots</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($panelData['pilots'] ?? 0)) ?></p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">ISK Efficiency</p>
+            <p class="text-slate-100 font-semibold"><?= number_format(($panelData['efficiency'] ?? 0) * 100, 1) ?>%</p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">Final Blows / Losses</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($panelData['final_blows'] ?? 0)) ?> / <?= number_format((int) ($panelData['losses'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($panelData['kill_involvements'] ?? 0)) ?></p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">ISK Killed / Lost</p>
+            <p class="text-slate-100 font-semibold"><?= supplycore_format_isk((float) ($panelData['isk_killed'] ?? 0)) ?> / <?= supplycore_format_isk((float) ($panelData['isk_lost'] ?? 0)) ?></p>
+        </div>
+    </div>
+
+    <?php $_panelAlliances = $panelData['alliances'] ?? []; ?>
+    <?php if ($_panelAlliances): ?>
+        <div class="divide-y divide-white/5">
+            <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2"><?= $panelAlliancesLabel ?></p>
+            <?php foreach ($_panelAlliances as $allianceRow): ?>
+                <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
+                <div class="flex items-center gap-2.5 px-4 py-2">
+                    <?php if ($allianceId > 0): ?>
+                        <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php elseif ($corporationId > 0): ?>
+                        <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php endif; ?>
+                    <span class="text-xs <?= $panelAllianceTextColor ?> flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
+                    <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php $_panelShips = $panelData['ships'] ?? []; ?>
+    <?php if ($_panelShips): ?>
+        <div class="mt-3 border-t border-slate-700/50 px-4 py-2">
+            <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
+            <div class="flex flex-wrap gap-2">
+                <?php foreach (array_slice($_panelShips, 0, 12) as $ship): ?>
+                    <div class="flex flex-col items-center gap-1 bg-slate-800/50 border border-white/6 rounded-md px-2 py-2 min-w-[72px]">
+                        <?php if (($ship['type_id'] ?? 0) > 0): ?>
+                            <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/render?size=64" alt="" class="w-12 h-12 object-contain" loading="lazy">
+                        <?php endif; ?>
+                        <span class="text-[11px] text-slate-300 text-center leading-tight max-w-[68px] truncate"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
+                        <span class="text-[10px] text-slate-500 font-semibold">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
+                    </div>
+                <?php endforeach; ?>
+                <?php if (count($_panelShips) > 12): ?>
+                    <span class="text-[10px] text-muted self-center">+<?= count($_panelShips) - 12 ?> more</span>
+                <?php endif; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>

--- a/public/theater-intelligence/partials/_battle_report_panel_merged.php
+++ b/public/theater-intelligence/partials/_battle_report_panel_merged.php
@@ -1,0 +1,86 @@
+<div class="coalition-panel rounded-lg overflow-hidden border <?= $panelBorderColor ?>">
+    <div class="<?= $panelHeaderBg ?> px-4 py-3 flex items-center justify-between border-b <?= $panelHeaderBorder ?>">
+        <h3 class="text-sm font-semibold <?= $panelTextColor ?>"><?= $panelLabel ?><?= $panelHeaderExtra ?></h3>
+        <span class="text-[10px] uppercase tracking-wider <?= $panelBadgeBg ?> <?= $panelTextColor ?> rounded-full px-1.5 py-0.5 ml-1"><?= $panelBadge ?></span>
+    </div>
+    <div class="px-4 pt-3">
+        <p class="mb-3 text-[11px] uppercase tracking-[0.08em] text-muted"><?= $panelSubtitle ?></p>
+    </div>
+
+    <div class="grid grid-cols-2 divide-x divide-y divide-white/5 border-b border-white/5 text-sm">
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">Unique Pilots</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($panelData['pilots'] ?? 0)) ?></p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">ISK Efficiency</p>
+            <p class="text-slate-100 font-semibold"><?= number_format(($panelData['efficiency'] ?? 0) * 100, 1) ?>%</p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">Final Blows / Losses</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($panelData['final_blows'] ?? 0)) ?> / <?= number_format((int) ($panelData['losses'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($panelData['kill_involvements'] ?? 0)) ?></p>
+        </div>
+        <div class="px-4 py-3">
+            <p class="text-xs text-muted">ISK Killed / Lost</p>
+            <p class="text-slate-100 font-semibold"><?= supplycore_format_isk((float) ($panelData['isk_killed'] ?? 0)) ?> / <?= supplycore_format_isk((float) ($panelData['isk_lost'] ?? 0)) ?></p>
+        </div>
+    </div>
+
+    <?php $_opAlliances = $panelData['alliances'] ?? []; ?>
+    <?php if ($_opAlliances): ?>
+        <div class="divide-y divide-white/5">
+            <p class="text-[10px] uppercase tracking-wider text-muted px-4 py-2"><?= $panelAlliancesLabel ?></p>
+            <?php foreach ($_opAlliances as $allianceRow): ?>
+                <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
+                <div class="flex items-center gap-2.5 px-4 py-2">
+                    <?php if ($allianceId > 0): ?>
+                        <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php elseif ($corporationId > 0): ?>
+                        <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php endif; ?>
+                    <span class="text-xs text-slate-200 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
+                    <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($panelThirdPartyAlliances)): ?>
+        <div class="divide-y divide-white/5 border-t border-slate-700/50">
+            <p class="text-[10px] uppercase tracking-wider text-slate-400 px-4 py-2">Third Party</p>
+            <?php foreach ($panelThirdPartyAlliances as $allianceRow): ?>
+                <?php $allianceId = (int) ($allianceRow['alliance_id'] ?? 0); ?>
+                <?php $corporationId = (int) ($allianceRow['corporation_id'] ?? 0); ?>
+                <div class="flex items-center gap-2.5 px-4 py-2">
+                    <?php if ($allianceId > 0): ?>
+                        <img src="https://images.evetech.net/alliances/<?= $allianceId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php elseif ($corporationId > 0): ?>
+                        <img src="https://images.evetech.net/corporations/<?= $corporationId ?>/logo?size=64" alt="" class="w-5 h-5 rounded-sm" loading="lazy">
+                    <?php endif; ?>
+                    <span class="text-xs text-slate-400 flex-1 truncate"><?= htmlspecialchars((string) ($allianceRow['name'] ?? ''), ENT_QUOTES) ?></span>
+                    <span class="text-xs text-muted"><?= number_format((int) ($allianceRow['pilots'] ?? 0)) ?> pilots</span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php $_panelShips = $panelData['ships'] ?? []; ?>
+    <?php if ($_panelShips): ?>
+        <div class="mt-3 border-t border-slate-700/50 px-4 py-2">
+            <p class="text-[10px] uppercase tracking-wider text-muted mb-1">Top Hulls (by appearances)</p>
+            <div class="flex flex-wrap gap-2">
+                <?php foreach (array_slice($_panelShips, 0, 12) as $ship): ?>
+                    <div class="flex flex-col items-center gap-1 bg-slate-800/50 border border-white/6 rounded-md px-2 py-2 min-w-[72px]">
+                        <?php if (($ship['type_id'] ?? 0) > 0): ?>
+                            <img src="https://images.evetech.net/types/<?= (int) $ship['type_id'] ?>/render?size=64" alt="" class="w-12 h-12 object-contain" loading="lazy">
+                        <?php endif; ?>
+                        <span class="text-[11px] text-slate-300 text-center leading-tight max-w-[68px] truncate"><?= htmlspecialchars((string) ($ship['name'] ?? ''), ENT_QUOTES) ?></span>
+                        <span class="text-[10px] text-slate-500 font-semibold">x<?= (int) ($ship['pilots'] ?? 0) ?></span>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>

--- a/public/theater-intelligence/partials/_header.php
+++ b/public/theater-intelligence/partials/_header.php
@@ -29,7 +29,9 @@
                 <span class="text-[10px] uppercase tracking-wider bg-red-900/60 text-red-300 rounded-full px-1.5 py-0.5">Hostile</span>
                 <?php $thirdPartyCount = count($sideAlliancesByPilots['third_party'] ?? []); ?>
                 <?php if ($thirdPartyCount > 0): ?>
-                    <span class="text-slate-400 text-sm">(+<?= $thirdPartyCount ?> unidentified)</span>
+                    <span class="text-slate-500">vs</span>
+                    <span class="text-amber-300 font-semibold"><?= htmlspecialchars($sideLabels['third_party'] ?? 'Third Party', ENT_QUOTES) ?></span>
+                    <span class="text-[10px] uppercase tracking-wider bg-amber-900/60 text-amber-300 rounded-full px-1.5 py-0.5">Third Party</span>
                 <?php endif; ?>
             </div>
             <div class="mt-2 flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs text-muted">
@@ -37,6 +39,9 @@
                 <span><?= htmlspecialchars($theaterStartActual, ENT_QUOTES) ?> — <?= htmlspecialchars($theaterEndActual, ENT_QUOTES) ?></span>
                 <span>Friendly: <?= number_format(count($sideAlliancesByPilots['friendly'] ?? [])) ?> alliances</span>
                 <span>Hostile: <?= number_format(count($sideAlliancesByPilots['opponent'] ?? [])) ?> alliances</span>
+                <?php if (count($sideAlliancesByPilots['third_party'] ?? []) > 0): ?>
+                    <span>Third Party: <?= number_format(count($sideAlliancesByPilots['third_party'])) ?> alliances</span>
+                <?php endif; ?>
             </div>
         </div>
         <?php include __DIR__ . '/_system_overview_map.php'; ?>

--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -424,7 +424,7 @@ function _render_structure_row(array $sk, array $resolvedEntities, array $shipTy
             <a href="?theater_id=<?= urlencode($theaterId) ?>" class="<?= $sideFilter === null && !$suspiciousOnly ? 'text-slate-50 font-semibold' : 'text-accent' ?>">All</a>
             <a href="?theater_id=<?= urlencode($theaterId) ?>&side=friendly" class="<?= $sideFilter === 'friendly' ? 'text-blue-300 font-semibold' : 'text-accent' ?>"><?= htmlspecialchars($sideLabels['friendly'] ?? 'Friendlies', ENT_QUOTES) ?></a>
             <a href="?theater_id=<?= urlencode($theaterId) ?>&side=opponent" class="<?= $sideFilter === 'opponent' ? 'text-red-300 font-semibold' : 'text-accent' ?>"><?= htmlspecialchars($sideLabels['opponent'] ?? 'Opposition', ENT_QUOTES) ?></a>
-            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=third_party" class="<?= $sideFilter === 'third_party' ? 'text-slate-400 font-semibold' : 'text-accent' ?>">Third Party</a>
+            <a href="?theater_id=<?= urlencode($theaterId) ?>&side=third_party" class="<?= $sideFilter === 'third_party' ? 'text-amber-300 font-semibold' : 'text-accent' ?>"><?= htmlspecialchars($sideLabels['third_party'] ?? 'Third Party', ENT_QUOTES) ?></a>
             <a href="?theater_id=<?= urlencode($theaterId) ?>&suspicious=1" class="<?= $suspiciousOnly ? 'text-yellow-300 font-semibold' : 'text-accent' ?>">Suspicious</a>
         </div>
     </div>

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -244,7 +244,7 @@ if ($viewSnapshot !== null && !$pendingLock) {
     }
 
     // Generate smart opponent labels supporting multiple hostile alliances
-    foreach (['friendly', 'opponent'] as $side) {
+    foreach (['friendly', 'opponent', 'third_party'] as $side) {
         $alliances = $sideAlliancesByPilots[$side];
         if ($alliances === []) {
             continue;


### PR DESCRIPTION
## Summary
Refactored the battle report display to dynamically support both 2-column and 3-column layouts based on whether third-party participants are present. When both opponent and third-party sides exist, they are displayed as separate columns with individual efficiency metrics. When only one hostile side exists, they are merged into a single column with combined statistics.

## Key Changes

- **Dynamic Layout Logic**: Added detection for opponent and third-party presence (`$hasOpponent`, `$hasThirdParty`, `$isThreeColumn`) to determine grid layout (2 or 3 columns)

- **Per-Panel Efficiency Calculation**: Changed from combined efficiency metrics to individual efficiency calculations for friendly, opponent, and third-party panels, allowing each side to display their own ISK efficiency independently

- **Efficiency Bar Visualization**: 
  - 2-column mode: Shows friendly vs combined hostile ISK lost (original behavior)
  - 3-column mode: Shows ISK destroyed by each side (friendly, opponent, third-party) with amber color for third party

- **Component Extraction**: Extracted repetitive panel markup into reusable partials:
  - `_battle_report_panel.php`: Standard single-side panel template
  - `_battle_report_panel_merged.php`: Merged panel template for combining opponent + third-party with separate alliance sections

- **Conditional Panel Rendering**: Opponent panel now conditionally uses merged template (2-column) or standard template (3-column), with third-party alliances displayed as a separate subsection when merged

- **Applied to Both Codebases**: Changes implemented consistently in both `public/theater-intelligence` and `public-proxy` directories

## Implementation Details

- Efficiency calculations now use `isk_killed / (isk_killed + isk_lost)` per panel instead of combined metrics
- Third-party alliances are visually distinguished with slate-400 text color when displayed in merged view
- Grid layout dynamically switches between `md:grid-cols-2` and `md:grid-cols-3` based on presence of both hostile sides
- Maintains backward compatibility: single hostile side displays identically to previous behavior

https://claude.ai/code/session_01D9MQ3VeCDiyMb8jT6apMM7