### PR TITLE
Switch to final-blow-based metrics for kills and ISK killed

### DIFF
--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -193,37 +193,29 @@ if ($viewSnapshot !== null) {
         if (isset($participantKillTotalsBySide[$side])) $participantKillTotalsBySide[$side] += $kills;
     }
 
+    // ── Final-blow-based ISK killed & kills ─────────────────────────
+    // Each side's isk_killed = sum of ISK from killmails where that side
+    // got the final blow.  Each side's kills = final blow count.
     $finalBlowsByGroup = db_theater_final_blows_by_attacker_group($theaterId);
     $finalBlowsBySide = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
+    $iskKilledBySide  = ['friendly' => 0.0, 'opponent' => 0.0, 'third_party' => 0.0];
     foreach ($finalBlowsByGroup as $fbRow) {
         $fbSide = $classifyAlliance((int) ($fbRow['alliance_id'] ?? 0), (int) ($fbRow['corporation_id'] ?? 0));
         $finalBlowsBySide[$fbSide] += (int) ($fbRow['final_blows'] ?? 0);
+        $iskKilledBySide[$fbSide]  += (float) ($fbRow['isk_killed'] ?? 0);
     }
-    // ── Loss-based ISK killed & efficiency (strict two-side model) ──────
-    // Canonical rule: isk_killed for a side = opposing side's isk_lost.
-    // Third-party losses are tracked for total_isk_destroyed but excluded
-    // from the friendly-vs-opponent efficiency calculation.
-    $friendlyLost = $sidePanels['friendly']['isk_lost'];
-    $opponentLost = $sidePanels['opponent']['isk_lost'];
-    $twoSideTotal = $friendlyLost + $opponentLost;
 
-    // friendly_isk_killed == opponent_isk_lost  (and vice versa)
-    $sidePanels['friendly']['isk_killed'] = $opponentLost;
-    $sidePanels['opponent']['isk_killed'] = $friendlyLost;
-    $sidePanels['third_party']['isk_killed'] = 0.0;
+    foreach (['friendly', 'opponent', 'third_party'] as $side) {
+        $sidePanels[$side]['isk_killed'] = $iskKilledBySide[$side];
+        $sidePanels[$side]['kills'] = $finalBlowsBySide[$side];
+    }
 
-    // Ship kills derived from opposing side's losses (same principle as ISK).
-    $sidePanels['friendly']['kills'] = $sidePanels['opponent']['losses'];
-    $sidePanels['opponent']['kills'] = $sidePanels['friendly']['losses'];
-    // Third party keeps its accumulated kill-involvement count from the
-    // alliance summary — the two-side derivation doesn't apply to them.
-
-    // efficiency = isk_killed / (isk_killed + isk_lost)  — two-side, symmetric
-    $sidePanels['friendly']['efficiency'] = $twoSideTotal > 0
-        ? $opponentLost / $twoSideTotal : 0.0;
-    $sidePanels['opponent']['efficiency'] = $twoSideTotal > 0
-        ? $friendlyLost / $twoSideTotal : 0.0;
-    $sidePanels['third_party']['efficiency'] = 0.0;
+    // efficiency = isk_killed / (isk_killed + isk_lost) per side
+    foreach (['friendly', 'opponent', 'third_party'] as $side) {
+        $total = $sidePanels[$side]['isk_killed'] + $sidePanels[$side]['isk_lost'];
+        $sidePanels[$side]['efficiency'] = $total > 0
+            ? $sidePanels[$side]['isk_killed'] / $total : 0.0;
+    }
 
     foreach ($sidePanels as $side => $data) {
         $sidePanels[$side]['final_blows'] = (int) ($finalBlowsBySide[$side] ?? 0);
@@ -339,20 +331,9 @@ if (!isset($classifyAlliance)) {
     };
 }
 
-// Final-blows correction: classify using PHP closure for consistency
-$fbByGroup = db_theater_final_blows_by_attacker_group($theaterId);
-if ($fbByGroup !== []) {
-    $correctedFb = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
-    foreach ($fbByGroup as $fbRow) {
-        $fbSide = $classifyAlliance((int) ($fbRow['alliance_id'] ?? 0), (int) ($fbRow['corporation_id'] ?? 0));
-        $correctedFb[$fbSide] += (int) ($fbRow['final_blows'] ?? 0);
-    }
-    foreach (['friendly', 'opponent', 'third_party'] as $side) {
-        if (isset($sidePanels[$side])) {
-            $sidePanels[$side]['final_blows'] = $correctedFb[$side];
-        }
-    }
-}
+// Final-blows correction is no longer needed here — final blows and
+// ISK killed are now computed from db_theater_final_blows_by_attacker_group()
+// in the main side-panel build above.
 
 // Promote third-party to opponent when no opponents configured
 if (($sideAlliancesByPilots['opponent'] ?? []) === [] && ($sideAlliancesByPilots['third_party'] ?? []) !== []) {

--- a/src/db.php
+++ b/src/db.php
@@ -16702,7 +16702,7 @@ function db_theater_fleet_composition(string $theaterId): array
  * using the same closure as kills/losses (avoids mismatch with Python's
  * graph-inferred side stored in theater_alliance_summary).
  *
- * @return list<array{alliance_id: int, corporation_id: int, final_blows: int}>
+ * @return list<array{alliance_id: int, corporation_id: int, final_blows: int, isk_killed: float}>
  */
 function db_theater_final_blows_by_attacker_group(string $theaterId): array
 {
@@ -16710,7 +16710,8 @@ function db_theater_final_blows_by_attacker_group(string $theaterId): array
         "SELECT
             COALESCE(ka.alliance_id, 0) AS alliance_id,
             COALESCE(ka.corporation_id, 0) AS corporation_id,
-            COUNT(*) AS final_blows
+            COUNT(*) AS final_blows,
+            COALESCE(SUM(ke.zkb_total_value), 0) AS isk_killed
          FROM killmail_attackers ka
          INNER JOIN killmail_events ke ON ke.sequence_id = ka.sequence_id
          INNER JOIN theater_battles tb ON tb.battle_id = ke.battle_id


### PR DESCRIPTION
## Summary
This PR refactors the theater statistics calculation to use final-blow attribution instead of the previous loss-based model. The new approach directly counts kills and ISK destroyed based on which side delivered the final blow, providing more accurate combat metrics.

## Key Changes

- **Replaced loss-based model with final-blow-based model**: Previously, a side's `isk_killed` was calculated as the opposing side's `isk_lost` (symmetric two-side model). Now it's calculated directly from killmails where that side got the final blow.

- **Updated `db_theater_final_blows_by_attacker_group()` query**: Extended the database function to return `isk_killed` (sum of zkb_total_value) in addition to final blow counts, eliminating the need for separate queries.

- **Simplified side-panel calculations**: 
  - `isk_killed` and `kills` are now computed directly from final blows for all sides (friendly, opponent, third_party)
  - Efficiency calculation now uses each side's own `isk_killed` and `isk_lost` rather than deriving from opposing losses
  - Removed the two-side symmetric model that excluded third-party losses from efficiency calculations

- **Removed redundant final-blows correction logic**: The duplicate final-blows classification code at the end of the file is no longer needed since final blows and ISK are now computed in the main side-panel build section.

## Implementation Details

- The efficiency formula remains `isk_killed / (isk_killed + isk_lost)` but now applies consistently to all sides based on their actual final-blow contributions
- Third-party sides now have their own independent efficiency metrics rather than being excluded from calculations
- All three sides (friendly, opponent, third_party) are treated uniformly in the new model

https://claude.ai/code/session_01GmQWHkEmoXJgAns9SeJJAP