### PR TITLE
Decouple next_due_at advancement from sync schedule status updates

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -890,10 +890,22 @@ class SupplyCoreDb:
                    last_run_at = UTC_TIMESTAMP(),
                    last_finished_at = UTC_TIMESTAMP(),
                    locked_until = NULL,
-                   next_due_at = DATE_ADD(UTC_TIMESTAMP(), INTERVAL interval_seconds SECOND),
                    last_error = CASE WHEN %s = 'success' THEN NULL ELSE last_error END
                WHERE job_key = %s AND execution_mode = 'python'""",
             (status[:20], status[:20], job_key[:120]),
+        )
+
+    def advance_next_due_at_by_interval(self, job_key: str) -> int:
+        """Push next_due_at forward by the job's configured interval_seconds.
+
+        Called by the worker_pool after completing a job so that
+        queue_due_recurring_jobs (and the PHP scheduler) won't re-queue it
+        before the scheduled interval has elapsed.  NOT called by the
+        loop_runner, which manages its own timing independently.
+        """
+        return self.execute(
+            "UPDATE sync_schedules SET next_due_at = DATE_ADD(UTC_TIMESTAMP(), INTERVAL interval_seconds SECOND) WHERE job_key = %s AND execution_mode = 'python'",
+            (job_key[:120],),
         )
 
     def advance_next_due_at(self, job_key: str) -> int:

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -565,6 +565,7 @@ def main(argv: list[str] | None = None) -> int:
             logger.info("worker job completed", payload=completed_payload)
             job_log.write_event("worker_pool.job_completed", completed_payload)
             _finalize_job(db, context.job_key, result, logger)
+            db.advance_next_due_at_by_interval(context.job_key)
         except Exception as error:  # noqa: BLE001
             fail_result = JobResult.failed(
                 job_key=context.job_key,
@@ -576,6 +577,7 @@ def main(argv: list[str] | None = None) -> int:
             logger.warning("worker job failed", payload=failed_payload)
             job_log.write_event("worker_pool.job_failed", failed_payload)
             _finalize_job(db, context.job_key, fail_result, logger)
+            db.advance_next_due_at_by_interval(context.job_key)
             if args.once:
                 return 1
         finally:


### PR DESCRIPTION
## Summary
Refactored the timing logic for recurring job scheduling by separating the advancement of `next_due_at` from the status update operation. This allows more granular control over when the next execution is scheduled.

## Key Changes
- Removed the `next_due_at` advancement from `update_sync_schedule_status()` in the database layer
- Created a new `advance_next_due_at_by_interval()` method that explicitly advances `next_due_at` by the job's configured interval
- Updated `worker_pool.py` to call `advance_next_due_at_by_interval()` after job completion (both success and failure paths)

## Implementation Details
- The new method is called by the worker pool after `_finalize_job()` completes, ensuring the next execution is scheduled only after the current job has fully finished
- This prevents the scheduler from re-queuing a job before the configured interval has elapsed
- The change maintains the existing behavior while providing clearer separation of concerns between status updates and scheduling logic
- The loop_runner continues to manage its own timing independently, as noted in the docstring

https://claude.ai/code/session_01PBbWX9R8MzjHPFoPbGQNXS