### PR TITLE
Add app base URL configuration setting

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -86,6 +86,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 'brand_tagline' => sanitize_brand_label((string) ($_POST['brand_tagline'] ?? brand_tagline()), 'Alliance logistics intelligence platform'),
                 'brand_logo_path' => sanitize_brand_asset_path((string) ($_POST['brand_logo_path'] ?? brand_logo_path()), '/assets/branding/supplycore-logo.svg'),
                 'brand_favicon_path' => sanitize_brand_asset_path((string) ($_POST['brand_favicon_path'] ?? brand_favicon_path()), '/assets/branding/supplycore-favicon.svg'),
+                'app_base_url' => sanitize_app_base_url((string) ($_POST['app_base_url'] ?? '')),
                 'app_timezone' => sanitize_timezone((string) ($_POST['app_timezone'] ?? 'UTC')),
                 'default_currency' => sanitize_currency((string) ($_POST['default_currency'] ?? 'ISK')),
             ]);
@@ -798,6 +799,11 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <label class="block space-y-2">
                             <span class="text-sm text-muted">Favicon path</span>
                             <input name="brand_favicon_path" value="<?= htmlspecialchars($settingValues['brand_favicon_path'] ?? brand_favicon_path(), ENT_QUOTES) ?>" class="w-full field-input" />
+                        </label>
+                        <label class="block space-y-2">
+                            <span class="text-sm text-muted">Base URL</span>
+                            <input name="app_base_url" value="<?= htmlspecialchars(get_setting('app_base_url', ''), ENT_QUOTES) ?>" placeholder="e.g. https://supplycore.example.com" class="w-full field-input" />
+                            <span class="text-xs text-muted">Public URL used in provisioning tokens and external integrations. Include the scheme (https://).</span>
                         </label>
                         <div class="grid gap-4 md:grid-cols-2">
                             <label class="block space-y-2">

--- a/src/functions.php
+++ b/src/functions.php
@@ -2252,6 +2252,21 @@ function sanitize_currency(string $currency): string
     return $currency;
 }
 
+function sanitize_app_base_url(string $value): string
+{
+    $url = rtrim(trim($value), '/');
+
+    if ($url === '') {
+        return '';
+    }
+
+    if (!preg_match('/^https?:\/\/.+/i', $url)) {
+        return '';
+    }
+
+    return mb_substr($url, 0, 255);
+}
+
 function sanitize_market_station_selection(?string $value): string
 {
     $stationIdValue = trim((string) $value);


### PR DESCRIPTION
## Summary
This PR adds a new configurable "Base URL" setting to the application settings page, allowing administrators to specify the public URL used for provisioning tokens and external integrations.

## Key Changes
- **New sanitization function**: Added `sanitize_app_base_url()` in `src/functions.php` that:
  - Trims whitespace and trailing slashes
  - Validates the URL format (requires `http://` or `https://` scheme)
  - Returns empty string for invalid URLs
  - Limits the URL to 255 characters using `mb_substr()`

- **Settings form integration**: Updated `public/settings/index.php` to:
  - Process the `app_base_url` POST parameter using the new sanitization function
  - Add a new form input field with placeholder and helper text
  - Display the current setting value with proper HTML escaping

## Implementation Details
- The URL validation uses a regex pattern to ensure URLs start with `http://` or `https://` (case-insensitive)
- Invalid or empty URLs are sanitized to an empty string rather than a default value
- The setting is stored alongside other application configuration (timezone, currency, branding)
- The form field includes user guidance indicating the scheme must be included

https://claude.ai/code/session_01WuC1MKyfHgRK5P3Gscxggh