### PR TITLE
Add source column to corp_contacts table for manual contact tracking

### DIFF
--- a/python/orchestrator/jobs/corp_standings_sync.py
+++ b/python/orchestrator/jobs/corp_standings_sync.py
@@ -173,15 +173,27 @@ def _ensure_tables(db: SupplyCoreDb) -> None:
             contact_type    ENUM('character', 'corporation', 'alliance', 'faction') NOT NULL,
             standing        DOUBLE NOT NULL,
             label_ids       JSON DEFAULT NULL,
+            source          ENUM('esi', 'manual') NOT NULL DEFAULT 'esi',
             fetched_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             UNIQUE KEY uq_corp_contact (corporation_id, contact_id, contact_type),
             KEY idx_corp_type (corporation_id, contact_type),
             KEY idx_contact_id (contact_id),
-            KEY idx_standing (corporation_id, standing)
+            KEY idx_standing (corporation_id, standing),
+            KEY idx_source (source)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
     """)
+
+    # Ensure source column exists on tables created before the migration.
+    try:
+        db.execute("""
+            ALTER TABLE corp_contacts
+                ADD COLUMN source ENUM('esi', 'manual') NOT NULL DEFAULT 'esi' AFTER label_ids,
+                ADD KEY idx_source (source)
+        """)
+    except Exception:
+        pass  # Column already exists
 
 
 # ── NPC standings fetcher ─────────────────────────────────────────────────────

--- a/src/db.php
+++ b/src/db.php
@@ -11834,7 +11834,19 @@ function db_corp_contacts_all(): array
              ORDER BY source ASC, contact_type ASC, standing DESC"
         );
     } catch (Throwable) {
-        return [];
+        // Fallback: source column may not exist yet (migration pending).
+        try {
+            return array_map(
+                static fn (array $row): array => array_merge($row, ['source' => 'esi']),
+                db_select(
+                    "SELECT corporation_id, contact_id, contact_type, standing, label_ids, 'esi' AS source, fetched_at
+                     FROM corp_contacts
+                     ORDER BY contact_type ASC, standing DESC"
+                )
+            );
+        } catch (Throwable) {
+            return [];
+        }
     }
 }
 
@@ -11916,11 +11928,30 @@ function db_corp_contact_standing(int $entityId, string $entityType = 'alliance'
 }
 
 /**
+ * Ensure the source column exists on corp_contacts (handles pre-migration tables).
+ */
+function db_corp_contacts_ensure_source_column(): void
+{
+    try {
+        db_execute(
+            "ALTER TABLE corp_contacts
+                ADD COLUMN source ENUM('esi', 'manual') NOT NULL DEFAULT 'esi' AFTER label_ids,
+                ADD KEY idx_source (source)"
+        );
+    } catch (Throwable) {
+        // Column already exists — nothing to do.
+    }
+}
+
+/**
  * Replace all manual corp contacts with the given list.
  * Each entry: ['contact_id' => int, 'contact_type' => string, 'standing' => float]
  */
 function db_corp_contacts_manual_replace(array $contacts): void
 {
+    // Ensure the source column exists before writing manual contacts.
+    db_corp_contacts_ensure_source_column();
+
     db_execute('DELETE FROM corp_contacts WHERE source = ?', ['manual']);
 
     foreach ($contacts as $c) {


### PR DESCRIPTION
## Summary
This PR adds a `source` column to the `corp_contacts` table to distinguish between contacts fetched from ESI and those added manually. It includes migration handling for existing tables and fallback logic to support pre-migration databases.

## Key Changes
- **Database Schema**: Added `source` ENUM column ('esi', 'manual') to `corp_contacts` table with a default value of 'esi' and corresponding index
- **PHP Migration Helper**: Created `db_corp_contacts_ensure_source_column()` function to safely add the column to existing tables, with exception handling for already-migrated databases
- **Fallback Query Logic**: Updated `db_corp_contacts_all()` to gracefully handle pre-migration tables by catching the initial query failure and falling back to a query without the source column in the ORDER BY clause, while still providing the source value in results
- **Manual Contact Operations**: Added column existence check in `db_corp_contacts_manual_replace()` before writing manual contacts to ensure the schema is ready
- **Python Migration**: Updated the table creation schema in `corp_standings_sync.py` to include the source column and added a try-except block to handle pre-existing tables

## Implementation Details
- The fallback mechanism in `db_corp_contacts_all()` uses nested try-catch blocks: the outer catches schema errors and attempts a simpler query, the inner catches any remaining errors and returns an empty array
- The `array_merge()` approach in the fallback ensures backward compatibility by adding the source value to existing result rows
- Both PHP and Python implementations use exception handling rather than explicit schema checks, allowing the code to be resilient to various migration states

https://claude.ai/code/session_01HVrmVVwhUXWeK3FZhb8HAZ