### PR TITLE
Implement two-lane intelligence model with behavioral scoring pipeline

### DIFF
--- a/database/migrations/20260414_behavioral_scoring_pipeline.sql
+++ b/database/migrations/20260414_behavioral_scoring_pipeline.sql
@@ -9,7 +9,8 @@ CREATE TABLE IF NOT EXISTS character_behavioral_scores (
     percentile_rank DECIMAL(10,6) NOT NULL DEFAULT 0.000000,
     confidence_tier VARCHAR(10) NOT NULL DEFAULT 'low',
     total_kill_count INT UNSIGNED NOT NULL DEFAULT 0,
-    small_kill_count INT UNSIGNED NOT NULL DEFAULT 0,
+    solo_kill_count INT UNSIGNED NOT NULL DEFAULT 0,
+    gang_kill_count INT UNSIGNED NOT NULL DEFAULT 0,
     large_battle_count INT UNSIGNED NOT NULL DEFAULT 0,
     fleet_absence_ratio DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
     post_engagement_continuation_rate DECIMAL(12,6) NOT NULL DEFAULT 0.000000,
@@ -55,12 +56,19 @@ CREATE TABLE IF NOT EXISTS small_engagement_copresence (
     KEY idx_small_copresence_computed (computed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- Register scheduler job (runs hourly, full rebuild of 90-day window)
-INSERT INTO scheduler_jobs (job_key, enabled, interval_minutes, interval_seconds, offset_seconds, priority_order, priority_tier, concurrency_mode, execution_mode, timeout_seconds, created_at, updated_at, current_status, trigger_mode, max_retries, retry_count)
-VALUES ('compute_behavioral_scoring', 1, 60, 3600, 1740, 29, 'normal', 'single', 'python', 1800, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1)
+-- Register scheduler job (runs hourly, full rebuild of 90-day window).
+-- Table is sync_schedules (not scheduler_jobs).
+INSERT INTO sync_schedules (
+    job_key, enabled, interval_minutes, interval_seconds, offset_seconds, offset_minutes,
+    priority, concurrency_policy, execution_mode, timeout_seconds,
+    next_run_at, next_due_at, current_state, tuning_mode,
+    discovered_from_code, explicitly_configured,
+    last_run_at, last_status, last_error, locked_until
+) VALUES (
+    'compute_behavioral_scoring', 1, 60, 3600, 1740, 29,
+    'normal', 'single', 'python', 1800,
+    UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic',
+    1, 1,
+    NULL, NULL, NULL, NULL
+)
 ON DUPLICATE KEY UPDATE enabled = 1, interval_minutes = 60, timeout_seconds = 1800;
-
--- Add tier breakdown columns (solo 1-4, gang 5-9, battle 10+)
-ALTER TABLE character_behavioral_scores
-    CHANGE COLUMN small_kill_count solo_kill_count INT UNSIGNED NOT NULL DEFAULT 0,
-    ADD COLUMN gang_kill_count INT UNSIGNED NOT NULL DEFAULT 0 AFTER solo_kill_count;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Two-lane intelligence model**: Lane 1 covers large battles (20+ participants) via the existing counterintel/suspicion pipeline; Lane 2 covers solo/gang engagements (1–19 participants) via a new behavioral scoring pipeline
- **New behavioral scoring pipeline** (`behavioral_scoring.py`): computes 8 signals per character (fleet absence ratio, continuation rate, kill concentration, geographic concentration, temporal burstiness, companion consistency, cross-side rate, asymmetry preference) using streaming queries to avoid loading all kill rows into memory at once
- **Blended intelligence** (`db_character_blended_intelligence()`): combines both lanes with dynamic weights based on large-battle evidence (0 battles → behavioral only, 1–4 → 35/65, 5–9 → 50/50, 10+ → 65/35)
- **3-tier fallback** in `db_battle_intelligence_character()`: characters with below-threshold or suspicion_v2 data now show intelligence instead of "No intelligence found"
- **Leaderboard rewritten** as a UNION query to include behavioral-only characters
- **On-demand Lane 2** computation appended to `compute_character_intelligence_on_demand()`
- **Fix counterintel threshold**: `participant_count >= 10` → `>= 20` everywhere to align with `MIN_ELIGIBLE_PARTICIPANTS`
- **Pipeline viewer**: alliance dossier gap count, behavioral scoring metrics, suspicion below-threshold count
- **Migration fix**: corrected table name from `scheduler_jobs` → `sync_schedules`; consolidated `CREATE TABLE` to use correct column names directly

## New database tables

- `character_behavioral_scores` — per-character Lane 2 risk score + all 8 signal components
- `character_behavioral_signals` — individual signal rows per character with text explanation
- `small_engagement_copresence` — copresence edges built from recurring companions in sub-battle kills

## Test plan

- [ ] Run migration — should complete without errors
- [ ] Trigger `compute_behavioral_scoring` job and verify rows written to `character_behavioral_scores`
- [ ] Open a character page — blended headline should appear; Lane 1 and Lane 2 sections visible
- [ ] Character with no large battles should show `behavioral_only` source badge
- [ ] Character with many large battles should show `battle_only` or `mixed_battle_dominant`
- [ ] Pipeline viewer Intelligence stage shows behavioral scored count and dossier gap

https://claude.ai/code/session_01MnRqx1gpS5uVmNy2tVYfvY
EOF
)