### PR TITLE
Add manual corp contacts alongside ESI-synced standings

### DIFF
--- a/database/migrations/20260403_corp_contacts_source.sql
+++ b/database/migrations/20260403_corp_contacts_source.sql
@@ -1,0 +1,6 @@
+-- Add source column to distinguish ESI-synced vs manually added contacts.
+-- Manual contacts are preserved during ESI sync; ESI contacts are refreshed each run.
+
+ALTER TABLE corp_contacts
+    ADD COLUMN source ENUM('esi', 'manual') NOT NULL DEFAULT 'esi' AFTER label_ids,
+    ADD KEY idx_source (source);

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1551,6 +1551,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
                 // Build corp contacts display data with resolved names
                 $corpContactsList = db_corp_contacts_all();
+                $esiContacts = array_filter($corpContactsList, static fn (array $c): bool => ((string) ($c['source'] ?? 'esi')) === 'esi');
+                $manualContacts = array_filter($corpContactsList, static fn (array $c): bool => ((string) ($c['source'] ?? 'esi')) === 'manual');
                 $contactAllianceIds = array_values(array_unique(array_filter(array_map(
                     static fn (array $c): int => $c['contact_type'] === 'alliance' ? (int) $c['contact_id'] : 0,
                     $corpContactsList
@@ -1566,6 +1568,27 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 foreach (db_entity_metadata_cache_get_many('corporation', $contactCorpIds) as $e) {
                     $contactNameMap['corporation:' . (int) $e['entity_id']] = (string) $e['entity_name'];
                 }
+
+                // Prepare manual contact picker selections
+                $manualFriendlyAllianceSelections = [];
+                $manualFriendlyCorporationSelections = [];
+                $manualHostileAllianceSelections = [];
+                $manualHostileCorporationSelections = [];
+                foreach ($manualContacts as $mc) {
+                    $mcId = (int) $mc['contact_id'];
+                    $mcType = (string) $mc['contact_type'];
+                    $mcStanding = (float) $mc['standing'];
+                    $mcName = $contactNameMap[$mcType . ':' . $mcId] ?? ucfirst($mcType) . ' #' . $mcId;
+                    $entry = ['id' => $mcId, 'name' => $mcName, 'type' => ucfirst($mcType)];
+                    if ($mcStanding > 0 && $mcType === 'alliance') { $manualFriendlyAllianceSelections[] = $entry; }
+                    elseif ($mcStanding > 0 && $mcType === 'corporation') { $manualFriendlyCorporationSelections[] = $entry; }
+                    elseif ($mcStanding < 0 && $mcType === 'alliance') { $manualHostileAllianceSelections[] = $entry; }
+                    elseif ($mcStanding < 0 && $mcType === 'corporation') { $manualHostileCorporationSelections[] = $entry; }
+                }
+                $manualFriendlyAlliancesText = implode("\n", array_map(static fn (array $r): string => $r['id'] . ' | ' . $r['name'], $manualFriendlyAllianceSelections));
+                $manualFriendlyCorporationsText = implode("\n", array_map(static fn (array $r): string => $r['id'] . ' | ' . $r['name'], $manualFriendlyCorporationSelections));
+                $manualHostileAlliancesText = implode("\n", array_map(static fn (array $r): string => $r['id'] . ' | ' . $r['name'], $manualHostileAllianceSelections));
+                $manualHostileCorporationsText = implode("\n", array_map(static fn (array $r): string => $r['id'] . ' | ' . $r['name'], $manualHostileCorporationSelections));
 
                 $statusState = is_array($killmailStatus['state'] ?? null) ? $killmailStatus['state'] : [];
                 $killmailHealth = is_array($killmailStatusSummary['health'] ?? null) ? $killmailStatusSummary['health'] : [];
@@ -1739,22 +1762,23 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <p>This powers the <span class="text-slate-100">Economic Warfare</span> page: hostile fit family reconstruction, module scoring, and supply pressure analysis across their full engagement history.</p>
                 </div>
 
-                <?php if ($corpContactsList !== []): ?>
-                <h3 class="text-base font-semibold text-slate-100 mt-6">In-Game Corp Contacts (ESI Standings)</h3>
-                <p class="mt-1 text-xs text-muted">These contacts are synced from your corporation's in-game standings via ESI. They serve as a fallback for side classification in Theater Intelligence when no manual tracked/opponent alliances are configured above.</p>
+                <h3 class="text-base font-semibold text-slate-100 mt-6">Corp Contacts (ESI + Manual Standings)</h3>
+                <p class="mt-1 text-xs text-muted">ESI contacts are synced from your corporation's in-game standings. You can also add manual contacts below — these are preserved across ESI syncs and used for theater side classification.</p>
 
-                <div class="grid gap-4 lg:grid-cols-2 mt-2">
-                    <?php
-                        $friendlyContacts = array_filter($corpContactsList, static fn (array $c): bool => (float) $c['standing'] > 0);
-                        $hostileContacts = array_filter($corpContactsList, static fn (array $c): bool => (float) $c['standing'] < 0);
-                    ?>
+                <?php if ($esiContacts !== []): ?>
+                <?php
+                    $esiFriendly = array_filter($esiContacts, static fn (array $c): bool => (float) $c['standing'] > 0);
+                    $esiHostile = array_filter($esiContacts, static fn (array $c): bool => (float) $c['standing'] < 0);
+                ?>
+                <p class="text-xs uppercase tracking-[0.14em] text-muted mt-4 mb-2">ESI Synced (read-only)</p>
+                <div class="grid gap-4 lg:grid-cols-2">
                     <div class="space-y-2">
                         <span class="text-sm text-blue-300">Friendly (positive standing)</span>
-                        <?php if ($friendlyContacts === []): ?>
-                            <p class="text-xs text-muted">No friendly contacts found.</p>
+                        <?php if ($esiFriendly === []): ?>
+                            <p class="text-xs text-muted">No friendly contacts from ESI.</p>
                         <?php else: ?>
                             <div class="max-h-72 overflow-y-auto rounded-lg border border-border bg-black/10 divide-y divide-border/50">
-                                <?php foreach ($friendlyContacts as $c):
+                                <?php foreach ($esiFriendly as $c):
                                     $cId = (int) $c['contact_id'];
                                     $cType = (string) $c['contact_type'];
                                     $cStanding = (float) $c['standing'];
@@ -1773,11 +1797,11 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     </div>
                     <div class="space-y-2">
                         <span class="text-sm text-red-300">Hostile (negative standing)</span>
-                        <?php if ($hostileContacts === []): ?>
-                            <p class="text-xs text-muted">No hostile contacts found.</p>
+                        <?php if ($esiHostile === []): ?>
+                            <p class="text-xs text-muted">No hostile contacts from ESI.</p>
                         <?php else: ?>
                             <div class="max-h-72 overflow-y-auto rounded-lg border border-border bg-black/10 divide-y divide-border/50">
-                                <?php foreach ($hostileContacts as $c):
+                                <?php foreach ($esiHostile as $c):
                                     $cId = (int) $c['contact_id'];
                                     $cType = (string) $c['contact_type'];
                                     $cStanding = (float) $c['standing'];
@@ -1795,12 +1819,65 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <?php endif; ?>
                     </div>
                 </div>
-
-                <div class="rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3 text-sm text-muted space-y-2">
-                    <p>These standings are read-only and synced automatically from ESI. To change them, update your corporation's contacts in-game and wait for the next sync.</p>
-                    <p>When no friendly/opponent alliances are configured manually above, Theater Intelligence uses these contacts to classify sides: <span class="text-blue-300">positive standing = friendly</span>, <span class="text-red-300">negative standing = opponent</span>.</p>
-                </div>
                 <?php endif; ?>
+
+                <p class="text-xs uppercase tracking-[0.14em] text-muted mt-4 mb-2">Manual Contacts (editable)</p>
+                <p class="text-xs text-muted mb-2">Add alliances or corporations here to supplement ESI standings. Friendly contacts get +10.0 standing, hostile contacts get -10.0.</p>
+
+                <div class="grid gap-4 lg:grid-cols-2">
+                    <div class="space-y-3">
+                        <span class="text-sm text-blue-300">Friendly Alliances</span>
+                        <textarea name="manual_friendly_alliance_contacts" id="manual_friendly_alliance_contacts" class="hidden"><?= htmlspecialchars($manualFriendlyAlliancesText, ENT_QUOTES) ?></textarea>
+                        <div class="flex gap-2">
+                            <input type="text" id="manual_friendly_alliance_search" autocomplete="off" placeholder="Search alliances or enter ID" class="w-full field-input" />
+                            <button type="button" id="manual_friendly_alliance_add" class="rounded-lg border border-border bg-black/30 px-3 py-2 text-sm text-slate-100 transition hover:bg-white/5">Add</button>
+                        </div>
+                        <p id="manual_friendly_alliance_status" class="text-xs text-muted"><?= htmlspecialchars($manualFriendlyAllianceSelections === [] ? 'No manual friendly alliances.' : count($manualFriendlyAllianceSelections) . ' manual friendly alliance' . (count($manualFriendlyAllianceSelections) === 1 ? '' : 's') . '.', ENT_QUOTES) ?></p>
+                        <ul id="manual_friendly_alliance_results" class="hidden max-h-60 overflow-y-auto surface-tertiary"></ul>
+                        <div id="manual_friendly_alliance_selected" class="space-y-2 rounded-lg border border-border bg-black/10 p-3"></div>
+                    </div>
+                    <div class="space-y-3">
+                        <span class="text-sm text-blue-300">Friendly Corporations</span>
+                        <textarea name="manual_friendly_corporation_contacts" id="manual_friendly_corporation_contacts" class="hidden"><?= htmlspecialchars($manualFriendlyCorporationsText, ENT_QUOTES) ?></textarea>
+                        <div class="flex gap-2">
+                            <input type="text" id="manual_friendly_corporation_search" autocomplete="off" placeholder="Search corporations or enter ID" class="w-full field-input" />
+                            <button type="button" id="manual_friendly_corporation_add" class="rounded-lg border border-border bg-black/30 px-3 py-2 text-sm text-slate-100 transition hover:bg-white/5">Add</button>
+                        </div>
+                        <p id="manual_friendly_corporation_status" class="text-xs text-muted"><?= htmlspecialchars($manualFriendlyCorporationSelections === [] ? 'No manual friendly corporations.' : count($manualFriendlyCorporationSelections) . ' manual friendly corporation' . (count($manualFriendlyCorporationSelections) === 1 ? '' : 's') . '.', ENT_QUOTES) ?></p>
+                        <ul id="manual_friendly_corporation_results" class="hidden max-h-60 overflow-y-auto surface-tertiary"></ul>
+                        <div id="manual_friendly_corporation_selected" class="space-y-2 rounded-lg border border-border bg-black/10 p-3"></div>
+                    </div>
+                </div>
+
+                <div class="grid gap-4 lg:grid-cols-2 mt-3">
+                    <div class="space-y-3">
+                        <span class="text-sm text-red-300">Hostile Alliances</span>
+                        <textarea name="manual_hostile_alliance_contacts" id="manual_hostile_alliance_contacts" class="hidden"><?= htmlspecialchars($manualHostileAlliancesText, ENT_QUOTES) ?></textarea>
+                        <div class="flex gap-2">
+                            <input type="text" id="manual_hostile_alliance_search" autocomplete="off" placeholder="Search alliances or enter ID" class="w-full field-input" />
+                            <button type="button" id="manual_hostile_alliance_add" class="rounded-lg border border-border bg-black/30 px-3 py-2 text-sm text-slate-100 transition hover:bg-white/5">Add</button>
+                        </div>
+                        <p id="manual_hostile_alliance_status" class="text-xs text-muted"><?= htmlspecialchars($manualHostileAllianceSelections === [] ? 'No manual hostile alliances.' : count($manualHostileAllianceSelections) . ' manual hostile alliance' . (count($manualHostileAllianceSelections) === 1 ? '' : 's') . '.', ENT_QUOTES) ?></p>
+                        <ul id="manual_hostile_alliance_results" class="hidden max-h-60 overflow-y-auto surface-tertiary"></ul>
+                        <div id="manual_hostile_alliance_selected" class="space-y-2 rounded-lg border border-border bg-black/10 p-3"></div>
+                    </div>
+                    <div class="space-y-3">
+                        <span class="text-sm text-red-300">Hostile Corporations</span>
+                        <textarea name="manual_hostile_corporation_contacts" id="manual_hostile_corporation_contacts" class="hidden"><?= htmlspecialchars($manualHostileCorporationsText, ENT_QUOTES) ?></textarea>
+                        <div class="flex gap-2">
+                            <input type="text" id="manual_hostile_corporation_search" autocomplete="off" placeholder="Search corporations or enter ID" class="w-full field-input" />
+                            <button type="button" id="manual_hostile_corporation_add" class="rounded-lg border border-border bg-black/30 px-3 py-2 text-sm text-slate-100 transition hover:bg-white/5">Add</button>
+                        </div>
+                        <p id="manual_hostile_corporation_status" class="text-xs text-muted"><?= htmlspecialchars($manualHostileCorporationSelections === [] ? 'No manual hostile corporations.' : count($manualHostileCorporationSelections) . ' manual hostile corporation' . (count($manualHostileCorporationSelections) === 1 ? '' : 's') . '.', ENT_QUOTES) ?></p>
+                        <ul id="manual_hostile_corporation_results" class="hidden max-h-60 overflow-y-auto surface-tertiary"></ul>
+                        <div id="manual_hostile_corporation_selected" class="space-y-2 rounded-lg border border-border bg-black/10 p-3"></div>
+                    </div>
+                </div>
+
+                <div class="rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3 text-sm text-muted space-y-2 mt-3">
+                    <p>ESI contacts are read-only — update them in-game and wait for the next sync. Manual contacts are saved with this form and persist across syncs.</p>
+                    <p>Theater Intelligence uses these contacts to classify sides: <span class="text-blue-300">positive standing = friendly</span>, <span class="text-red-300">negative standing = opponent</span>.</p>
+                </div>
 
                 <script>
                     (() => {
@@ -2153,6 +2230,51 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             selectedId: 'opponent_corporation_selected',
                             allowedType: 'Corporation',
                             initialItems: <?= json_encode($opponentCorporationSelections, JSON_THROW_ON_ERROR) ?>,
+                        });
+
+                        // Manual corp contact pickers
+                        createTrackedEntityPicker({
+                            inputId: 'manual_friendly_alliance_search',
+                            addButtonId: 'manual_friendly_alliance_add',
+                            hiddenId: 'manual_friendly_alliance_contacts',
+                            resultsId: 'manual_friendly_alliance_results',
+                            statusId: 'manual_friendly_alliance_status',
+                            selectedId: 'manual_friendly_alliance_selected',
+                            allowedType: 'Alliance',
+                            initialItems: <?= json_encode($manualFriendlyAllianceSelections, JSON_THROW_ON_ERROR) ?>,
+                        });
+
+                        createTrackedEntityPicker({
+                            inputId: 'manual_friendly_corporation_search',
+                            addButtonId: 'manual_friendly_corporation_add',
+                            hiddenId: 'manual_friendly_corporation_contacts',
+                            resultsId: 'manual_friendly_corporation_results',
+                            statusId: 'manual_friendly_corporation_status',
+                            selectedId: 'manual_friendly_corporation_selected',
+                            allowedType: 'Corporation',
+                            initialItems: <?= json_encode($manualFriendlyCorporationSelections, JSON_THROW_ON_ERROR) ?>,
+                        });
+
+                        createTrackedEntityPicker({
+                            inputId: 'manual_hostile_alliance_search',
+                            addButtonId: 'manual_hostile_alliance_add',
+                            hiddenId: 'manual_hostile_alliance_contacts',
+                            resultsId: 'manual_hostile_alliance_results',
+                            statusId: 'manual_hostile_alliance_status',
+                            selectedId: 'manual_hostile_alliance_selected',
+                            allowedType: 'Alliance',
+                            initialItems: <?= json_encode($manualHostileAllianceSelections, JSON_THROW_ON_ERROR) ?>,
+                        });
+
+                        createTrackedEntityPicker({
+                            inputId: 'manual_hostile_corporation_search',
+                            addButtonId: 'manual_hostile_corporation_add',
+                            hiddenId: 'manual_hostile_corporation_contacts',
+                            resultsId: 'manual_hostile_corporation_results',
+                            statusId: 'manual_hostile_corporation_status',
+                            selectedId: 'manual_hostile_corporation_selected',
+                            allowedType: 'Corporation',
+                            initialItems: <?= json_encode($manualHostileCorporationSelections, JSON_THROW_ON_ERROR) ?>,
                         });
                     })();
                 </script>

--- a/python/orchestrator/jobs/corp_standings_sync.py
+++ b/python/orchestrator/jobs/corp_standings_sync.py
@@ -318,12 +318,12 @@ def _upsert_contacts(
 
         db.execute(
             """
-            INSERT INTO corp_contacts (corporation_id, contact_id, contact_type, standing, label_ids, fetched_at)
-            VALUES (%s, %s, %s, %s, %s, %s)
+            INSERT INTO corp_contacts (corporation_id, contact_id, contact_type, standing, label_ids, source, fetched_at)
+            VALUES (%s, %s, %s, %s, %s, 'esi', %s)
             ON DUPLICATE KEY UPDATE
-                standing = VALUES(standing),
-                label_ids = VALUES(label_ids),
-                fetched_at = VALUES(fetched_at),
+                standing = IF(source = 'manual', standing, VALUES(standing)),
+                label_ids = IF(source = 'manual', label_ids, VALUES(label_ids)),
+                fetched_at = IF(source = 'manual', fetched_at, VALUES(fetched_at)),
                 updated_at = CURRENT_TIMESTAMP
             """,
             [corp_id, contact_id, contact_type, standing, label_json, fetched_at],

--- a/src/db.php
+++ b/src/db.php
@@ -11829,9 +11829,9 @@ function db_corp_contacts_all(): array
 {
     try {
         return db_select(
-            'SELECT corporation_id, contact_id, contact_type, standing, label_ids, fetched_at
+            "SELECT corporation_id, contact_id, contact_type, standing, label_ids, COALESCE(source, 'esi') AS source, fetched_at
              FROM corp_contacts
-             ORDER BY corporation_id ASC, contact_type ASC, standing DESC'
+             ORDER BY source ASC, contact_type ASC, standing DESC"
         );
     } catch (Throwable) {
         return [];
@@ -11912,6 +11912,52 @@ function db_corp_contact_standing(int $entityId, string $entityType = 'alliance'
         return $row !== null ? (float) $row['standing'] : null;
     } catch (Throwable) {
         return null;
+    }
+}
+
+/**
+ * Replace all manual corp contacts with the given list.
+ * Each entry: ['contact_id' => int, 'contact_type' => string, 'standing' => float]
+ */
+function db_corp_contacts_manual_replace(array $contacts): void
+{
+    db_execute('DELETE FROM corp_contacts WHERE source = ?', ['manual']);
+
+    foreach ($contacts as $c) {
+        $contactId = (int) ($c['contact_id'] ?? 0);
+        $contactType = (string) ($c['contact_type'] ?? '');
+        $standing = (float) ($c['standing'] ?? 0);
+
+        if ($contactId <= 0 || !in_array($contactType, ['alliance', 'corporation'], true) || $standing == 0) {
+            continue;
+        }
+
+        db_execute(
+            "INSERT INTO corp_contacts (corporation_id, contact_id, contact_type, standing, source, fetched_at)
+             VALUES (0, ?, ?, ?, 'manual', UTC_TIMESTAMP())
+             ON DUPLICATE KEY UPDATE
+                standing = VALUES(standing),
+                source = 'manual',
+                updated_at = CURRENT_TIMESTAMP",
+            [$contactId, $contactType, $standing]
+        );
+    }
+}
+
+/**
+ * Fetch all manually added corp contacts.
+ */
+function db_corp_contacts_manual(): array
+{
+    try {
+        return db_select(
+            "SELECT contact_id, contact_type, standing
+             FROM corp_contacts
+             WHERE source = 'manual'
+             ORDER BY standing DESC, contact_type ASC"
+        );
+    } catch (Throwable) {
+        return [];
     }
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -19065,11 +19065,45 @@ function killmail_settings_from_request(array $request): array
             static fn (array $row): array => ['corporation_id' => (int) ($row['id'] ?? 0), 'label' => $row['label'] ?? null],
             (array) ($resolvedOpponents['corporations'] ?? [])
         ),
+        'manual_contacts' => killmail_parse_manual_contacts(
+            (string) ($request['manual_friendly_alliance_contacts'] ?? ''),
+            (string) ($request['manual_friendly_corporation_contacts'] ?? ''),
+            (string) ($request['manual_hostile_alliance_contacts'] ?? ''),
+            (string) ($request['manual_hostile_corporation_contacts'] ?? '')
+        ),
         'unresolved' => array_values(array_merge(
             (array) ($resolvedEntities['unresolved'] ?? []),
             (array) ($resolvedOpponents['unresolved'] ?? [])
         )),
     ];
+}
+
+/**
+ * Parse manual contact entries from "ID | Name" textarea format (4 fields: friendly/hostile x alliance/corporation).
+ * Friendly entries get +10 standing, hostile get -10.
+ */
+function killmail_parse_manual_contacts(string $friendlyAlliances, string $friendlyCorporations, string $hostileAlliances, string $hostileCorporations): array
+{
+    $contacts = [];
+    $parse = static function (string $raw, string $type, float $standing) use (&$contacts): void {
+        foreach (explode("\n", $raw) as $line) {
+            $line = trim($line);
+            if ($line === '') {
+                continue;
+            }
+            $parts = explode('|', $line, 2);
+            $id = (int) trim($parts[0] ?? '');
+            if ($id <= 0) {
+                continue;
+            }
+            $contacts[] = ['contact_id' => $id, 'contact_type' => $type, 'standing' => $standing];
+        }
+    };
+    $parse($friendlyAlliances, 'alliance', 10.0);
+    $parse($friendlyCorporations, 'corporation', 10.0);
+    $parse($hostileAlliances, 'alliance', -10.0);
+    $parse($hostileCorporations, 'corporation', -10.0);
+    return $contacts;
 }
 
 function save_killmail_intelligence_settings(array $request): array
@@ -19087,6 +19121,7 @@ function save_killmail_intelligence_settings(array $request): array
         db_killmail_tracked_corporations_replace((array) ($payload['corporations'] ?? []));
         db_killmail_opponent_alliances_replace((array) ($payload['opponent_alliances'] ?? []));
         db_killmail_opponent_corporations_replace((array) ($payload['opponent_corporations'] ?? []));
+        db_corp_contacts_manual_replace((array) ($payload['manual_contacts'] ?? []));
 
         $reloadedSettings = get_settings(array_keys((array) ($payload['settings'] ?? [])));
         foreach ((array) ($payload['settings'] ?? []) as $key => $value) {


### PR DESCRIPTION
## Summary

- Add `source` column (`esi`/`manual`) to `corp_contacts` table to distinguish ESI-synced from manually added contacts
- ESI sync now preserves manual contacts — won't overwrite entries where `source='manual'`
- Add 4 entity search pickers in Killmail Intelligence settings for manually adding friendly/hostile alliances and corporations
- ESI contacts displayed as read-only list; manual contacts are editable with add/remove
- Manual contacts get +10.0 (friendly) or -10.0 (hostile) standing and are used by Theater Intelligence for side classification

## Test plan

- [ ] Run migration: `ALTER TABLE corp_contacts ADD COLUMN source ...`
- [ ] Verify ESI contacts still display correctly in the read-only section
- [ ] Add a manual friendly alliance and hostile corporation, save, verify they persist
- [ ] Run `corp_standings_sync` job — confirm manual contacts are not overwritten
- [ ] Verify Theater Intelligence uses both ESI and manual contacts for classification

https://claude.ai/code/session_01RoMu1toZhgLzQrfm7SGYqv