### PR TITLE
Add theater overview listing and classic battle report view

### DIFF
--- a/public-proxy/index.php
+++ b/public-proxy/index.php
@@ -7,26 +7,155 @@ require_once __DIR__ . '/lib/api-client.php';
 $config = proxy_config();
 $siteName = proxy_e((string) ($config['site_name'] ?? 'Battle Reports'));
 
+$page = max(1, (int) ($_GET['page'] ?? 1));
+$data = proxy_api_get('/api/public/theaters.php', ['page' => (string) $page, 'per_page' => '50']);
+
+$theaters = (array) ($data['theaters'] ?? []);
+$hasError = isset($data['error']) && $data['error'] !== null;
+
 ?>
 <!doctype html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?= $siteName ?></title>
+    <title>Theater Overview — <?= $siteName ?></title>
     <link rel="stylesheet" href="assets/css/proxy.css">
 </head>
 <body>
 <div class="proxy-shell">
     <main class="proxy-main">
-        <header class="proxy-header">
-            <h1 class="proxy-title"><?= $siteName ?></h1>
-            <p class="proxy-subtitle">Theater battle reports are accessed via direct link.</p>
-        </header>
-        <section class="proxy-card">
-            <p class="proxy-muted">To view a battle report, use a URL like:</p>
-            <code class="proxy-code">theater?theater_id=YOUR_THEATER_ID</code>
+
+        <section class="surface-primary">
+            <div class="text-center">
+                <p class="text-xs uppercase tracking-widest text-muted">Battle Reports</p>
+                <h1 class="mt-1 text-2xl font-semibold text-slate-50"><?= $siteName ?></h1>
+                <p class="mt-2 text-sm text-muted">Select a battle to view the full report.</p>
+            </div>
         </section>
+
+        <?php if ($hasError): ?>
+            <section class="surface-primary mt-4">
+                <p class="proxy-error"><?= proxy_e((string) $data['error']) ?></p>
+            </section>
+        <?php elseif ($theaters === []): ?>
+            <section class="surface-primary mt-4">
+                <p class="text-sm text-muted">No theaters found.</p>
+            </section>
+        <?php else: ?>
+            <section class="surface-primary mt-4">
+                <div class="table-shell">
+                    <table class="table-ui">
+                        <thead>
+                            <tr class="border-b border-border/70 text-xs uppercase tracking-wider text-muted">
+                                <th class="px-3 py-2 text-left">Battle</th>
+                                <th class="px-3 py-2 text-left">Outcome</th>
+                                <th class="px-3 py-2 text-left">Location</th>
+                                <th class="px-3 py-2 text-right">Scale</th>
+                                <th class="px-3 py-2 text-right">ISK Destroyed</th>
+                                <th class="px-3 py-2 text-right">Duration</th>
+                                <th class="px-3 py-2 text-left">When</th>
+                                <th class="px-3 py-2 text-right"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($theaters as $t): ?>
+                                <?php
+                                    $participantCount = (int) ($t['participant_count'] ?? 0);
+                                    $killCount = (int) ($t['total_kills'] ?? 0);
+                                    $battleCount = (int) ($t['battle_count'] ?? 0);
+                                    $totalIsk = (float) ($t['total_isk'] ?? 0);
+
+                                    $verdict = (string) ($t['ai_verdict'] ?? '');
+                                    $headline = (string) ($t['ai_headline'] ?? '');
+
+                                    // Verdict badge styling
+                                    $verdictLabel = '';
+                                    $verdictColorClass = 'text-slate-300';
+                                    $verdictBgClass = 'bg-slate-700';
+                                    if ($verdict !== '') {
+                                        $verdictLabel = match ($verdict) {
+                                            'decisive_victory' => 'Decisive Victory',
+                                            'victory' => 'Victory',
+                                            'close_fight' => 'Close Fight',
+                                            'defeat' => 'Defeat',
+                                            'decisive_defeat' => 'Decisive Defeat',
+                                            'stalemate' => 'Stalemate',
+                                            default => ucfirst(str_replace('_', ' ', $verdict)),
+                                        };
+                                        $verdictColorClass = match ($verdict) {
+                                            'decisive_victory' => 'text-green-400',
+                                            'victory' => 'text-green-300',
+                                            'close_fight' => 'text-yellow-400',
+                                            'defeat' => 'text-red-300',
+                                            'decisive_defeat' => 'text-red-400',
+                                            'stalemate' => 'text-slate-400',
+                                            default => 'text-slate-300',
+                                        };
+                                        $verdictBgClass = str_contains($verdict, 'victory') ? 'bg-green-900/40' : (str_contains($verdict, 'defeat') ? 'bg-red-900/40' : 'bg-slate-700');
+                                    }
+                                ?>
+                                <tr class="border-b border-border/50 hover:bg-white/[0.02] transition">
+                                    <td class="px-3 py-3">
+                                        <div class="text-sm font-medium">
+                                            <span class="text-blue-300"><?= proxy_e((string) ($t['friendly_label'] ?? 'Friendlies')) ?></span>
+                                            <span class="text-slate-500 mx-1">vs</span>
+                                            <span class="text-red-300"><?= proxy_e((string) ($t['hostile_label'] ?? 'Opposition')) ?></span>
+                                        </div>
+                                        <?php if ($headline !== ''): ?>
+                                            <p class="text-[11px] text-slate-400 mt-0.5 leading-tight max-w-xs"><?= proxy_e($headline) ?></p>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td class="px-3 py-3">
+                                        <?php if ($verdictLabel !== ''): ?>
+                                            <span class="inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider <?= $verdictColorClass ?> <?= $verdictBgClass ?>">
+                                                <?= proxy_e($verdictLabel) ?>
+                                            </span>
+                                        <?php else: ?>
+                                            <?php if (($t['locked_at'] ?? '') !== ''): ?>
+                                                <span class="text-amber-400 text-xs">Locked</span>
+                                            <?php else: ?>
+                                                <span class="text-slate-500 text-xs">Live</span>
+                                            <?php endif; ?>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td class="px-3 py-3">
+                                        <p class="text-sm text-slate-100"><?= proxy_e((string) ($t['primary_system_name'] ?? '-')) ?></p>
+                                        <p class="text-[11px] text-muted"><?= proxy_e((string) ($t['region_name'] ?? '')) ?></p>
+                                        <?php if ((int) ($t['system_count'] ?? 0) > 1): ?>
+                                            <p class="text-[10px] text-slate-500">+<?= (int) ($t['system_count'] ?? 0) - 1 ?> systems</p>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td class="px-3 py-3 text-right">
+                                        <p class="text-sm text-slate-100"><?= number_format($participantCount) ?> pilots</p>
+                                        <p class="text-[11px] text-muted"><?= number_format($killCount) ?> kills<?= $battleCount > 1 ? ' · ' . $battleCount . ' battles' : '' ?></p>
+                                    </td>
+                                    <td class="px-3 py-3 text-right text-sm text-slate-100"><?= proxy_format_isk($totalIsk) ?></td>
+                                    <td class="px-3 py-3 text-right text-sm text-slate-300"><?= proxy_e((string) ($t['duration_label'] ?? '')) ?></td>
+                                    <td class="px-3 py-3 text-slate-300 text-xs"><?= proxy_e((string) ($t['start_time'] ?? '')) ?></td>
+                                    <td class="px-3 py-3 text-right">
+                                        <a class="inline-block rounded px-3 py-1.5 text-xs font-medium bg-blue-600 text-white hover:bg-blue-500 transition-colors"
+                                           href="theater?theater_id=<?= urlencode((string) ($t['theater_id'] ?? '')) ?>">
+                                            View Report
+                                        </a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+
+                <?php if (count($theaters) >= 50): ?>
+                    <div class="mt-3 flex gap-3 text-sm">
+                        <?php if ($page > 1): ?>
+                            <a href="?page=<?= $page - 1 ?>" class="text-blue-400 hover:text-blue-300">&#8592; Previous</a>
+                        <?php endif; ?>
+                        <a href="?page=<?= $page + 1 ?>" class="text-blue-400 hover:text-blue-300">Next &#8594;</a>
+                    </div>
+                <?php endif; ?>
+            </section>
+        <?php endif; ?>
+
     </main>
 </div>
 </body>

--- a/public-proxy/partials/_battle_report.php
+++ b/public-proxy/partials/_battle_report.php
@@ -34,6 +34,21 @@
     $gridCols = $isThreeColumn ? 'md:grid-cols-3' : 'md:grid-cols-2';
 ?>
 <section class="surface-primary mt-4">
+    <!-- View Toggle -->
+    <div class="flex items-center justify-end mb-3">
+        <div class="inline-flex rounded-md border border-slate-700 overflow-hidden text-xs" role="group">
+            <button type="button" id="sc-br-view-summary" class="px-3 py-1.5 font-medium transition-colors bg-slate-700 text-slate-100" onclick="window._scBrToggle('summary')">
+                Summary
+            </button>
+            <button type="button" id="sc-br-view-classic" class="px-3 py-1.5 font-medium transition-colors bg-slate-800/60 text-slate-400 hover:text-slate-200" onclick="window._scBrToggle('classic')">
+                Classic
+            </button>
+        </div>
+    </div>
+
+    <!-- Summary view (default) -->
+    <div id="sc-br-summary">
+
     <!-- Efficiency Bar -->
     <div class="flex items-center gap-3 mb-3">
         <span class="text-xs font-semibold text-blue-300"><?= number_format($ourEfficiency * 100, 1) ?>%</span>
@@ -141,6 +156,13 @@
         <?php endif; ?>
     </div>
 
+    </div><!-- /sc-br-summary -->
+
+    <!-- Classic view (br.evetools.org-style) -->
+    <div id="sc-br-classic" style="display: none;">
+        <?php include __DIR__ . '/_battle_report_classic.php'; ?>
+    </div>
+
     <?php if ($dataQualityNotes !== []): ?>
         <div class="mt-3 pt-2 border-t border-white/5">
             <?php foreach ($dataQualityNotes as $note): ?>
@@ -149,4 +171,33 @@
         </div>
     <?php endif; ?>
 </section>
+
+<script>
+(function() {
+    var KEY = 'sc_br_view';
+    window._scBrToggle = function(view) {
+        var summary = document.getElementById('sc-br-summary');
+        var classic = document.getElementById('sc-br-classic');
+        var btnSummary = document.getElementById('sc-br-view-summary');
+        var btnClassic = document.getElementById('sc-br-view-classic');
+        if (!summary || !classic) return;
+        if (view === 'classic') {
+            summary.style.display = 'none';
+            classic.style.display = '';
+            btnSummary.className = 'px-3 py-1.5 font-medium transition-colors bg-slate-800/60 text-slate-400 hover:text-slate-200';
+            btnClassic.className = 'px-3 py-1.5 font-medium transition-colors bg-slate-700 text-slate-100';
+        } else {
+            summary.style.display = '';
+            classic.style.display = 'none';
+            btnSummary.className = 'px-3 py-1.5 font-medium transition-colors bg-slate-700 text-slate-100';
+            btnClassic.className = 'px-3 py-1.5 font-medium transition-colors bg-slate-800/60 text-slate-400 hover:text-slate-200';
+        }
+        try { localStorage.setItem(KEY, view); } catch(e) {}
+    };
+    try {
+        var saved = localStorage.getItem(KEY);
+        if (saved === 'classic') window._scBrToggle('classic');
+    } catch(e) {}
+})();
+</script>
 <?php endif; ?>

--- a/public-proxy/partials/_battle_report_classic.php
+++ b/public-proxy/partials/_battle_report_classic.php
@@ -1,0 +1,386 @@
+<?php
+/**
+ * Classic battle report view for the public proxy — resembles br.evetools.org layout.
+ *
+ * Shows pilots grouped by alliance → corporation in side-by-side columns,
+ * with ship type renders, dead-pilot highlighting, and an ISK summary header.
+ *
+ * Expected variables from theater.php scope:
+ *   $participants, $classifyAlliance, $resolvedEntities, $shipTypeNames,
+ *   $sideLabels, $sidePanels, $sideAlliancesByPilots
+ */
+
+// ── Group participants by side → alliance → corporation ──
+$classicSides = ['friendly' => [], 'opponent' => [], 'third_party' => []];
+foreach ($participants as $p) {
+    $pSide = $classifyAlliance((int) ($p['alliance_id'] ?? 0), (int) ($p['corporation_id'] ?? 0));
+    $classicSides[$pSide][] = $p;
+}
+
+$_podTypeIds = [670, 33328];
+
+$_classicGroupParticipants = static function (array $participantRows) use ($resolvedEntities, $shipTypeNames, $_podTypeIds): array {
+    $byAlliance = [];
+    foreach ($participantRows as $p) {
+        $aid = (int) ($p['alliance_id'] ?? 0);
+        $cid = (int) ($p['corporation_id'] ?? 0);
+        $key = $aid > 0 ? "a:{$aid}" : "c:{$cid}";
+        if (!isset($byAlliance[$key])) {
+            $allianceName = '';
+            if ($aid > 0) {
+                $allianceName = (string) ($resolvedEntities['alliance'][$aid]['name'] ?? $p['alliance_name'] ?? 'Alliance #' . $aid);
+            }
+            $byAlliance[$key] = [
+                'alliance_id' => $aid,
+                'alliance_name' => $allianceName,
+                'corps' => [],
+                'pilot_count' => 0,
+            ];
+        }
+        $corpKey = "c:{$cid}";
+        if (!isset($byAlliance[$key]['corps'][$corpKey])) {
+            $corpName = $cid > 0
+                ? (string) ($resolvedEntities['corporation'][$cid]['name'] ?? $p['corporation_name'] ?? 'Corp #' . $cid)
+                : 'Unknown Corp';
+            $byAlliance[$key]['corps'][$corpKey] = [
+                'corporation_id' => $cid,
+                'corporation_name' => $corpName,
+                'pilots' => [],
+            ];
+        }
+
+        // Resolve flying ship
+        $flyingShipId = (int) ($p['flying_ship_type_id'] ?? 0);
+        $flyingShipName = '';
+        if ($flyingShipId > 0 && !in_array($flyingShipId, $_podTypeIds, true)) {
+            $flyingShipName = (string) ($shipTypeNames[$flyingShipId] ?? '');
+        } else {
+            $flyingShipId = 0;
+            $lostJson = $p['ships_lost_detail'] ?? null;
+            if (is_string($lostJson)) {
+                $lostArr = json_decode($lostJson, true);
+                if (is_array($lostArr)) {
+                    foreach ($lostArr as $entry) {
+                        $stid = (int) ($entry['ship_type_id'] ?? 0);
+                        if ($stid > 0 && !in_array($stid, $_podTypeIds, true)) {
+                            $flyingShipId = $stid;
+                            $flyingShipName = (string) ($shipTypeNames[$stid] ?? '');
+                            break;
+                        }
+                    }
+                }
+            }
+            if ($flyingShipId === 0) {
+                $shipJson = $p['ship_type_ids'] ?? null;
+                if (is_string($shipJson)) {
+                    $decoded = json_decode($shipJson, true);
+                    if (is_array($decoded)) {
+                        foreach ($decoded as $stid) {
+                            $stid = (int) $stid;
+                            if ($stid > 0 && !in_array($stid, $_podTypeIds, true)) {
+                                $flyingShipId = $stid;
+                                $flyingShipName = (string) ($shipTypeNames[$stid] ?? '');
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        $deaths = (int) ($p['deaths'] ?? $p['loss_count'] ?? 0);
+        $charName = (string) ($p['character_name'] ?? 'Unknown');
+
+        $byAlliance[$key]['corps'][$corpKey]['pilots'][] = [
+            'character_id' => (int) ($p['character_id'] ?? 0),
+            'alliance_id' => $aid,
+            'corporation_id' => $cid,
+            'character_name' => $charName,
+            'flying_ship_id' => $flyingShipId,
+            'flying_ship_name' => $flyingShipName,
+            'deaths' => $deaths,
+            'kills' => (int) ($p['kills'] ?? $p['kill_count'] ?? 0),
+            'damage_done' => (float) ($p['damage_done'] ?? 0),
+            'isk_lost' => (float) ($p['isk_lost'] ?? 0),
+        ];
+        $byAlliance[$key]['pilot_count']++;
+    }
+
+    uasort($byAlliance, static fn(array $a, array $b): int => $b['pilot_count'] <=> $a['pilot_count']);
+
+    foreach ($byAlliance as &$allianceGroup) {
+        $corps = array_values($allianceGroup['corps']);
+        usort($corps, static fn(array $a, array $b): int => count($b['pilots']) <=> count($a['pilots']));
+        $allianceGroup['corps'] = $corps;
+    }
+    unset($allianceGroup);
+
+    return array_values($byAlliance);
+};
+
+$hasOpponent = ($sidePanels['opponent']['pilots'] ?? 0) > 0;
+$hasThirdParty = ($sidePanels['third_party']['pilots'] ?? 0) > 0;
+$isThreeColumn = $hasOpponent && $hasThirdParty;
+
+if (!$isThreeColumn) {
+    $classicSides['opponent'] = array_merge($classicSides['opponent'], $classicSides['third_party']);
+    $classicSides['third_party'] = [];
+}
+
+$groupedFriendly = $_classicGroupParticipants($classicSides['friendly']);
+$groupedOpponent = $_classicGroupParticipants($classicSides['opponent']);
+$groupedThirdParty = $isThreeColumn ? $_classicGroupParticipants($classicSides['third_party']) : [];
+
+// Compute summary stats per side
+$classicStats = [];
+foreach (['friendly', 'opponent', 'third_party'] as $side) {
+    $pilots = 0; $shipsLost = 0;
+    foreach ($classicSides[$side] as $p) {
+        $pilots++;
+        $shipsLost += (int) ($p['deaths'] ?? $p['loss_count'] ?? 0);
+    }
+    $totalIskK = (float) ($sidePanels[$side]['isk_killed'] ?? 0);
+    $totalIskL = (float) ($sidePanels[$side]['isk_lost'] ?? 0);
+    $classicStats[$side] = [
+        'pilots' => $pilots,
+        'isk_destroyed' => $totalIskK,
+        'isk_lost' => $totalIskL,
+        'ships_lost' => $shipsLost,
+        'efficiency' => ($totalIskK + $totalIskL) > 0 ? ($totalIskK / ($totalIskK + $totalIskL)) * 100 : 0,
+    ];
+}
+
+// Find top damage dealer
+$_classicTopDmg = 0;
+$_classicTopDmgChar = 0;
+foreach ($participants as $p) {
+    $d = (float) ($p['damage_done'] ?? 0);
+    if ($d > $_classicTopDmg) {
+        $_classicTopDmg = $d;
+        $_classicTopDmgChar = (int) ($p['character_id'] ?? 0);
+    }
+}
+
+$gridCols = $isThreeColumn ? 'lg:grid-cols-3 md:grid-cols-2' : 'md:grid-cols-2';
+
+$classicPanelConfig = [
+    [
+        'side' => 'friendly',
+        'label' => proxy_e($sideLabels['friendly'] ?? 'Friendlies'),
+        'teamLetter' => 'A',
+        'groups' => $groupedFriendly,
+        'stats' => $classicStats['friendly'],
+    ],
+    [
+        'side' => 'opponent',
+        'label' => proxy_e($sideLabels['opponent'] ?? 'Opposition') . (!$isThreeColumn && $hasThirdParty ? ' <span style="color:#888;font-weight:normal;font-size:11px">+ Third Party</span>' : ''),
+        'teamLetter' => 'B',
+        'groups' => $groupedOpponent,
+        'stats' => $classicStats['opponent'],
+    ],
+];
+
+if ($isThreeColumn) {
+    $classicPanelConfig[] = [
+        'side' => 'third_party',
+        'label' => proxy_e($sideLabels['third_party'] ?? 'Third Party'),
+        'teamLetter' => 'C',
+        'groups' => $groupedThirdParty,
+        'stats' => $classicStats['third_party'],
+    ];
+}
+
+// Efficiency bar
+$friendlyIskK = $classicStats['friendly']['isk_destroyed'];
+$opponentIskK = $classicStats['opponent']['isk_destroyed'];
+$tpIskK = $classicStats['third_party']['isk_destroyed'] ?? 0;
+$totalIskK = $friendlyIskK + $opponentIskK + $tpIskK;
+$friendlyBarPct = $totalIskK > 0 ? ($friendlyIskK / $totalIskK) * 100 : ($isThreeColumn ? 33.3 : 50);
+$opponentBarPct = $totalIskK > 0 ? ($opponentIskK / $totalIskK) * 100 : ($isThreeColumn ? 33.3 : 50);
+$tpBarPct = $isThreeColumn ? (100 - $friendlyBarPct - $opponentBarPct) : 0;
+?>
+<style>
+    .br-classic-panel { background: #000011; border: 1px solid #444; color: #eee; }
+    .br-classic-header { background: #333; text-align: center; padding: 6px 10px; border-bottom: 1px solid #444; }
+    .br-classic-header h4 { margin: 0; font-size: 13px; font-weight: 600; color: #eee; }
+    .br-classic-stats { padding: 5px 10px; border-bottom: 1px solid #444; font-size: 12px; }
+    .br-classic-stats-row { display: flex; justify-content: space-between; padding: 2px 0; }
+    .br-classic-stats-label { color: #ccc; }
+    .br-classic-stats-value { font-weight: 700; color: #eee; }
+    .br-classic-alliance { display: flex; align-items: center; gap: 6px; padding: 4px 8px; background: rgba(51,51,51,0.5); border-bottom: 1px solid #444; }
+    .br-classic-corp { display: flex; align-items: center; gap: 5px; padding: 3px 8px 3px 16px; background: rgba(40,40,40,0.6); border-bottom: 1px solid #333; }
+    .br-classic-pilot { display: flex; align-items: center; gap: 6px; padding: 2px 6px; border-bottom: 1px solid #222; transition: background 0.1s; }
+    .br-classic-pilot:hover { background: #282828; }
+    .br-classic-pilot.dead { background: #480000; }
+    .br-classic-pilot.dead:hover { background: #580000; }
+    .br-classic-ship-icon { width: 32px; height: 34px; border-radius: 6px; flex-shrink: 0; object-fit: cover; }
+    .br-classic-ship-icon.dead { opacity: 0.45; }
+    .br-classic-pilot-body { flex: 1; min-width: 0; }
+    .br-classic-pilot-top { display: flex; justify-content: space-between; align-items: baseline; gap: 4px; }
+    .br-classic-pilot-name { color: gold; font-weight: 700; font-size: 12px; text-decoration: none; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .br-classic-pilot-name:hover { text-decoration: underline; }
+    .br-classic-pilot.dead .br-classic-pilot-name { color: #c9a84c; }
+    .br-classic-loss-value { color: #f00000; font-size: 11px; font-weight: 700; white-space: nowrap; flex-shrink: 0; }
+    .br-classic-pilot-bottom { display: flex; justify-content: space-between; align-items: baseline; gap: 4px; }
+    .br-classic-ship-name { color: #e0e0e0; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .br-classic-dmg { color: #888; font-size: 10px; white-space: nowrap; flex-shrink: 0; }
+    .br-classic-dmg.top { color: #00FF00; font-weight: 700; }
+    .br-classic-org-icons { display: flex; gap: 2px; flex-shrink: 0; align-items: center; }
+    .br-classic-org-icon { width: 28px; height: 28px; border-radius: 3px; }
+    .br-classic-eff-bar { display: flex; height: 8px; border-radius: 2px; overflow: hidden; background: #222; }
+    .br-classic-eff-bar .seg-a { background: #3b7; }
+    .br-classic-eff-bar .seg-b { background: #b33; }
+    .br-classic-eff-bar .seg-c { background: #b90; }
+    .br-classic-no-pilots { text-align: center; padding: 16px; color: #555; font-size: 12px; }
+</style>
+
+<!-- Efficiency bar -->
+<div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;">
+    <span style="font-size:11px;font-weight:600;color:#6c6"><?= number_format($friendlyBarPct, 1) ?>%</span>
+    <div class="br-classic-eff-bar" style="flex:1;">
+        <div class="seg-a" style="width:<?= number_format($friendlyBarPct, 1) ?>%"></div>
+        <div class="seg-b" style="width:<?= number_format($opponentBarPct, 1) ?>%"></div>
+        <?php if ($isThreeColumn): ?>
+            <div class="seg-c" style="width:<?= number_format($tpBarPct, 1) ?>%"></div>
+        <?php endif; ?>
+    </div>
+    <span style="font-size:11px;font-weight:600;color:#c66"><?= number_format($opponentBarPct, 1) ?>%</span>
+    <?php if ($isThreeColumn): ?>
+        <span style="font-size:11px;font-weight:600;color:#cc6"><?= number_format($tpBarPct, 1) ?>%</span>
+    <?php endif; ?>
+</div>
+
+<!-- Side-by-side team panels -->
+<div class="grid <?= $gridCols ?>" style="gap:12px;">
+    <?php foreach ($classicPanelConfig as $cfg): ?>
+    <div class="br-classic-panel">
+        <!-- Team header -->
+        <div class="br-classic-header">
+            <h4>Team <?= $cfg['teamLetter'] ?> — <?= $cfg['label'] ?> (<?= $cfg['stats']['pilots'] ?>)</h4>
+        </div>
+
+        <!-- Stats block -->
+        <div class="br-classic-stats">
+            <div class="br-classic-stats-row">
+                <span class="br-classic-stats-label">ISK Lost</span>
+                <span class="br-classic-stats-value"><?= proxy_format_isk($cfg['stats']['isk_lost']) ?></span>
+            </div>
+            <div class="br-classic-stats-row">
+                <span class="br-classic-stats-label">Efficiency</span>
+                <span class="br-classic-stats-value"><?= number_format($cfg['stats']['efficiency'], 1) ?>%</span>
+            </div>
+            <div class="br-classic-stats-row">
+                <span class="br-classic-stats-label">Ships Lost</span>
+                <span class="br-classic-stats-value"><?= $cfg['stats']['ships_lost'] ?> ships</span>
+            </div>
+            <div class="br-classic-stats-row">
+                <span class="br-classic-stats-label">Inflicted Damage</span>
+                <span class="br-classic-stats-value"><?= proxy_format_isk($cfg['stats']['isk_destroyed']) ?></span>
+            </div>
+        </div>
+
+        <!-- Column header -->
+        <div style="display:flex;justify-content:space-between;padding:4px 8px;background:#333;border-bottom:1px solid #444;font-size:11px;">
+            <div>
+                <span style="color:gold;font-weight:600;">Pilot</span>
+                <span style="color:#888;margin-left:8px;">Ship</span>
+            </div>
+            <div style="display:flex;gap:8px;align-items:center;">
+                <span style="color:gold;font-size:10px;">loss value</span>
+                <span style="color:#888;font-size:10px;">Corp</span>
+                <span style="color:#888;font-size:10px;">Ally</span>
+            </div>
+        </div>
+
+        <?php if ($cfg['groups'] === []): ?>
+            <div class="br-classic-no-pilots">No pilots</div>
+        <?php endif; ?>
+
+        <?php foreach ($cfg['groups'] as $allianceGroup): ?>
+            <!-- Alliance header -->
+            <div class="br-classic-alliance">
+                <?php if ($allianceGroup['alliance_id'] > 0): ?>
+                    <img src="https://images.evetech.net/alliances/<?= $allianceGroup['alliance_id'] ?>/logo?size=64" alt="" style="width:18px;height:18px;border-radius:2px;" loading="lazy">
+                <?php endif; ?>
+                <span style="font-size:11px;font-weight:600;color:#ddd;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
+                    <?= proxy_e($allianceGroup['alliance_name'] ?: 'No Alliance') ?>
+                </span>
+                <span style="font-size:10px;color:#888;">(<?= $allianceGroup['pilot_count'] ?>)</span>
+            </div>
+
+            <?php foreach ($allianceGroup['corps'] as $corp): ?>
+                <!-- Corporation header -->
+                <div class="br-classic-corp">
+                    <?php if ($corp['corporation_id'] > 0): ?>
+                        <img src="https://images.evetech.net/corporations/<?= $corp['corporation_id'] ?>/logo?size=64" alt="" style="width:15px;height:15px;border-radius:2px;" loading="lazy">
+                    <?php endif; ?>
+                    <span style="font-size:10px;color:#999;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
+                        <?= proxy_e($corp['corporation_name']) ?>
+                    </span>
+                    <span style="font-size:10px;color:#666;">(<?= count($corp['pilots']) ?>)</span>
+                </div>
+
+                <!-- Pilot rows -->
+                <?php foreach ($corp['pilots'] as $pilot): ?>
+                    <?php
+                        $isDead = $pilot['deaths'] > 0;
+                        $isTopDmg = $pilot['character_id'] === $_classicTopDmgChar && $_classicTopDmg > 0;
+                    ?>
+                    <div class="br-classic-pilot <?= $isDead ? 'dead' : '' ?>">
+                        <!-- Ship icon -->
+                        <?php if ($pilot['flying_ship_id'] > 0): ?>
+                            <img src="https://images.evetech.net/types/<?= $pilot['flying_ship_id'] ?>/render?size=64"
+                                 alt="" class="br-classic-ship-icon <?= $isDead ? 'dead' : '' ?>" loading="lazy"
+                                 title="<?= proxy_e($pilot['flying_ship_name']) ?>">
+                        <?php else: ?>
+                            <div class="br-classic-ship-icon" style="background:#111;display:flex;align-items:center;justify-content:center;">
+                                <span style="color:#444;font-size:10px;">?</span>
+                            </div>
+                        <?php endif; ?>
+
+                        <!-- Pilot info -->
+                        <div class="br-classic-pilot-body">
+                            <div class="br-classic-pilot-top">
+                                <span class="br-classic-pilot-name" title="<?= proxy_e($pilot['character_name']) ?>">
+                                    <?= proxy_e($pilot['character_name']) ?>
+                                </span>
+                                <?php if ($isDead && $pilot['isk_lost'] > 0): ?>
+                                    <span class="br-classic-loss-value"><?= proxy_format_isk($pilot['isk_lost']) ?></span>
+                                <?php endif; ?>
+                            </div>
+                            <div class="br-classic-pilot-bottom">
+                                <span class="br-classic-ship-name"><?= proxy_e($pilot['flying_ship_name'] ?: '—') ?></span>
+                                <?php if ($pilot['damage_done'] > 0): ?>
+                                    <span class="br-classic-dmg <?= $isTopDmg ? 'top' : '' ?>" title="Damage done">
+                                        <?php
+                                            $dmg = $pilot['damage_done'];
+                                            if ($dmg >= 1e9) echo number_format($dmg / 1e9, 2) . 'b';
+                                            elseif ($dmg >= 1e6) echo number_format($dmg / 1e6, 1) . 'M';
+                                            elseif ($dmg >= 1e3) echo number_format($dmg / 1e3, 1) . 'k';
+                                            else echo number_format($dmg, 0);
+                                        ?>
+                                    </span>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+
+                        <!-- Corp + Alliance icons -->
+                        <div class="br-classic-org-icons">
+                            <?php if ($pilot['corporation_id'] > 0): ?>
+                                <img src="https://images.evetech.net/corporations/<?= $pilot['corporation_id'] ?>/logo?size=64"
+                                     alt="" class="br-classic-org-icon" loading="lazy"
+                                     title="<?= proxy_e($corp['corporation_name']) ?>">
+                            <?php endif; ?>
+                            <?php if ($pilot['alliance_id'] > 0): ?>
+                                <img src="https://images.evetech.net/alliances/<?= $pilot['alliance_id'] ?>/logo?size=64"
+                                     alt="" class="br-classic-org-icon" loading="lazy"
+                                     title="<?= proxy_e($allianceGroup['alliance_name']) ?>">
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            <?php endforeach; ?>
+        <?php endforeach; ?>
+    </div>
+    <?php endforeach; ?>
+</div>

--- a/public-proxy/partials/_header.php
+++ b/public-proxy/partials/_header.php
@@ -1,5 +1,6 @@
 <section class="surface-primary">
-    <div class="text-center">
+    <a href="./" class="text-sm text-blue-400 hover:text-blue-300">&larr; Back to Theater Overview</a>
+    <div class="mt-3 text-center">
         <p class="text-xs uppercase tracking-widest text-muted">Battle Report — Theater Detail</p>
         <h1 class="mt-1 text-2xl font-semibold text-slate-50">
             <?= proxy_e((string) ($theater['primary_system_name'] ?? 'Unknown')) ?>

--- a/public-proxy/partials/_killmails.php
+++ b/public-proxy/partials/_killmails.php
@@ -1,0 +1,109 @@
+<?php
+$killmails = (array) ($killmails ?? []);
+if ($killmails === []) return;
+
+// Classify killmails by side using victim's alliance/corporation
+$killmailsBySide = ['friendly' => [], 'opponent' => [], 'third_party' => []];
+
+// Build a character_id → participant lookup for side classification
+$charParticipantMap = [];
+foreach ($participants as $p) {
+    $cid = (int) ($p['character_id'] ?? 0);
+    if ($cid > 0) {
+        $charParticipantMap[$cid] = $p;
+    }
+}
+
+foreach ($killmails as $km) {
+    $victimCharId = (int) ($km['victim_character_id'] ?? 0);
+    $p = $charParticipantMap[$victimCharId] ?? null;
+    if ($p !== null) {
+        $side = $classifyAlliance((int) ($p['alliance_id'] ?? 0), (int) ($p['corporation_id'] ?? 0));
+    } else {
+        $side = 'third_party';
+    }
+    $killmailsBySide[$side][] = $km;
+}
+
+$totalKillmails = count($killmails);
+$friendlyLosses = count($killmailsBySide['friendly']);
+$hostileLosses = count($killmailsBySide['opponent']);
+$thirdPartyLosses = count($killmailsBySide['third_party']);
+?>
+<section class="surface-primary mt-4">
+    <h2 class="text-lg font-semibold text-slate-50">Killmails</h2>
+    <p class="text-xs text-muted mt-1">
+        <?= number_format($totalKillmails) ?> killmails &mdash;
+        <span class="text-blue-300"><?= number_format($friendlyLosses) ?> friendly losses</span> ·
+        <span class="text-red-300"><?= number_format($hostileLosses) ?> hostile losses</span>
+        <?php if ($thirdPartyLosses > 0): ?>
+            · <span class="text-amber-300"><?= number_format($thirdPartyLosses) ?> third party losses</span>
+        <?php endif; ?>
+    </p>
+
+    <details class="mt-3" open>
+        <summary class="cursor-pointer text-sm text-slate-100">All Killmails</summary>
+        <div class="mt-2 table-shell">
+            <table class="table-ui text-xs">
+                <thead>
+                    <tr class="border-b border-border/70 text-muted uppercase tracking-wider text-[10px]">
+                        <th class="px-2 py-1.5 text-left">Victim</th>
+                        <th class="px-2 py-1.5 text-left">Ship</th>
+                        <th class="px-2 py-1.5 text-left">Side</th>
+                        <th class="px-2 py-1.5 text-right"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($killmails as $km): ?>
+                        <?php
+                            $seqId = (int) ($km['sequence_id'] ?? 0);
+                            $victimCharId = (int) ($km['victim_character_id'] ?? 0);
+                            $victimName = (string) ($km['victim_character_name'] ?? 'Unknown');
+                            $shipName = (string) ($km['victim_ship_name'] ?? 'Unknown');
+                            $shipTypeId = (int) ($km['victim_ship_type_id'] ?? 0);
+
+                            $p = $charParticipantMap[$victimCharId] ?? null;
+                            $kmSide = $p !== null ? $classifyAlliance((int) ($p['alliance_id'] ?? 0), (int) ($p['corporation_id'] ?? 0)) : 'third_party';
+                            $sideColor = match ($kmSide) {
+                                'friendly' => 'text-blue-300',
+                                'opponent' => 'text-red-300',
+                                default => 'text-amber-300',
+                            };
+                            $sideBadge = match ($kmSide) {
+                                'friendly' => ['bg-blue-900/60 text-blue-300', $sideLabels['friendly'] ?? 'Friendly'],
+                                'opponent' => ['bg-red-900/60 text-red-300', $sideLabels['opponent'] ?? 'Hostile'],
+                                default => ['bg-amber-900/60 text-amber-300', $sideLabels['third_party'] ?? 'Third Party'],
+                            };
+                        ?>
+                        <tr class="border-b border-border/50">
+                            <td class="px-2 py-1.5 text-slate-100">
+                                <div class="flex items-center gap-1.5">
+                                    <?php if ($victimCharId > 0): ?>
+                                        <img src="https://images.evetech.net/characters/<?= $victimCharId ?>/portrait?size=32" alt="" class="w-4 h-4 rounded-full" loading="lazy">
+                                    <?php endif; ?>
+                                    <?= proxy_e($victimName) ?>
+                                </div>
+                            </td>
+                            <td class="px-2 py-1.5 text-slate-300">
+                                <div class="flex items-center gap-1.5">
+                                    <?php if ($shipTypeId > 0): ?>
+                                        <img src="https://images.evetech.net/types/<?= $shipTypeId ?>/render?size=32" alt="" class="w-4 h-4 rounded" loading="lazy">
+                                    <?php endif; ?>
+                                    <?= proxy_e($shipName) ?>
+                                </div>
+                            </td>
+                            <td class="px-2 py-1.5">
+                                <span class="inline-block rounded-full px-1.5 py-0.5 text-[9px] uppercase tracking-wider <?= $sideBadge[0] ?>"><?= proxy_e($sideBadge[1]) ?></span>
+                            </td>
+                            <td class="px-2 py-1.5 text-right">
+                                <?php if ($seqId > 0): ?>
+                                    <a href="killmail?sequence_id=<?= $seqId ?>" class="text-blue-400 hover:text-blue-300">View &rarr;</a>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </details>
+</section>

--- a/public-proxy/partials/_location_map.php
+++ b/public-proxy/partials/_location_map.php
@@ -1,0 +1,30 @@
+<?php
+$mapSvg = (string) ($mapSvg ?? '');
+if ($mapSvg === '') return;
+?>
+<section class="surface-primary mt-4">
+    <h2 class="text-lg font-semibold text-slate-50">
+        Battle Location
+        <?php if (count($systems) === 1 && isset($systems[0])): ?>
+            <span class="text-muted text-sm font-normal ml-1">&mdash; <?= proxy_e((string) ($systems[0]['system_name'] ?? 'Unknown')) ?></span>
+        <?php endif; ?>
+    </h2>
+
+    <div class="mt-3 rounded-lg overflow-hidden border border-slate-700/50">
+        <?= $mapSvg ?>
+    </div>
+
+    <?php if (count($systems) > 1): ?>
+        <div class="mt-3 grid gap-2 md:grid-cols-4">
+            <?php foreach ($systems as $sys): ?>
+                <div class="surface-tertiary">
+                    <p class="text-sm font-semibold text-slate-100"><?= proxy_e((string) ($sys['system_name'] ?? 'Unknown')) ?></p>
+                    <p class="text-xs text-muted mt-1">
+                        Participants: <?= number_format((int) ($sys['participant_count'] ?? 0)) ?>
+                        &middot; Weight: <?= number_format((float) ($sys['weight'] ?? 0), 2) ?>
+                    </p>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+</section>

--- a/public-proxy/partials/_participants.php
+++ b/public-proxy/partials/_participants.php
@@ -99,8 +99,8 @@
                                     </td>
                                     <td class="px-2 py-1.5 text-slate-300"><?= proxy_e($flyingShipName($p)) ?></td>
                                     <td class="px-2 py-1.5 text-right"><?= number_format((int) ($p['damage_done'] ?? 0)) ?></td>
-                                    <td class="px-2 py-1.5 text-right"><?= (int) ($p['kill_count'] ?? 0) ?></td>
-                                    <td class="px-2 py-1.5 text-right"><?= (int) ($p['loss_count'] ?? 0) ?></td>
+                                    <td class="px-2 py-1.5 text-right"><?= (int) ($p['kills'] ?? $p['kill_count'] ?? 0) ?></td>
+                                    <td class="px-2 py-1.5 text-right"><?= (int) ($p['deaths'] ?? $p['loss_count'] ?? 0) ?></td>
                                 </tr>
                             <?php endforeach; ?>
                         </tbody>

--- a/public-proxy/theater.php
+++ b/public-proxy/theater.php
@@ -36,6 +36,8 @@ $sideLabels         = (array) ($data['side_labels'] ?? ['friendly' => 'Friendlie
 $sideAlliancesByPilots = (array) ($data['side_alliances_by_pilots'] ?? []);
 $sidePanels         = (array) ($data['side_panels'] ?? []);
 $dataQualityNotes   = (array) ($data['data_quality_notes'] ?? []);
+$killmails          = (array) ($data['killmails'] ?? []);
+$mapSvg             = $data['map_svg'] ?? null;
 $durationLabel      = (string) ($data['duration_label'] ?? '0m');
 $totalIskDestroyed  = (float) ($data['total_isk_destroyed'] ?? 0);
 $theaterStartActual = (string) ($data['theater_start_actual'] ?? '');
@@ -87,11 +89,13 @@ $systemName = proxy_e((string) ($theater['primary_system_name'] ?? 'Unknown'));
     <main class="proxy-main">
 
         <?php include __DIR__ . '/partials/_header.php'; ?>
+        <?php include __DIR__ . '/partials/_location_map.php'; ?>
         <?php include __DIR__ . '/partials/_battle_report.php'; ?>
         <?php include __DIR__ . '/partials/_battles.php'; ?>
         <?php include __DIR__ . '/partials/_timeline.php'; ?>
         <?php include __DIR__ . '/partials/_alliance_summary.php'; ?>
         <?php include __DIR__ . '/partials/_participants.php'; ?>
+        <?php include __DIR__ . '/partials/_killmails.php'; ?>
 
     </main>
 </div>

--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -347,6 +347,62 @@ foreach ($participantsAll as $p) {
     $cleanParticipants[] = $p;
 }
 
+// ── Killmails: load victim killmails for all battles in this theater ──
+$battleIds = array_values(array_filter(array_map(
+    static fn(array $b): int => (int) ($b['battle_id'] ?? 0),
+    $battles
+), static fn(int $id): bool => $id > 0));
+$killmails = $battleIds !== [] ? db_theater_victim_killmails_by_battles($battleIds) : [];
+
+// Resolve victim ship names and enrich killmail rows
+$killmailShipIds = array_values(array_unique(array_filter(
+    array_map(static fn(array $km): int => (int) ($km['victim_ship_type_id'] ?? 0), $killmails),
+    static fn(int $id): bool => $id > 0
+)));
+$killmailShipNames = $killmailShipIds !== [] ? db_market_orders_current_compact_type_names($killmailShipIds) : [];
+
+// Build a character_id → name lookup from participants
+$charNameMap = [];
+foreach ($participantsAll as $p) {
+    $cid = (int) ($p['character_id'] ?? 0);
+    if ($cid > 0) {
+        $charNameMap[$cid] = (string) ($p['character_name'] ?? '');
+    }
+}
+
+$cleanKillmails = [];
+foreach ($killmails as $km) {
+    $victimCharId = (int) ($km['victim_character_id'] ?? 0);
+    $victimShipId = (int) ($km['victim_ship_type_id'] ?? 0);
+    $cleanKillmails[] = [
+        'sequence_id'        => (int) ($km['sequence_id'] ?? 0),
+        'killmail_id'        => (int) ($km['killmail_id'] ?? 0),
+        'victim_character_id'   => $victimCharId,
+        'victim_character_name' => $charNameMap[$victimCharId] ?? '',
+        'victim_ship_type_id'   => $victimShipId,
+        'victim_ship_name'      => (string) ($killmailShipNames[$victimShipId] ?? ''),
+    ];
+}
+
+// ── SVG map: generate/read the cached theater map ──
+$mapSvg = null;
+$mapSystemIds = array_values(array_filter(
+    array_map(static fn(array $s): int => (int) ($s['system_id'] ?? 0), $systems),
+    static fn(int $id): bool => $id > 0
+));
+if ($mapSystemIds !== []) {
+    $svgPath = supplycore_theater_map_svg($theaterId, $mapSystemIds, 1);
+    if ($svgPath !== null) {
+        $svgFullPath = dirname(__DIR__, 2) . $svgPath;
+        if (is_file($svgFullPath)) {
+            $mapSvg = file_get_contents($svgFullPath);
+            if ($mapSvg === false) {
+                $mapSvg = null;
+            }
+        }
+    }
+}
+
 // ── Build response ──
 $response = [
     'theater' => [
@@ -383,6 +439,8 @@ $response = [
     'display_kill_total'    => $displayKillTotal,
     'reported_kill_total'   => $reportedKillTotal,
     'observed_kill_total'   => $observedKillTotal,
+    'killmails'             => $cleanKillmails,
+    'map_svg'               => $mapSvg,
 ];
 
 // Unlocked theaters are live data — shorter cache

--- a/public/api/public/theaters.php
+++ b/public/api/public/theaters.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../../src/bootstrap.php';
+require_once __DIR__ . '/../../../src/public_api.php';
+
+// ── Authenticate ──
+$apiKey = public_api_authenticate();
+
+// ── Optional filters ──
+$page = max(1, (int) ($_GET['page'] ?? 1));
+$perPage = min(50, max(1, (int) ($_GET['per_page'] ?? 50)));
+$offset = ($page - 1) * $perPage;
+
+// ── Load theaters (only those with tracked-alliance participation) ──
+$theaters = db_theaters_list($perPage, $offset);
+
+$theaterIds = array_column($theaters, 'theater_id');
+$sideLabelsMap = $theaterIds !== [] ? db_theater_side_labels($theaterIds) : [];
+
+// ── Build response rows ──
+$rows = [];
+foreach ($theaters as $t) {
+    $tid = (string) ($t['theater_id'] ?? '');
+    $sides = $sideLabelsMap[$tid] ?? [];
+    $friendlyBucket = $sides['friendly'] ?? null;
+    $hostileBucket = $sides['hostile'] ?? null;
+
+    $friendlyLabel = 'Friendlies';
+    if ($friendlyBucket !== null) {
+        $friendlyLabel = $friendlyBucket['top_name'] . ($friendlyBucket['count'] > 1 ? ' +' . ($friendlyBucket['count'] - 1) : '');
+    }
+
+    $hostileLabel = 'Unclassified Hostiles';
+    if ($hostileBucket !== null) {
+        $otherCount = $hostileBucket['count'] - 1;
+        $hostileLabel = $hostileBucket['top_name'] . ($otherCount > 0 ? ' +' . $otherCount : '');
+    }
+
+    $durationSec = max(1, (int) ($t['duration_seconds'] ?? 0));
+    $durationLabel = $durationSec >= 3600
+        ? number_format($durationSec / 3600, 1) . 'h'
+        : ($durationSec >= 120 ? number_format($durationSec / 60, 0) . 'm' : $durationSec . 's');
+
+    $rows[] = [
+        'theater_id'          => $tid,
+        'primary_system_name' => (string) ($t['primary_system_name'] ?? ''),
+        'region_name'         => (string) ($t['region_name'] ?? ''),
+        'battle_count'        => (int) ($t['battle_count'] ?? 0),
+        'system_count'        => (int) ($t['system_count'] ?? 0),
+        'participant_count'   => (int) ($t['participant_count'] ?? 0),
+        'total_kills'         => (int) ($t['total_kills'] ?? 0),
+        'total_isk'           => (float) ($t['total_isk'] ?? 0),
+        'duration_seconds'    => $durationSec,
+        'duration_label'      => $durationLabel,
+        'start_time'          => (string) ($t['start_time'] ?? ''),
+        'end_time'            => (string) ($t['end_time'] ?? ''),
+        'locked_at'           => (string) ($t['locked_at'] ?? ''),
+        'ai_headline'         => (string) ($t['ai_headline'] ?? ''),
+        'ai_verdict'          => (string) ($t['ai_verdict'] ?? ''),
+        'friendly_label'      => $friendlyLabel,
+        'hostile_label'       => $hostileLabel,
+    ];
+}
+
+public_api_respond([
+    'theaters' => $rows,
+    'page'     => $page,
+    'per_page' => $perPage,
+], 60);


### PR DESCRIPTION
## Summary
This PR adds a theater overview page listing all available battles and introduces a classic (br.evetools.org-style) battle report view alongside the existing summary view. Users can now browse battles from a central index and toggle between two different report layouts.

## Key Changes

### Theater Overview Page
- **New `public/api/public/theaters.php`**: API endpoint that returns paginated list of theaters with summary data (participants, kills, ISK destroyed, duration, AI verdict/headline, and friendly/hostile labels)
- **Updated `public-proxy/index.php`**: Replaced static placeholder with dynamic theater listing table showing:
  - Battle participants (friendly vs hostile labels)
  - AI-generated verdict badges (Decisive Victory, Close Fight, Defeat, etc.) with color-coded styling
  - Location (system, region, multi-system indicator)
  - Scale metrics (participant count, kill count, total ISK)
  - Duration and timestamp
  - Pagination support (50 theaters per page)

### Classic Battle Report View
- **New `public-proxy/partials/_battle_report_classic.php`**: Full classic-style battle report layout featuring:
  - Side-by-side two/three-column layout (friendly, opponent, optional third party)
  - Participants grouped by alliance → corporation hierarchy
  - Ship type renders with dead-pilot highlighting (red background)
  - ISK summary header with efficiency bar showing damage distribution
  - Per-side statistics (ISK lost, efficiency %, ships lost, damage inflicted)
  - Top damage dealer highlighting in green
  - Organization logos (alliance/corporation) inline with pilot rows
  - Resembles br.evetools.org classic layout

### View Toggle
- **Updated `public-proxy/partials/_battle_report.php`**: Added toggle buttons to switch between Summary and Classic views
  - JavaScript-based toggle with localStorage persistence
  - Default view is Summary; user preference is remembered across sessions
  - Both views share the same underlying data

### Supporting Changes
- **New `public-proxy/partials/_killmails.php`**: Killmail listing section showing victim losses grouped by side
- **New `public-proxy/partials/_location_map.php`**: Battle location map display with multi-system support
- **Updated `public/api/public/theater.php`**: Added killmail data and SVG map to theater API response
- **Updated `public-proxy/theater.php`**: Passes killmails and map SVG to view templates
- **Updated `public-proxy/partials/_header.php`**: Added back-link to theater overview
- **Updated `public-proxy/partials/_participants.php`**: Minor formatting adjustments

## Implementation Details
- Classic view uses inline CSS styling for dark EVE-themed appearance with gold/red/green accent colors
- Efficiency bar uses three-color segments (green for friendly, red for opponent, orange for third party)
- Ship type resolution falls back through multiple sources: flying_ship_type_id → ships_lost_detail → ship_type_ids
- Pod types (670, 33328) are filtered out from ship displays
- Theater listing includes AI-generated headlines and verdicts when available
- All user-facing text is properly escaped with `proxy_e()` for XSS protection

https://claude.ai/code/session_01LsamoTb56VTuTLV1cKQpF9