### PR TITLE
Add default ESI corp scopes and fall back to in-game standings for theaters

### DIFF
--- a/public/theater-intelligence/index.php
+++ b/public/theater-intelligence/index.php
@@ -17,11 +17,15 @@ $theaters = db_theaters_list($perPage, $offset, $regionFilter, $minAnomaly);
 $theaterIds = array_column($theaters, 'theater_id');
 $sideLabelsMap = db_theater_side_labels($theaterIds);
 
-// Tracked alliances for the region filter dropdown
+// Tracked alliances for the region filter dropdown (fall back to corp contacts)
 $trackedAlliances = db_killmail_tracked_alliances_active();
 $trackedAllianceIds = array_map('intval', array_column($trackedAlliances, 'alliance_id'));
+if ($trackedAllianceIds === []) {
+    $contacts = db_corp_contacts_by_standing();
+    $trackedAllianceIds = array_map('intval', $contacts['friendly_alliance_ids'] ?? []);
+}
 
-// Load distinct regions that have theaters for the filter dropdown (tracked alliances only)
+// Load distinct regions that have theaters for the filter dropdown
 $theaterRegions = [];
 if ($trackedAllianceIds !== []) {
     $regionPlaceholders = implode(',', array_fill(0, count($trackedAllianceIds), '?'));

--- a/src/db.php
+++ b/src/db.php
@@ -16289,6 +16289,13 @@ function db_counterintel_scores_for_characters(array $characterIds): array
 function db_theaters_list(int $limit = 50, int $offset = 0, ?string $regionFilter = null, ?float $minAnomaly = null): array
 {
     $trackedAllianceIds = array_map('intval', array_column(db_killmail_tracked_alliances_active(), 'alliance_id'));
+
+    // Fall back to in-game corp contacts when no tracked alliances are configured
+    if ($trackedAllianceIds === []) {
+        $contacts = db_corp_contacts_by_standing();
+        $trackedAllianceIds = array_map('intval', $contacts['friendly_alliance_ids'] ?? []);
+    }
+
     if ($trackedAllianceIds === []) {
         return [];
     }
@@ -16560,6 +16567,14 @@ function db_theater_side_labels(array $theaterIds): array
     // Load tracked/opponent alliance IDs for runtime classification
     $trackedAllianceIds = array_map('intval', array_column(db_killmail_tracked_alliances_active(), 'alliance_id'));
     $opponentAllianceIds = array_map('intval', array_column(db_killmail_opponent_alliances_active(), 'alliance_id'));
+
+    // Fall back to in-game corp contacts when no tracked/opponent alliances are configured
+    if ($trackedAllianceIds === [] && $opponentAllianceIds === []) {
+        $contacts = db_corp_contacts_by_standing();
+        $trackedAllianceIds = array_map('intval', $contacts['friendly_alliance_ids'] ?? []);
+        $opponentAllianceIds = array_map('intval', $contacts['hostile_alliance_ids'] ?? []);
+    }
+
     $trackedSet = array_flip($trackedAllianceIds);
     $opponentSet = array_flip($opponentAllianceIds);
 


### PR DESCRIPTION
## Summary

- Add `esi-corporations.read_standings.v1` and `esi-corporations.read_contacts.v1` to the default ESI scopes seed in `schema.sql`
- Theater overview, side label classification, and region filter now fall back to in-game corp contacts (from ESI standings) when no tracked/opponent alliances are manually configured
- This means you can remove manually tracked alliances and the app will use your in-game diplomatic standings instead

## Test plan

- [ ] Remove all tracked alliances from the webapp
- [ ] Verify Theater Overview still shows theaters using in-game standings
- [ ] Verify matchup labels (Friendly vs Opponent) classify correctly from corp contacts
- [ ] Verify region filter dropdown still populates
- [ ] Confirm fresh installs get the full scope list in the Enabled Scopes field

https://claude.ai/code/session_01RoMu1toZhgLzQrfm7SGYqv