### PR TITLE
Remove character contacts from corp standings sync

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1552,9 +1552,12 @@ include __DIR__ . '/../../src/views/partials/header.php';
 
                 // Build corp contacts display data with resolved names
                 $corpContactsList = db_corp_contacts_all();
-                $esiContacts = array_filter($corpContactsList, static fn (array $c): bool => ((string) ($c['source'] ?? 'esi')) === 'esi');
+                $esiContacts = array_filter($corpContactsList, static fn (array $c): bool =>
+                    ((string) ($c['source'] ?? 'esi')) === 'esi'
+                    && in_array((string) ($c['contact_type'] ?? ''), ['alliance', 'corporation', 'faction'], true)
+                );
                 $manualContacts = array_filter($corpContactsList, static fn (array $c): bool => ((string) ($c['source'] ?? 'esi')) === 'manual');
-                $contactIdsByType = ['alliance' => [], 'corporation' => [], 'character' => []];
+                $contactIdsByType = ['alliance' => [], 'corporation' => []];
                 foreach ($corpContactsList as $c) {
                     $cType = (string) $c['contact_type'];
                     $cId = (int) $c['contact_id'];

--- a/python/orchestrator/jobs/corp_standings_sync.py
+++ b/python/orchestrator/jobs/corp_standings_sync.py
@@ -422,7 +422,7 @@ def _fetch_alliance_contacts(gateway, alliance_id: int, access_token: str) -> tu
 def _queue_contact_names(db: SupplyCoreDb, contacts: list[dict[str, Any]]) -> None:
     """Queue contact entity IDs for background name resolution."""
     ids_by_type: dict[str, list[int]] = {}
-    resolvable_types = ("character", "corporation", "alliance")
+    resolvable_types = ("corporation", "alliance")
     for entry in contacts:
         contact_id = int(entry.get("contact_id") or 0)
         contact_type = str(entry.get("contact_type") or "").strip()
@@ -455,7 +455,7 @@ def _upsert_contacts(
 ) -> int:
     """Upsert player contacts into corp_contacts table. Returns rows written."""
     written = 0
-    valid_types = ("character", "corporation", "alliance", "faction")
+    valid_types = ("corporation", "alliance", "faction")
 
     for entry in contacts:
         contact_id = int(entry.get("contact_id") or 0)


### PR DESCRIPTION
## Summary
This PR removes support for character-type contacts from the corporate standings synchronization system. Character contacts are no longer processed, stored, or resolved during the sync operation.

## Key Changes
- **PHP Settings**: Updated contact filtering logic to exclude character-type contacts from ESI contact processing and removed 'character' from the contact types dictionary
- **Python Orchestrator**: 
  - Removed 'character' from the list of resolvable contact types in `_queue_contact_names()`
  - Removed 'character' from valid contact types in `_upsert_contacts()`
  - Retained support for 'corporation', 'alliance', and 'faction' types

## Implementation Details
- ESI contacts are now filtered to only include 'alliance', 'corporation', and 'faction' types
- Character contact IDs will no longer be queued for background name resolution
- Character contacts will be rejected during the upsert operation if encountered
- Manual contacts continue to be processed independently of these type restrictions

https://claude.ai/code/session_01RtmXAyPL8Mnt1j7TXDkvES