### PR TITLE
Fix ESI login save disabling esi_enabled

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -159,12 +159,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             break;
 
         case 'esi-login':
+            // Note: esi_enabled is NOT saved here — it is controlled exclusively
+            // from Automation Control to avoid accidentally disabling ESI login.
             $saved = save_settings([
                 'esi_client_id' => trim($_POST['esi_client_id'] ?? ''),
                 'esi_client_secret' => trim($_POST['esi_client_secret'] ?? ''),
                 'esi_callback_url' => trim($_POST['esi_callback_url'] ?? ''),
                 'esi_scopes' => trim($_POST['esi_scopes'] ?? implode(' ', esi_default_scopes())),
-                'esi_enabled' => isset($_POST['esi_enabled']) ? '1' : '0',
             ]);
             break;
 


### PR DESCRIPTION
## Summary
- The ESI Login form showed `esi_enabled` as read-only status text (no input), but the save handler checked `$_POST['esi_enabled']` — always unset, so it reset to `'0'` on every save
- Removed `esi_enabled` from the ESI Login save handler since it's controlled exclusively by Automation Control

## Test plan
- [ ] Save ESI Login settings and verify `esi_enabled` remains unchanged
- [ ] Verify Automation Control still toggles `esi_enabled` correctly

https://claude.ai/code/session_01HVrmVVwhUXWeK3FZhb8HAZ