### PR TITLE
Skip DOM swap and flash when section content is unchanged

### DIFF
--- a/public/assets/js/ui-live-refresh.js
+++ b/public/assets/js/ui-live-refresh.js
@@ -245,6 +245,15 @@
         return;
       }
 
+      // Skip the DOM swap entirely when the new HTML is identical to what's
+      // already on screen — avoids jarring flash animations and layout reflows
+      // when nothing actually changed (which is common with frequent SSE events).
+      if (current.innerHTML === replacement.innerHTML) {
+        updateVersionState(payload.current_versions || {});
+        renderDiagnostics();
+        return;
+      }
+
       transitionSwap(current, replacement);
       state.lastSectionRefreshAt[sectionKey] = new Date().toISOString();
       flashSection(sectionKey);
@@ -297,7 +306,7 @@
     const changedVersionKeys = Object.keys(eventPayload.changed_versions || {}).filter((versionKey) => {
       const nextVersion = Number(eventPayload.changed_versions[versionKey]?.version || 0);
       const currentVersion = Number(state.currentVersions[versionKey]?.version || 0);
-      return nextVersion >= currentVersion;
+      return nextVersion > currentVersion;
     });
 
     scheduleRefresh(changedVersionKeys);


### PR DESCRIPTION
## Summary

- **Content diffing before DOM swap** — compares `innerHTML` of the current section against the server response. If identical, skips the DOM replacement, view transition, and flash animation entirely. This eliminates the constant visual jank on the dashboard (and all pages) when SSE events fire but the visible data hasn't actually changed.
- **Strict version comparison** (`>` instead of `>=`) — events where the version hasn't increased no longer trigger fragment fetches at all, saving unnecessary HTTP roundtrips.

## Test plan

- [ ] Open the dashboard and observe — sections should no longer flash constantly when background jobs complete without changing visible data
- [ ] Trigger an actual data change (e.g. market sync with price movement) and confirm the affected section still updates with a flash
- [ ] Check browser console for no new errors in the live-refresh code
- [ ] Verify the buy-all page also benefits from reduced flashing

https://claude.ai/code/session_01MV1LVgtqJqrWtdVgrpqVVd