### PR TITLE
Add coalition name customization for battle reports

### DIFF
--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -131,6 +131,18 @@ if ($viewSnapshot !== null) {
         $sideLabels[$side] = $preferredName . ($otherCount > 0 ? " +{$otherCount}" : '');
     }
 
+    // Override side labels with coalition names when configured
+    $friendlyCoalitionName = trim((string) db_app_setting_get('friendly_coalition_name', ''));
+    $opponentCoalitionName = trim((string) db_app_setting_get('opponent_coalition_name', ''));
+    if ($friendlyCoalitionName !== '' && $sideAlliancesByPilots['friendly'] !== []) {
+        $otherCount = count($sideAlliancesByPilots['friendly']) - 1;
+        $sideLabels['friendly'] = $friendlyCoalitionName . ($otherCount > 0 ? " +{$otherCount}" : '');
+    }
+    if ($opponentCoalitionName !== '' && $sideAlliancesByPilots['opponent'] !== []) {
+        $otherCount = count($sideAlliancesByPilots['opponent']) - 1;
+        $sideLabels['opponent'] = $opponentCoalitionName . ($otherCount > 0 ? " +{$otherCount}" : '');
+    }
+
     // Opponent model
     $opponentModel = ['primary_opponent' => null, 'opponents' => [], 'opponent_summary_label' => $sideLabels['opponent']];
     $opponentAlliancesSorted = $sideAlliancesByPilots['opponent'];

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -393,6 +393,8 @@ $settingValues = get_settings([
     'killmail_ingestion_poll_sleep_seconds',
     'killmail_ingestion_max_sequences_per_run',
     'killmail_demand_prediction_mode',
+    'friendly_coalition_name',
+    'opponent_coalition_name',
     'killmail_backfill_start_date',
     'scheduler_operational_profile',
     'incremental_updates_enabled',
@@ -1533,6 +1535,19 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <label class="block space-y-2">
                         <span class="text-sm text-muted">Max Sequences Per Run</span>
                         <input type="number" min="1" max="5000" step="1" name="killmail_ingestion_max_sequences_per_run" value="<?= htmlspecialchars($settingValues['killmail_ingestion_max_sequences_per_run'] ?? '5000', ENT_QUOTES) ?>" class="w-full field-input" />
+                    </label>
+                </div>
+
+                <h3 class="text-base font-semibold text-slate-100 mt-6">Coalition Names</h3>
+                <p class="mt-1 text-xs text-muted">Optional display names for each side in battle reports. When set, this name replaces the largest alliance name in the side header (e.g. "WinterCo" instead of "Fraternity.").</p>
+                <div class="grid gap-4 lg:grid-cols-2 mt-2">
+                    <label class="block space-y-2">
+                        <span class="text-sm text-muted">Friendly Coalition Name</span>
+                        <input type="text" name="friendly_coalition_name" maxlength="100" placeholder="e.g. WinterCo" value="<?= htmlspecialchars((string) ($settingValues['friendly_coalition_name'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" />
+                    </label>
+                    <label class="block space-y-2">
+                        <span class="text-sm text-muted">Opponent Coalition Name</span>
+                        <input type="text" name="opponent_coalition_name" maxlength="100" placeholder="e.g. Imperium" value="<?= htmlspecialchars((string) ($settingValues['opponent_coalition_name'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" />
                     </label>
                 </div>
 

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -262,6 +262,18 @@ if ($viewSnapshot !== null && !$pendingLock) {
         $sideLabels[$side] = $preferredName . ($otherCount > 0 ? " +{$otherCount}" : '');
     }
 
+    // Override side labels with coalition names when configured
+    $friendlyCoalitionName = trim((string) db_app_setting_get('friendly_coalition_name', ''));
+    $opponentCoalitionName = trim((string) db_app_setting_get('opponent_coalition_name', ''));
+    if ($friendlyCoalitionName !== '' && $sideAlliancesByPilots['friendly'] !== []) {
+        $otherCount = count($sideAlliancesByPilots['friendly']) - 1;
+        $sideLabels['friendly'] = $friendlyCoalitionName . ($otherCount > 0 ? " +{$otherCount}" : '');
+    }
+    if ($opponentCoalitionName !== '' && $sideAlliancesByPilots['opponent'] !== []) {
+        $otherCount = count($sideAlliancesByPilots['opponent']) - 1;
+        $sideLabels['opponent'] = $opponentCoalitionName . ($otherCount > 0 ? " +{$otherCount}" : '');
+    }
+
     // Structured opponent model for programmatic access
     $opponentModel = [
         'primary_opponent' => null,

--- a/src/functions.php
+++ b/src/functions.php
@@ -19014,6 +19014,8 @@ function killmail_settings_from_request(array $request): array
             'killmail_ingestion_poll_sleep_seconds' => (string) max(6, min(300, (int) ($request['killmail_ingestion_poll_sleep_seconds'] ?? 10))),
             'killmail_ingestion_max_sequences_per_run' => (string) max(1, min(5000, (int) ($request['killmail_ingestion_max_sequences_per_run'] ?? 5000))),
             'killmail_demand_prediction_mode' => trim((string) ($request['killmail_demand_prediction_mode'] ?? 'baseline')),
+            'friendly_coalition_name' => trim(mb_substr(trim((string) ($request['friendly_coalition_name'] ?? '')), 0, 100)),
+            'opponent_coalition_name' => trim(mb_substr(trim((string) ($request['opponent_coalition_name'] ?? '')), 0, 100)),
         ],
         'alliances' => array_map(
             static fn (array $row): array => ['alliance_id' => (int) ($row['id'] ?? 0), 'label' => $row['label'] ?? null],


### PR DESCRIPTION
## Summary
This PR adds the ability to customize the display names for friendly and opponent sides in battle reports. Users can now configure optional coalition names that will replace the largest alliance name in side headers throughout the application.

## Key Changes
- **Settings UI**: Added two new input fields in the settings page for "Friendly Coalition Name" and "Opponent Coalition Name" with a 100-character limit and helpful placeholder examples
- **Theater API**: Implemented coalition name override logic in the public theater API endpoint to use configured names when available
- **Theater Intelligence View**: Applied the same coalition name override logic to the theater intelligence view for consistent display across the application
- **Settings Processing**: Added validation and sanitization for the new coalition name settings, including trimming and character limit enforcement

## Implementation Details
- Coalition names are optional and only applied when explicitly configured (non-empty after trimming)
- When a coalition name is set, it replaces the largest alliance name in the side header while preserving the "+N" indicator for additional alliances
- The implementation is consistent across both the public API and internal views
- Input validation includes UTF-8 safe substring truncation and HTML entity escaping for security
- The feature gracefully falls back to the default behavior (largest alliance name) when coalition names are not configured

https://claude.ai/code/session_019RhdUSJsooLkdhVivmFW2J