### PR TITLE
Reclassify final blows using PHP closure for consistency

### DIFF
--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -181,7 +181,12 @@ if ($viewSnapshot !== null) {
         if (isset($participantKillTotalsBySide[$side])) $participantKillTotalsBySide[$side] += $kills;
     }
 
-    $finalBlowsBySide = db_theater_final_blows_by_side($theaterId);
+    $finalBlowsByGroup = db_theater_final_blows_by_attacker_group($theaterId);
+    $finalBlowsBySide = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
+    foreach ($finalBlowsByGroup as $fbRow) {
+        $fbSide = $classifyAlliance((int) ($fbRow['alliance_id'] ?? 0), (int) ($fbRow['corporation_id'] ?? 0));
+        $finalBlowsBySide[$fbSide] += (int) ($fbRow['final_blows'] ?? 0);
+    }
     foreach ($sidePanels as $side => $data) {
         $sidePanels[$side]['final_blows'] = (int) ($finalBlowsBySide[$side] ?? 0);
         $sidePanels[$side]['kill_involvements'] = (int) ($participantKillTotalsBySide[$side] ?? 0);
@@ -287,13 +292,18 @@ if ($viewSnapshot !== null) {
 
 // ── Post-processing (applies to both paths) ──
 
-// Final-blows fallback
-if (($sidePanels['friendly']['final_blows'] ?? 0) === 0 && ($sidePanels['opponent']['final_blows'] ?? 0) === 0) {
-    $derivedFriendlyFb = ($sidePanels['opponent']['losses'] ?? 0) + ($sidePanels['third_party']['losses'] ?? 0);
-    $derivedOpponentFb = $sidePanels['friendly']['losses'] ?? 0;
-    if ($derivedFriendlyFb > 0 || $derivedOpponentFb > 0) {
-        $sidePanels['friendly']['final_blows'] = $derivedFriendlyFb;
-        $sidePanels['opponent']['final_blows'] = $derivedOpponentFb;
+// Final-blows correction: classify using PHP closure for consistency
+$fbByGroup = db_theater_final_blows_by_attacker_group($theaterId);
+if ($fbByGroup !== []) {
+    $correctedFb = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
+    foreach ($fbByGroup as $fbRow) {
+        $fbSide = $classifyAlliance((int) ($fbRow['alliance_id'] ?? 0), (int) ($fbRow['corporation_id'] ?? 0));
+        $correctedFb[$fbSide] += (int) ($fbRow['final_blows'] ?? 0);
+    }
+    foreach (['friendly', 'opponent', 'third_party'] as $side) {
+        if (isset($sidePanels[$side])) {
+            $sidePanels[$side]['final_blows'] = $correctedFb[$side];
+        }
     }
 }
 

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -406,7 +406,12 @@ if ($viewSnapshot !== null && !$pendingLock) {
             'pilots' => (int) ($a['participant_count'] ?? 0),
         ];
     }
-    $finalBlowsBySide = db_theater_final_blows_by_side($theaterId);
+    $finalBlowsByGroup = db_theater_final_blows_by_attacker_group($theaterId);
+    $finalBlowsBySide = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
+    foreach ($finalBlowsByGroup as $fbRow) {
+        $fbSide = $classifyAlliance((int) ($fbRow['alliance_id'] ?? 0), (int) ($fbRow['corporation_id'] ?? 0));
+        $finalBlowsBySide[$fbSide] += (int) ($fbRow['final_blows'] ?? 0);
+    }
     foreach ($sidePanels as $side => $data) {
         $sidePanels[$side]['final_blows'] = (int) ($finalBlowsBySide[$side] ?? 0);
         $sidePanels[$side]['kill_involvements'] = (int) ($participantKillTotalsBySide[$side] ?? 0);
@@ -575,18 +580,21 @@ if ($viewSnapshot !== null && !$pendingLock) {
     }
 }
 
-// ── Final-blows fallback for snapshots with stale (zero) timeline data ───────
-// When both sides show 0 final blows but losses exist, derive from opponent losses:
-// every ship loss has exactly one final-blow attacker on the other side.
-if (
-    ($sidePanels['friendly']['final_blows'] ?? 0) === 0
-    && ($sidePanels['opponent']['final_blows'] ?? 0) === 0
-) {
-    $derivedFriendlyFb = ($sidePanels['opponent']['losses'] ?? 0) + ($sidePanels['third_party']['losses'] ?? 0);
-    $derivedOpponentFb = $sidePanels['friendly']['losses'] ?? 0;
-    if ($derivedFriendlyFb > 0 || $derivedOpponentFb > 0) {
-        $sidePanels['friendly']['final_blows'] = $derivedFriendlyFb;
-        $sidePanels['opponent']['final_blows'] = $derivedOpponentFb;
+// ── Final-blows correction: classify using PHP closure for consistency ────────
+// The Python job may classify sides via graph inference, but PHP uses explicit
+// tracked/opponent config.  Re-derive final blows from killmail_attackers
+// so they match the same classification used for kills and losses.
+$fbByGroup = db_theater_final_blows_by_attacker_group($theaterId);
+if ($fbByGroup !== []) {
+    $correctedFb = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
+    foreach ($fbByGroup as $fbRow) {
+        $fbSide = $classifyAlliance((int) ($fbRow['alliance_id'] ?? 0), (int) ($fbRow['corporation_id'] ?? 0));
+        $correctedFb[$fbSide] += (int) ($fbRow['final_blows'] ?? 0);
+    }
+    foreach (['friendly', 'opponent', 'third_party'] as $side) {
+        if (isset($sidePanels[$side])) {
+            $sidePanels[$side]['final_blows'] = $correctedFb[$side];
+        }
     }
 }
 

--- a/src/db.php
+++ b/src/db.php
@@ -16389,37 +16389,31 @@ function db_theater_fleet_composition(string $theaterId): array
     );
 }
 
-function db_theater_final_blows_by_side(string $theaterId): array
+/**
+ * Count final blows per attacker alliance/corporation for a theater.
+ *
+ * Returns raw per-group counts so the caller can classify sides consistently
+ * using the same closure as kills/losses (avoids mismatch with Python's
+ * graph-inferred side stored in theater_alliance_summary).
+ *
+ * @return list<array{alliance_id: int, corporation_id: int, final_blows: int}>
+ */
+function db_theater_final_blows_by_attacker_group(string $theaterId): array
 {
-    $rows = db_select(
+    return db_select(
         "SELECT
-            CASE
-                WHEN tas.side = 'friendly' THEN 'friendly'
-                WHEN tas.side = 'opponent' THEN 'opponent'
-                ELSE 'third_party'
-            END AS side,
+            COALESCE(ka.alliance_id, 0) AS alliance_id,
+            COALESCE(ka.corporation_id, 0) AS corporation_id,
             COUNT(*) AS final_blows
          FROM killmail_attackers ka
          INNER JOIN killmail_events ke ON ke.sequence_id = ka.sequence_id
          INNER JOIN theater_battles tb ON tb.battle_id = ke.battle_id
-         LEFT JOIN theater_alliance_summary tas
-              ON tas.theater_id = tb.theater_id
-              AND tas.alliance_id = COALESCE(ka.alliance_id, 0)
-              AND tas.corporation_id = CASE WHEN COALESCE(ka.alliance_id, 0) > 0 THEN 0 ELSE COALESCE(ka.corporation_id, 0) END
          WHERE tb.theater_id = ?
            AND ka.final_blow = 1
            AND (ka.character_id IS NULL OR ka.character_id != ke.victim_character_id)
-         GROUP BY side",
+         GROUP BY COALESCE(ka.alliance_id, 0), COALESCE(ka.corporation_id, 0)",
         [$theaterId]
     );
-    $result = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
-    foreach ($rows as $row) {
-        $side = (string) ($row['side'] ?? 'third_party');
-        if (isset($result[$side])) {
-            $result[$side] = (int) ($row['final_blows'] ?? 0);
-        }
-    }
-    return $result;
 }
 
 /**


### PR DESCRIPTION
## Summary
Refactored final blow classification to use the same PHP closure (`$classifyAlliance`) that is used for kills and losses, ensuring consistent side assignment across all metrics. Previously, final blows were classified via the Python-inferred `theater_alliance_summary.side` column, which could diverge from PHP's explicit tracked/opponent configuration.

## Key Changes
- **Database function refactor**: Renamed `db_theater_final_blows_by_side()` to `db_theater_final_blows_by_attacker_group()` to return raw per-group counts (alliance_id, corporation_id, final_blows) instead of pre-classified sides
- **Removed JOIN to theater_alliance_summary**: The query no longer relies on Python's graph-inferred side classification, eliminating the source of inconsistency
- **Consistent classification**: Both `public/theater-intelligence/view.php` and `public/api/public/theater.php` now classify final blows using the same `$classifyAlliance` closure applied to kills and losses
- **Replaced fallback logic**: Removed the zero-final-blows derivation fallback and replaced it with a correction step that always reclassifies final blows for consistency

## Implementation Details
- The new `db_theater_final_blows_by_attacker_group()` function groups by `COALESCE(ka.alliance_id, 0)` and `COALESCE(ka.corporation_id, 0)` to provide raw attacker group data
- Classification happens in PHP after data retrieval, allowing the same business logic to apply uniformly across all three metrics (kills, losses, final blows)
- The correction step runs unconditionally when final blow data exists, ensuring final blows always match the PHP-side classification scheme

https://claude.ai/code/session_01PrNtpuwrzqL2WWPCmcUipb