### PR TITLE
Fix ISK and kill/loss calculations to match EVE BR model

### DIFF
--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -215,7 +215,8 @@ if ($viewSnapshot !== null) {
     // Ship kills derived from opposing side's losses (same principle as ISK).
     $sidePanels['friendly']['kills'] = $sidePanels['opponent']['losses'];
     $sidePanels['opponent']['kills'] = $sidePanels['friendly']['losses'];
-    $sidePanels['third_party']['kills'] = 0;
+    // Third party keeps its accumulated kill-involvement count from the
+    // alliance summary — the two-side derivation doesn't apply to them.
 
     // efficiency = isk_killed / (isk_killed + isk_lost)  — two-side, symmetric
     $sidePanels['friendly']['efficiency'] = $twoSideTotal > 0

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -441,7 +441,8 @@ if ($viewSnapshot !== null && !$pendingLock) {
     // friendly_kills == opponent_losses (how many enemy ships died).
     $sidePanels['friendly']['kills'] = $sidePanels['opponent']['losses'];
     $sidePanels['opponent']['kills'] = $sidePanels['friendly']['losses'];
-    $sidePanels['third_party']['kills'] = 0;
+    // Third party keeps its accumulated kill-involvement count from the
+    // alliance summary — the two-side derivation doesn't apply to them.
 
     // efficiency = isk_killed / (isk_killed + isk_lost)  — two-side, symmetric
     $sidePanels['friendly']['efficiency'] = $twoSideTotal > 0


### PR DESCRIPTION
## Summary

Refactors all battle/theater calculations to a strict loss-based model matching EVE BR (br.evetools.org). All side-level metrics — ISK and ship counts — are now derived from victim losses, never from attacker attribution.

## Changes

### ISK Model
- `friendly_isk_killed = enemy_isk_lost` (exact identity)
- `enemy_isk_killed = friendly_isk_lost` (symmetric)
- `total_isk_destroyed = friendly + enemy + third_party losses`
- Efficiency two-side only, third parties excluded
- Per-alliance `total_isk_killed` kept as analytics metadata

### Ship Kill/Loss Counts
- `friendly_kills = opponent_losses` (how many enemy ships died)
- `opponent_kills = friendly_losses` (how many friendly ships died)
- Panels show "Kills / Losses" (victim-derived) with final blows as secondary detail
- Third-party panel keeps accumulated kill-involvement count (outside the two-side model)

### Event-Set Expansion
- Theater analysis queries killmails in theater systems within ±5min of theater window
- Entity-overlap guard: candidates must share character/corp/alliance with base set
- Sub-threshold battle absorption (<10 participants) during clustering
- All thresholds configurable via `app_settings`
- Diagnostics logged per theater

### Files Changed (14 files, ~1000 lines)
- `theater_analysis.py` — expanded killmail loading with overlap guard + diagnostics
- `theater_clustering.py` — sub-threshold absorption + configurable settings
- `view.php`, `theater.php` API — loss-based side panels (ISK + kills)
- Panel partials (4 files) — "Kills / Losses" display with final blows detail
- `functions.php` — AI battle report facts with third-party ISK tracking
- `test_theater_ai_build_facts.php` — PHP ISK invariant tests
- `test_theater_engagement_expansion.py` — 8 Python regression tests
- `validate_theater_expansion.sql` — human-runnable before/after queries

## Offline validated
- 8 Python tests + 6 PHP tests passing
- ISK invariants: `friendly_isk_killed == enemy_isk_lost`
- Noise rejection: unrelated same-system kills filtered
- Clustering: constellation merge, multi-wave merge
- Third-party: correct in totals, excluded from efficiency

## Requires live DB validation
- Whether expansion captures missing killmails on real theaters
- Whether over-inclusion occurs in busy systems
- Magnitude of total_isk_destroyed change
- Appropriateness of 5-min expansion margin

Run `bin/validate_theater_expansion.sql` before/after re-running jobs.

## Test plan
- [x] PHP ISK invariant tests pass
- [x] Python engagement expansion tests pass (8 tests)
- [ ] Deploy and re-run `theater_clustering` + `theater_analysis`
- [ ] Compare before/after via `bin/validate_theater_expansion.sql`
- [ ] Visually compare a theater with its EVE BR equivalent

https://claude.ai/code/session_01Usj5JUuVCZaJQ81FcRqpB7