### PR TITLE
Define BATCH_SIZE constant in behavioral intelligence batch processing

### DIFF
--- a/python/orchestrator/jobs/behavioral_intelligence_v2.py
+++ b/python/orchestrator/jobs/behavioral_intelligence_v2.py
@@ -632,6 +632,7 @@ def run_compute_suspicion_scores_v2(
     # ── Cohort-normalize the behavioral evidence rows ────────────
     _bv2_cohort_normalize(bv2_evidence_rows)
 
+    BATCH_SIZE = 500
     suspicion_ids: set[int] = set()
     with db.transaction() as (_, cursor):
         for i in range(0, len(insert_tuples), BATCH_SIZE):


### PR DESCRIPTION
## Summary
Added explicit definition of the `BATCH_SIZE` constant in the behavioral intelligence v2 job before it is used in the batch insert loop.

## Key Changes
- Defined `BATCH_SIZE = 500` constant immediately before the database transaction loop that uses it for batching insert operations

## Implementation Details
The constant was previously undefined at this point in the code, which would have caused a `NameError` at runtime when the loop attempted to use `BATCH_SIZE` for chunking the insert tuples. This change ensures the constant is properly defined before use in the range calculation for the batch insert loop.

https://claude.ai/code/session_01AVMspSEadU8UHd9mJ5BSZo