### PR TITLE
Add InfluxDB read modes for time-series analytics migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,12 @@ DB_USERNAME=supplycore
 DB_PASSWORD=StrongPasswordHere
 DB_SOCKET=
 APP_ENV=development
+
+# InfluxDB time-series analytics (optional)
+# INFLUXDB_ENABLED=0
+# INFLUXDB_URL=http://127.0.0.1:8086
+# INFLUXDB_ORG=my-org
+# INFLUXDB_BUCKET=supplycore_rollups
+# INFLUXDB_TOKEN=
+# INFLUXDB_READ_MODE=disabled
+# INFLUXDB_WRITE_ON_ROLLUP=0

--- a/database/migrations/20260412_influxdb_read_mode_settings.sql
+++ b/database/migrations/20260412_influxdb_read_mode_settings.sql
@@ -1,0 +1,16 @@
+-- Migration: Add InfluxDB read_mode and write_on_rollup settings
+-- These settings control the InfluxDB analytics migration:
+--   influxdb.read_mode:      disabled|fallback|preferred|primary
+--   influxdb.write_on_rollup: dual-write to InfluxDB during rollup sync jobs
+--
+-- Existing influxdb.enabled and influxdb.read_enabled settings remain
+-- for backward compatibility.  The new read_mode supersedes read_enabled
+-- when explicitly set.
+
+INSERT INTO app_settings (setting_key, setting_value, updated_at)
+VALUES ('influxdb.read_mode', 'disabled', NOW())
+ON DUPLICATE KEY UPDATE updated_at = updated_at;
+
+INSERT INTO app_settings (setting_key, setting_value, updated_at)
+VALUES ('influxdb.write_on_rollup', '0', NOW())
+ON DUPLICATE KEY UPDATE updated_at = updated_at;

--- a/docs/INFLUXDB_ANALYTICS_MIGRATION.md
+++ b/docs/INFLUXDB_ANALYTICS_MIGRATION.md
@@ -1,0 +1,236 @@
+# InfluxDB Analytics Migration
+
+## Overview
+
+SupplyCore uses a two-engine analytics architecture:
+
+- **MariaDB** — source of truth for application state, relational entities, configuration, entity mapping, UI lookups, and durable business records.
+- **InfluxDB** — analytical time-series engine for historical rollups, trend calculations, charting data, and aggregation-driven workloads.
+
+This separation moves expensive time-window calculations, historical scans, and bucketed aggregations out of MariaDB and into InfluxDB where they are cheaper and faster.
+
+## What Lives Where
+
+### MariaDB (relational state)
+
+| Category | Examples |
+|---|---|
+| Current market orders | `market_orders_current`, `market_order_current_projection` |
+| Entity metadata | `ref_item_types`, `doctrine_fits`, `doctrine_groups` |
+| Configuration | `app_settings`, `esi_oauth_tokens` |
+| Job state | `job_runs`, `compute_job_locks`, `sync_state` |
+| Raw order history | `market_orders_history` (48h rolling window) |
+| Snapshot summaries | `market_order_snapshots_summary` |
+| Comparison outcomes | Computed from current orders, not historical |
+| Doctrine readiness | `doctrine_readiness`, `doctrine_item_stock_1d` (relational joins needed) |
+
+### InfluxDB (time-series analytics)
+
+| Category | Measurement | Window |
+|---|---|---|
+| Hourly price rollups | `market_item_price` | `1h` |
+| Daily price rollups | `market_item_price` | `1d` |
+| Hourly stock rollups | `market_item_stock` | `1h` |
+| Daily stock rollups | `market_item_stock` | `1d` |
+| Killmail item losses | `killmail_item_loss` | `1h`, `1d` |
+| Killmail hull losses | `killmail_hull_loss` | `1d` |
+| Killmail doctrine activity | `killmail_doctrine_activity` | `1d` |
+| Doctrine fit activity | `doctrine_fit_activity` | `1d` |
+| Doctrine group activity | `doctrine_group_activity` | `1d` |
+| Doctrine stock pressure | `doctrine_fit_stock_pressure` | `1d` |
+
+### Queries That Move to InfluxDB
+
+- Daily aggregate by date/type/source (alliance trends page)
+- Price deviation series (alliance vs hub comparison over time)
+- Stock health series (volume/listing trends over time)
+- Stock window summaries (charting data for UI)
+- Historical comparison windows (N-day lookbacks)
+- Trend direction calculations (period-over-period deltas)
+
+### Queries That Stay in MariaDB
+
+- Current market order aggregation (live snapshot, not historical)
+- Cross-source price comparisons (relational join of current data)
+- Doctrine readiness calculations (relational fit/group/item joins)
+- Deal alert detection (current-state anomaly, not time-series)
+- Entity lookups, settings, authentication
+
+## InfluxDB Measurement Schema
+
+### `market_item_price`
+
+**Tags:** `window` (1h/1d), `source_type`, `source_id`, `type_id`
+
+**Fields:** `sample_count`, `listing_count_sum`, `avg_price_sum`, `weighted_price_numerator`, `weighted_price_denominator`, `listing_count`, `min_price`, `max_price`, `avg_price`, `weighted_price`
+
+### `market_item_stock`
+
+**Tags:** `window` (1h/1d), `source_type`, `source_id`, `type_id`
+
+**Fields:** `sample_count`, `stock_units_sum`, `listing_count_sum`, `local_stock_units`, `listing_count`
+
+### Tag Design Notes
+
+- `source_type` and `source_id` are tags (low cardinality: 2 source types, ~4 source IDs).
+- `type_id` is a tag for efficient per-item filtering (bounded by tracked item count).
+- `window` discriminates hourly vs daily buckets within the same measurement.
+- All numeric values are fields (never tags) to enable aggregation.
+
+## Configuration
+
+### Environment Variables
+
+```bash
+INFLUXDB_ENABLED=1              # Master switch for InfluxDB integration
+INFLUXDB_URL=http://127.0.0.1:8086
+INFLUXDB_ORG=my-org
+INFLUXDB_BUCKET=supplycore_rollups
+INFLUXDB_TOKEN=<api-token>
+INFLUXDB_READ_MODE=disabled     # disabled|fallback|preferred|primary
+INFLUXDB_WRITE_ON_ROLLUP=0     # Dual-write during rollup sync jobs
+```
+
+### Read Modes
+
+| Mode | Behavior |
+|---|---|
+| `disabled` | Never read from InfluxDB (default, safe for new installs) |
+| `fallback` | Query MariaDB first; try InfluxDB only if MariaDB returns empty |
+| `preferred` | Query InfluxDB first; fall back to MariaDB if InfluxDB returns empty |
+| `primary` | Use InfluxDB exclusively; MariaDB is not queried for time-series analytics |
+
+### Runtime Settings (UI)
+
+The following settings are editable in Settings > InfluxDB:
+
+- `influxdb.enabled` — master switch
+- `influxdb.read_mode` — read routing mode
+- `influxdb.write_on_rollup` — enable inline dual-write during rollup jobs
+
+## Migration Steps
+
+### Phase 1: Enable dual-write (safe, no read changes)
+
+```bash
+# In .env or app_settings:
+INFLUXDB_ENABLED=1
+INFLUXDB_WRITE_ON_ROLLUP=1
+INFLUXDB_READ_MODE=disabled
+```
+
+This makes the hourly/daily rollup sync jobs write to both MariaDB and InfluxDB simultaneously. No read paths change. Existing batch export (`influx-rollup-export`) continues to work as before.
+
+### Phase 2: Validate data parity
+
+```bash
+python -m orchestrator influx-validate --days 14
+python -m orchestrator influx-validate --days 14 --verbose
+```
+
+Confirm that InfluxDB row counts match MariaDB for all market datasets.
+
+### Phase 3: Enable fallback reads
+
+```bash
+INFLUXDB_READ_MODE=fallback
+```
+
+InfluxDB is only used when MariaDB returns empty results. Low risk — if InfluxDB has data where MariaDB doesn't, users see data they wouldn't have seen before.
+
+### Phase 4: Switch to preferred reads
+
+```bash
+INFLUXDB_READ_MODE=preferred
+```
+
+InfluxDB is queried first for all time-series analytics. MariaDB is the fallback. This reduces MariaDB load for historical queries.
+
+### Phase 5: Switch to primary reads
+
+```bash
+INFLUXDB_READ_MODE=primary
+```
+
+MariaDB is no longer queried for time-series analytics. This is the target state. MariaDB rollup tables can optionally have their retention reduced.
+
+### Rollback
+
+At any point, set `INFLUXDB_READ_MODE=disabled` to revert all reads to MariaDB. No data is lost because MariaDB rollup tables are still populated by the sync jobs.
+
+## Write Path Architecture
+
+```
+ESI API
+  └── market_hub_current_sync.py
+        └── market_orders_history (MariaDB, 48h window)
+              ├── analytics_bucket_1h_sync.py
+              │     ├── market_item_stock_1h (MariaDB)
+              │     ├── market_item_price_1h (MariaDB)
+              │     └── [dual-write] → InfluxDB market_item_stock/price (1h)
+              └── analytics_bucket_1d_sync.py
+                    ├── market_item_stock_1d (MariaDB)
+                    ├── market_item_price_1d (MariaDB)
+                    └── [dual-write] → InfluxDB market_item_stock/price (1d)
+
+Batch export (still available):
+  influx-rollup-export → reads MariaDB rollups → writes InfluxDB
+```
+
+### Late/Delayed Data
+
+The rollup sync jobs use `ON DUPLICATE KEY UPDATE`, so re-running them safely refreshes recent buckets without corrupting historical state. The InfluxDB dual-write uses the same bucket_start timestamp, so late-arriving data produces the correct point overwrite.
+
+## Retention Strategy
+
+| Layer | Retention | Notes |
+|---|---|---|
+| `market_orders_history` | 48 hours | Raw order snapshots, short-lived |
+| MariaDB rollup tables | 14–90 days | Configurable, can reduce after migration |
+| InfluxDB `supplycore_rollups` | Unlimited (or bucket retention policy) | Primary long-term store post-migration |
+
+Configure InfluxDB bucket retention via the InfluxDB UI or CLI:
+```bash
+influx bucket update --name supplycore_rollups --retention 365d
+```
+
+## Validation Command
+
+```bash
+# Compare all market datasets for the last 14 days
+python -m orchestrator influx-validate
+
+# Compare specific dataset with sample output
+python -m orchestrator influx-validate --dataset market_item_price_1d --days 30 --verbose
+```
+
+Output shows row count comparison and ratio. A ratio near 1.0 indicates parity.
+
+## MariaDB Index Considerations
+
+After switching to `primary` read mode, the following MariaDB indexes become lower priority for interactive queries (they still matter for the rollup INSERT jobs):
+
+- `market_item_stock_1d`: `idx_*_bucket_type`, `idx_*_type_bucket` — less queried interactively
+- `market_item_price_1d`: `idx_*_bucket_type`, `idx_*_type_bucket` — less queried interactively
+- `market_item_stock_1h`: same pattern
+- `market_item_price_1h`: same pattern
+- `market_history_daily`: time-range indexes — replaced by InfluxDB queries
+
+Do NOT drop these indexes during migration. They are still used by rollup sync jobs and the batch export. Consider dropping only after the MariaDB rollup tables are retired entirely.
+
+## Troubleshooting
+
+### InfluxDB dual-write failures
+
+Dual-write failures during rollup sync are logged to stderr but do not fail the sync job. MariaDB rollups are always written. Check `storage/logs/worker.log` for `[influx_writer]` messages.
+
+### Empty InfluxDB results
+
+1. Confirm `INFLUXDB_ENABLED=1` and the bucket/org/token are correct
+2. Run `python -m orchestrator influx-rollup-inspect` to check measurement coverage
+3. Run `python -m orchestrator influx-validate` to compare row counts
+4. If dual-write was recently enabled, wait for the next rollup sync cycle
+
+### Switching back to MariaDB
+
+Set `INFLUXDB_READ_MODE=disabled` in Settings or `.env`. All reads immediately revert to MariaDB. No restart required (runtime setting).

--- a/python/orchestrator/config.py
+++ b/python/orchestrator/config.py
@@ -252,6 +252,8 @@ def load_php_runtime_config(app_root: Path) -> OrchestratorConfig:
         "influx": {
             "enabled": os.getenv("INFLUXDB_ENABLED", "0") == "1",
             "read_enabled": os.getenv("INFLUXDB_READ_ENABLED", "0") == "1",
+            "read_mode": os.getenv("INFLUXDB_READ_MODE", "disabled"),
+            "write_on_rollup": os.getenv("INFLUXDB_WRITE_ON_ROLLUP", "0") == "1",
             "url": os.getenv("INFLUXDB_URL", "http://127.0.0.1:8086").rstrip("/"),
             "org": os.getenv("INFLUXDB_ORG", ""),
             "bucket": os.getenv("INFLUXDB_BUCKET", "supplycore_rollups"),
@@ -261,6 +263,8 @@ def load_php_runtime_config(app_root: Path) -> OrchestratorConfig:
         "influxdb": {
             "enabled": os.getenv("INFLUXDB_ENABLED", "0") == "1",
             "read_enabled": os.getenv("INFLUXDB_READ_ENABLED", "0") == "1",
+            "read_mode": os.getenv("INFLUXDB_READ_MODE", "disabled"),
+            "write_on_rollup": os.getenv("INFLUXDB_WRITE_ON_ROLLUP", "0") == "1",
             "url": os.getenv("INFLUXDB_URL", "http://127.0.0.1:8086").rstrip("/"),
             "org": os.getenv("INFLUXDB_ORG", ""),
             "bucket": os.getenv("INFLUXDB_BUCKET", "supplycore_rollups"),

--- a/python/orchestrator/influx_validate.py
+++ b/python/orchestrator/influx_validate.py
@@ -1,0 +1,191 @@
+"""Validate InfluxDB time-series data against MariaDB rollup tables.
+
+Compares row counts and sample values for each market rollup dataset to
+confirm that InfluxDB contains the same data as MariaDB.  Useful during
+migration to verify that dual-write or batch export is producing correct
+results before switching reads to InfluxDB.
+
+Usage:
+    python -m orchestrator influx-validate --app-root /var/www/SupplyCore
+    python -m orchestrator influx-validate --dataset market_item_price_1d --days 7
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .config import load_php_runtime_config, resolve_app_root
+from .db import SupplyCoreDb
+from .influx import InfluxClient, InfluxConfig, InfluxQueryError
+
+
+_MARKET_DATASETS = {
+    "market_item_price_1h": {"measurement": "market_item_price", "window": "1h", "bucket_col": "bucket_start", "fields": ["weighted_price", "avg_price", "min_price", "max_price", "listing_count"]},
+    "market_item_price_1d": {"measurement": "market_item_price", "window": "1d", "bucket_col": "bucket_start", "fields": ["weighted_price", "avg_price", "min_price", "max_price", "listing_count"]},
+    "market_item_stock_1h": {"measurement": "market_item_stock", "window": "1h", "bucket_col": "bucket_start", "fields": ["local_stock_units", "listing_count", "sample_count"]},
+    "market_item_stock_1d": {"measurement": "market_item_stock", "window": "1d", "bucket_col": "bucket_start", "fields": ["local_stock_units", "listing_count", "sample_count"]},
+}
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate InfluxDB data against MariaDB rollups")
+    parser.add_argument("--app-root", default=resolve_app_root(__file__))
+    parser.add_argument("--dataset", action="append", default=[])
+    parser.add_argument("--days", type=int, default=14, help="Compare the last N days of data")
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _count_maria_rows(db: SupplyCoreDb, table: str, bucket_col: str, days: int) -> int:
+    result = db.fetch_scalar(
+        f"SELECT COUNT(*) FROM {table} WHERE {bucket_col} >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL {days} DAY)"
+    )
+    return max(0, int(result))
+
+
+def _count_influx_points(client: InfluxClient, bucket: str, measurement: str, window: str, days: int) -> int:
+    flux = f"""
+from(bucket: "{bucket}")
+  |> range(start: -{days}d)
+  |> filter(fn: (r) => r._measurement == "{measurement}")
+  |> filter(fn: (r) => r.window == "{window}")
+  |> group()
+  |> count()
+"""
+    rows = client.query_flux(flux)
+    return sum(int(row.get("_value") or 0) for row in rows)
+
+
+def _sample_maria(db: SupplyCoreDb, table: str, bucket_col: str, fields: list[str], days: int, limit: int = 5) -> list[dict[str, Any]]:
+    cols = ", ".join(["source_type", "source_id", "type_id", bucket_col, *fields])
+    return db.fetch_all(
+        f"SELECT {cols} FROM {table} WHERE {bucket_col} >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL {days} DAY) ORDER BY {bucket_col} DESC LIMIT {limit}"
+    )
+
+
+def _sample_influx(client: InfluxClient, bucket: str, measurement: str, window: str, fields: list[str], days: int, limit: int = 5) -> list[dict[str, Any]]:
+    field_filter = " or ".join(f'r._field == "{f}"' for f in fields)
+    flux = f"""
+from(bucket: "{bucket}")
+  |> range(start: -{days}d)
+  |> filter(fn: (r) => r._measurement == "{measurement}")
+  |> filter(fn: (r) => r.window == "{window}")
+  |> filter(fn: (r) => {field_filter})
+  |> pivot(rowKey: ["_time", "type_id", "source_type", "source_id"], columnKey: ["_field"], valueColumn: "_value")
+  |> sort(columns: ["_time"], desc: true)
+  |> limit(n: {limit})
+"""
+    return client.query_flux(flux)
+
+
+def _validate_dataset(
+    db: SupplyCoreDb,
+    client: InfluxClient,
+    influx_bucket: str,
+    dataset_key: str,
+    spec: dict[str, Any],
+    days: int,
+    verbose: bool,
+) -> dict[str, Any]:
+    maria_count = _count_maria_rows(db, dataset_key, spec["bucket_col"], days)
+    try:
+        influx_count = _count_influx_points(client, influx_bucket, spec["measurement"], spec["window"], days)
+    except InfluxQueryError as exc:
+        return {"dataset": dataset_key, "status": "error", "error": str(exc), "maria_rows": maria_count, "influx_points": 0}
+
+    # InfluxDB counts individual field writes as separate points per field,
+    # so the comparison is approximate.  A reasonable heuristic: InfluxDB
+    # should have at least as many "logical rows" as MariaDB when counting
+    # by unique (time, tags) combinations.  We compare raw counts divided by
+    # the number of exported fields to approximate logical row count.
+    field_count = max(1, len(spec["fields"]))
+    influx_logical = influx_count // field_count
+    ratio = influx_logical / maria_count if maria_count > 0 else (1.0 if influx_count == 0 else float("inf"))
+    status = "ok" if 0.9 <= ratio <= 1.1 else ("warn" if 0.5 <= ratio <= 2.0 else "mismatch")
+
+    result: dict[str, Any] = {
+        "dataset": dataset_key,
+        "status": status,
+        "maria_rows": maria_count,
+        "influx_points": influx_count,
+        "influx_logical_rows": influx_logical,
+        "ratio": round(ratio, 3),
+    }
+
+    if verbose:
+        result["maria_sample"] = _sample_maria(db, dataset_key, spec["bucket_col"], spec["fields"], days)
+        try:
+            result["influx_sample"] = _sample_influx(client, influx_bucket, spec["measurement"], spec["window"], spec["fields"], days)
+        except InfluxQueryError as exc:
+            result["influx_sample_error"] = str(exc)
+
+    return result
+
+
+def validate_main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    app_root = Path(args.app_root).resolve()
+    runtime = load_php_runtime_config(app_root)
+    influx_raw = dict(runtime.raw.get("influxdb", {}))
+    influx_config = InfluxConfig.from_runtime(influx_raw)
+
+    if not influx_config.enabled:
+        print("InfluxDB is disabled.  Enable it to run validation.")
+        return 1
+
+    errors = influx_config.validate()
+    if errors:
+        for e in errors:
+            print(f"Config error: {e}")
+        return 1
+
+    datasets = list(args.dataset) if args.dataset else list(_MARKET_DATASETS.keys())
+    for key in datasets:
+        if key not in _MARKET_DATASETS:
+            print(f"Unknown dataset: {key}.  Available: {', '.join(_MARKET_DATASETS.keys())}")
+            return 1
+
+    db = SupplyCoreDb(dict(runtime.raw.get("db", {})))
+    client = InfluxClient(influx_config)
+
+    try:
+        health = client.health()
+        print(f"InfluxDB health: {health.get('status', 'unknown')}")
+    except InfluxQueryError as exc:
+        print(f"InfluxDB unreachable: {exc}")
+        return 1
+
+    all_ok = True
+    print(f"\nValidation window: last {args.days} days")
+    print(f"{'Dataset':<30} {'Status':<10} {'MariaDB':<10} {'InfluxDB':<12} {'Ratio':<8}")
+    print("-" * 72)
+
+    for key in datasets:
+        spec = _MARKET_DATASETS[key]
+        result = _validate_dataset(db, client, influx_config.bucket, key, spec, args.days, args.verbose)
+        status_marker = {"ok": "OK", "warn": "WARN", "mismatch": "MISMATCH", "error": "ERROR"}.get(result["status"], "?")
+        print(f"{result['dataset']:<30} {status_marker:<10} {result['maria_rows']:<10} {result.get('influx_logical_rows', result.get('influx_points', 0)):<12} {result.get('ratio', '—'):<8}")
+
+        if result["status"] in ("mismatch", "error"):
+            all_ok = False
+            if "error" in result:
+                print(f"  Error: {result['error']}")
+
+        if args.verbose and "maria_sample" in result:
+            print(f"  MariaDB sample ({len(result['maria_sample'])} rows):")
+            for row in result["maria_sample"][:3]:
+                print(f"    {row}")
+        if args.verbose and "influx_sample" in result:
+            print(f"  InfluxDB sample ({len(result['influx_sample'])} rows):")
+            for row in result["influx_sample"][:3]:
+                print(f"    {row}")
+
+    print()
+    if all_ok:
+        print("All datasets validated successfully.")
+    else:
+        print("Some datasets have mismatches — review before switching read_mode.")
+    return 0 if all_ok else 1

--- a/python/orchestrator/influx_writer.py
+++ b/python/orchestrator/influx_writer.py
@@ -1,0 +1,112 @@
+"""Inline InfluxDB dual-write helpers for rollup sync jobs.
+
+When ``influxdb.write_on_rollup`` is enabled, rollup sync jobs can push
+points directly to InfluxDB as part of the same processing pass that
+populates the MariaDB rollup tables.  This eliminates the latency gap
+between MariaDB rollup completion and the separate ``influx_export``
+batch, making InfluxDB data available for reads almost immediately.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+from .config import OrchestratorConfig
+from .influx import InfluxConfig, InfluxWriter, InfluxWriteError, encode_point
+
+
+@dataclass(slots=True)
+class RollupInfluxBridge:
+    """Lightweight bridge between rollup processors and InfluxDB writes."""
+
+    writer: InfluxWriter | None
+    enabled: bool
+    batch_size: int
+    _pending: list[str]
+    _written: int
+
+    @classmethod
+    def from_config(cls, config: OrchestratorConfig) -> "RollupInfluxBridge":
+        influx_raw = dict(config.raw.get("influxdb", config.raw.get("influx", {})))
+        influx_enabled = bool(influx_raw.get("enabled", False))
+        write_on_rollup = bool(influx_raw.get("write_on_rollup", False))
+
+        if not influx_enabled or not write_on_rollup:
+            return cls(writer=None, enabled=False, batch_size=0, _pending=[], _written=0)
+
+        influx_config = InfluxConfig.from_runtime(influx_raw)
+        errors = influx_config.validate()
+        if errors:
+            print(f"[influx_writer] InfluxDB config invalid, dual-write disabled: {'; '.join(errors)}", file=sys.stderr)
+            return cls(writer=None, enabled=False, batch_size=0, _pending=[], _written=0)
+
+        batch_size = max(100, int(influx_raw.get("rollup_write_batch_size", 500)))
+        return cls(
+            writer=InfluxWriter(influx_config),
+            enabled=True,
+            batch_size=batch_size,
+            _pending=[],
+            _written=0,
+        )
+
+    @property
+    def written_count(self) -> int:
+        return self._written
+
+    def enqueue_market_price(
+        self,
+        bucket_start: date | datetime,
+        source_type: str,
+        source_id: int,
+        type_id: int,
+        window: str,
+        fields: dict[str, Any],
+    ) -> None:
+        if not self.enabled:
+            return
+        tags = {
+            "window": window,
+            "source_type": source_type,
+            "source_id": str(source_id),
+            "type_id": str(type_id),
+        }
+        self._pending.append(encode_point("market_item_price", tags, fields, bucket_start))
+        self._maybe_flush()
+
+    def enqueue_market_stock(
+        self,
+        bucket_start: date | datetime,
+        source_type: str,
+        source_id: int,
+        type_id: int,
+        window: str,
+        fields: dict[str, Any],
+    ) -> None:
+        if not self.enabled:
+            return
+        tags = {
+            "window": window,
+            "source_type": source_type,
+            "source_id": str(source_id),
+            "type_id": str(type_id),
+        }
+        self._pending.append(encode_point("market_item_stock", tags, fields, bucket_start))
+        self._maybe_flush()
+
+    def _maybe_flush(self) -> None:
+        if len(self._pending) >= self.batch_size:
+            self.flush()
+
+    def flush(self) -> None:
+        if not self._pending or not self.writer:
+            return
+        try:
+            self.writer.write_lines(self._pending)
+            self._written += len(self._pending)
+        except InfluxWriteError as exc:
+            print(f"[influx_writer] Dual-write flush failed ({len(self._pending)} points): {exc}", file=sys.stderr)
+        finally:
+            self._pending = []

--- a/python/orchestrator/jobs/analytics_bucket_1d_sync.py
+++ b/python/orchestrator/jobs/analytics_bucket_1d_sync.py
@@ -1,7 +1,68 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..influx_writer import RollupInfluxBridge
 from .sync_runtime import run_sync_phase_job
+
+
+def _dual_write_stock(db: SupplyCoreDb, bridge: RollupInfluxBridge) -> None:
+    if not bridge.enabled:
+        return
+    rows = db.fetch_all(
+        "SELECT bucket_start, source_type, source_id, type_id, sample_count, "
+        "stock_units_sum, listing_count_sum, local_stock_units, listing_count "
+        "FROM market_item_stock_1d "
+        "WHERE bucket_start >= DATE_SUB(UTC_DATE(), INTERVAL 14 DAY)"
+    )
+    for row in rows:
+        bridge.enqueue_market_stock(
+            bucket_start=row["bucket_start"],
+            source_type=row["source_type"],
+            source_id=int(row["source_id"]),
+            type_id=int(row["type_id"]),
+            window="1d",
+            fields={
+                "sample_count": int(row.get("sample_count") or 0),
+                "stock_units_sum": int(row.get("stock_units_sum") or 0),
+                "listing_count_sum": int(row.get("listing_count_sum") or 0),
+                "local_stock_units": int(row.get("local_stock_units") or 0),
+                "listing_count": int(row.get("listing_count") or 0),
+            },
+        )
+    bridge.flush()
+
+
+def _dual_write_price(db: SupplyCoreDb, bridge: RollupInfluxBridge) -> None:
+    if not bridge.enabled:
+        return
+    rows = db.fetch_all(
+        "SELECT bucket_start, source_type, source_id, type_id, sample_count, "
+        "listing_count_sum, avg_price_sum, weighted_price_numerator, weighted_price_denominator, "
+        "listing_count, min_price, max_price, avg_price, weighted_price "
+        "FROM market_item_price_1d "
+        "WHERE bucket_start >= DATE_SUB(UTC_DATE(), INTERVAL 14 DAY)"
+    )
+    for row in rows:
+        bridge.enqueue_market_price(
+            bucket_start=row["bucket_start"],
+            source_type=row["source_type"],
+            source_id=int(row["source_id"]),
+            type_id=int(row["type_id"]),
+            window="1d",
+            fields={
+                "sample_count": int(row.get("sample_count") or 0),
+                "listing_count_sum": int(row.get("listing_count_sum") or 0),
+                "avg_price_sum": float(row.get("avg_price_sum") or 0),
+                "weighted_price_numerator": float(row.get("weighted_price_numerator") or 0),
+                "weighted_price_denominator": float(row.get("weighted_price_denominator") or 0),
+                "listing_count": int(row.get("listing_count") or 0),
+                "min_price": float(row.get("min_price") or 0),
+                "max_price": float(row.get("max_price") or 0),
+                "avg_price": float(row.get("avg_price") or 0),
+                "weighted_price": float(row.get("weighted_price") or 0),
+            },
+        )
+    bridge.flush()
 
 
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
@@ -58,12 +119,31 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
                 listing_count = VALUES(listing_count), min_price = VALUES(min_price), max_price = VALUES(max_price),
                 avg_price = VALUES(avg_price), weighted_price = VALUES(weighted_price)"""
     )
+
+    # Dual-write to InfluxDB when enabled — reads back the freshly upserted
+    # rollup rows so InfluxDB stays in sync without a separate export pass.
+    influx_written = 0
+    try:
+        bridge = RollupInfluxBridge.from_config(db._config) if hasattr(db, '_config') else None
+        if bridge is None:
+            from ..config import load_php_runtime_config, resolve_app_root
+            from pathlib import Path
+            config = load_php_runtime_config(Path(resolve_app_root(__file__)))
+            bridge = RollupInfluxBridge.from_config(config)
+        if bridge.enabled:
+            _dual_write_stock(db, bridge)
+            _dual_write_price(db, bridge)
+            influx_written = bridge.written_count
+    except Exception as exc:
+        import sys
+        print(f"[analytics_bucket_1d_sync] InfluxDB dual-write failed (non-fatal): {exc}", file=sys.stderr)
+
     return {
         "rows_processed": rows_processed,
         "rows_written": stock_written + price_written,
         "warnings": [] if rows_processed > 0 else ["No history rows available in the last 14d for daily analytics buckets."],
-        "summary": f"Upserted {stock_written} stock and {price_written} price daily bucket rows.",
-        "meta": {"window_days": 14},
+        "summary": f"Upserted {stock_written} stock and {price_written} price daily bucket rows. InfluxDB: {influx_written} points.",
+        "meta": {"window_days": 14, "influx_points_written": influx_written},
     }
 
 

--- a/python/orchestrator/jobs/analytics_bucket_1h_sync.py
+++ b/python/orchestrator/jobs/analytics_bucket_1h_sync.py
@@ -1,7 +1,68 @@
 from __future__ import annotations
 
 from ..db import SupplyCoreDb
+from ..influx_writer import RollupInfluxBridge
 from .sync_runtime import run_sync_phase_job
+
+
+def _dual_write_stock(db: SupplyCoreDb, bridge: RollupInfluxBridge) -> None:
+    if not bridge.enabled:
+        return
+    rows = db.fetch_all(
+        "SELECT bucket_start, source_type, source_id, type_id, sample_count, "
+        "stock_units_sum, listing_count_sum, local_stock_units, listing_count "
+        "FROM market_item_stock_1h "
+        "WHERE bucket_start >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 48 HOUR)"
+    )
+    for row in rows:
+        bridge.enqueue_market_stock(
+            bucket_start=row["bucket_start"],
+            source_type=row["source_type"],
+            source_id=int(row["source_id"]),
+            type_id=int(row["type_id"]),
+            window="1h",
+            fields={
+                "sample_count": int(row.get("sample_count") or 0),
+                "stock_units_sum": int(row.get("stock_units_sum") or 0),
+                "listing_count_sum": int(row.get("listing_count_sum") or 0),
+                "local_stock_units": int(row.get("local_stock_units") or 0),
+                "listing_count": int(row.get("listing_count") or 0),
+            },
+        )
+    bridge.flush()
+
+
+def _dual_write_price(db: SupplyCoreDb, bridge: RollupInfluxBridge) -> None:
+    if not bridge.enabled:
+        return
+    rows = db.fetch_all(
+        "SELECT bucket_start, source_type, source_id, type_id, sample_count, "
+        "listing_count_sum, avg_price_sum, weighted_price_numerator, weighted_price_denominator, "
+        "listing_count, min_price, max_price, avg_price, weighted_price "
+        "FROM market_item_price_1h "
+        "WHERE bucket_start >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 48 HOUR)"
+    )
+    for row in rows:
+        bridge.enqueue_market_price(
+            bucket_start=row["bucket_start"],
+            source_type=row["source_type"],
+            source_id=int(row["source_id"]),
+            type_id=int(row["type_id"]),
+            window="1h",
+            fields={
+                "sample_count": int(row.get("sample_count") or 0),
+                "listing_count_sum": int(row.get("listing_count_sum") or 0),
+                "avg_price_sum": float(row.get("avg_price_sum") or 0),
+                "weighted_price_numerator": float(row.get("weighted_price_numerator") or 0),
+                "weighted_price_denominator": float(row.get("weighted_price_denominator") or 0),
+                "listing_count": int(row.get("listing_count") or 0),
+                "min_price": float(row.get("min_price") or 0),
+                "max_price": float(row.get("max_price") or 0),
+                "avg_price": float(row.get("avg_price") or 0),
+                "weighted_price": float(row.get("weighted_price") or 0),
+            },
+        )
+    bridge.flush()
 
 
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
@@ -58,12 +119,31 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
                 listing_count = VALUES(listing_count), min_price = VALUES(min_price), max_price = VALUES(max_price),
                 avg_price = VALUES(avg_price), weighted_price = VALUES(weighted_price)"""
     )
+
+    # Dual-write to InfluxDB when enabled — reads back the freshly upserted
+    # rollup rows so InfluxDB stays in sync without a separate export pass.
+    influx_written = 0
+    try:
+        bridge = RollupInfluxBridge.from_config(db._config) if hasattr(db, '_config') else None
+        if bridge is None:
+            from ..config import load_php_runtime_config, resolve_app_root
+            from pathlib import Path
+            config = load_php_runtime_config(Path(resolve_app_root(__file__)))
+            bridge = RollupInfluxBridge.from_config(config)
+        if bridge.enabled:
+            _dual_write_stock(db, bridge)
+            _dual_write_price(db, bridge)
+            influx_written = bridge.written_count
+    except Exception as exc:
+        import sys
+        print(f"[analytics_bucket_1h_sync] InfluxDB dual-write failed (non-fatal): {exc}", file=sys.stderr)
+
     return {
         "rows_processed": rows_processed,
         "rows_written": stock_written + price_written,
         "warnings": [] if rows_processed > 0 else ["No history rows available in the last 48h for hourly analytics buckets."],
-        "summary": f"Upserted {stock_written} stock and {price_written} price hourly bucket rows.",
-        "meta": {"window_hours": 48},
+        "summary": f"Upserted {stock_written} stock and {price_written} price hourly bucket rows. InfluxDB: {influx_written} points.",
+        "meta": {"window_hours": 48, "influx_points_written": influx_written},
     }
 
 

--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -117,6 +117,12 @@ def parse_args() -> argparse.Namespace:
     influx_sample.add_argument("--group-by", action="append", default=[], help="Optional tag keys to group summary output by.")
     influx_sample.add_argument("--verbose", action="store_true")
 
+    influx_validate = subparsers.add_parser("influx-validate", help="Validate InfluxDB data against MariaDB rollup tables for migration parity")
+    influx_validate.add_argument("--app-root", default=resolve_app_root(__file__))
+    influx_validate.add_argument("--dataset", action="append", default=[], help="Limit validation to one or more dataset keys.")
+    influx_validate.add_argument("--days", type=int, default=14, help="Compare the last N days of data.")
+    influx_validate.add_argument("--verbose", action="store_true")
+
     compute_buy_all = subparsers.add_parser("compute-buy-all", help="Materialize Buy All planner data into precomputed MariaDB tables")
     compute_buy_all.add_argument("--app-root", default=resolve_app_root(__file__))
     compute_buy_all.add_argument("--verbose", action="store_true")
@@ -295,6 +301,14 @@ def main() -> int:
             *(sum([["--dataset", dataset] for dataset in args.dataset], [])),
             "--limit", str(args.limit),
             *(sum([["--group-by", group] for group in args.group_by], [])),
+            *( ["--verbose"] if args.verbose else [] ),
+        ])
+    if command == "influx-validate":
+        from .influx_validate import validate_main as run_influx_validate
+        return run_influx_validate([
+            "--app-root", args.app_root,
+            *(sum([["--dataset", dataset] for dataset in args.dataset], [])),
+            "--days", str(args.days),
             *( ["--verbose"] if args.verbose else [] ),
         ])
     if command == "compute-buy-all":

--- a/src/config/runtime_settings.php
+++ b/src/config/runtime_settings.php
@@ -53,6 +53,8 @@ return [
         'fields' => [
             'influxdb.enabled' => ['type' => 'bool', 'default' => false, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
             'influxdb.read_enabled' => ['type' => 'bool', 'default' => false, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'influxdb.read_mode' => ['type' => 'string', 'default' => 'disabled', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
+            'influxdb.write_on_rollup' => ['type' => 'bool', 'default' => false, 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
             'influxdb.url' => ['type' => 'string', 'default' => 'http://127.0.0.1:8086', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
             'influxdb.org' => ['type' => 'string', 'default' => '', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],
             'influxdb.bucket' => ['type' => 'string', 'default' => 'supplycore_rollups', 'editable' => true, 'sensitive' => false, 'env_only' => false, 'database_backed' => true],

--- a/src/db.php
+++ b/src/db.php
@@ -2431,6 +2431,21 @@ function db_market_item_stock_window_summaries(string $sourceType, int $sourceId
 {
     db_time_series_analytics_ensure_schema();
 
+    $readMode = db_influx_read_mode();
+
+    // In 'primary' mode, skip MariaDB entirely for unfiltered queries.
+    if ($typeIds === [] && $readMode === 'primary') {
+        return db_market_item_stock_window_summaries_influx($sourceType, $sourceId, $startDate, $endDate);
+    }
+
+    // In 'preferred' mode, try InfluxDB first for unfiltered queries.
+    if ($typeIds === [] && $readMode === 'preferred') {
+        $influxRows = db_market_item_stock_window_summaries_influx($sourceType, $sourceId, $startDate, $endDate);
+        if ($influxRows !== []) {
+            return $influxRows;
+        }
+    }
+
     $params = [$sourceType, $sourceId, $startDate, $endDate];
     $typeFilterSql = '';
     if ($typeIds !== []) {
@@ -2442,7 +2457,7 @@ function db_market_item_stock_window_summaries(string $sourceType, int $sourceId
         $params = array_merge($params, $normalizedTypeIds);
     }
 
-    return db_select_cached(
+    $mariaRows = db_select_cached(
         "SELECT
             mis.bucket_start AS observed_date,
             mis.type_id,
@@ -2469,6 +2484,16 @@ function db_market_item_stock_window_summaries(string $sourceType, int $sourceId
         60,
         'market.item-stock.daily'
     );
+
+    // In 'fallback' mode, try InfluxDB when MariaDB returned nothing.
+    if ($mariaRows === [] && $typeIds === [] && $readMode === 'fallback') {
+        $influxRows = db_market_item_stock_window_summaries_influx($sourceType, $sourceId, $startDate, $endDate);
+        if ($influxRows !== []) {
+            return $influxRows;
+        }
+    }
+
+    return $mariaRows;
 }
 
 function db_upsert_esi_oauth_token(array $token): bool
@@ -5995,7 +6020,53 @@ function db_market_history_daily_recent_window(string $sourceType, int $sourceId
 
 function db_influx_read_enabled(): bool
 {
-    return (bool) config('influxdb.enabled', false) && (bool) config('influxdb.read_enabled', false);
+    if ((bool) config('influxdb.enabled', false) && (bool) config('influxdb.read_enabled', false)) {
+        return true;
+    }
+
+    $readMode = db_influx_read_mode();
+    return $readMode === 'preferred' || $readMode === 'primary';
+}
+
+/**
+ * Return the active InfluxDB read mode.
+ *
+ * Modes:
+ *   disabled   – never read from InfluxDB (default / legacy).
+ *   fallback   – try InfluxDB only when MariaDB returns empty.
+ *   preferred  – try InfluxDB first; fall back to MariaDB on empty/error.
+ *   primary    – use InfluxDB exclusively; MariaDB is not queried for
+ *                time-series analytics at all.
+ *
+ * The mode is resolved from ``influxdb.read_mode`` (new) with backward
+ * compatibility for the older boolean ``influxdb.read_enabled`` flag.
+ */
+function db_influx_read_mode(): string
+{
+    static $resolved = null;
+    if ($resolved !== null) {
+        return $resolved;
+    }
+
+    if (!(bool) config('influxdb.enabled', false)) {
+        $resolved = 'disabled';
+        return $resolved;
+    }
+
+    $explicit = trim((string) config('influxdb.read_mode', ''));
+    if (in_array($explicit, ['disabled', 'fallback', 'preferred', 'primary'], true)) {
+        $resolved = $explicit;
+        return $resolved;
+    }
+
+    // Backward compatibility: honour the legacy boolean flag.
+    if ((bool) config('influxdb.read_enabled', false)) {
+        $resolved = 'preferred';
+        return $resolved;
+    }
+
+    $resolved = 'disabled';
+    return $resolved;
 }
 
 function db_influx_query_rows(string $flux): array
@@ -6343,7 +6414,7 @@ function db_market_history_stock_health_influx(
     $rangeStart = $startDate . 'T00:00:00Z';
     $rangeStop = date('Y-m-d', strtotime($endDate . ' +1 day')) . 'T00:00:00Z';
 
-    $flux = <<<FLUX
+    $stockFlux = <<<FLUX
 from(bucket: "{$qBucket}")
   |> range(start: {$rangeStart}, stop: {$rangeStop})
   |> filter(fn: (r) => r._measurement == "market_item_stock")
@@ -6355,9 +6426,35 @@ from(bucket: "{$qBucket}")
   |> keep(columns: ["_time", "type_id", "local_stock_units", "listing_count"])
 FLUX;
 
-    $influxRows = db_influx_query_rows($flux);
+    $priceFlux = <<<FLUX
+from(bucket: "{$qBucket}")
+  |> range(start: {$rangeStart}, stop: {$rangeStop})
+  |> filter(fn: (r) => r._measurement == "market_item_price")
+  |> filter(fn: (r) => r.window == "1d")
+  |> filter(fn: (r) => r.source_type == "{$qSourceType}")
+  |> filter(fn: (r) => r.source_id == "{$safeSourceId}")
+  |> filter(fn: (r) => r._field == "avg_price")
+  |> pivot(rowKey: ["_time", "type_id"], columnKey: ["_field"], valueColumn: "_value")
+  |> keep(columns: ["_time", "type_id", "avg_price"])
+FLUX;
+
+    $influxRows = db_influx_query_rows($stockFlux);
     if ($influxRows === []) {
         return [];
+    }
+    $influxPriceRows = db_influx_query_rows($priceFlux);
+
+    $priceByKey = [];
+    foreach ($influxPriceRows as $row) {
+        $typeId = max(0, (int) ($row['type_id'] ?? 0));
+        $time = trim((string) ($row['_time'] ?? ''));
+        if ($typeId <= 0 || $time === '') {
+            continue;
+        }
+        $tradeDate = gmdate('Y-m-d', strtotime($time) ?: 0);
+        if ($tradeDate !== '1970-01-01') {
+            $priceByKey[$tradeDate . ':' . $typeId] = max(0.0, (float) ($row['avg_price'] ?? 0));
+        }
     }
 
     $typeIds = [];
@@ -6385,9 +6482,132 @@ FLUX;
             'buy_volume' => 0,
             'sell_order_count' => max(0, (int) round((float) ($row['listing_count'] ?? 0))),
             'buy_order_count' => 0,
-            'avg_sell_price' => null,
+            'avg_sell_price' => isset($priceByKey[$key]) ? $priceByKey[$key] : null,
             'avg_buy_price' => null,
             'last_observed_at' => gmdate('Y-m-d H:i:s', strtotime($time) ?: 0),
+        ];
+    }
+
+    if ($results === []) {
+        return [];
+    }
+
+    $typeNamesById = [];
+    foreach (db_ref_item_types_by_ids(array_values($typeIds)) as $typeRow) {
+        $tid = max(0, (int) ($typeRow['type_id'] ?? 0));
+        if ($tid > 0) {
+            $typeNamesById[$tid] = (string) ($typeRow['type_name'] ?? '');
+        }
+    }
+
+    $rows = array_values($results);
+    foreach ($rows as &$r) {
+        $r['type_name'] = $typeNamesById[(int) $r['type_id']] ?? '';
+    }
+    unset($r);
+
+    usort($rows, static fn (array $a, array $b): int => strcmp($a['observed_date'], $b['observed_date']) ?: ($a['type_id'] <=> $b['type_id']));
+
+    return $rows;
+}
+
+/**
+ * InfluxDB-backed stock window summaries with price data.
+ * Returns the same row shape as db_market_item_stock_window_summaries().
+ */
+function db_market_item_stock_window_summaries_influx(
+    string $sourceType,
+    int $sourceId,
+    string $startDate,
+    string $endDate
+): array {
+    if (!db_influx_read_enabled() || $sourceId <= 0) {
+        return [];
+    }
+
+    $bucket = trim((string) config('influxdb.bucket', 'supplycore_rollups'));
+    if ($bucket === '') {
+        return [];
+    }
+
+    $qBucket = addslashes($bucket);
+    $qSourceType = addslashes($sourceType);
+    $safeSourceId = (string) $sourceId;
+    $rangeStart = $startDate . 'T00:00:00Z';
+    $rangeStop = date('Y-m-d', strtotime($endDate . ' +1 day')) . 'T00:00:00Z';
+
+    $stockFlux = <<<FLUX
+from(bucket: "{$qBucket}")
+  |> range(start: {$rangeStart}, stop: {$rangeStop})
+  |> filter(fn: (r) => r._measurement == "market_item_stock")
+  |> filter(fn: (r) => r.window == "1d")
+  |> filter(fn: (r) => r.source_type == "{$qSourceType}")
+  |> filter(fn: (r) => r.source_id == "{$safeSourceId}")
+  |> filter(fn: (r) => r._field == "local_stock_units" or r._field == "listing_count")
+  |> pivot(rowKey: ["_time", "type_id"], columnKey: ["_field"], valueColumn: "_value")
+  |> keep(columns: ["_time", "type_id", "local_stock_units", "listing_count"])
+FLUX;
+
+    $priceFlux = <<<FLUX
+from(bucket: "{$qBucket}")
+  |> range(start: {$rangeStart}, stop: {$rangeStop})
+  |> filter(fn: (r) => r._measurement == "market_item_price")
+  |> filter(fn: (r) => r.window == "1d")
+  |> filter(fn: (r) => r.source_type == "{$qSourceType}")
+  |> filter(fn: (r) => r.source_id == "{$safeSourceId}")
+  |> filter(fn: (r) => r._field == "avg_price")
+  |> pivot(rowKey: ["_time", "type_id"], columnKey: ["_field"], valueColumn: "_value")
+  |> keep(columns: ["_time", "type_id", "avg_price"])
+FLUX;
+
+    $stockRows = db_influx_query_rows($stockFlux);
+    if ($stockRows === []) {
+        return [];
+    }
+    $priceRows = db_influx_query_rows($priceFlux);
+
+    $priceByKey = [];
+    foreach ($priceRows as $row) {
+        $typeId = max(0, (int) ($row['type_id'] ?? 0));
+        $time = trim((string) ($row['_time'] ?? ''));
+        if ($typeId <= 0 || $time === '') {
+            continue;
+        }
+        $tradeDate = gmdate('Y-m-d', strtotime($time) ?: 0);
+        if ($tradeDate === '1970-01-01') {
+            continue;
+        }
+        $priceByKey[$tradeDate . ':' . $typeId] = max(0.0, (float) ($row['avg_price'] ?? 0));
+    }
+
+    $typeIds = [];
+    $results = [];
+    foreach ($stockRows as $row) {
+        $typeId = max(0, (int) ($row['type_id'] ?? 0));
+        $time = trim((string) ($row['_time'] ?? ''));
+        if ($typeId <= 0 || $time === '') {
+            continue;
+        }
+        $tradeDate = gmdate('Y-m-d', strtotime($time) ?: 0);
+        if ($tradeDate === '1970-01-01') {
+            continue;
+        }
+        $key = $tradeDate . ':' . $typeId;
+        if (isset($results[$key])) {
+            continue;
+        }
+        $typeIds[$typeId] = $typeId;
+        $results[$key] = [
+            'observed_date' => $tradeDate,
+            'type_id' => $typeId,
+            'type_name' => '',
+            'sell_volume' => max(0, (int) round((float) ($row['local_stock_units'] ?? 0))),
+            'buy_volume' => 0,
+            'sell_order_count' => max(0, (int) round((float) ($row['listing_count'] ?? 0))),
+            'buy_order_count' => 0,
+            'avg_sell_price' => isset($priceByKey[$key]) ? $priceByKey[$key] : null,
+            'avg_buy_price' => null,
+            'last_observed_at' => $tradeDate . ' 00:00:00',
         ];
     }
 
@@ -6545,7 +6765,15 @@ function db_market_history_daily_aggregate_by_date_type_source(
     string $endDate,
     array $typeIds = []
 ): array {
-    if ($typeIds === [] && db_influx_read_enabled()) {
+    $readMode = db_influx_read_mode();
+
+    // In 'primary' mode, InfluxDB is the only source for time-series reads.
+    if ($typeIds === [] && $readMode === 'primary') {
+        return db_market_history_daily_aggregate_influx($sourceType, $sourceId, $startDate, $endDate);
+    }
+
+    // In 'preferred' mode, try InfluxDB first; fall back to MariaDB on empty.
+    if ($typeIds === [] && $readMode === 'preferred') {
         $influxRows = db_market_history_daily_aggregate_influx($sourceType, $sourceId, $startDate, $endDate);
         if ($influxRows !== []) {
             return $influxRows;
@@ -6567,7 +6795,7 @@ function db_market_history_daily_aggregate_by_date_type_source(
         $params = array_merge($params, $normalizedTypeIds);
     }
 
-    return db_select_cached(
+    $mariaRows = db_select_cached(
         "SELECT
             mhd.trade_date,
             mhd.type_id,
@@ -6589,6 +6817,16 @@ function db_market_history_daily_aggregate_by_date_type_source(
         60,
         'market.history.aggregate'
     );
+
+    // In 'fallback' mode, try InfluxDB only when MariaDB returned nothing.
+    if ($mariaRows === [] && $typeIds === [] && $readMode === 'fallback') {
+        $influxRows = db_market_history_daily_aggregate_influx($sourceType, $sourceId, $startDate, $endDate);
+        if ($influxRows !== []) {
+            return $influxRows;
+        }
+    }
+
+    return $mariaRows;
 }
 
 function db_market_history_daily_deviation_series(
@@ -6598,7 +6836,13 @@ function db_market_history_daily_deviation_series(
     string $endDate,
     array $typeIds = []
 ): array {
-    if ($typeIds === [] && db_influx_read_enabled()) {
+    $readMode = db_influx_read_mode();
+
+    if ($typeIds === [] && $readMode === 'primary') {
+        return db_market_history_deviation_influx($allianceStructureId, $hubSourceId, $startDate, $endDate);
+    }
+
+    if ($typeIds === [] && $readMode === 'preferred') {
         $influxRows = db_market_history_deviation_influx($allianceStructureId, $hubSourceId, $startDate, $endDate);
         if ($influxRows !== []) {
             return $influxRows;
@@ -6619,7 +6863,7 @@ function db_market_history_daily_deviation_series(
         $params = array_merge($params, $normalizedTypeIds);
     }
 
-    return db_select_cached(
+    $mariaRows = db_select_cached(
         "SELECT
             a.trade_date,
             a.type_id,
@@ -6649,6 +6893,15 @@ function db_market_history_daily_deviation_series(
         60,
         'market.history.deviation'
     );
+
+    if ($mariaRows === [] && $typeIds === [] && $readMode === 'fallback') {
+        $influxRows = db_market_history_deviation_influx($allianceStructureId, $hubSourceId, $startDate, $endDate);
+        if ($influxRows !== []) {
+            return $influxRows;
+        }
+    }
+
+    return $mariaRows;
 }
 
 // UI paths that depend on long-lived market history must read from the
@@ -6662,7 +6915,15 @@ function db_market_orders_history_stock_health_series(
     array $typeIds = [],
     bool $allowRawFallback = false
 ): array {
-    if ($typeIds === [] && db_influx_read_enabled()) {
+    $readMode = db_influx_read_mode();
+
+    // In 'primary' mode, InfluxDB is the only source.
+    if ($typeIds === [] && $readMode === 'primary') {
+        return db_market_history_stock_health_influx($sourceType, $sourceId, $startDate, $endDate);
+    }
+
+    // In 'preferred' mode, try InfluxDB first.
+    if ($typeIds === [] && ($readMode === 'preferred')) {
         $influxRows = db_market_history_stock_health_influx($sourceType, $sourceId, $startDate, $endDate);
         if ($influxRows !== []) {
             return $influxRows;
@@ -6670,6 +6931,15 @@ function db_market_orders_history_stock_health_series(
     }
 
     $rows = db_market_item_stock_window_summaries($sourceType, $sourceId, $startDate, $endDate, $typeIds);
+
+    // In 'fallback' mode, try InfluxDB when MariaDB rollups are empty.
+    if ($rows === [] && $typeIds === [] && $readMode === 'fallback') {
+        $influxRows = db_market_history_stock_health_influx($sourceType, $sourceId, $startDate, $endDate);
+        if ($influxRows !== []) {
+            return $influxRows;
+        }
+    }
+
     if ($rows !== [] || $allowRawFallback === false) {
         return $rows;
     }


### PR DESCRIPTION
## Summary

This PR implements a phased migration strategy for moving time-series analytics queries from MariaDB to InfluxDB. It introduces configurable read modes that allow gradual adoption of InfluxDB as the primary analytics engine while maintaining MariaDB as a fallback, enabling safe validation and rollback at each phase.

## Key Changes

- **New `db_influx_read_mode()` function** — Resolves the active InfluxDB read mode from configuration with backward compatibility for the legacy `influxdb.read_enabled` boolean flag. Supports four modes:
  - `disabled` — Never read from InfluxDB (default, safe for new installs)
  - `fallback` — Query MariaDB first; try InfluxDB only if MariaDB returns empty
  - `preferred` — Query InfluxDB first; fall back to MariaDB if InfluxDB returns empty
  - `primary` — Use InfluxDB exclusively; MariaDB is not queried for time-series analytics

- **Updated query functions to respect read modes** — Modified `db_market_item_stock_window_summaries()`, `db_market_history_daily_aggregate_by_date_type_source()`, and `db_market_history_daily_deviation_series()` to route queries based on the active read mode and whether filters are applied (unfiltered queries only use InfluxDB).

- **New InfluxDB-backed query function** — Added `db_market_item_stock_window_summaries_influx()` to provide InfluxDB implementation of stock window summaries with price data, matching the MariaDB result shape.

- **Enhanced `db_market_history_stock_health_influx()`** — Extended to fetch and join price data from InfluxDB, enriching stock health results with average sell prices.

- **Inline dual-write support** — Added `RollupInfluxBridge` class and dual-write helpers in rollup sync jobs (`analytics_bucket_1h_sync.py`, `analytics_bucket_1d_sync.py`) to write freshly computed rollups to InfluxDB immediately, eliminating latency between MariaDB and InfluxDB data.

- **Validation tooling** — Added `influx_validate.py` command to compare row counts and sample data between MariaDB rollup tables and InfluxDB measurements, enabling safe migration validation before switching read modes.

- **Configuration and documentation** — Added new settings (`influxdb.read_mode`, `influxdb.write_on_rollup`), database migration, environment variable examples, and comprehensive migration guide (`INFLUXDB_ANALYTICS_MIGRATION.md`) covering architecture, configuration, phased migration steps, and troubleshooting.

## Implementation Details

- Read mode resolution is cached at runtime to avoid repeated configuration lookups.
- Unfiltered queries (empty `$typeIds` array) are the only candidates for InfluxDB routing; filtered queries always use MariaDB to ensure consistency with entity metadata.
- Dual-write failures during rollup sync are logged to stderr but do not fail the sync job; MariaDB rollups are always written.
- InfluxDB point counts are divided by field count to approximate logical row counts for validation comparison.
- All InfluxDB queries use Flux with proper tag/field filtering and pivot operations to match MariaDB result shapes.

https://claude.ai/code/session_014vLPqFUYWXfA3ETpm4oxf6