### PR TITLE
Refactor battle stats to per-character ledger model

### DIFF
--- a/public-proxy/partials/_battle_report.php
+++ b/public-proxy/partials/_battle_report.php
@@ -93,7 +93,6 @@
                     'pilots' => ($enemyPanel['pilots'] ?? 0) + ($thirdPartyPanel['pilots'] ?? 0),
                     'efficiency' => $enemyEfficiency,
                     'kills' => ($enemyPanel['kills'] ?? 0) + ($thirdPartyPanel['kills'] ?? 0),
-                    'final_blows' => ($enemyPanel['final_blows'] ?? 0) + ($thirdPartyPanel['final_blows'] ?? 0),
                     'losses' => ($enemyPanel['losses'] ?? 0) + ($thirdPartyPanel['losses'] ?? 0),
                     'kill_involvements' => ($enemyPanel['kill_involvements'] ?? 0) + ($thirdPartyPanel['kill_involvements'] ?? 0),
                     'isk_killed' => ($enemyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_killed'] ?? 0),

--- a/public-proxy/partials/_battle_report_panel_merged.php
+++ b/public-proxy/partials/_battle_report_panel_merged.php
@@ -19,7 +19,7 @@
         <div class="px-4 py-3">
             <p class="text-xs text-muted">Kills / Losses</p>
             <p class="text-slate-100 font-semibold"><?= number_format((int) ($_brp_data['kills'] ?? 0)) ?> / <?= number_format((int) ($_brp_data['losses'] ?? 0)) ?></p>
-            <p class="text-[10px] text-muted">Final blows: <?= number_format((int) ($_brp_data['final_blows'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($_brp_data['kill_involvements'] ?? 0)) ?></p>
         </div>
         <div class="px-4 py-3">
             <p class="text-xs text-muted">ISK Killed / Lost</p>

--- a/public/theater-intelligence/partials/_battle_report.php
+++ b/public/theater-intelligence/partials/_battle_report.php
@@ -115,7 +115,6 @@
                         'pilots' => ($enemyPanel['pilots'] ?? 0) + ($thirdPartyPanel['pilots'] ?? 0),
                         'efficiency' => $enemyEfficiency,
                         'kills' => ($enemyPanel['kills'] ?? 0) + ($thirdPartyPanel['kills'] ?? 0),
-                        'final_blows' => ($enemyPanel['final_blows'] ?? 0) + ($thirdPartyPanel['final_blows'] ?? 0),
                         'losses' => ($enemyPanel['losses'] ?? 0) + ($thirdPartyPanel['losses'] ?? 0),
                         'kill_involvements' => ($enemyPanel['kill_involvements'] ?? 0) + ($thirdPartyPanel['kill_involvements'] ?? 0),
                         'isk_killed' => ($enemyPanel['isk_killed'] ?? 0) + ($thirdPartyPanel['isk_killed'] ?? 0),

--- a/public/theater-intelligence/partials/_battle_report_panel_merged.php
+++ b/public/theater-intelligence/partials/_battle_report_panel_merged.php
@@ -19,7 +19,7 @@
         <div class="px-4 py-3">
             <p class="text-xs text-muted">Kills / Losses</p>
             <p class="text-slate-100 font-semibold"><?= number_format((int) ($panelData['kills'] ?? 0)) ?> / <?= number_format((int) ($panelData['losses'] ?? 0)) ?></p>
-            <p class="text-[10px] text-muted">Final blows: <?= number_format((int) ($panelData['final_blows'] ?? 0)) ?></p>
+            <p class="text-[10px] text-muted">Kill involvements: <?= number_format((int) ($panelData['kill_involvements'] ?? 0)) ?></p>
         </div>
         <div class="px-4 py-3">
             <p class="text-xs text-muted">ISK Killed / Lost</p>


### PR DESCRIPTION
## Summary

- Replaces the previous battle stats attribution logic (group-level killmail processing, loss-based ISK shortcuts, separate PHP final-blow queries) with a single per-character ledger built from killmails
- Each killmail is processed exactly once: victim gets `losses`/`isk_lost`, final blow attacker gets `final_kills`/`isk_killed`, all listed attackers get `contributed_kills`
- Alliance/side totals are now strict rollups of character stats — no more double-counting ISK across groups or inconsistent models between PHP endpoints
- Adds `final_kills`, `contributed_kills`, `isk_killed` columns to `theater_participants` and `total_contributed_kills` to `theater_alliance_summary`

### Invariants enforced
- `sum(isk_lost) = sum(isk_killed) = total destroyed ISK`
- `sum(final_kills) = sum(losses) = number of killmails`
- `sum(contributed_kills) >= number of killmails`

### Naming conventions
- `kills` = final kills (canonical unique kill credit)
- `contributed_kills` / `kill_involvements` = listed on killmail (includes zero-damage attackers)
- `isk_killed` = ISK from killmails where character got final blow

## Test plan

- [x] 8 new unit tests covering single attacker, multi-attacker, zero-damage attacker, multi-killmail aggregation, group rollup, ISK/count invariants, third-party final blow
- [x] 8 existing theater engagement tests updated and passing
- [ ] Run migration `20260411_theater_participant_battle_stats.sql`
- [ ] Re-run `theater_analysis` job to recompute all theaters with ledger model
- [ ] Verify `contributed_kills` / kill involvements populate correctly after re-analysis
- [ ] Verify side panel kills/ISK match across both `/theater-intelligence/view.php` and `/api/public/theater.php`

https://claude.ai/code/session_01Hm66vURhTS2tHkhRKCANbE