### PR TITLE
Support cross-loop job dependencies in scheduling graph

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -1118,20 +1118,10 @@ class SupplyCoreDb:
         if token != "":
             return token
 
-        cached = self.fetch_one(
-            """SELECT JSON_UNQUOTE(JSON_EXTRACT(payload_json, '$.access_token')) AS access_token
-                FROM esi_cache_entries
-                WHERE namespace_key = 'cache.esi.oauth.token'
-                  AND cache_key = 'latest'
-                  AND (expires_at IS NULL OR expires_at > UTC_TIMESTAMP())
-                ORDER BY updated_at DESC, id DESC
-                LIMIT 1"""
-        ) or {}
-        cached_token = str(cached.get("access_token") or "").strip()
-        if cached_token != "":
-            return cached_token
-
-        # No valid token found — try to refresh using the stored refresh_token.
+        # Primary token expired — go straight to refresh.  The old cache
+        # fallback (esi_cache_entries) is intentionally skipped: after a
+        # re-authentication the cache may still hold a revoked token with a
+        # NULL or stale expires_at, causing persistent 401s from ESI.
         return self._try_refresh_esi_token()
 
     def _try_refresh_esi_token(self) -> str | None:

--- a/python/orchestrator/loop_runner.py
+++ b/python/orchestrator/loop_runner.py
@@ -290,9 +290,10 @@ def _run_loop(
     shutdown_event: threading.Event,
     pause_between_cycles: float,
     run_once: bool = False,
+    known_external_keys: set[str] | None = None,
 ) -> None:
     """Run the tier-by-tier loop continuously (or once)."""
-    graph_nodes = build_graph(definitions)
+    graph_nodes = build_graph(definitions, known_external_keys=known_external_keys)
     tiers, _tier_map = _topological_tiers(graph_nodes)
     cycle = 0
 
@@ -469,11 +470,18 @@ def main(argv: list[str] | None = None) -> int:
 
     threads: list[threading.Thread] = []
 
+    # Each loop needs to know about the other loop's job keys so that
+    # cross-loop dependencies are silently stripped instead of logged as
+    # "unknown jobs" warnings.
+    fast_keys = set(fast_defs.keys())
+    bg_keys = set(bg_defs.keys())
+
     if not args.background_only and fast_defs:
         fast_thread = threading.Thread(
             target=_run_loop,
             args=("fast", fast_defs, db, raw_config, logger,
                   args.max_parallel, shutdown_event, args.fast_pause, args.once),
+            kwargs={"known_external_keys": bg_keys},
             name="fast-loop",
             daemon=True,
         )
@@ -484,6 +492,7 @@ def main(argv: list[str] | None = None) -> int:
             target=_run_loop,
             args=("background", bg_defs, db, raw_config, logger,
                   args.max_parallel, shutdown_event, args.background_pause, args.once),
+            kwargs={"known_external_keys": fast_keys},
             name="background-loop",
             daemon=True,
         )

--- a/python/orchestrator/scheduling_graph.py
+++ b/python/orchestrator/scheduling_graph.py
@@ -61,29 +61,44 @@ class CyclicDependencyError(ValueError):
 # Graph builder
 # ---------------------------------------------------------------------------
 
-def build_graph(definitions: dict[str, dict[str, Any]]) -> dict[str, JobNode]:
+def build_graph(
+    definitions: dict[str, dict[str, Any]],
+    known_external_keys: set[str] | None = None,
+) -> dict[str, JobNode]:
     """Build the full dependency graph from worker job definitions.
 
     Each definition may contain:
       - ``depends_on``: list of job keys that must complete first
       - ``concurrency_group``: resource-level mutual exclusion label
       - ``lock_group``: legacy field, used as fallback concurrency_group
+
+    Args:
+        definitions: job definitions to include in this graph.
+        known_external_keys: job keys that exist in the full registry but are
+            not part of *this* graph (e.g. jobs in another loop).  Dependencies
+            on these keys are silently stripped (they run in a different loop
+            and are assumed fresh).  Dependencies on keys that are neither in
+            ``definitions`` nor in ``known_external_keys`` are logged as
+            warnings — those indicate a real configuration error.
     """
     nodes: dict[str, JobNode] = {}
     all_keys = set(definitions.keys())
+    external = known_external_keys or set()
 
     for key, defn in definitions.items():
         raw_deps = defn.get("depends_on") or []
         if isinstance(raw_deps, str):
             raw_deps = [raw_deps]
-        # Only keep dependencies that actually exist in the registry.
+        # Only keep dependencies that actually exist in this graph.
         deps = tuple(d for d in raw_deps if d in all_keys)
         if len(deps) != len(raw_deps):
-            missing = set(raw_deps) - all_keys
-            logger.warning(
-                "scheduling_graph: job %s depends on unknown jobs: %s (ignored)",
-                key, ", ".join(sorted(missing)),
-            )
+            # Distinguish cross-loop deps (expected) from truly unknown jobs.
+            truly_missing = set(raw_deps) - all_keys - external
+            if truly_missing:
+                logger.warning(
+                    "scheduling_graph: job %s depends on unknown jobs: %s (ignored)",
+                    key, ", ".join(sorted(truly_missing)),
+                )
         # Concurrency group: prefer explicit field, fall back to lock_group.
         cg = str(defn.get("concurrency_group") or defn.get("lock_group") or "")
         nodes[key] = JobNode(


### PR DESCRIPTION
## Summary
This PR adds support for cross-loop job dependencies by allowing the scheduling graph builder to distinguish between jobs in external loops (which are expected) and truly unknown job references (which indicate configuration errors).

## Key Changes

- **scheduling_graph.py**: 
  - Added optional `known_external_keys` parameter to `build_graph()` to accept job keys that exist in other loops
  - Updated dependency filtering logic to only warn about truly missing jobs, not those in external loops
  - Enhanced docstring to document the new parameter and behavior

- **loop_runner.py**:
  - Modified `_run_loop()` to accept and pass through `known_external_keys` parameter
  - Updated main loop initialization to compute job key sets for both fast and background loops
  - Each loop now passes the other loop's job keys when building its graph, enabling silent stripping of cross-loop dependencies

- **db.py**:
  - Removed fallback to stale ESI token cache in `fetch_latest_esi_access_token()`
  - Added clarifying comment explaining the removal: cached tokens may be revoked after re-authentication, causing persistent 401 errors from ESI

## Implementation Details

The solution allows two independent job loops (fast and background) to coexist while supporting dependencies between them. When a job in one loop depends on a job in another loop, that dependency is now silently ignored (since the external job runs in a different loop and is assumed fresh), rather than being logged as a configuration warning. Only truly unknown job references are now logged as warnings.

https://claude.ai/code/session_01PWJ3appqUnuMneM4AdEFuZ