### PR TITLE
Optimize MariaDB performance + Neo4j/InfluxDB query offload

### DIFF
--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -550,7 +550,7 @@ if [[ ${HEALTH_CHECK} -eq 1 && ${#RESTART_SERVICES[@]} -gt 0 && ${DRY_RUN} -eq 0
   UNHEALTHY_SERVICES=()
   for svc in "${RESTART_SERVICES[@]}"; do
     # Skip already-failed services
-    local skip=false
+    skip=false
     for failed in "${FAILED_SERVICES[@]+"${FAILED_SERVICES[@]}"}"; do
       if [[ "${failed}" == "${svc}" ]]; then
         skip=true


### PR DESCRIPTION
## Summary

- **MariaDB server tuning config** (`setup/mariadb_performance.cnf`): InnoDB buffer pool (8G/4 instances), thread pool, histogram statistics, SSD I/O tuning, optimizer switches — derived from [mariadb.org/mariadb-30x-faster](https://mariadb.org/mariadb-30x-faster/), [VolkanSah/optimize-MySQL-MariaDB](https://github.com/VolkanSah/optimize-MySQL-MariaDB), and [Medium tuning guide](https://medium.com/@x0goe/5-mariadb-performance-tuning-techniques-for-faster-queries-3f4e43df29b8)
- **ANALYZE TABLE + 20+ new indexes** migration: persistent histogram statistics on 60+ tables (up to 30x query speedup on complex JOINs) plus missing indexes on killmail_events, entity_metadata_cache, corp_contacts, copresence edges, community assignments, economic warfare scores, market_history_daily
- **PDO connection tuning**: Unix socket support, session-level `optimizer_use_condition_selectivity = 4`, proper numeric type handling
- **Neo4j offload** (5 graph queries): community overview, constellation maps, co-presence edges, item dependency intelligence, alliance relationship graphs — all with MariaDB fallback wrappers
- **InfluxDB offload** (5 time-series queries): killmail hull/item loss summaries, doctrine fit/group activity trends, market stock window summaries with read-mode routing
- **update-and-restart.sh improvements**: auto-stash dirty working tree, migration failure aborts restart, `--graceful-stop`, `--build-assets`, `--analyze-tables`, post-restart health verification, missing CORE_UNITS added

## Test plan

- [x] Migration applied successfully on production (31s including ANALYZE TABLE on 107M rows)
- [x] All 5 services restarted cleanly after deploy
- [ ] Verify Neo4j-preferred queries activate when Neo4j is enabled
- [ ] Verify InfluxDB-preferred queries activate when InfluxDB read_mode is set
- [ ] Run `./scripts/update-and-restart.sh --dry-run` to verify new flags parse correctly
- [ ] Apply `setup/mariadb_performance.cnf` to MariaDB server and verify buffer pool / thread pool settings

https://claude.ai/code/session_019j99LKjgWutzqa6EJgPqfg