### PR TITLE
Use environment variables in docker-compose configuration

### DIFF
--- a/public-proxy/docker-compose.yml
+++ b/public-proxy/docker-compose.yml
@@ -8,14 +8,14 @@ services:
     environment:
       # ── Required ──────────────────────────────────────────
       # Base URL of your SupplyCore instance (no trailing slash)
-      - SUPPLYCORE_URL=https://supplycore.example.com
+      - SUPPLYCORE_URL=${SUPPLYCORE_URL}
       # API key ID (starts with pk_)
-      - API_KEY_ID=pk_your_key_id_here
+      - API_KEY_ID=${API_KEY_ID}
       # API shared secret (64-char hex string)
-      - API_SECRET=your_shared_secret_here
+      - API_SECRET=${API_SECRET}
 
       # ── Optional ──────────────────────────────────────────
       # Request timeout in seconds (default: 15)
-      #- TIMEOUT=15
+      - TIMEOUT=${TIMEOUT:-15}
       # Site branding shown in the proxy header (default: Battle Reports)
-      #- SITE_NAME=Battle Reports
+      - SITE_NAME=${SITE_NAME:-Battle Reports}


### PR DESCRIPTION
## Summary
Updated the docker-compose.yml configuration to use environment variables instead of hardcoded placeholder values, enabling better flexibility for different deployment environments.

## Key Changes
- Replaced hardcoded `SUPPLYCORE_URL` with `${SUPPLYCORE_URL}` environment variable
- Replaced hardcoded `API_KEY_ID` with `${API_KEY_ID}` environment variable
- Replaced hardcoded `API_SECRET` with `${API_SECRET}` environment variable
- Uncommented and parameterized `TIMEOUT` with default value of 15 seconds (`${TIMEOUT:-15}`)
- Uncommented and parameterized `SITE_NAME` with default value of "Battle Reports" (`${SITE_NAME:-Battle Reports}`)

## Implementation Details
- Required environment variables (`SUPPLYCORE_URL`, `API_KEY_ID`, `API_SECRET`) must be provided at runtime
- Optional environment variables (`TIMEOUT`, `SITE_NAME`) now have sensible defaults and can be overridden if needed
- This change allows the same docker-compose configuration to be used across multiple environments without modification

https://claude.ai/code/session_01AEWS31hY7asvPQvLG1Jtcv