### PR TITLE
Fix contact name resolution and add alliance contacts

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -3017,7 +3017,7 @@ INSERT INTO app_settings (setting_key, setting_value) VALUES
     ('esi_client_id', '961316f6177d4a0283fef0bd72fbd224'),
     ('esi_client_secret', 'eat_iasVmhqov40Ud568JVAyctOErv5E6AgV_3S6eiZ'),
     ('esi_callback_url', 'http://192.168.178.47/callback'),
-    ('esi_scopes', 'publicData esi-location.read_location.v1 esi-search.search_structures.v1 esi-universe.read_structures.v1 esi-markets.structure_markets.v1 esi-corporations.read_standings.v1 esi-corporations.read_contacts.v1'),
+    ('esi_scopes', 'publicData esi-location.read_location.v1 esi-search.search_structures.v1 esi-universe.read_structures.v1 esi-markets.structure_markets.v1 esi-corporations.read_standings.v1 esi-corporations.read_contacts.v1 esi-alliances.read_contacts.v1'),
     ('ollama_enabled', '0'),
     ('ollama_url', 'http://localhost:11434/api'),
     ('ollama_model', 'qwen2.5:1.5b-instruct'),

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1566,14 +1566,13 @@ include __DIR__ . '/../../src/views/partials/header.php';
                 $contactCorpIds = array_keys($contactIdsByType['corporation']);
                 $contactCharacterIds = array_keys($contactIdsByType['character']);
                 $contactNameMap = [];
-                foreach (db_entity_metadata_cache_get_many('alliance', $contactAllianceIds) as $e) {
-                    $contactNameMap['alliance:' . (int) $e['entity_id']] = (string) $e['entity_name'];
-                }
-                foreach (db_entity_metadata_cache_get_many('corporation', $contactCorpIds) as $e) {
-                    $contactNameMap['corporation:' . (int) $e['entity_id']] = (string) $e['entity_name'];
-                }
-                foreach (db_entity_metadata_cache_get_many('character', $contactCharacterIds) as $e) {
-                    $contactNameMap['character:' . (int) $e['entity_id']] = (string) $e['entity_name'];
+                foreach (['alliance' => $contactAllianceIds, 'corporation' => $contactCorpIds, 'character' => $contactCharacterIds] as $cacheType => $cacheIds) {
+                    foreach (db_entity_metadata_cache_get_many($cacheType, $cacheIds) as $e) {
+                        $name = trim((string) ($e['entity_name'] ?? ''));
+                        if ($name !== '') {
+                            $contactNameMap[$cacheType . ':' . (int) $e['entity_id']] = $name;
+                        }
+                    }
                 }
 
                 // Queue any unresolved contact IDs for background name resolution

--- a/python/orchestrator/jobs/corp_standings_sync.py
+++ b/python/orchestrator/jobs/corp_standings_sync.py
@@ -1,19 +1,19 @@
-"""Corporation Standings & Contacts Sync.
+"""Corporation & Alliance Standings & Contacts Sync.
 
-Fetches two ESI endpoints for each tracked corporation:
+Fetches ESI endpoints for each tracked corporation (and its alliance):
 
 1. ``/corporations/{id}/standings`` — NPC standings (agents, NPC corps, factions).
    Scope: ``esi-corporations.read_standings.v1``
 
-2. ``/corporations/{id}/contacts/`` — Player contacts (characters, corps, alliances).
+2. ``/corporations/{id}/contacts/`` — Corp-level player contacts.
    Scope: ``esi-corporations.read_contacts.v1``
 
-The contacts data is the primary source for determining which player alliances
-and corporations are friendly or hostile from the in-game diplomatic perspective.
-The standings data supplements this with NPC faction alignment.
+3. ``/alliances/{id}/contacts/`` — Alliance-level player contacts.
+   Scope: ``esi-alliances.read_contacts.v1``
 
-Both routes are part of the ESI rate-limit group ``corp-member``
-(300 tokens / 15 min).
+The alliance contacts are the primary diplomatic standings.  Corporation
+contacts supplement them.  Both are stored in ``corp_contacts`` and used for
+theater side classification.
 """
 
 from __future__ import annotations
@@ -30,8 +30,9 @@ log = logging.getLogger(__name__)
 
 JOB_KEY = "corp_standings_sync"
 
-# ESI rate-limit group for both endpoints.
+# ESI rate-limit groups.
 _ESI_GROUP = "corp-member"
+_ESI_GROUP_ALLIANCE = "alliance-member"
 
 
 def _processor(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None) -> dict[str, object]:
@@ -128,6 +129,24 @@ def _processor(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None) -> di
         except Exception as exc:
             warnings.append(f"Failed to fetch contacts for corporation {corp_id}: {exc}")
 
+        # ── Alliance contacts ───────────────────────────────────────────
+        alliance_id = _resolve_alliance_id(gateway, db, corp_id, access_token)
+        if alliance_id:
+            try:
+                ally_contacts, ally_error = _fetch_alliance_contacts(gateway, alliance_id, access_token)
+                rows_processed += len(ally_contacts)
+                if ally_contacts:
+                    written = _upsert_contacts(db, corp_id, ally_contacts, now_sql)
+                    rows_written += written
+                    log.info("Alliance %d (corp %d): %d alliance contacts upserted.", alliance_id, corp_id, written)
+                else:
+                    log.info("Alliance %d (corp %d): 0 alliance contact entries.", alliance_id, corp_id)
+                if ally_error:
+                    warnings.append(ally_error)
+                _queue_contact_names(db, ally_contacts)
+            except Exception as exc:
+                warnings.append(f"Failed to fetch alliance contacts for alliance {alliance_id} (corp {corp_id}): {exc}")
+
         # Update sync state for this corporation.
         db.execute(
             """
@@ -146,7 +165,7 @@ def _processor(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None) -> di
         "rows_processed": rows_processed,
         "rows_written": rows_written,
         "warnings": warnings,
-        "summary": f"Synced standings + contacts for {len(corp_ids)} corporation(s) ({rows_written} upserts).",
+        "summary": f"Synced standings + corp/alliance contacts for {len(corp_ids)} corporation(s) ({rows_written} upserts).",
         "meta": {"corporation_ids": corp_ids},
     }
 
@@ -305,6 +324,93 @@ def _fetch_contacts(gateway, corp_id: int, access_token: str) -> tuple[list[dict
             break
         if resp.status_code != 200:
             log.warning("ESI contacts for corp %d returned %d", corp_id, resp.status_code)
+            continue
+        body = resp.body
+        if isinstance(body, list):
+            all_contacts.extend(body)
+
+    return all_contacts, error_msg
+
+
+# ── Alliance contact helpers ─────────────────────────────────────────────────
+
+def _resolve_alliance_id(gateway, db: SupplyCoreDb, corp_id: int, access_token: str) -> int | None:
+    """Look up the alliance_id for a corporation, using the entity cache or ESI."""
+    # Check entity_metadata_cache first.
+    row = db.fetch_one(
+        """SELECT metadata_json FROM entity_metadata_cache
+           WHERE entity_type = 'corporation' AND entity_id = %s
+             AND resolution_status = 'resolved'
+             AND metadata_json IS NOT NULL""",
+        (corp_id,),
+    )
+    if row and row.get("metadata_json"):
+        try:
+            meta = row["metadata_json"]
+            if isinstance(meta, str):
+                import json as _json
+                meta = _json.loads(meta)
+            aid = int(meta.get("alliance_id") or 0)
+            if aid > 0:
+                return aid
+        except (ValueError, TypeError, KeyError):
+            pass
+
+    # Fall back to ESI.
+    if gateway is None:
+        return None
+    try:
+        resp = gateway.get(
+            f"/v5/corporations/{corp_id}/",
+            access_token=None,
+            group="esi-characters",
+            route_template="/corporations/{corporation_id}/",
+            identity=f"corp:{corp_id}",
+        )
+        if resp.status_code == 200 and isinstance(resp.body, dict):
+            aid = int(resp.body.get("alliance_id") or 0)
+            return aid if aid > 0 else None
+    except Exception as exc:
+        log.warning("Failed to look up alliance for corp %d: %s", corp_id, exc)
+    return None
+
+
+def _fetch_alliance_contacts(gateway, alliance_id: int, access_token: str) -> tuple[list[dict[str, Any]], str | None]:
+    """Fetch all pages of contacts for an alliance.
+
+    ESI endpoint: GET /alliances/{alliance_id}/contacts/
+    Scope: esi-alliances.read_contacts.v1
+    Returns: (contacts_list, optional_error_message)
+    """
+    if gateway is None:
+        return [], None
+
+    all_contacts: list[dict[str, Any]] = []
+    error_msg: str | None = None
+    path = f"/latest/alliances/{alliance_id}/contacts/"
+
+    responses = gateway.get_paginated(
+        path,
+        access_token=access_token,
+        group=_ESI_GROUP_ALLIANCE,
+        route_template="/alliances/{alliance_id}/contacts/",
+        identity=f"alliance:{alliance_id}",
+        max_pages=20,
+    )
+
+    for resp in responses:
+        if resp.status_code == 304:
+            continue
+        if resp.status_code in (401, 403):
+            error_msg = (
+                f"ESI alliance contacts for alliance {alliance_id} returned {resp.status_code} — "
+                f"token expired or missing scope esi-alliances.read_contacts.v1. "
+                f"Re-authenticate with updated scopes in Settings → ESI Auth."
+            )
+            log.warning("%s", error_msg)
+            break
+        if resp.status_code != 200:
+            log.warning("ESI alliance contacts for %d returned %d", alliance_id, resp.status_code)
             continue
         body = resp.body
         if isinstance(body, list):

--- a/src/functions.php
+++ b/src/functions.php
@@ -14796,6 +14796,7 @@ function esi_default_scopes(): array
         'esi-markets.structure_markets.v1',
         'esi-corporations.read_standings.v1',
         'esi-corporations.read_contacts.v1',
+        'esi-alliances.read_contacts.v1',
     ];
 }
 
@@ -14808,6 +14809,7 @@ function esi_required_corp_standings_scopes(): array
     return [
         'esi-corporations.read_standings.v1',
         'esi-corporations.read_contacts.v1',
+        'esi-alliances.read_contacts.v1',
     ];
 }
 


### PR DESCRIPTION
## Summary

- **Fix names showing as IDs**: The entity_metadata_cache lookup stored empty strings for failed/null name resolutions. The `??` null coalescing operator doesn't catch empty strings, so resolved names never appeared. Now filters out empty names so the fallback "Type #ID" renders until the background resolver populates them.
- **Add alliance contacts**: The sync only fetched `/corporations/{id}/contacts/` (corp-level contacts, often personal character standings). Now also fetches `/alliances/{id}/contacts/` for the alliance's diplomatic standings — the actual contact list you want.
- **Add +5/±5 standing groups**: ESI contacts are grouped with sub-headers (Standing +10, +5, -10, -5) with distinct color coding.
- **New ESI scope**: Adds `esi-alliances.read_contacts.v1` to default scopes. Re-authentication required to grant it.

## Test plan

- [ ] Re-authenticate ESI with updated scopes (new scope: `esi-alliances.read_contacts.v1`)
- [ ] Run `corp_standings_sync` — verify alliance contacts are fetched and stored
- [ ] Run `entity_metadata_resolve_sync` — verify queued names resolve
- [ ] Check Settings → Corp Contacts — names should display instead of IDs
- [ ] Verify +10/+5 and -10/-5 grouping with sub-headers appears correctly

https://claude.ai/code/session_01A3yRf58WrEAqm5xANpfmUW