### PR TITLE
Fix AI battle briefing perspective and missing fleet comp data

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -16949,11 +16949,12 @@ function db_theater_fleet_composition(string $theaterId): array
     // Use flying_ship_type_id from theater_participants (the non-pod combat ship each pilot flew)
     // rather than battle_participants.ship_type_id which may be recorded as the capsule when a
     // pilot loses their ship and is subsequently podded.
-    // Includes alliance_id/corporation_id so PHP can classify sides using live standings.
+    // Includes side from Python theater analysis so PHP can split into friendly/enemy compositions.
     return db_select(
         "SELECT tp.flying_ship_type_id AS ship_type_id,
                 COALESCE(rit.type_name, CONCAT('Type #', tp.flying_ship_type_id)) AS ship_name,
                 COALESCE(rig.group_name, '') AS ship_group,
+                tp.side,
                 COALESCE(tp.alliance_id, 0) AS alliance_id,
                 COALESCE(tp.corporation_id, 0) AS corporation_id,
                 COUNT(*) AS pilot_count
@@ -16964,7 +16965,7 @@ function db_theater_fleet_composition(string $theaterId): array
            AND tp.flying_ship_type_id IS NOT NULL
            AND tp.flying_ship_type_id > 0
          GROUP BY tp.flying_ship_type_id, rit.type_name, rig.group_name,
-                  COALESCE(tp.alliance_id, 0), COALESCE(tp.corporation_id, 0)
+                  tp.side, COALESCE(tp.alliance_id, 0), COALESCE(tp.corporation_id, 0)
          ORDER BY pilot_count DESC",
         [$theaterId]
     );


### PR DESCRIPTION
## Summary
- **Fix empty fleet compositions**: `db_theater_fleet_composition()` was missing `tp.side` in the SELECT/GROUP BY, so `friendly_fleet_composition` and `enemy_fleet_composition` were always empty arrays — the AI had no ship data to work with
- **Fix wrong perspective**: The AI prompt now explicitly names which alliances are "ours" (e.g. Fraternity., NCDot) vs "theirs" (e.g. The Initiative.), and enforces loss-report framing when we lost instead of writing a victory report for the enemy
- **Fix verdict flip**: Verdict instruction now explicitly states that if our side lost the ISK war, the verdict must be defeat/decisive_defeat

## Test plan
- [ ] Lock a battle report where the friendly coalition lost and verify the AI writes a loss report from our perspective
- [ ] Verify `friendly_fleet_composition` and `enemy_fleet_composition` are populated in the facts JSON
- [ ] Check the headline reflects our outcome (e.g. "Defeat in RD-G2R" not "The Initiative Prevails")
- [ ] Verify verdict is correct (defeat/decisive_defeat when we lost)

https://claude.ai/code/session_016ostdpjS6UXFpzzMm1hseG