### PR TITLE
Fix ship summary query to properly join item groups and market groups

### DIFF
--- a/python/orchestrator/jobs/compute_alliance_dossiers.py
+++ b/python/orchestrator/jobs/compute_alliance_dossiers.py
@@ -210,12 +210,14 @@ def _load_ship_summary(db: SupplyCoreDb, alliance_id: int) -> dict[str, Any]:
         """
         SELECT ka.ship_type_id,
                COALESCE(rit.type_name, CONCAT('Type #', ka.ship_type_id)) AS ship_name,
-               COALESCE(rit.group_name, '') AS group_name,
-               COALESCE(rit.market_group_name, '') AS market_group_name,
+               COALESCE(rig.group_name, '') AS group_name,
+               COALESCE(rmg.market_group_name, '') AS market_group_name,
                COUNT(*) AS usage_count
         FROM killmail_attackers ka
         INNER JOIN killmail_events ke ON ke.sequence_id = ka.sequence_id
         LEFT JOIN ref_item_types rit ON rit.type_id = ka.ship_type_id
+        LEFT JOIN ref_item_groups rig ON rig.group_id = rit.group_id
+        LEFT JOIN ref_market_groups rmg ON rmg.market_group_id = rit.market_group_id
         WHERE ka.alliance_id = %s
           AND ka.ship_type_id IS NOT NULL AND ka.ship_type_id > 0
           AND ke.zkb_npc = 0


### PR DESCRIPTION
## Summary
Fixed a SQL query bug in the ship summary loading function where group and market group names were being incorrectly referenced from the item types table instead of their respective lookup tables.

## Key Changes
- Corrected table aliases in the SELECT clause:
  - Changed `rit.group_name` to `rig.group_name` to reference the ref_item_groups table
  - Changed `rit.market_group_name` to `rmg.market_group_name` to reference the ref_market_groups table
- Added missing LEFT JOINs to properly fetch the group and market group data:
  - `LEFT JOIN ref_item_groups rig ON rig.group_id = rit.group_id`
  - `LEFT JOIN ref_market_groups rmg ON rmg.market_group_id = rit.market_group_id`

## Implementation Details
The original query was attempting to select `group_name` and `market_group_name` directly from the `ref_item_types` table (aliased as `rit`), but these columns don't exist there. The fix properly joins the related reference tables and uses the correct table aliases to retrieve the group and market group information.

https://claude.ai/code/session_01HagdiNnR2VqvE6oYgnmoMJ