### PR TITLE
Fix SQL GROUP BY clause in ship summary query

### DIFF
--- a/python/orchestrator/jobs/compute_alliance_dossiers.py
+++ b/python/orchestrator/jobs/compute_alliance_dossiers.py
@@ -221,7 +221,7 @@ def _load_ship_summary(db: SupplyCoreDb, alliance_id: int) -> dict[str, Any]:
         WHERE ka.alliance_id = %s
           AND ka.ship_type_id IS NOT NULL AND ka.ship_type_id > 0
           AND ke.zkb_npc = 0
-        GROUP BY ka.ship_type_id
+        GROUP BY ka.ship_type_id, rit.type_name, rig.group_name, rmg.market_group_name
         ORDER BY usage_count DESC
         LIMIT 30
         """,


### PR DESCRIPTION
## Summary
Fixed a SQL query in the ship summary loading function to include all non-aggregated columns in the GROUP BY clause, ensuring compliance with standard SQL semantics and preventing potential query errors.

## Key Changes
- Updated the GROUP BY clause in `_load_ship_summary()` to include `rit.type_name`, `rig.group_name`, and `rmg.market_group_name` alongside the existing `ka.ship_type_id`
- This ensures all selected columns that are not part of an aggregate function are included in the GROUP BY clause

## Implementation Details
The query selects ship usage data grouped by ship type, but was also selecting additional descriptive columns (type name, rig group name, market group name) without including them in the GROUP BY clause. This violates SQL standard GROUP BY requirements and could cause issues with certain database configurations. The fix ensures the query is properly formed and will work consistently across different database systems.

https://claude.ai/code/session_01HR3MqpEXMR1qyUAwSBAbio