### PR TITLE
Fix DAG scheduling by scoping job definitions to worker queues

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -596,13 +596,15 @@ class SupplyCoreDb:
         completed = {str(r["job_key"]) for r in worker_rows if r.get("job_key")}
 
         # Source 2: sync_schedules — jobs completed by the PHP scheduler daemon
-        # background dispatch path.  These update last_finished_at and
-        # last_status in sync_schedules but never create worker_jobs rows.
+        # background dispatch path or the loop_runner.  These update
+        # last_finished_at and last_status in sync_schedules but never
+        # create worker_jobs rows.  Do NOT filter on enabled — a job may
+        # be disabled in the PHP scheduler but still satisfy DAG
+        # dependencies for downstream worker-pool jobs.
         try:
             schedule_rows = self.fetch_all(
                 """SELECT DISTINCT job_key FROM sync_schedules
-                   WHERE enabled = 1
-                     AND last_finished_at IS NOT NULL
+                   WHERE last_finished_at IS NOT NULL
                      AND last_finished_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL %s SECOND)
                      AND last_status IN ('success', 'skipped', 'skipped_no_change',
                                          'skipped_within_freshness_window',

--- a/python/orchestrator/loop_runner.py
+++ b/python/orchestrator/loop_runner.py
@@ -89,6 +89,15 @@ def _run_single_job(
         status = str(result.get("status") or "success")
 
         _finalize_job(db, job_key, result, logger)
+        # Keep next_due_at in sync so the PHP scheduler and worker-pool
+        # DAG planner see accurate timing.  Without this, next_due_at
+        # stays permanently in the past, causing the PHP scheduler to
+        # treat every job as perpetually overdue and the worker-pool to
+        # queue stale cross-queue entries that block DAG resolution.
+        try:
+            db.advance_next_due_at_by_interval(job_key)
+        except Exception:
+            pass  # best-effort; row may not exist for sub-pipeline jobs
 
         return JobOutcome(
             job_key=job_key,
@@ -105,6 +114,10 @@ def _run_single_job(
         ).to_dict()
 
         _finalize_job(db, job_key, fail_result, logger)
+        try:
+            db.advance_next_due_at_by_interval(job_key)
+        except Exception:
+            pass
 
         return JobOutcome(
             job_key=job_key,

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -416,7 +416,21 @@ def main(argv: list[str] | None = None) -> int:
             reaped = db.reap_stale_running_jobs()
             if reaped > 0:
                 logger.info("reaped stale running jobs", payload={"event": "worker_pool.reaped_stale", "worker_id": worker_id, "reaped": reaped})
-            seed_result = db.queue_due_recurring_jobs(WORKER_JOB_DEFINITIONS)
+
+            # ── Scope job definitions to this worker's queues ─────────
+            # Each worker instance (sync vs compute) must only queue and
+            # schedule jobs it can actually claim.  Previously every worker
+            # queued ALL definitions, leaving cross-queue jobs permanently
+            # stuck in 'queued' status.  The DAG scheduler then saw those
+            # unclearable jobs as unsatisfied dependencies, blocking the
+            # downstream jobs this worker *could* run.
+            scoped_definitions = {
+                key: defn for key, defn in WORKER_JOB_DEFINITIONS.items()
+                if (str(defn.get("queue_name") or "default") in queue_names
+                    and str(defn.get("workload_class") or "sync") in workload_classes)
+            }
+
+            seed_result = db.queue_due_recurring_jobs(scoped_definitions)
 
             # ── DAG-aware dispatch ────────────────────────────────────
             # 1. Gather current state from the database.
@@ -424,10 +438,20 @@ def main(argv: list[str] | None = None) -> int:
             completed_keys = db.get_recently_completed_job_keys(within_seconds=7200)
             queued_keys = db.get_queued_job_keys()
 
+            # Only consider queued jobs that this worker can claim for the
+            # DAG plan.  Jobs from other queues may sit in 'queued' status
+            # but should not block dependency resolution for our jobs.
+            claimable_queued_keys = {
+                k for k in queued_keys if k in scoped_definitions
+            }
+
             # 2. Compute the scheduling plan — which jobs are ready?
+            #    Use the full registry for graph building (so cross-queue
+            #    dependencies are known) but only treat our claimable jobs
+            #    as "due" for dispatch decisions.
             plan = compute_scheduling_plan(
                 definitions=WORKER_JOB_DEFINITIONS,
-                due_job_keys=queued_keys,
+                due_job_keys=claimable_queued_keys,
                 completed_job_keys=completed_keys,
                 running_job_keys=running_keys,
             )


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where jobs from different queues were blocking DAG dependency resolution in the worker pool. The problem occurred because all job definitions were being queued regardless of whether the current worker instance could claim them, causing cross-queue jobs to remain stuck in 'queued' status and block downstream jobs.

## Key Changes

- **Worker pool job scoping**: Filter job definitions to only those matching the current worker's queue names and workload classes before queuing and scheduling. This prevents workers from queuing jobs they cannot claim.

- **DAG-aware dispatch filtering**: When computing the scheduling plan, only consider queued jobs that this worker can actually claim (`claimable_queued_keys`). The full job registry is still used for graph building to preserve cross-queue dependency knowledge, but only claimable jobs are treated as "due" for dispatch decisions.

- **Next due time synchronization**: Add `advance_next_due_at_by_interval()` calls in `loop_runner.py` after job completion (both success and failure paths) to keep `next_due_at` in sync. This prevents the PHP scheduler from treating jobs as perpetually overdue and prevents stale recurring job entries from being queued.

- **Completed job filtering fix**: Remove the `enabled = 1` filter from the `sync_schedules` query in `get_recently_completed_job_keys()`. Disabled jobs should still satisfy DAG dependencies for downstream worker-pool jobs, and the loop_runner may complete jobs regardless of their enabled status.

## Implementation Details

The scoping logic uses a dictionary comprehension to filter `WORKER_JOB_DEFINITIONS` based on:
- `queue_name` matching one of the worker's `queue_names` (defaulting to "default")
- `workload_class` matching one of the worker's `workload_classes` (defaulting to "sync")

This ensures each worker instance only manages jobs it's configured to handle, while the DAG scheduler still has full visibility of the dependency graph for accurate planning.

https://claude.ai/code/session_01ACJdFvCZLxUkAEpoU6KqTe