### PR TITLE
Optimize buy-all page: session lock fix, in-flight dedup, caching

### DIFF
--- a/public/api/ui-refresh-fragment.php
+++ b/public/api/ui-refresh-fragment.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../src/bootstrap.php';
 
+// Release the session file lock early — fragment rendering is read-only for
+// session data and we don't want to block concurrent requests.
+session_write_close();
+
 $requestStart = microtime(true);
 
 header('Content-Type: application/json; charset=UTF-8');

--- a/public/api/ui-refresh-state.php
+++ b/public/api/ui-refresh-state.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../src/bootstrap.php';
 
+// Release the session file lock early — this endpoint is read-only.
+session_write_close();
+
 $requestStart = microtime(true);
 
 header('Content-Type: application/json; charset=UTF-8');

--- a/public/api/ui-refresh-stream.php
+++ b/public/api/ui-refresh-stream.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../src/bootstrap.php';
 
+// Release the session file lock immediately — this endpoint never writes
+// session data, and holding the lock for the full 60 s stream lifetime
+// blocks every other request from the same browser session on session_start().
+session_write_close();
+
 $pageId = trim((string) ($_GET['page_id'] ?? ''));
 $config = supplycore_live_refresh_page_config($pageId);
 if ($config === null) {


### PR DESCRIPTION
## Summary

- **Fix 53s page load caused by PHP session file lock contention** — the SSE stream endpoint held the session lock for its full 60s lifetime, blocking every other request from the same browser session on `session_start()`. Added `session_write_close()` to all three live-refresh API endpoints (stream, fragment, state) since none write session data.
- **Add in-flight deduplication guard in `ui-live-refresh.js`** — prevents duplicate concurrent fragment requests (HAR showed two `buyall-overview` requests firing 2s apart, both running the full ~55s uncached computation).
- **Skip redundant auto-refresh when SSE is active** — the 60s unconditional refresh is now skipped when SSE has recently delivered events, eliminating redundant expensive fragment requests.
- **Add 30s Redis cache-aside to `buy_all_planner_data()`** — concurrent fragment requests with the same query params share computed results instead of each running the full computation independently.

## Test plan

- [ ] Load the buy-all page and confirm TTFB drops from ~53s to under 1s
- [ ] Verify live-refresh SSE stream still connects and delivers events
- [ ] Open the page in two tabs simultaneously — both should load quickly (no session lock blocking)
- [ ] Trigger a data change and confirm fragment refreshes still fire via SSE
- [ ] Verify the 60s auto-refresh fires only when SSE has been quiet (check browser console)
- [ ] Confirm cached planner data invalidates when underlying data domains update

https://claude.ai/code/session_01MV1LVgtqJqrWtdVgrpqVVd