### PR TITLE
Fix bad substitution in update-and-restart.sh health check

### DIFF
--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -542,12 +542,12 @@ for svc in "${RESTART_SERVICES[@]}"; do
 done
 
 # ------- Health verification -------
+UNHEALTHY_SERVICES=()
 if [[ ${HEALTH_CHECK} -eq 1 && ${#RESTART_SERVICES[@]} -gt 0 && ${DRY_RUN} -eq 0 ]]; then
   log "Verifying service health (timeout: ${HEALTH_CHECK_TIMEOUT}s per service)"
   # Short initial settle time
   sleep 2
 
-  UNHEALTHY_SERVICES=()
   for svc in "${RESTART_SERVICES[@]}"; do
     # Skip already-failed services
     skip=false
@@ -585,7 +585,7 @@ else
   done
 fi
 
-TOTAL_FAILED=$(( ${#FAILED_SERVICES[@]} + ${#UNHEALTHY_SERVICES[@]:-0} ))
+TOTAL_FAILED=$(( ${#FAILED_SERVICES[@]} + ${#UNHEALTHY_SERVICES[@]} ))
 if [[ ${TOTAL_FAILED} -gt 0 ]]; then
   log_warn "Completed update-and-restart with ${TOTAL_FAILED} issue(s)"
   exit 1


### PR DESCRIPTION
## Summary

- Fix `${#UNHEALTHY_SERVICES[@]:-0}` — array length syntax doesn't support default values in bash
- Initialize `UNHEALTHY_SERVICES=()` before the health check `if` block so it's always defined regardless of code path
- Remove duplicate initialization inside the `if` block

This was the second bash bug in the update-and-restart.sh rewrite (first was `local` outside a function). Both are now fixed.

## Test plan

- [ ] Run `./scripts/update-and-restart.sh --no-migrations --no-sync-units` and verify it completes without errors
- [ ] Run with `--no-health-check` to verify the else path also works

https://claude.ai/code/session_019j99LKjgWutzqa6EJgPqfg