### PR TITLE
Fix OAuth token refresh to properly store and validate refresh tokens

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -17002,6 +17002,7 @@ function esi_store_oauth_and_cache(array $tokenPayload, array $verifyPayload): v
         db_esi_cache_put('cache.esi.oauth.verify', 'latest', json_encode($verifyPayload, JSON_THROW_ON_ERROR));
         db_esi_cache_put('cache.esi.oauth.token', 'latest', json_encode([
             'access_token' => $tokenPayload['access_token'] ?? '',
+            'refresh_token' => $tokenPayload['refresh_token'] ?? '',
             'token_type' => $tokenPayload['token_type'] ?? 'Bearer',
             'expires_in' => $tokenPayload['expires_in'] ?? null,
             'scope' => $scopes,
@@ -17041,11 +17042,11 @@ function esi_refresh_oauth_token(array $storedToken): array
     $expiresIn = (int) ($tokenPayload['expires_in'] ?? 0);
     $expiresAt = (new DateTimeImmutable('now', new DateTimeZone('UTC')))->modify('+' . max(0, $expiresIn) . ' seconds')->format('Y-m-d H:i:s');
     $nextAccessToken = trim((string) ($tokenPayload['access_token'] ?? ''));
-    $nextRefreshToken = trim((string) ($tokenPayload['refresh_token'] ?? $refreshToken));
+    $nextRefreshToken = trim((string) ($tokenPayload['refresh_token'] ?? ''));
     $tokenType = trim((string) ($tokenPayload['token_type'] ?? ($storedToken['token_type'] ?? 'Bearer')));
     $scopes = trim((string) ($tokenPayload['scope'] ?? ($storedToken['scopes'] ?? esi_scopes_string())));
 
-    if ($nextAccessToken === '' || (int) ($storedToken['id'] ?? 0) <= 0) {
+    if ($nextAccessToken === '' || $nextRefreshToken === '' || (int) ($storedToken['id'] ?? 0) <= 0) {
         throw new RuntimeException('ESI session refresh returned an invalid token payload. Please reconnect your character.');
     }
 
@@ -17060,6 +17061,7 @@ function esi_refresh_oauth_token(array $storedToken): array
 
     db_esi_cache_put('cache.esi.oauth.token', 'latest', json_encode([
         'access_token' => $nextAccessToken,
+        'refresh_token' => $nextRefreshToken,
         'token_type' => $tokenType !== '' ? $tokenType : 'Bearer',
         'expires_in' => $tokenPayload['expires_in'] ?? null,
         'scope' => $scopes,


### PR DESCRIPTION
## Summary
This PR fixes the OAuth token refresh flow to properly persist and validate refresh tokens, ensuring that ESI sessions can be reliably renewed without requiring users to reconnect.

## Key Changes
- **Store refresh token on initial OAuth**: Added `refresh_token` to the cached token payload when initially storing OAuth credentials
- **Fix refresh token fallback logic**: Changed `esi_refresh_oauth_token()` to use an empty string fallback instead of the old `$refreshToken` variable, preventing stale token reuse
- **Add refresh token validation**: Enhanced validation to ensure both `access_token` and `refresh_token` are present after refresh, preventing invalid token states from being cached
- **Persist refreshed token**: Added `refresh_token` to the cached token payload after successful refresh, ensuring the new token is available for subsequent refreshes

## Implementation Details
The changes ensure that:
1. Refresh tokens are captured and stored from the initial OAuth response
2. Token refresh operations validate that both access and refresh tokens are returned by the OAuth provider
3. The newly refreshed tokens (including the refresh token) are properly persisted to the cache for future use
4. The fallback behavior no longer relies on potentially stale variables, using explicit empty string defaults instead

https://claude.ai/code/session_01GqZFrTbDi6JbUpCB6UJAkR