### PR TITLE
Increase recent job activity history from 15 to 50 completions

### DIFF
--- a/public/pipeline/index.php
+++ b/public/pipeline/index.php
@@ -307,7 +307,7 @@ $overallPct = $stageCount > 0 ? round($overallPct / $stageCount) : 0;
      ══════════════════════════════════════════════════════════════════════════ -->
 <section class="mt-8 rounded-2xl border border-white/8 bg-gradient-to-br from-slate-900/80 via-slate-950/90 to-slate-900/80 px-6 py-5 shadow-[0_2px_24px_rgba(0,0,0,0.25)]">
     <h2 class="text-sm font-semibold uppercase tracking-wider text-slate-400">Recent Activity</h2>
-    <p class="mt-1 text-xs text-slate-500">Last 15 completed pipeline jobs.</p>
+    <p class="mt-1 text-xs text-slate-500">Last 50 completed pipeline jobs.</p>
 
     <?php if ($recentRuns === []): ?>
         <p class="mt-4 text-sm text-slate-500">No recent job runs recorded.</p>

--- a/src/db.php
+++ b/src/db.php
@@ -18393,13 +18393,13 @@ function db_pipeline_observatory_data(): array
     }
     $jobHealth['total'] = array_sum($jobHealth);
 
-    // ── Recent job activity (last 15 completions) ────────────────────────────
+    // ── Recent job activity (last 50 completions) ────────────────────────────
     $recentRuns = db_select(
         "SELECT job_name, status, duration_ms, rows_processed, rows_written, started_at, finished_at
          FROM job_runs
          WHERE status IN ('success', 'failed', 'skipped')
          ORDER BY finished_at DESC
-         LIMIT 15"
+         LIMIT 50"
     );
 
     // ── Per-stage last-run timestamps ────────────────────────────────────────


### PR DESCRIPTION
## Summary
Updated the pipeline observatory to display a larger history of recent job activity, increasing the query limit and corresponding UI label from 15 to 50 completed jobs.

## Changes
- **src/db.php**: Updated `db_pipeline_observatory_data()` to fetch the last 50 job runs instead of 15
  - Modified SQL query `LIMIT` clause from 15 to 50
  - Updated inline comment to reflect the new limit
- **public/pipeline/index.php**: Updated the "Recent Activity" section description to indicate "Last 50 completed pipeline jobs" instead of "Last 15"

## Details
This change provides better visibility into recent pipeline job history by displaying a larger sample of completed runs. The modification is consistent across both the data retrieval layer and the UI presentation.

https://claude.ai/code/session_01RXH2C4Uh3iqnEz3C9fnUgi