### PR TITLE
Fix classifyAlliance closure initialization in theater post-processing

### DIFF
--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -304,6 +304,17 @@ if ($viewSnapshot !== null) {
 
 // ── Post-processing (applies to both paths) ──
 
+// Ensure $classifyAlliance closure exists (fast path restores vars but not the closure)
+if (!isset($classifyAlliance)) {
+    $classifyAlliance = static function (int $allianceId, int $corporationId = 0) use ($trackedAllianceIds, $opponentAllianceIds, $trackedCorporationIds, $opponentCorporationIds): string {
+        if ($allianceId > 0 && in_array($allianceId, $trackedAllianceIds, true)) return 'friendly';
+        if ($corporationId > 0 && in_array($corporationId, $trackedCorporationIds, true)) return 'friendly';
+        if ($allianceId > 0 && in_array($allianceId, $opponentAllianceIds, true)) return 'opponent';
+        if ($corporationId > 0 && in_array($corporationId, $opponentCorporationIds, true)) return 'opponent';
+        return 'third_party';
+    };
+}
+
 // Final-blows correction: classify using PHP closure for consistency
 $fbByGroup = db_theater_final_blows_by_attacker_group($theaterId);
 if ($fbByGroup !== []) {


### PR DESCRIPTION
## Summary
Adds a safety check to ensure the `$classifyAlliance` closure is always defined before use in the post-processing phase of the theater API endpoint. This prevents potential undefined function errors when the fast path execution restores variables but not the closure itself.

## Key Changes
- Added conditional initialization of `$classifyAlliance` closure in the post-processing section
- The closure classifies alliances/corporations as 'friendly', 'opponent', or 'third_party' based on tracked and opponent lists
- Closure captures all necessary classification arrays via `use` statement for consistent classification logic

## Implementation Details
- The check uses `isset()` to determine if the closure needs initialization
- The closure is marked as `static` for better performance and to prevent accidental variable capture
- Classification logic follows a priority order: tracked alliances → tracked corporations → opponent alliances → opponent corporations → default to third_party
- This ensures the final-blows correction logic that follows can safely use the closure regardless of which code path was executed

https://claude.ai/code/session_01GVK6sHypxkKY8RJWzkHr3g