### PR TITLE
Block AI crawlers causing site slowness

### DIFF
--- a/public-proxy/lib/api-client.php
+++ b/public-proxy/lib/api-client.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+// Block known AI crawlers before any work. Mirror of src/bootstrap.php.
+if (preg_match('/ClaudeBot|GPTBot|CCBot|anthropic-ai|ChatGPT-User|Bytespider|PetalBot|Google-Extended/i', $_SERVER['HTTP_USER_AGENT'] ?? '')) {
+    http_response_code(403);
+    header('Content-Type: text/plain');
+    exit('Forbidden');
+}
+
 /**
  * SupplyCore Public API Client — HMAC-authenticated HTTP requests.
  *

--- a/public-proxy/robots.txt
+++ b/public-proxy/robots.txt
@@ -1,0 +1,25 @@
+# AI crawlers — full site block
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+# Regular crawlers
+User-agent: *
+Allow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,29 @@
+# AI crawlers — full site block
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+# Regular crawlers — restrict internal pages
+User-agent: *
+Disallow: /api/
+Disallow: /settings/
+Disallow: /log-viewer/
+Disallow: /callback/
+Allow: /

--- a/setup/nginx-block-ai-crawlers.conf
+++ b/setup/nginx-block-ai-crawlers.conf
@@ -1,0 +1,18 @@
+# ── AI Crawler Blocking ────────────────────────────────────────────
+# Include this inside each `server { }` block, or in a shared
+# snippet that both the main app and public-proxy vhosts include.
+#
+#   server {
+#       ...
+#       include /etc/nginx/snippets/block-ai-crawlers.conf;
+#       ...
+#   }
+#
+# To deploy:
+#   sudo cp setup/nginx-block-ai-crawlers.conf /etc/nginx/snippets/block-ai-crawlers.conf
+#   sudo nginx -t && sudo systemctl reload nginx
+# ───────────────────────────────────────────────────────────────────
+
+if ($http_user_agent ~* "(ClaudeBot|GPTBot|CCBot|anthropic-ai|ChatGPT-User|Bytespider|PetalBot|Google-Extended)") {
+    return 403;
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+// Block known AI crawlers before any expensive work (session, DB, etc.).
+// Primary blocking should be done at the nginx level via
+// setup/nginx-block-ai-crawlers.conf — this is a defense-in-depth fallback.
+if (preg_match('/ClaudeBot|GPTBot|CCBot|anthropic-ai|ChatGPT-User|Bytespider|PetalBot|Google-Extended/i', $_SERVER['HTTP_USER_AGENT'] ?? '')) {
+    http_response_code(403);
+    header('Content-Type: text/plain');
+    exit('Forbidden');
+}
+
 session_start();
 
 require_once __DIR__ . '/functions.php';


### PR DESCRIPTION
## Summary
- ClaudeBot and GPTBot were hammering battle-intelligence pages at 50+ req/s from `45.83.233.47`, saturating PHP workers and causing 10s page loads for real users
- Adds `robots.txt` for both main app and public-proxy (polite signal)
- Adds **nginx snippet** at `setup/nginx-block-ai-crawlers.conf` for fast 403 rejection before PHP
- Adds PHP-level UA check in `bootstrap.php` and proxy `api-client.php` as defense-in-depth fallback

## Nginx deployment

After merging, deploy the nginx snippet on your server:

```bash
sudo cp setup/nginx-block-ai-crawlers.conf /etc/nginx/snippets/block-ai-crawlers.conf
```

Then add this line inside each `server { }` block:

```nginx
include /etc/nginx/snippets/block-ai-crawlers.conf;
```

Then reload:

```bash
sudo nginx -t && sudo systemctl reload nginx
```

## Test plan
- [ ] `curl -A "ClaudeBot" -I https://yoursite/` should return `403`
- [ ] `curl -A "GPTBot" -I https://yoursite/` should return `403`
- [ ] `curl -A "Mozilla/5.0" -I https://yoursite/` should return `200`
- [ ] `curl https://yoursite/robots.txt` returns the disallow rules
- [ ] Monitor access logs — bot requests should flip from 200 to 403
- [ ] Real user page loads should improve immediately

https://claude.ai/code/session_01Fnv8XcWN5sf5uhZzSCuuzK