### PR TITLE
Improve theater map routing and simplify battle report display

### DIFF
--- a/public-proxy/partials/_battle_report_classic_standalone.php
+++ b/public-proxy/partials/_battle_report_classic_standalone.php
@@ -1,0 +1,13 @@
+<?php if ($allianceSummary !== []): ?>
+<section class="surface-primary mt-4">
+    <?php include __DIR__ . '/_battle_report_classic.php'; ?>
+
+    <?php if ($dataQualityNotes !== []): ?>
+        <div class="mt-3 pt-2 border-t border-white/5">
+            <?php foreach ($dataQualityNotes as $note): ?>
+                <p class="text-[10px] text-slate-500 leading-relaxed"><?= proxy_e((string) $note) ?></p>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+</section>
+<?php endif; ?>

--- a/public-proxy/theater.php
+++ b/public-proxy/theater.php
@@ -90,12 +90,7 @@ $systemName = proxy_e((string) ($theater['primary_system_name'] ?? 'Unknown'));
 
         <?php include __DIR__ . '/partials/_header.php'; ?>
         <?php include __DIR__ . '/partials/_location_map.php'; ?>
-        <?php include __DIR__ . '/partials/_battle_report.php'; ?>
-        <?php include __DIR__ . '/partials/_battles.php'; ?>
-        <?php include __DIR__ . '/partials/_timeline.php'; ?>
-        <?php include __DIR__ . '/partials/_alliance_summary.php'; ?>
-        <?php include __DIR__ . '/partials/_participants.php'; ?>
-        <?php include __DIR__ . '/partials/_killmails.php'; ?>
+        <?php include __DIR__ . '/partials/_battle_report_classic_standalone.php'; ?>
 
     </main>
 </div>

--- a/src/functions.php
+++ b/src/functions.php
@@ -32041,7 +32041,7 @@ function supplycore_theater_map_svg(string $theaterId, array $systemIds, int $ho
         return null;
     }
     $cacheKey = substr(md5($theaterId . ':' . implode(',', $systemIds)), 0, 12);
-    $cacheFile = sprintf('%s/theater-%s-h%d-v4.svg', $cacheDir, $cacheKey, $hops);
+    $cacheFile = sprintf('%s/theater-%s-h%d-v5.svg', $cacheDir, $cacheKey, $hops);
     $cacheTtl = supplycore_threat_corridor_map_cache_minutes() * 60;
     if (is_file($cacheFile) && ((time() - (int) filemtime($cacheFile)) < $cacheTtl)) {
         return '/threat-corridors/svg/' . basename($cacheFile);
@@ -32090,8 +32090,52 @@ function supplycore_theater_map_svg(string $theaterId, array $systemIds, int $ho
         $adjacency[$b][] = $a;
     }
 
-    // Battle-system edges: any edge where both endpoints are battle systems
+    // Layout: battle systems spread horizontally
+    $battleNodeIds = array_values(array_filter($nodeIds, static fn(int $sid): bool => isset($battleSet[$sid])));
+    sort($battleNodeIds);
+
+    // Route edges: find shortest path between every pair of battle systems
+    // so the full route is shown even when battles are separated by
+    // intermediate (non-battle) systems.
     $battleEdges = [];
+    $routeNodeSet = []; // intermediate nodes on the route
+    if (count($battleNodeIds) >= 2) {
+        for ($bi = 0; $bi < count($battleNodeIds) - 1; $bi++) {
+            for ($bj = $bi + 1; $bj < count($battleNodeIds); $bj++) {
+                $src = $battleNodeIds[$bi];
+                $dst = $battleNodeIds[$bj];
+                $bfsQueue = [$src];
+                $bfsPrev  = [$src => -1];
+                $found    = false;
+                while ($bfsQueue !== []) {
+                    $cur = array_shift($bfsQueue);
+                    if ($cur === $dst) {
+                        $found = true;
+                        break;
+                    }
+                    foreach ($adjacency[$cur] as $nb) {
+                        if (!isset($bfsPrev[$nb])) {
+                            $bfsPrev[$nb] = $cur;
+                            $bfsQueue[]   = $nb;
+                        }
+                    }
+                }
+                if ($found) {
+                    $cur = $dst;
+                    while ($bfsPrev[$cur] !== -1) {
+                        $prev = $bfsPrev[$cur];
+                        $key  = min($cur, $prev) . ':' . max($cur, $prev);
+                        $battleEdges[$key] = true;
+                        if (!isset($battleSet[$cur])) {
+                            $routeNodeSet[$cur] = true;
+                        }
+                        $cur = $prev;
+                    }
+                }
+            }
+        }
+    }
+    // Also include direct battle-to-battle edges
     foreach ($edges as $edge) {
         $a = (int) ($edge[0] ?? 0);
         $b = (int) ($edge[1] ?? 0);
@@ -32102,10 +32146,6 @@ function supplycore_theater_map_svg(string $theaterId, array $systemIds, int $ho
             $battleEdges[min($a, $b) . ':' . max($a, $b)] = true;
         }
     }
-
-    // Layout: battle systems spread horizontally
-    $battleNodeIds = array_values(array_filter($nodeIds, static fn(int $sid): bool => isset($battleSet[$sid])));
-    sort($battleNodeIds);
     $battleCount = count($battleNodeIds);
     $positions = [];
     foreach ($battleNodeIds as $idx => $sid) {
@@ -32133,10 +32173,12 @@ function supplycore_theater_map_svg(string $theaterId, array $systemIds, int $ho
         }
     }
 
-    // Mark boundary nodes: beyond the requested hops, used only for stub edges
+    // Mark boundary nodes: beyond the requested hops, used only for stub edges.
+    // Route-intermediate nodes (on the shortest path between battle systems) are
+    // kept as full nodes so the complete route is visible.
     $theaterBoundarySet = [];
     foreach ($nodeIds as $sid) {
-        if (!isset($battleSet[$sid]) && ($distance[$sid] ?? PHP_INT_MAX) > $hops) {
+        if (!isset($battleSet[$sid]) && !isset($routeNodeSet[$sid]) && ($distance[$sid] ?? PHP_INT_MAX) > $hops) {
             $theaterBoundarySet[$sid] = true;
         }
     }
@@ -32234,7 +32276,7 @@ function supplycore_theater_map_svg(string $theaterId, array $systemIds, int $ho
     };
 
     $svg = [];
-    $svg[] = '<svg xmlns="http://www.w3.org/2000/svg" width="' . $width . '" height="' . $height . '" viewBox="0 0 ' . $width . ' ' . $height . '">';
+    $svg[] = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' . $width . ' ' . $height . '" style="width:100%;height:auto">';
     $svg[] = '<defs>'
         . '<filter id="battle-glow" x="-40%" y="-40%" width="180%" height="180%">'
         . '<feGaussianBlur stdDeviation="3.5" result="blur"/>'


### PR DESCRIPTION
## Summary
This PR enhances the theater map visualization to show complete supply routes between battle systems and simplifies the battle report display on the theater page.

## Key Changes

### Theater Map Routing (src/functions.php)
- **Route path visualization**: Implemented breadth-first search (BFS) to find shortest paths between all pairs of battle systems, ensuring the complete supply route is visible even when battles are separated by intermediate systems
- **Intermediate node preservation**: Route-intermediate nodes are now kept as full nodes (not boundary stubs) so the complete route path is displayed
- **Cache invalidation**: Updated cache file version from v4 to v5 to invalidate old cached maps
- **SVG responsiveness**: Modified SVG output to use `viewBox` with responsive styling (`width:100%;height:auto`) instead of fixed width/height attributes

### Battle Report Display
- **New standalone partial**: Created `_battle_report_classic_standalone.php` that wraps the classic battle report with data quality notes in a styled container
- **Simplified theater page**: Replaced multiple battle report partials (`_battle_report.php`, `_battles.php`, `_timeline.php`, `_alliance_summary.php`, `_participants.php`, `_killmails.php`) with a single consolidated `_battle_report_classic_standalone.php` include

## Implementation Details
- The BFS algorithm tracks previous nodes to reconstruct the shortest path between each pair of battle systems
- Route nodes are collected in `$routeNodeSet` and excluded from boundary node classification, ensuring they remain visible in the final SVG
- The boundary node logic now checks three conditions: not a battle system, not on a route path, and beyond the hop distance limit

https://claude.ai/code/session_019Ms37nygJBLxj83LHjfdXt