### PR TITLE
Exclude AOE weapons from standing discrepancy detection

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -11791,7 +11791,9 @@ function db_theater_standing_discrepancies(string $theaterId): array
 {
     try {
         // Find cases where a "friendly" entity killed another "friendly" entity
-        // by looking at killmail attacker/victim alliance pairs within the theater
+        // by looking at killmail attacker/victim alliance pairs within the theater.
+        // Exclude AOE weapons (smartbombs group=141, bombs group=1015) — splash
+        // damage is not intentional hostile action and does not affect standings.
         return db_select(
             "SELECT
                 ka.alliance_id AS attacker_alliance_id,
@@ -11807,6 +11809,9 @@ function db_theater_standing_discrepancies(string $theaterId): array
                AND ka.alliance_id > 0
                AND ke.victim_alliance_id > 0
                AND ka.alliance_id != ke.victim_alliance_id
+               AND (ka.weapon_type_id IS NULL OR ka.weapon_type_id NOT IN (
+                   SELECT rit.type_id FROM ref_item_types rit WHERE rit.group_id IN (141, 1015)
+               ))
              GROUP BY ka.alliance_id, ka.corporation_id,
                       ke.victim_alliance_id, ke.victim_corporation_id
              HAVING cross_kills >= 1


### PR DESCRIPTION
## Summary
Updated the `db_theater_standing_discrepancies()` function to exclude kills made with AOE weapons (smartbombs and bombs) when detecting hostile actions between allied entities. This prevents splash damage incidents from incorrectly flagging standing discrepancies.

## Key Changes
- Added filter to exclude kills where the weapon type is a smartbomb (group 141) or bomb (group 1015)
- Implemented subquery to dynamically reference weapon group IDs from the `ref_item_types` table
- Updated inline documentation to clarify that AOE splash damage is not considered intentional hostile action

## Implementation Details
The change adds a WHERE clause condition that filters out killmails where `ka.weapon_type_id` matches any type belonging to the excluded weapon groups. This ensures that accidental AOE damage does not contribute to standing discrepancy calculations, which should only reflect intentional hostile actions between allied entities.

https://claude.ai/code/session_01PYVyTY5ozpdF9EMFPwTSCo