### PR TITLE
Fix ISK calculations and theater event-set completeness

### DIFF
--- a/public-proxy/partials/_battle_report.php
+++ b/public-proxy/partials/_battle_report.php
@@ -92,6 +92,7 @@
                 $_brp_data = [
                     'pilots' => ($enemyPanel['pilots'] ?? 0) + ($thirdPartyPanel['pilots'] ?? 0),
                     'efficiency' => $enemyEfficiency,
+                    'kills' => ($enemyPanel['kills'] ?? 0) + ($thirdPartyPanel['kills'] ?? 0),
                     'final_blows' => ($enemyPanel['final_blows'] ?? 0) + ($thirdPartyPanel['final_blows'] ?? 0),
                     'losses' => ($enemyPanel['losses'] ?? 0) + ($thirdPartyPanel['losses'] ?? 0),
                     'kill_involvements' => ($enemyPanel['kill_involvements'] ?? 0) + ($thirdPartyPanel['kill_involvements'] ?? 0),

--- a/public-proxy/partials/_battle_report_panel.php
+++ b/public-proxy/partials/_battle_report_panel.php
@@ -17,9 +17,9 @@
             <p class="text-slate-100 font-semibold"><?= number_format(($_brp_data['efficiency'] ?? 0) * 100, 1) ?>%</p>
         </div>
         <div class="px-4 py-3">
-            <p class="text-xs text-muted">Final Blows / Losses</p>
-            <p class="text-slate-100 font-semibold"><?= number_format((int) ($_brp_data['final_blows'] ?? 0)) ?> / <?= number_format((int) ($_brp_data['losses'] ?? 0)) ?></p>
-            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($_brp_data['kill_involvements'] ?? 0)) ?></p>
+            <p class="text-xs text-muted">Kills / Losses</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($_brp_data['kills'] ?? 0)) ?> / <?= number_format((int) ($_brp_data['losses'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Final blows: <?= number_format((int) ($_brp_data['final_blows'] ?? 0)) ?></p>
         </div>
         <div class="px-4 py-3">
             <p class="text-xs text-muted">ISK Killed / Lost</p>

--- a/public-proxy/partials/_battle_report_panel_merged.php
+++ b/public-proxy/partials/_battle_report_panel_merged.php
@@ -17,9 +17,9 @@
             <p class="text-slate-100 font-semibold"><?= number_format(($_brp_data['efficiency'] ?? 0) * 100, 1) ?>%</p>
         </div>
         <div class="px-4 py-3">
-            <p class="text-xs text-muted">Final Blows / Losses</p>
-            <p class="text-slate-100 font-semibold"><?= number_format((int) ($_brp_data['final_blows'] ?? 0)) ?> / <?= number_format((int) ($_brp_data['losses'] ?? 0)) ?></p>
-            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($_brp_data['kill_involvements'] ?? 0)) ?></p>
+            <p class="text-xs text-muted">Kills / Losses</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($_brp_data['kills'] ?? 0)) ?> / <?= number_format((int) ($_brp_data['losses'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Final blows: <?= number_format((int) ($_brp_data['final_blows'] ?? 0)) ?></p>
         </div>
         <div class="px-4 py-3">
             <p class="text-xs text-muted">ISK Killed / Lost</p>

--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -212,6 +212,11 @@ if ($viewSnapshot !== null) {
     $sidePanels['opponent']['isk_killed'] = $friendlyLost;
     $sidePanels['third_party']['isk_killed'] = 0.0;
 
+    // Ship kills derived from opposing side's losses (same principle as ISK).
+    $sidePanels['friendly']['kills'] = $sidePanels['opponent']['losses'];
+    $sidePanels['opponent']['kills'] = $sidePanels['friendly']['losses'];
+    $sidePanels['third_party']['kills'] = 0;
+
     // efficiency = isk_killed / (isk_killed + isk_lost)  — two-side, symmetric
     $sidePanels['friendly']['efficiency'] = $twoSideTotal > 0
         ? $opponentLost / $twoSideTotal : 0.0;

--- a/public/theater-intelligence/partials/_battle_report.php
+++ b/public/theater-intelligence/partials/_battle_report.php
@@ -114,6 +114,7 @@
                     $panelData = [
                         'pilots' => ($enemyPanel['pilots'] ?? 0) + ($thirdPartyPanel['pilots'] ?? 0),
                         'efficiency' => $enemyEfficiency,
+                        'kills' => ($enemyPanel['kills'] ?? 0) + ($thirdPartyPanel['kills'] ?? 0),
                         'final_blows' => ($enemyPanel['final_blows'] ?? 0) + ($thirdPartyPanel['final_blows'] ?? 0),
                         'losses' => ($enemyPanel['losses'] ?? 0) + ($thirdPartyPanel['losses'] ?? 0),
                         'kill_involvements' => ($enemyPanel['kill_involvements'] ?? 0) + ($thirdPartyPanel['kill_involvements'] ?? 0),

--- a/public/theater-intelligence/partials/_battle_report_panel.php
+++ b/public/theater-intelligence/partials/_battle_report_panel.php
@@ -17,9 +17,9 @@
             <p class="text-slate-100 font-semibold"><?= number_format(($panelData['efficiency'] ?? 0) * 100, 1) ?>%</p>
         </div>
         <div class="px-4 py-3">
-            <p class="text-xs text-muted">Final Blows / Losses</p>
-            <p class="text-slate-100 font-semibold"><?= number_format((int) ($panelData['final_blows'] ?? 0)) ?> / <?= number_format((int) ($panelData['losses'] ?? 0)) ?></p>
-            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($panelData['kill_involvements'] ?? 0)) ?></p>
+            <p class="text-xs text-muted">Kills / Losses</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($panelData['kills'] ?? 0)) ?> / <?= number_format((int) ($panelData['losses'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Final blows: <?= number_format((int) ($panelData['final_blows'] ?? 0)) ?></p>
         </div>
         <div class="px-4 py-3">
             <p class="text-xs text-muted">ISK Killed / Lost</p>

--- a/public/theater-intelligence/partials/_battle_report_panel_merged.php
+++ b/public/theater-intelligence/partials/_battle_report_panel_merged.php
@@ -17,9 +17,9 @@
             <p class="text-slate-100 font-semibold"><?= number_format(($panelData['efficiency'] ?? 0) * 100, 1) ?>%</p>
         </div>
         <div class="px-4 py-3">
-            <p class="text-xs text-muted">Final Blows / Losses</p>
-            <p class="text-slate-100 font-semibold"><?= number_format((int) ($panelData['final_blows'] ?? 0)) ?> / <?= number_format((int) ($panelData['losses'] ?? 0)) ?></p>
-            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($panelData['kill_involvements'] ?? 0)) ?></p>
+            <p class="text-xs text-muted">Kills / Losses</p>
+            <p class="text-slate-100 font-semibold"><?= number_format((int) ($panelData['kills'] ?? 0)) ?> / <?= number_format((int) ($panelData['losses'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Final blows: <?= number_format((int) ($panelData['final_blows'] ?? 0)) ?></p>
         </div>
         <div class="px-4 py-3">
             <p class="text-xs text-muted">ISK Killed / Lost</p>

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -437,6 +437,12 @@ if ($viewSnapshot !== null && !$pendingLock) {
     $sidePanels['opponent']['isk_killed'] = $friendlyLost;
     $sidePanels['third_party']['isk_killed'] = 0.0;
 
+    // Ship kills derived from opposing side's losses (same principle as ISK).
+    // friendly_kills == opponent_losses (how many enemy ships died).
+    $sidePanels['friendly']['kills'] = $sidePanels['opponent']['losses'];
+    $sidePanels['opponent']['kills'] = $sidePanels['friendly']['losses'];
+    $sidePanels['third_party']['kills'] = 0;
+
     // efficiency = isk_killed / (isk_killed + isk_lost)  — two-side, symmetric
     $sidePanels['friendly']['efficiency'] = $twoSideTotal > 0
         ? $opponentLost / $twoSideTotal : 0.0;


### PR DESCRIPTION
## Summary

Refactors all battle/theater ISK calculations to a strict loss-based model matching EVE BR (br.evetools.org), and adds engagement expansion to capture killmails that were being excluded from theater event sets.

### ISK Model (commits 1-2)
- **All side-level metrics derived from victim losses only** — never from attacker attribution
- `friendly_isk_killed = enemy_isk_lost` (exact identity, not summed from attacker data)
- `enemy_isk_killed = friendly_isk_lost` (symmetric)
- `total_isk_destroyed = friendly + enemy + third_party losses`
- Efficiency = two-side only, third parties excluded
- Per-alliance `total_isk_killed` kept as analytics metadata (all participants credited)

### Ship Kills (commit 5)
- Same principle applied to kill counts: `friendly_kills = opponent_losses`
- Side panels now show "Kills / Losses" (victim-derived) instead of "Final Blows / Losses" (attacker-derived)
- Final blows shown as secondary detail

### Event-Set Expansion (commits 3-4)
- **Engagement expansion**: theater analysis now also queries killmails in theater systems within ±5min of the theater window, capturing sub-threshold battles, boundary-split kills, and third-party opportunists
- **Entity-overlap guard**: expansion candidates must share at least one character, corporation, or alliance with the base set to prevent noise contamination
- **Sub-threshold battle absorption**: battles with <10 participants in theater systems are absorbed into the theater during clustering
- All thresholds configurable via `app_settings`
- Diagnostics logged per theater (base vs expanded counts, rejected noise)

## What is validated offline
- 8 Python tests + 6 PHP tests passing
- ISK invariants: `friendly_isk_killed == enemy_isk_lost`, third-party exclusion from efficiency
- Clustering: same-constellation merge, multi-wave engagement merge
- Noise rejection: unrelated same-system kills filtered by overlap guard
- Third-party handling: final blow attribution, victim inclusion in totals

## What requires live DB validation
- Whether real theaters gain additional killmails from expansion
- Whether over-inclusion occurs in busy systems (staging, trade hubs)
- Magnitude of `total_isk_destroyed` change on real theaters
- Whether theater time boundaries become too wide after absorption
- Whether the 5-min expansion margin is appropriate

`bin/validate_theater_expansion.sql` contains the exact queries to run before/after for comparison.

## Test plan
- [x] PHP ISK invariant tests pass (`bin/test_theater_ai_build_facts.php`)
- [x] Python engagement expansion tests pass (8 tests)
- [ ] Deploy and re-run `theater_clustering` + `theater_analysis`
- [ ] Compare before/after using `bin/validate_theater_expansion.sql`
- [ ] Visually compare a theater with its EVE BR equivalent
- [ ] Check expansion diagnostics in logs for rejected noise counts

https://claude.ai/code/session_01Usj5JUuVCZaJQ81FcRqpB7