### PR TITLE
Implement per-character battle stats ledger as canonical source of truth

### DIFF
--- a/database/migrations/20260411_theater_participant_battle_stats.sql
+++ b/database/migrations/20260411_theater_participant_battle_stats.sql
@@ -1,0 +1,14 @@
+-- Add per-character battle stats columns to theater_participants.
+--
+-- kills (existing) is repurposed to mean final_kills (canonical unique kill credit).
+-- final_kills mirrors kills for explicitness.
+-- contributed_kills = listed-on-killmail involvement count (includes zero-damage).
+-- isk_killed = ISK value of killmails where the character got final blow.
+
+ALTER TABLE theater_participants
+  ADD COLUMN final_kills INT UNSIGNED NOT NULL DEFAULT 0 AFTER kills,
+  ADD COLUMN contributed_kills INT UNSIGNED NOT NULL DEFAULT 0 AFTER final_kills,
+  ADD COLUMN isk_killed DECIMAL(20,2) NOT NULL DEFAULT 0 AFTER contributed_kills;
+
+ALTER TABLE theater_alliance_summary
+  ADD COLUMN total_contributed_kills INT UNSIGNED NOT NULL DEFAULT 0 AFTER total_kills;

--- a/public-proxy/partials/_battle_report_panel.php
+++ b/public-proxy/partials/_battle_report_panel.php
@@ -19,7 +19,7 @@
         <div class="px-4 py-3">
             <p class="text-xs text-muted">Kills / Losses</p>
             <p class="text-slate-100 font-semibold"><?= number_format((int) ($_brp_data['kills'] ?? 0)) ?> / <?= number_format((int) ($_brp_data['losses'] ?? 0)) ?></p>
-            <p class="text-[10px] text-muted">Final blows: <?= number_format((int) ($_brp_data['final_blows'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($_brp_data['kill_involvements'] ?? 0)) ?></p>
         </div>
         <div class="px-4 py-3">
             <p class="text-xs text-muted">ISK Killed / Lost</p>

--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -162,11 +162,14 @@ if ($viewSnapshot !== null) {
         if ($opponentModel['primary_opponent'] === null) $opponentModel['primary_opponent'] = $entry;
     }
 
-    // Build side panels
+    // ── Build side panels from alliance summary (derived from character ledger) ──
+    // total_kills = final kills, total_isk_killed = final-blow-owned ISK.
+    // All stats are rolled up from the per-character ledger — no separate
+    // DB queries or loss-based shortcuts needed.
     $sidePanels = [
-        'friendly'    => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'final_blows' => 0, 'kill_involvements' => 0, 'efficiency' => 0.0],
-        'opponent'    => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'final_blows' => 0, 'kill_involvements' => 0, 'efficiency' => 0.0],
-        'third_party' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'final_blows' => 0, 'kill_involvements' => 0, 'efficiency' => 0.0],
+        'friendly'    => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'kill_involvements' => 0, 'efficiency' => 0.0],
+        'opponent'    => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'kill_involvements' => 0, 'efficiency' => 0.0],
+        'third_party' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'kill_involvements' => 0, 'efficiency' => 0.0],
     ];
     foreach ($allianceSummary as $a) {
         $aid = (int) ($a['alliance_id'] ?? 0);
@@ -174,10 +177,10 @@ if ($viewSnapshot !== null) {
         $side = $classifyAlliance($aid, $corpId);
         if (!isset($sidePanels[$side])) continue;
         $sidePanels[$side]['pilots'] += (int) ($a['participant_count'] ?? 0);
-        $sidePanels[$side]['kills'] += (int) ($a['total_kills'] ?? 0);
+        $sidePanels[$side]['kills'] += (int) ($a['total_kills'] ?? 0);             // final kills
         $sidePanels[$side]['losses'] += (int) ($a['total_losses'] ?? 0);
+        $sidePanels[$side]['isk_killed'] += (float) ($a['total_isk_killed'] ?? 0); // final-blow ISK
         $sidePanels[$side]['isk_lost'] += (float) ($a['total_isk_lost'] ?? 0);
-        // NOTE: isk_killed is derived from opposing side's losses below — not accumulated here.
         if ($aid > 0) {
             $entryName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $aid, (string) ($a['alliance_name'] ?? ''), 'Alliance');
         } else {
@@ -186,31 +189,15 @@ if ($viewSnapshot !== null) {
         $sidePanels[$side]['alliances'][] = ['alliance_id' => $aid, 'corporation_id' => $corpId, 'name' => $entryName, 'pilots' => (int) ($a['participant_count'] ?? 0)];
     }
 
+    // kill_involvements = sum of contributed_kills (listed-on-killmail) per side
     $participantKillTotalsBySide = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
     foreach ($participantsAll as $row) {
-        $kills = (int) ($row['kills'] ?? 0);
+        $contributedKills = (int) ($row['contributed_kills'] ?? $row['kills'] ?? 0);
         $side = $classifyAlliance((int) ($row['alliance_id'] ?? 0), (int) ($row['corporation_id'] ?? 0));
-        if (isset($participantKillTotalsBySide[$side])) $participantKillTotalsBySide[$side] += $kills;
+        if (isset($participantKillTotalsBySide[$side])) $participantKillTotalsBySide[$side] += $contributedKills;
     }
 
-    // ── Final-blow-based ISK killed & kills ─────────────────────────
-    // Each side's isk_killed = sum of ISK from killmails where that side
-    // got the final blow.  Each side's kills = final blow count.
-    $finalBlowsByGroup = db_theater_final_blows_by_attacker_group($theaterId);
-    $finalBlowsBySide = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
-    $iskKilledBySide  = ['friendly' => 0.0, 'opponent' => 0.0, 'third_party' => 0.0];
-    foreach ($finalBlowsByGroup as $fbRow) {
-        $fbSide = $classifyAlliance((int) ($fbRow['alliance_id'] ?? 0), (int) ($fbRow['corporation_id'] ?? 0));
-        $finalBlowsBySide[$fbSide] += (int) ($fbRow['final_blows'] ?? 0);
-        $iskKilledBySide[$fbSide]  += (float) ($fbRow['isk_killed'] ?? 0);
-    }
-
-    foreach (['friendly', 'opponent', 'third_party'] as $side) {
-        $sidePanels[$side]['isk_killed'] = $iskKilledBySide[$side];
-        $sidePanels[$side]['kills'] = $finalBlowsBySide[$side];
-    }
-
-    // efficiency = isk_killed / (isk_killed + isk_lost) per side
+    // Efficiency = isk_killed / (isk_killed + isk_lost) per side
     foreach (['friendly', 'opponent', 'third_party'] as $side) {
         $total = $sidePanels[$side]['isk_killed'] + $sidePanels[$side]['isk_lost'];
         $sidePanels[$side]['efficiency'] = $total > 0
@@ -218,7 +205,6 @@ if ($viewSnapshot !== null) {
     }
 
     foreach ($sidePanels as $side => $data) {
-        $sidePanels[$side]['final_blows'] = (int) ($finalBlowsBySide[$side] ?? 0);
         $sidePanels[$side]['kill_involvements'] = (int) ($participantKillTotalsBySide[$side] ?? 0);
         usort($data['alliances'], static fn(array $l, array $r): int => $r['pilots'] <=> $l['pilots']);
         $sidePanels[$side]['alliances'] = array_slice($data['alliances'], 0, 4);
@@ -331,9 +317,8 @@ if (!isset($classifyAlliance)) {
     };
 }
 
-// Final-blows correction is no longer needed here — final blows and
-// ISK killed are now computed from db_theater_final_blows_by_attacker_group()
-// in the main side-panel build above.
+// No final-blows correction needed — all stats are derived from the
+// per-character ledger via alliance_summary.
 
 // Promote third-party to opponent when no opponents configured
 if (($sideAlliancesByPilots['opponent'] ?? []) === [] && ($sideAlliancesByPilots['third_party'] ?? []) !== []) {
@@ -343,7 +328,7 @@ if (($sideAlliancesByPilots['opponent'] ?? []) === [] && ($sideAlliancesByPilots
 if (($sideAlliancesByPilots['opponent'] ?? []) !== [] && ($sideAlliancesByPilots['third_party'] ?? []) === []
     && ($sidePanels['opponent']['pilots'] ?? 0) === 0 && ($sidePanels['third_party']['pilots'] ?? 0) > 0) {
     $sidePanels['opponent'] = $sidePanels['third_party'];
-    $sidePanels['third_party'] = ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'final_blows' => 0, 'kill_involvements' => 0, 'efficiency' => 0.0];
+    $sidePanels['third_party'] = ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'kill_involvements' => 0, 'efficiency' => 0.0];
 }
 
 // ── Strip suspicion data from participants ──

--- a/public/theater-intelligence/partials/_battle_report_panel.php
+++ b/public/theater-intelligence/partials/_battle_report_panel.php
@@ -19,7 +19,7 @@
         <div class="px-4 py-3">
             <p class="text-xs text-muted">Kills / Losses</p>
             <p class="text-slate-100 font-semibold"><?= number_format((int) ($panelData['kills'] ?? 0)) ?> / <?= number_format((int) ($panelData['losses'] ?? 0)) ?></p>
-            <p class="text-[10px] text-muted">Final blows: <?= number_format((int) ($panelData['final_blows'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($panelData['kill_involvements'] ?? 0)) ?></p>
         </div>
         <div class="px-4 py-3">
             <p class="text-xs text-muted">ISK Killed / Lost</p>

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -419,11 +419,12 @@ if ($viewSnapshot !== null && !$pendingLock) {
     $participantKillTotal = 0;
     $participantKillTotalsBySide = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
     foreach ($participantsAll as $row) {
-        $kills = (int) ($row['kills'] ?? 0);
+        // contributed_kills = listed-on-killmail involvement count (including zero-damage)
+        $contributedKills = (int) ($row['contributed_kills'] ?? $row['kills'] ?? 0);
         $side = $classifyAlliance((int) ($row['alliance_id'] ?? 0), (int) ($row['corporation_id'] ?? 0));
-        $participantKillTotal += $kills;
+        $participantKillTotal += $contributedKills;
         if (isset($participantKillTotalsBySide[$side])) {
-            $participantKillTotalsBySide[$side] += $kills;
+            $participantKillTotalsBySide[$side] += $contributedKills;
         }
     }
     $reportedKillTotal = (int) ($theater['total_kills'] ?? 0);
@@ -437,15 +438,17 @@ if ($viewSnapshot !== null && !$pendingLock) {
     if ($reportedKillTotal !== $observedKillTotal) {
         $dataQualityNotes[] = 'Theater aggregate kills (' . number_format($reportedKillTotal) . ') differ from observed detail kills (' . number_format($observedKillTotal) . ').';
     }
-    if ($allianceKillTotal > 0 && $allianceLossTotal > 0 && abs($allianceKillTotal - $allianceLossTotal) > 0) {
-        $dataQualityNotes[] = 'Alliance kill-involvements (' . number_format($allianceKillTotal) . ') differ from losses (' . number_format($allianceLossTotal) . '). This is expected when multiple alliances assist on the same killmail.';
-    }
+    // total_kills in alliance_summary now means final kills (= losses count).
+    // Contributed kills (kill_involvements) may exceed final kills — that's normal.
 
-    // ── Build side panels from alliance + participant + composition data ──
+    // ── Build side panels from alliance summary (derived from character ledger) ──
+    // total_kills = final kills, total_isk_killed = final-blow-owned ISK.
+    // All stats are rolled up from the per-character ledger — no loss-based
+    // shortcuts or separate DB queries needed.
     $sidePanels = [
-        'friendly' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => []],
-        'opponent' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => []],
-        'third_party' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => []],
+        'friendly'    => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'kill_involvements' => 0, 'efficiency' => 0.0],
+        'opponent'    => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'kill_involvements' => 0, 'efficiency' => 0.0],
+        'third_party' => ['pilots' => 0, 'kills' => 0, 'losses' => 0, 'isk_killed' => 0.0, 'isk_lost' => 0.0, 'alliances' => [], 'ship_pilots' => 0, 'ships' => [], 'kill_involvements' => 0, 'efficiency' => 0.0],
     ];
     foreach ($allianceSummary as $a) {
         $aid = (int) ($a['alliance_id'] ?? 0);
@@ -453,11 +456,10 @@ if ($viewSnapshot !== null && !$pendingLock) {
         $side = $classifyAlliance($aid, $corpId);
         if (!isset($sidePanels[$side])) continue;
         $sidePanels[$side]['pilots'] += (int) ($a['participant_count'] ?? 0);
-        $sidePanels[$side]['kills'] += (int) ($a['total_kills'] ?? 0);
+        $sidePanels[$side]['kills'] += (int) ($a['total_kills'] ?? 0);             // final kills
         $sidePanels[$side]['losses'] += (int) ($a['total_losses'] ?? 0);
+        $sidePanels[$side]['isk_killed'] += (float) ($a['total_isk_killed'] ?? 0); // final-blow ISK
         $sidePanels[$side]['isk_lost'] += (float) ($a['total_isk_lost'] ?? 0);
-        // NOTE: isk_killed is derived from opposing side's losses below — not accumulated here.
-        // For corp-only entries, resolve as corporation; otherwise as alliance
         if ($aid > 0) {
             $entryName = killmail_entity_preferred_name($resolvedEntities, 'alliance', $aid, (string) ($a['alliance_name'] ?? ''), 'Alliance');
         } else {
@@ -470,41 +472,16 @@ if ($viewSnapshot !== null && !$pendingLock) {
             'pilots' => (int) ($a['participant_count'] ?? 0),
         ];
     }
-    $finalBlowsByGroup = db_theater_final_blows_by_attacker_group($theaterId);
-    $finalBlowsBySide = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
-    foreach ($finalBlowsByGroup as $fbRow) {
-        $fbSide = $classifyAlliance((int) ($fbRow['alliance_id'] ?? 0), (int) ($fbRow['corporation_id'] ?? 0));
-        $finalBlowsBySide[$fbSide] += (int) ($fbRow['final_blows'] ?? 0);
+
+    // Efficiency = isk_killed / (isk_killed + isk_lost) per side
+    foreach (['friendly', 'opponent', 'third_party'] as $side) {
+        $total = $sidePanels[$side]['isk_killed'] + $sidePanels[$side]['isk_lost'];
+        $sidePanels[$side]['efficiency'] = $total > 0
+            ? $sidePanels[$side]['isk_killed'] / $total : 0.0;
     }
-    // ── Loss-based ISK killed & efficiency (strict two-side model) ──────
-    // Canonical rule: isk_killed for a side = opposing side's isk_lost.
-    // Third-party losses are tracked for total_isk_destroyed but excluded
-    // from the friendly-vs-opponent efficiency calculation.
-    $friendlyLost = $sidePanels['friendly']['isk_lost'];
-    $opponentLost = $sidePanels['opponent']['isk_lost'];
-    $twoSideTotal = $friendlyLost + $opponentLost;
 
-    // friendly_isk_killed == opponent_isk_lost  (and vice versa)
-    $sidePanels['friendly']['isk_killed'] = $opponentLost;
-    $sidePanels['opponent']['isk_killed'] = $friendlyLost;
-    $sidePanels['third_party']['isk_killed'] = 0.0;
-
-    // Ship kills derived from opposing side's losses (same principle as ISK).
-    // friendly_kills == opponent_losses (how many enemy ships died).
-    $sidePanels['friendly']['kills'] = $sidePanels['opponent']['losses'];
-    $sidePanels['opponent']['kills'] = $sidePanels['friendly']['losses'];
-    // Third party keeps its accumulated kill-involvement count from the
-    // alliance summary — the two-side derivation doesn't apply to them.
-
-    // efficiency = isk_killed / (isk_killed + isk_lost)  — two-side, symmetric
-    $sidePanels['friendly']['efficiency'] = $twoSideTotal > 0
-        ? $opponentLost / $twoSideTotal : 0.0;
-    $sidePanels['opponent']['efficiency'] = $twoSideTotal > 0
-        ? $friendlyLost / $twoSideTotal : 0.0;
-    $sidePanels['third_party']['efficiency'] = 0.0;
-
+    // kill_involvements = sum of contributed_kills (listed-on-killmail) per side
     foreach ($sidePanels as $side => $data) {
-        $sidePanels[$side]['final_blows'] = (int) ($finalBlowsBySide[$side] ?? 0);
         $sidePanels[$side]['kill_involvements'] = (int) ($participantKillTotalsBySide[$side] ?? 0);
         usort($data['alliances'], static fn(array $l, array $r): int => $r['pilots'] <=> $l['pilots']);
         $sidePanels[$side]['alliances'] = array_slice($data['alliances'], 0, 4);
@@ -669,50 +646,10 @@ if ($viewSnapshot !== null && !$pendingLock) {
     }
 }
 
-// ── Final-blows correction: classify using PHP closure for consistency ────────
-// The Python job may classify sides via graph inference, but PHP uses explicit
-// tracked/opponent config.  Re-derive final blows from killmail_attackers
-// so they match the same classification used for kills and losses.
-$fbByGroup = db_theater_final_blows_by_attacker_group($theaterId);
-if ($fbByGroup !== []) {
-    $correctedFb = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
-    foreach ($fbByGroup as $fbRow) {
-        $fbSide = $classifyAlliance((int) ($fbRow['alliance_id'] ?? 0), (int) ($fbRow['corporation_id'] ?? 0));
-        $correctedFb[$fbSide] += (int) ($fbRow['final_blows'] ?? 0);
-    }
-    foreach (['friendly', 'opponent', 'third_party'] as $side) {
-        if (isset($sidePanels[$side])) {
-            $sidePanels[$side]['final_blows'] = $correctedFb[$side];
-        }
-    }
-}
-
-// ── Loss-count correction: count ALL killmail victims, including corp-only ───
-// The alliance_summary only tracks losses for victims WITH an alliance.
-// Victims without an alliance (corp-only players) were silently dropped,
-// causing opposition losses to be understated.  Query killmail_events directly
-// for accurate totals.
-$rawLossesByVictimAlliance = db_theater_losses_by_victim_alliance($theaterId);
-if ($rawLossesByVictimAlliance !== []) {
-    $correctedLosses = ['friendly' => 0, 'opponent' => 0, 'third_party' => 0];
-    $correctedIskLost = ['friendly' => 0.0, 'opponent' => 0.0, 'third_party' => 0.0];
-    foreach ($rawLossesByVictimAlliance as $row) {
-        $side = $classifyAlliance((int) ($row['victim_alliance_id'] ?? 0), (int) ($row['victim_corporation_id'] ?? 0));
-        $correctedLosses[$side] += (int) ($row['losses'] ?? 0);
-        $correctedIskLost[$side] += (float) ($row['isk_lost'] ?? 0);
-    }
-    foreach (['friendly', 'opponent', 'third_party'] as $side) {
-        if (isset($sidePanels[$side]) && $correctedLosses[$side] >= ($sidePanels[$side]['losses'] ?? 0)) {
-            $sidePanels[$side]['losses'] = $correctedLosses[$side];
-            $sidePanels[$side]['isk_lost'] = $correctedIskLost[$side];
-            // Recompute efficiency with corrected ISK
-            $totalIsk = ($sidePanels[$side]['isk_killed'] ?? 0) + $correctedIskLost[$side];
-            $sidePanels[$side]['efficiency'] = $totalIsk > 0
-                ? ($sidePanels[$side]['isk_killed'] ?? 0) / $totalIsk
-                : 0.0;
-        }
-    }
-}
+// No final-blows correction or loss-count correction needed — all stats
+// are derived from the per-character ledger via alliance_summary.  The
+// ledger processes each killmail exactly once, crediting the victim with
+// losses/isk_lost and the final-blow attacker with kills/isk_killed.
 
 // ── Promote third-party to opponent when no opponents are configured ─────────
 // Handles both fresh renders and locked snapshots saved before this logic existed.
@@ -743,7 +680,7 @@ if (($sideAlliancesByPilots['opponent'] ?? []) !== [] && ($sideAlliancesByPilots
         'pilots' => 0, 'kills' => 0, 'losses' => 0,
         'isk_killed' => 0.0, 'isk_lost' => 0.0,
         'alliances' => [], 'ship_pilots' => 0, 'ships' => [],
-        'final_blows' => 0, 'kill_involvements' => 0, 'efficiency' => 0.0,
+        'kill_involvements' => 0, 'efficiency' => 0.0,
     ];
 }
 

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -717,10 +717,91 @@ def _detect_turning_points(
     return turning_points
 
 
+# ── Per-character ledger (source of truth) ─────────────────────────────────
+
+
+def _empty_ledger_entry() -> dict[str, Any]:
+    return {
+        "final_kills": 0,
+        "contributed_kills": 0,
+        "losses": 0,
+        "isk_killed": 0.0,
+        "isk_lost": 0.0,
+        "damage_done": 0.0,
+    }
+
+
+def _build_character_ledger(
+    killmails: list[dict[str, Any]],
+) -> dict[int, dict[str, Any]]:
+    """Build per-character stats from killmails — the single source of truth.
+
+    For each killmail (expanded per-attacker via LEFT JOIN):
+      - Victim: losses += 1, isk_lost += total_value  (once per killmail_id)
+      - Final blow attacker: final_kills += 1, isk_killed += total_value
+      - Every listed attacker: contributed_kills += 1
+        (includes zero-damage; dedup by killmail_id + attacker_character_id)
+
+    Invariants across the full set:
+      sum(losses)      == number of unique killmails
+      sum(final_kills) == number of unique killmails
+      sum(isk_lost)    == total destroyed ISK
+      sum(isk_killed)  == total destroyed ISK
+      sum(contributed_kills) >= number of unique killmails
+    """
+    ledger: dict[int, dict[str, Any]] = {}
+    seen_victim: set[int] = set()             # killmail_id
+    seen_final_blow: set[int] = set()         # killmail_id
+    seen_attacker: set[tuple[int, int]] = set()  # (killmail_id, attacker_character_id)
+
+    for km in killmails:
+        km_id = int(km.get("killmail_id") or 0)
+        if km_id <= 0:
+            continue
+
+        isk = float(km.get("total_value") or 0)
+
+        # ── Victim (once per killmail) ────────────────────────────────
+        victim_id = int(km.get("victim_character_id") or 0)
+        if victim_id > 0 and km_id not in seen_victim:
+            seen_victim.add(km_id)
+            entry = ledger.setdefault(victim_id, _empty_ledger_entry())
+            entry["losses"] += 1
+            entry["isk_lost"] += isk
+
+        # ── Attacker ─────────────────────────────────────────────────
+        attacker_id = int(km.get("attacker_character_id") or 0)
+        if attacker_id <= 0:
+            continue
+
+        # Final blow (once per killmail)
+        is_final = int(km.get("attacker_final_blow") or 0)
+        if is_final == 1 and km_id not in seen_final_blow:
+            seen_final_blow.add(km_id)
+            entry = ledger.setdefault(attacker_id, _empty_ledger_entry())
+            entry["final_kills"] += 1
+            entry["isk_killed"] += isk
+
+        # Contributed kill — every listed attacker, including dmg=0
+        atk_key = (km_id, attacker_id)
+        if atk_key not in seen_attacker:
+            seen_attacker.add(atk_key)
+            entry = ledger.setdefault(attacker_id, _empty_ledger_entry())
+            entry["contributed_kills"] += 1
+
+        # Damage accumulation (raw per-row, no dedup needed)
+        attacker_damage = float(km.get("attacker_damage_done") or 0)
+        if attacker_damage > 0:
+            entry = ledger.setdefault(attacker_id, _empty_ledger_entry())
+            entry["damage_done"] += attacker_damage
+
+    return ledger
+
+
 # ── Alliance summary computation ───────────────────────────────────────────
 
 def _compute_alliance_summary(
-    killmails: list[dict[str, Any]],
+    character_ledger: dict[int, dict[str, Any]],
     bp_rows: list[dict[str, Any]],
     side_configuration: dict[str, set[int]],
     char_sides: dict[int, str],
@@ -728,13 +809,16 @@ def _compute_alliance_summary(
 ) -> list[dict[str, Any]]:
     """Compute per-alliance (or per-corporation for allianceless entities) summary.
 
+    Derives all totals from the per-character ledger — no direct killmail
+    processing.  This guarantees that group totals are exact rollups of
+    character truth.
+
     Grouping key is (alliance_id, corporation_id):
       - Entities WITH an alliance  → (alliance_id, 0)
       - Entities WITHOUT an alliance → (0, corporation_id)
     This ensures NPC-corp / allianceless-corp pilots get their own row
     instead of being lumped under a single alliance_id=0 bucket.
     """
-    # (alliance_id, corporation_id) → accumulated stats
     group_stats: dict[tuple[int, int], dict[str, Any]] = {}
 
     def _group_key_for(alliance_id: int, corporation_id: int) -> tuple[int, int]:
@@ -747,51 +831,39 @@ def _compute_alliance_summary(
     def _get_entry(key: tuple[int, int]) -> dict[str, Any]:
         return group_stats.setdefault(key, _empty_alliance_stats(key[0], key[1]))
 
-    # Count participants per group
+    # Build group membership and roll up character ledger entries.
+    # Each character appears once in bp_rows (per battle); collect unique
+    # characters per group key and accumulate their ledger stats.
     group_participants: dict[tuple[int, int], set[int]] = defaultdict(set)
+    seen_char_in_group: set[tuple[int, tuple[int, int]]] = set()
+
     for p in bp_rows:
         aid = int(p.get("alliance_id") or 0)
         corp_id = int(p.get("corporation_id") or 0)
         cid = int(p.get("character_id") or 0)
-        if cid > 0 and (aid > 0 or corp_id > 0):
-            gk = _group_key_for(aid, corp_id)
-            group_participants[gk].add(cid)
+        if cid <= 0 or (aid <= 0 and corp_id <= 0):
+            continue
 
-    # Process killmails for kills/losses/damage — deduplicate by killmail_id
-    # since rows are expanded per-attacker from the LEFT JOIN.
-    seen_loss_km: set[int] = set()
-    seen_kill_km: set[tuple[int, tuple[int, int]]] = set()
-    for km in killmails:
-        km_id = int(km.get("killmail_id") or 0)
-        victim_alliance = int(km.get("victim_alliance_id") or 0)
-        victim_corp = int(km.get("victim_corporation_id") or 0)
-        isk = float(km.get("total_value") or 0)
+        gk = _group_key_for(aid, corp_id)
+        group_participants[gk].add(cid)
 
-        attacker_alliance = int(km.get("attacker_alliance_id") or 0)
-        attacker_corp = int(km.get("attacker_corporation_id") or 0)
-        attacker_damage = float(km.get("attacker_damage_done") or 0)
+        # Roll up this character's ledger into the group (once per char+group)
+        char_group_key = (cid, gk)
+        if char_group_key in seen_char_in_group:
+            continue
+        seen_char_in_group.add(char_group_key)
 
-        # Record loss for victim group (once per killmail)
-        if km_id not in seen_loss_km:
-            seen_loss_km.add(km_id)
-            loss_key = _group_key_for(victim_alliance, victim_corp)
-            entry = _get_entry(loss_key)
-            entry["total_losses"] += 1
-            entry["total_isk_lost"] += isk
+        ledger_entry = character_ledger.get(cid)
+        if ledger_entry is None:
+            continue
 
-        # Record kill involvement for attacker group (once per killmail per group).
-        # Per-alliance total_isk_killed is analytics metadata — credited to every
-        # participating group (not just final blow).  Side-level ISK killed and
-        # efficiency are derived from victim losses in the PHP presentation layer.
-        atk_key = _group_key_for(attacker_alliance, attacker_corp)
-        if atk_key != (0, 0):
-            entry = _get_entry(atk_key)
-            entry["total_damage"] += attacker_damage
-            kill_key = (km_id, atk_key)
-            if kill_key not in seen_kill_km:
-                seen_kill_km.add(kill_key)
-                entry["total_kills"] += 1
-                entry["total_isk_killed"] += isk
+        entry = _get_entry(gk)
+        entry["total_kills"] += ledger_entry["final_kills"]
+        entry["total_contributed_kills"] += ledger_entry["contributed_kills"]
+        entry["total_losses"] += ledger_entry["losses"]
+        entry["total_isk_killed"] += ledger_entry["isk_killed"]
+        entry["total_isk_lost"] += ledger_entry["isk_lost"]
+        entry["total_damage"] += ledger_entry["damage_done"]
 
     # Finalize
     result: list[dict[str, Any]] = []
@@ -814,6 +886,7 @@ def _empty_alliance_stats(alliance_id: int, corporation_id: int = 0) -> dict[str
         "side": "third_party",
         "participant_count": 0,
         "total_kills": 0,
+        "total_contributed_kills": 0,
         "total_losses": 0,
         "total_damage": 0.0,
         "total_isk_lost": 0.0,
@@ -830,18 +903,26 @@ def _compute_participants(
     char_sides: dict[int, str],
     theater_id: str,
     ship_group_map: dict[int, int] | None = None,
+    character_ledger: dict[int, dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
-    """Compute per-character stats across the theater."""
+    """Compute per-character stats across the theater.
+
+    Core stats (kills, deaths, isk_killed, isk_lost, damage_done) are taken
+    from the character_ledger which is the single source of truth.
+    Ship resolution, role inference, entry/exit times, and damage_taken
+    are still derived from killmail rows.
+    """
     char_stats: dict[int, dict[str, Any]] = {}
     char_battles: dict[int, set[str]] = defaultdict(set)
     char_times: dict[int, list[datetime]] = defaultdict(list)
-    # Track ship type frequency per character for role + flying ship resolution
     char_ship_counts: dict[int, dict[int, int]] = defaultdict(lambda: defaultdict(int))
 
-    # Group IDs that are non-combat (pods, shuttles, industrials, etc.)
     _NON_COMBAT_GROUP_IDS: frozenset[int] = frozenset(
         gid for gid, role in FLEET_FUNCTION_BY_GROUP.items() if role == "non_combat"
     )
+
+    if character_ledger is None:
+        character_ledger = {}
 
     # Initialize from battle participants
     for p in bp_rows:
@@ -854,6 +935,7 @@ def _compute_participants(
         if cid not in char_stats:
             aid = int(p.get("alliance_id") or 0)
             corp_id = int(p.get("corporation_id") or 0)
+            ledger = character_ledger.get(cid, _empty_ledger_entry())
 
             char_stats[cid] = {
                 "character_id": cid,
@@ -863,12 +945,16 @@ def _compute_participants(
                 "side": char_sides.get(cid, "third_party"),
                 "ship_type_ids": [],
                 "ships_lost_detail": defaultdict(lambda: {"count": 0, "isk_lost": 0.0, "killmail_ids": []}),
-                "kills": 0,
-                "deaths": 0,
-                "damage_done": 0.0,
-                "damage_taken": 0.0,
-                "isk_lost": 0.0,
-                "role_proxy": "mainline_dps",  # placeholder, resolved after all data
+                # Canonical stats from ledger
+                "kills": ledger["final_kills"],          # kills = final kills
+                "final_kills": ledger["final_kills"],
+                "contributed_kills": ledger["contributed_kills"],
+                "deaths": ledger["losses"],
+                "damage_done": ledger["damage_done"],
+                "damage_taken": 0.0,                     # computed below from killmails
+                "isk_killed": ledger["isk_killed"],
+                "isk_lost": ledger["isk_lost"],
+                "role_proxy": "mainline_dps",
                 "flying_ship_type_id": None,
             }
 
@@ -876,7 +962,6 @@ def _compute_participants(
         st = int(p.get("ship_type_id") or 0)
         if st > 0 and st not in char_stats[cid]["ship_type_ids"]:
             char_stats[cid]["ship_type_ids"].append(st)
-        # Count ship type frequency from battle participation
         if st > 0:
             char_ship_counts[cid][st] += 1
 
@@ -888,10 +973,11 @@ def _compute_participants(
         if km_id > 0:
             km_total_hp_damage[km_id] += attacker_damage
 
-    # Process killmails — deduplicate by killmail_id since rows are expanded
-    # per-attacker from the LEFT JOIN.
-    seen_deaths: set[tuple[int, int]] = set()  # (killmail_id, victim_id)
-    seen_attacker_kills: set[tuple[int, int]] = set()  # (killmail_id, attacker_id)
+    # Process killmails for damage_taken, ship loss detail, timestamps, and
+    # attacker ship counts — stats that require killmail-row-level data.
+    # Core kill/death/ISK stats come from the ledger above.
+    seen_deaths: set[tuple[int, int]] = set()
+    seen_attacker_time: set[tuple[int, int]] = set()
     for km in killmails:
         km_id = int(km.get("killmail_id") or 0)
         km_time = _parse_dt(km.get("killmail_time"))
@@ -899,16 +985,13 @@ def _compute_participants(
         victim_id = int(km.get("victim_character_id") or 0)
         isk = float(km.get("total_value") or 0)
 
-        # Count death only once per (killmail, victim) pair
+        # Damage taken + ship loss detail (once per killmail per victim)
         death_key = (km_id, victim_id)
         if victim_id > 0 and victim_id in char_stats and death_key not in seen_deaths:
             seen_deaths.add(death_key)
-            char_stats[victim_id]["deaths"] += 1
             char_stats[victim_id]["damage_taken"] += km_total_hp_damage.get(km_id, 0.0)
-            char_stats[victim_id]["isk_lost"] += isk
             char_times[victim_id].append(km_time)
 
-            # Track per-ship-type loss breakdown
             victim_ship = int(km.get("victim_ship_type_id") or 0)
             if victim_ship > 0:
                 loss = char_stats[victim_id]["ships_lost_detail"][victim_ship]
@@ -920,21 +1003,16 @@ def _compute_participants(
                 if victim_ship not in char_stats[victim_id]["ship_type_ids"]:
                     char_stats[victim_id]["ship_type_ids"].append(victim_ship)
 
+        # Attacker timestamps and ship counts
         attacker_id = int(km.get("attacker_character_id") or 0)
-        attacker_damage = float(km.get("attacker_damage_done") or 0)
-
         if attacker_id > 0 and attacker_id in char_stats:
-            # Count kill participation once per (killmail, attacker) pair
             atk_key = (km_id, attacker_id)
-            if atk_key not in seen_attacker_kills:
-                seen_attacker_kills.add(atk_key)
-                char_stats[attacker_id]["kills"] += 1
+            if atk_key not in seen_attacker_time:
+                seen_attacker_time.add(atk_key)
                 char_times[attacker_id].append(km_time)
-                # Count attacker ship type for flying ship resolution
                 atk_ship = int(km.get("attacker_ship_type_id") or 0)
                 if atk_ship > 0:
                     char_ship_counts[attacker_id][atk_ship] += 1
-            char_stats[attacker_id]["damage_done"] += attacker_damage
 
     # ── Resolve flying ship + role from most-common non-pod ship ──────────
     for cid, stats in char_stats.items():
@@ -942,7 +1020,6 @@ def _compute_participants(
         if not counts:
             continue
 
-        # Find the most common ship that isn't non-combat (pods, shuttles, etc.)
         best_ship = 0
         best_count = 0
         fallback_ship = 0
@@ -950,7 +1027,6 @@ def _compute_participants(
         for stid, cnt in counts.items():
             group_id = (ship_group_map or {}).get(stid, 0)
             if group_id in _NON_COMBAT_GROUP_IDS:
-                # Track as fallback in case ALL ships are non-combat
                 if cnt > fallback_count:
                     fallback_ship = stid
                     fallback_count = cnt
@@ -990,16 +1066,19 @@ def _compute_participants(
             "ship_type_ids": ship_json,
             "ships_lost_detail": ships_lost_json,
             "flying_ship_type_id": stats.get("flying_ship_type_id"),
-            "kills": stats["kills"],
+            "kills": stats["kills"],                        # = final_kills
+            "final_kills": stats["final_kills"],
+            "contributed_kills": stats["contributed_kills"],
             "deaths": stats["deaths"],
             "damage_done": stats["damage_done"],
             "damage_taken": stats["damage_taken"],
+            "isk_killed": stats["isk_killed"],
             "isk_lost": stats["isk_lost"],
             "role_proxy": stats["role_proxy"],
             "entry_time": entry_time,
             "exit_time": exit_time,
             "battles_present": len(char_battles.get(cid, set())),
-            "suspicion_score": None,  # populated in theater_suspicion phase
+            "suspicion_score": None,
             "is_suspicious": 0,
         })
 
@@ -1297,15 +1376,16 @@ def _flush_analysis(
                 """
                 INSERT INTO theater_alliance_summary (
                     theater_id, alliance_id, corporation_id, alliance_name, side,
-                    participant_count, total_kills, total_losses,
+                    participant_count, total_kills, total_contributed_kills, total_losses,
                     total_damage, total_isk_lost, total_isk_killed, efficiency
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 [
                     (
                         theater_id, a["alliance_id"], a.get("corporation_id", 0),
                         a["alliance_name"], a["side"],
-                        a["participant_count"], a["total_kills"], a["total_losses"],
+                        a["participant_count"], a["total_kills"],
+                        a["total_contributed_kills"], a["total_losses"],
                         a["total_damage"], a["total_isk_lost"], a["total_isk_killed"],
                         a["efficiency"],
                     )
@@ -1322,18 +1402,21 @@ def _flush_analysis(
                 INSERT INTO theater_participants (
                     theater_id, character_id, character_name, alliance_id,
                     corporation_id, side, ship_type_ids, ships_lost_detail,
-                    flying_ship_type_id, kills, deaths,
+                    flying_ship_type_id, kills, final_kills, contributed_kills,
+                    isk_killed, deaths,
                     damage_done, damage_taken, isk_lost, role_proxy,
                     entry_time, exit_time, battles_present,
                     suspicion_score, is_suspicious
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 [
                     (
                         p["theater_id"], p["character_id"], p["character_name"],
                         p["alliance_id"], p["corporation_id"], p["side"],
                         p["ship_type_ids"], p["ships_lost_detail"],
-                        p.get("flying_ship_type_id"), p["kills"], p["deaths"],
+                        p.get("flying_ship_type_id"), p["kills"],
+                        p["final_kills"], p["contributed_kills"],
+                        p["isk_killed"], p["deaths"],
                         p["damage_done"], p["damage_taken"], p["isk_lost"], p["role_proxy"],
                         p["entry_time"], p["exit_time"], p["battles_present"],
                         p["suspicion_score"], p["is_suspicious"],
@@ -1521,11 +1604,14 @@ def run_theater_analysis(
             # Detect turning points
             turning_points = _detect_turning_points(timeline)
 
-            # Compute alliance summary
-            alliance_summary = _compute_alliance_summary(killmails, bp_rows, side_configuration, char_sides, relationship_graph)
+            # Build per-character ledger — single source of truth
+            character_ledger = _build_character_ledger(killmails)
 
-            # Compute participant stats
-            participant_stats = _compute_participants(killmails, bp_rows, char_sides, theater_id, ship_group_map)
+            # Compute alliance summary from character ledger
+            alliance_summary = _compute_alliance_summary(character_ledger, bp_rows, side_configuration, char_sides, relationship_graph)
+
+            # Compute participant stats from character ledger
+            participant_stats = _compute_participants(killmails, bp_rows, char_sides, theater_id, ship_group_map, character_ledger)
 
             # Detect structure kills (player-owned structures with no victim character)
             structure_kills = _compute_structure_kills(killmails, side_configuration, theater_id, relationship_graph)

--- a/python/tests/test_battle_stats_ledger.py
+++ b/python/tests/test_battle_stats_ledger.py
@@ -1,0 +1,406 @@
+"""Tests for per-character battle stats ledger and group rollup.
+
+Validates the canonical model: build per-character stats from killmails first,
+then roll up into groups.  All invariants must hold.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+# ── Bootstrap: stub heavy dependencies ─────────────────────────────────────
+_PYTHON_DIR = str(Path(__file__).resolve().parents[1])
+if _PYTHON_DIR not in sys.path:
+    sys.path.insert(0, _PYTHON_DIR)
+
+from unittest.mock import MagicMock
+
+_stub_db = types.ModuleType("orchestrator.db")
+_stub_db.SupplyCoreDb = MagicMock  # type: ignore[attr-defined]
+sys.modules.setdefault("orchestrator.db", _stub_db)
+
+_stub_jobs_init = types.ModuleType("orchestrator.jobs")
+_stub_jobs_init.__path__ = [str(Path(_PYTHON_DIR) / "orchestrator" / "jobs")]  # type: ignore[attr-defined]
+sys.modules["orchestrator.jobs"] = _stub_jobs_init
+
+from orchestrator.jobs.theater_analysis import (  # noqa: E402
+    _build_character_ledger,
+    _compute_alliance_summary,
+    _empty_ledger_entry,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _km(
+    killmail_id: int,
+    victim_character_id: int = 0,
+    victim_alliance_id: int = 0,
+    victim_corporation_id: int = 0,
+    total_value: float = 0.0,
+    attacker_character_id: int = 0,
+    attacker_alliance_id: int = 0,
+    attacker_corporation_id: int = 0,
+    attacker_damage_done: float = 0.0,
+    attacker_final_blow: int = 0,
+) -> dict[str, Any]:
+    """Build a killmail row matching the LEFT JOIN schema."""
+    return {
+        "killmail_id": killmail_id,
+        "sequence_id": killmail_id,
+        "system_id": 30000001,
+        "killmail_time": "2026-04-01 10:05:00",
+        "battle_id": "b1",
+        "victim_character_id": victim_character_id,
+        "victim_corporation_id": victim_corporation_id,
+        "victim_alliance_id": victim_alliance_id,
+        "victim_ship_type_id": 0,
+        "total_value": total_value,
+        "attacker_character_id": attacker_character_id,
+        "attacker_corporation_id": attacker_corporation_id,
+        "attacker_alliance_id": attacker_alliance_id,
+        "attacker_ship_type_id": 0,
+        "attacker_damage_done": attacker_damage_done,
+        "attacker_final_blow": attacker_final_blow,
+        "zkb_npc": 0,
+    }
+
+
+# ── Test: Single attacker killmail ─────────────────────────────────────────
+
+class TestSingleAttackerKillmail(unittest.TestCase):
+    """One killmail, one victim, one attacker with final blow."""
+
+    def test_single_attacker(self) -> None:
+        kms = [
+            _km(1, victim_character_id=10, victim_alliance_id=100,
+                total_value=100.0,
+                attacker_character_id=20, attacker_alliance_id=200,
+                attacker_final_blow=1, attacker_damage_done=500),
+        ]
+
+        ledger = _build_character_ledger(kms)
+
+        # Victim
+        self.assertEqual(ledger[10]["losses"], 1)
+        self.assertEqual(ledger[10]["isk_lost"], 100.0)
+        self.assertEqual(ledger[10]["final_kills"], 0)
+        self.assertEqual(ledger[10]["isk_killed"], 0.0)
+        self.assertEqual(ledger[10]["contributed_kills"], 0)
+
+        # Attacker
+        self.assertEqual(ledger[20]["final_kills"], 1)
+        self.assertEqual(ledger[20]["contributed_kills"], 1)
+        self.assertEqual(ledger[20]["isk_killed"], 100.0)
+        self.assertEqual(ledger[20]["losses"], 0)
+        self.assertEqual(ledger[20]["isk_lost"], 0.0)
+        self.assertEqual(ledger[20]["damage_done"], 500.0)
+
+
+# ── Test: Multi-attacker killmail ──────────────────────────────────────────
+
+class TestMultiAttackerKillmail(unittest.TestCase):
+    """One killmail, one victim, two attackers — only final blow gets ISK."""
+
+    def test_multi_attacker(self) -> None:
+        kms = [
+            # Attacker B gets final blow
+            _km(1, victim_character_id=10, victim_alliance_id=100,
+                total_value=500.0,
+                attacker_character_id=20, attacker_alliance_id=200,
+                attacker_final_blow=1, attacker_damage_done=900),
+            # Attacker C assisted (same killmail, NOT final blow)
+            _km(1, victim_character_id=10, victim_alliance_id=100,
+                total_value=500.0,
+                attacker_character_id=30, attacker_alliance_id=200,
+                attacker_final_blow=0, attacker_damage_done=100),
+        ]
+
+        ledger = _build_character_ledger(kms)
+
+        # Victim: 1 loss, full ISK
+        self.assertEqual(ledger[10]["losses"], 1)
+        self.assertEqual(ledger[10]["isk_lost"], 500.0)
+
+        # Final blow attacker: 1 final kill, 1 contributed kill, full ISK
+        self.assertEqual(ledger[20]["final_kills"], 1)
+        self.assertEqual(ledger[20]["contributed_kills"], 1)
+        self.assertEqual(ledger[20]["isk_killed"], 500.0)
+
+        # Assisting attacker: 0 final kills, 1 contributed kill, 0 ISK
+        self.assertEqual(ledger[30]["final_kills"], 0)
+        self.assertEqual(ledger[30]["contributed_kills"], 1)
+        self.assertEqual(ledger[30]["isk_killed"], 0.0)
+
+
+# ── Test: Zero-damage attacker still gets contributed_kills ────────────────
+
+class TestZeroDamageAttacker(unittest.TestCase):
+    """An attacker listed on the killmail with damage_done=0 (e.g. ewar)
+    still gets contributed_kills += 1."""
+
+    def test_zero_damage_attacker(self) -> None:
+        kms = [
+            _km(1, victim_character_id=10, victim_alliance_id=100,
+                total_value=500.0,
+                attacker_character_id=20, attacker_alliance_id=200,
+                attacker_final_blow=1, attacker_damage_done=1000),
+            # Zero-damage attacker (ewar/booster)
+            _km(1, victim_character_id=10, victim_alliance_id=100,
+                total_value=500.0,
+                attacker_character_id=30, attacker_alliance_id=200,
+                attacker_final_blow=0, attacker_damage_done=0),
+        ]
+
+        ledger = _build_character_ledger(kms)
+
+        # Zero-damage attacker still counted
+        self.assertEqual(ledger[30]["contributed_kills"], 1)
+        self.assertEqual(ledger[30]["final_kills"], 0)
+        self.assertEqual(ledger[30]["isk_killed"], 0.0)
+        self.assertEqual(ledger[30]["damage_done"], 0.0)
+
+
+# ── Test: Multi-killmail aggregation ───────────────────────────────────────
+
+class TestMultiKillmailAggregation(unittest.TestCase):
+    """Multiple killmails — character stats accumulate correctly."""
+
+    def test_multi_killmail_character_accumulation(self) -> None:
+        kms = [
+            # KM 1: A kills B
+            _km(1, victim_character_id=20, victim_alliance_id=200,
+                total_value=300.0,
+                attacker_character_id=10, attacker_alliance_id=100,
+                attacker_final_blow=1, attacker_damage_done=100),
+            # KM 2: B kills A
+            _km(2, victim_character_id=10, victim_alliance_id=100,
+                total_value=700.0,
+                attacker_character_id=20, attacker_alliance_id=200,
+                attacker_final_blow=1, attacker_damage_done=200),
+        ]
+
+        ledger = _build_character_ledger(kms)
+
+        # Character 10: 1 final kill (KM1) + 1 loss (KM2)
+        self.assertEqual(ledger[10]["final_kills"], 1)
+        self.assertEqual(ledger[10]["isk_killed"], 300.0)
+        self.assertEqual(ledger[10]["losses"], 1)
+        self.assertEqual(ledger[10]["isk_lost"], 700.0)
+
+        # Character 20: 1 final kill (KM2) + 1 loss (KM1)
+        self.assertEqual(ledger[20]["final_kills"], 1)
+        self.assertEqual(ledger[20]["isk_killed"], 700.0)
+        self.assertEqual(ledger[20]["losses"], 1)
+        self.assertEqual(ledger[20]["isk_lost"], 300.0)
+
+
+# ── Test: Group rollup from ledger ─────────────────────────────────────────
+
+class TestGroupRollup(unittest.TestCase):
+    """Alliance summary must be exact rollup of character ledger."""
+
+    def test_group_totals_match_character_sums(self) -> None:
+        kms = [
+            # KM 1: Alliance 200 victim, Alliance 100 attacker (final blow)
+            _km(1, victim_character_id=20, victim_alliance_id=200,
+                total_value=500.0,
+                attacker_character_id=10, attacker_alliance_id=100,
+                attacker_final_blow=1, attacker_damage_done=100),
+            # KM 1: Alliance 100 also has a second attacker
+            _km(1, victim_character_id=20, victim_alliance_id=200,
+                total_value=500.0,
+                attacker_character_id=11, attacker_alliance_id=100,
+                attacker_final_blow=0, attacker_damage_done=50),
+            # KM 2: Alliance 100 victim, Alliance 200 attacker
+            _km(2, victim_character_id=10, victim_alliance_id=100,
+                total_value=800.0,
+                attacker_character_id=20, attacker_alliance_id=200,
+                attacker_final_blow=1, attacker_damage_done=200),
+        ]
+
+        ledger = _build_character_ledger(kms)
+
+        bp_rows = [
+            {"character_id": 10, "alliance_id": 100, "corporation_id": 0},
+            {"character_id": 11, "alliance_id": 100, "corporation_id": 0},
+            {"character_id": 20, "alliance_id": 200, "corporation_id": 0},
+        ]
+        side_configuration = {
+            "friendly_alliance_ids": {100},
+            "friendly_corporation_ids": set(),
+            "opponent_alliance_ids": {200},
+            "opponent_corporation_ids": set(),
+        }
+        char_sides = {10: "friendly", 11: "friendly", 20: "opponent"}
+
+        summary = _compute_alliance_summary(ledger, bp_rows, side_configuration, char_sides)
+
+        friendly = [s for s in summary if s["alliance_id"] == 100][0]
+        opponent = [s for s in summary if s["alliance_id"] == 200][0]
+
+        # Friendly group: char 10 (1 final kill, 1 loss) + char 11 (0 final, 0 loss)
+        self.assertEqual(friendly["total_kills"], 1)         # final kills
+        self.assertEqual(friendly["total_contributed_kills"], 2)  # both chars on KM1
+        self.assertEqual(friendly["total_losses"], 1)
+        self.assertEqual(friendly["total_isk_killed"], 500.0)
+        self.assertEqual(friendly["total_isk_lost"], 800.0)
+
+        # Opponent group: char 20 (1 final kill, 1 loss)
+        self.assertEqual(opponent["total_kills"], 1)
+        self.assertEqual(opponent["total_contributed_kills"], 1)
+        self.assertEqual(opponent["total_losses"], 1)
+        self.assertEqual(opponent["total_isk_killed"], 800.0)
+        self.assertEqual(opponent["total_isk_lost"], 500.0)
+
+
+# ── Test: Invariants ───────────────────────────────────────────────────────
+
+class TestInvariants(unittest.TestCase):
+    """Verify invariants hold across the full battle."""
+
+    def test_isk_and_count_invariants(self) -> None:
+        """For N killmails:
+        sum(isk_lost)   == total_destroyed
+        sum(isk_killed) == total_destroyed
+        sum(losses)     == N
+        sum(final_kills) == N
+        sum(contributed_kills) >= N
+        """
+        kms = [
+            # KM 1: 3 attackers
+            _km(1, victim_character_id=10, victim_alliance_id=100,
+                total_value=100.0,
+                attacker_character_id=20, attacker_alliance_id=200,
+                attacker_final_blow=1, attacker_damage_done=80),
+            _km(1, victim_character_id=10, victim_alliance_id=100,
+                total_value=100.0,
+                attacker_character_id=30, attacker_alliance_id=200,
+                attacker_final_blow=0, attacker_damage_done=15),
+            _km(1, victim_character_id=10, victim_alliance_id=100,
+                total_value=100.0,
+                attacker_character_id=40, attacker_alliance_id=300,
+                attacker_final_blow=0, attacker_damage_done=5),
+            # KM 2: 1 attacker
+            _km(2, victim_character_id=20, victim_alliance_id=200,
+                total_value=250.0,
+                attacker_character_id=10, attacker_alliance_id=100,
+                attacker_final_blow=1, attacker_damage_done=300),
+            # KM 3: 2 attackers
+            _km(3, victim_character_id=30, victim_alliance_id=200,
+                total_value=50.0,
+                attacker_character_id=10, attacker_alliance_id=100,
+                attacker_final_blow=1, attacker_damage_done=40),
+            _km(3, victim_character_id=30, victim_alliance_id=200,
+                total_value=50.0,
+                attacker_character_id=40, attacker_alliance_id=300,
+                attacker_final_blow=0, attacker_damage_done=10),
+        ]
+
+        ledger = _build_character_ledger(kms)
+
+        total_destroyed = 100.0 + 250.0 + 50.0  # 400.0
+        num_killmails = 3
+
+        sum_isk_lost = sum(e["isk_lost"] for e in ledger.values())
+        sum_isk_killed = sum(e["isk_killed"] for e in ledger.values())
+        sum_losses = sum(e["losses"] for e in ledger.values())
+        sum_final_kills = sum(e["final_kills"] for e in ledger.values())
+        sum_contributed = sum(e["contributed_kills"] for e in ledger.values())
+
+        self.assertEqual(sum_isk_lost, total_destroyed,
+                         "sum(isk_lost) must equal total destroyed ISK")
+        self.assertEqual(sum_isk_killed, total_destroyed,
+                         "sum(isk_killed) must equal total destroyed ISK")
+        self.assertEqual(sum_losses, num_killmails,
+                         "sum(losses) must equal number of killmails")
+        self.assertEqual(sum_final_kills, num_killmails,
+                         "sum(final_kills) must equal number of killmails")
+        self.assertGreaterEqual(sum_contributed, num_killmails,
+                                "sum(contributed_kills) must be >= number of killmails")
+
+    def test_group_rollup_preserves_invariants(self) -> None:
+        """Group rollup must not break ISK invariants."""
+        kms = [
+            _km(1, victim_character_id=10, victim_alliance_id=100,
+                total_value=1000.0,
+                attacker_character_id=20, attacker_alliance_id=200,
+                attacker_final_blow=1, attacker_damage_done=500),
+            _km(1, victim_character_id=10, victim_alliance_id=100,
+                total_value=1000.0,
+                attacker_character_id=30, attacker_alliance_id=300,
+                attacker_final_blow=0, attacker_damage_done=500),
+            _km(2, victim_character_id=20, victim_alliance_id=200,
+                total_value=600.0,
+                attacker_character_id=10, attacker_alliance_id=100,
+                attacker_final_blow=1, attacker_damage_done=600),
+        ]
+
+        ledger = _build_character_ledger(kms)
+
+        bp_rows = [
+            {"character_id": 10, "alliance_id": 100, "corporation_id": 0},
+            {"character_id": 20, "alliance_id": 200, "corporation_id": 0},
+            {"character_id": 30, "alliance_id": 300, "corporation_id": 0},
+        ]
+        side_configuration = {
+            "friendly_alliance_ids": {100},
+            "friendly_corporation_ids": set(),
+            "opponent_alliance_ids": {200},
+            "opponent_corporation_ids": set(),
+        }
+        char_sides = {10: "friendly", 20: "opponent", 30: "third_party"}
+
+        summary = _compute_alliance_summary(ledger, bp_rows, side_configuration, char_sides)
+
+        total_destroyed = 1000.0 + 600.0
+        group_isk_killed = sum(s["total_isk_killed"] for s in summary)
+        group_isk_lost = sum(s["total_isk_lost"] for s in summary)
+        group_kills = sum(s["total_kills"] for s in summary)
+        group_losses = sum(s["total_losses"] for s in summary)
+
+        self.assertEqual(group_isk_killed, total_destroyed)
+        self.assertEqual(group_isk_lost, total_destroyed)
+        self.assertEqual(group_kills, 2)   # 2 killmails
+        self.assertEqual(group_losses, 2)  # 2 killmails
+
+
+# ── Test: Third-party final blow ───────────────────────────────────────────
+
+class TestThirdPartyFinalBlow(unittest.TestCase):
+    """Third-party gets the final blow — ISK killed goes to them, not
+    to the group that dealt the most damage."""
+
+    def test_third_party_gets_isk_killed(self) -> None:
+        kms = [
+            # Third party gets final blow
+            _km(1, victim_character_id=20, victim_alliance_id=200,
+                total_value=1000.0,
+                attacker_character_id=30, attacker_alliance_id=300,
+                attacker_final_blow=1, attacker_damage_done=50),
+            # Friendly did 95% damage but no final blow
+            _km(1, victim_character_id=20, victim_alliance_id=200,
+                total_value=1000.0,
+                attacker_character_id=10, attacker_alliance_id=100,
+                attacker_final_blow=0, attacker_damage_done=950),
+        ]
+
+        ledger = _build_character_ledger(kms)
+
+        # Third party char gets the ISK killed
+        self.assertEqual(ledger[30]["final_kills"], 1)
+        self.assertEqual(ledger[30]["isk_killed"], 1000.0)
+
+        # Friendly char gets contributed kill but no ISK killed
+        self.assertEqual(ledger[10]["contributed_kills"], 1)
+        self.assertEqual(ledger[10]["final_kills"], 0)
+        self.assertEqual(ledger[10]["isk_killed"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_theater_engagement_expansion.py
+++ b/python/tests/test_theater_engagement_expansion.py
@@ -32,6 +32,7 @@ sys.modules["orchestrator.jobs"] = _stub_jobs_init
 
 # Now import the specific modules we need
 from orchestrator.jobs.theater_analysis import (  # noqa: E402
+    _build_character_ledger,
     _compute_alliance_summary,
     _compute_timeline,
     _load_expanded_killmails,
@@ -138,7 +139,8 @@ class TestCleanTwoSideFight(unittest.TestCase):
         }
         char_sides = {10: "friendly", 20: "opponent"}
 
-        summary = _compute_alliance_summary(kms, bp_rows, side_configuration, char_sides)
+        character_ledger = _build_character_ledger(kms)
+        summary = _compute_alliance_summary(character_ledger, bp_rows, side_configuration, char_sides)
 
         friendly = [s for s in summary if s["alliance_id"] == 100][0]
         opponent = [s for s in summary if s["alliance_id"] == 200][0]
@@ -184,15 +186,22 @@ class TestThirdPartyFinalBlow(unittest.TestCase):
         }
         char_sides = {10: "friendly", 20: "opponent", 30: "third_party"}
 
-        summary = _compute_alliance_summary(kms, bp_rows, side_configuration, char_sides)
+        character_ledger = _build_character_ledger(kms)
+        summary = _compute_alliance_summary(character_ledger, bp_rows, side_configuration, char_sides)
 
         opponent = [s for s in summary if s["alliance_id"] == 200][0]
         friendly = [s for s in summary if s["alliance_id"] == 100][0]
+        third_party = [s for s in summary if s["alliance_id"] == 300][0]
 
         # Enemy STILL lost 1000 ISK regardless of who got final blow
         self.assertEqual(opponent["total_isk_lost"], 1000.0)
-        # Friendly gets ISK killed credit (they participated)
-        self.assertEqual(friendly["total_isk_killed"], 1000.0)
+        # ISK killed now goes to the final-blow group (third party), not friendly
+        self.assertEqual(third_party["total_isk_killed"], 1000.0)
+        self.assertEqual(third_party["total_kills"], 1)
+        # Friendly has contributed_kills but no final kill / ISK killed
+        self.assertEqual(friendly["total_isk_killed"], 0.0)
+        self.assertEqual(friendly["total_contributed_kills"], 1)
+        self.assertEqual(friendly["total_kills"], 0)
 
 
 class TestThirdPartyVictimInSameEngagement(unittest.TestCase):


### PR DESCRIPTION
## Summary

Refactors battle statistics computation to use a per-character ledger as the single source of truth, eliminating inconsistencies from direct killmail processing. All group-level statistics are now derived from character ledger entries, ensuring invariants hold across the full battle.

## Key Changes

- **New `_build_character_ledger()` function**: Processes killmails once to build canonical per-character stats:
  - `final_kills`: unique kill credit (final blow only)
  - `contributed_kills`: listed-on-killmail involvement count (includes zero-damage participants)
  - `losses`: victim count
  - `isk_killed`: ISK value of killmails where character got final blow
  - `isk_lost`: total ISK lost as victim
  - `damage_done`: cumulative damage dealt

- **Refactored `_compute_alliance_summary()`**: Now accepts character ledger instead of raw killmails; rolls up character stats into group totals. Guarantees group totals are exact rollups of character truth.

- **Updated `_compute_participants()`**: Initializes character stats from ledger; only uses killmail rows for damage_taken, ship loss detail, and timestamps.

- **Added `total_contributed_kills` field**: Tracks kill involvement count at both character and alliance levels, distinct from final kills.

- **Database schema**: Added `final_kills`, `contributed_kills`, and `isk_killed` columns to `theater_participants` and `theater_alliance_summary`.

- **Comprehensive test suite** (`test_battle_stats_ledger.py`): 406 lines validating:
  - Single and multi-attacker killmails
  - Zero-damage participants (ewar/boosters)
  - Multi-killmail character accumulation
  - Group rollup accuracy
  - Invariants: `sum(isk_lost) == sum(isk_killed) == total_destroyed`, `sum(losses) == sum(final_kills) == killmail_count`, `sum(contributed_kills) >= killmail_count`
  - Third-party final blow handling

## Notable Implementation Details

- Deduplication uses sets to track `(killmail_id, attacker_character_id)` pairs for contributed kills and `(killmail_id, victim_character_id)` for losses, ensuring each participant is counted once per killmail.
- ISK killed is credited only to the final blow attacker, not distributed among all participants.
- Contributed kills include all listed attackers, even those with zero damage (ewar, boosters).
- PHP presentation layer updated to use `contributed_kills` for kill involvement metrics while maintaining `kills` (final kills) for canonical kill credit.

https://claude.ai/code/session_01Hm66vURhTS2tHkhRKCANbE