### PR TITLE
Replace error_log with file-based request performance logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 .venv*/
 public-proxy/.config.vault
 public-proxy/config.php
+/logs/

--- a/src/functions.php
+++ b/src/functions.php
@@ -70,7 +70,16 @@ function supplycore_request_perf_init(): void
             'repeated_patterns' => $repeatedPatterns,
         ];
 
-        error_log(json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+        $logFile = dirname(__DIR__) . '/logs/request_perf.log';
+        $logDir = dirname($logFile);
+        if (!is_dir($logDir)) {
+            @mkdir($logDir, 0755, true);
+        }
+        @file_put_contents(
+            $logFile,
+            date('Y-m-d H:i:s') . ' ' . json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE) . "\n",
+            FILE_APPEND | LOCK_EX
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
Changed the request performance logging mechanism from using PHP's `error_log()` function to writing directly to a dedicated log file with timestamps.

## Key Changes
- Replaced `error_log()` call with file-based logging to `logs/request_perf.log`
- Added automatic log directory creation with proper permissions (0755)
- Added timestamps to each log entry in `Y-m-d H:i:s` format
- Implemented atomic writes using `FILE_APPEND` and `LOCK_EX` flags for thread-safe logging
- Added `/logs/` directory to `.gitignore` to prevent log files from being committed

## Implementation Details
- Log directory is created relative to the project root (`dirname(__DIR__) . '/logs/`)
- Directory creation uses `@mkdir()` with error suppression to gracefully handle existing directories
- Each log entry includes a timestamp prefix followed by the JSON payload
- File operations use error suppression (`@`) to prevent warnings if directory creation or file writing fails
- Lock exclusion (`LOCK_EX`) ensures concurrent writes don't corrupt the log file

https://claude.ai/code/session_01QC1bJt1Ncqshyh5EFB8q1F