### PR TITLE
Fix change-aware skip resetting freshness clock and add stale queue r…

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -243,6 +243,27 @@ class SupplyCoreDb:
                  AND lock_expires_at < UTC_TIMESTAMP()"""
         )
 
+    def reap_stale_queued_jobs(self, stale_seconds: int = 3600) -> int:
+        """Mark queued jobs that have been waiting too long as failed.
+
+        This cleans up orphaned rows — e.g. jobs that were queued by a
+        worker that can't claim them (wrong queue) or jobs that were
+        permanently blocked by the DAG scheduler.  Without this, stale
+        'queued' rows prevent ``queue_due_recurring_jobs`` from ever
+        re-evaluating the job (the ``existing`` check skips it).
+        """
+        safe = max(600, stale_seconds)
+        return self.execute(
+            """UPDATE worker_jobs
+               SET status = 'failed',
+                   last_error = 'Reaped: queued for too long without being claimed',
+                   last_finished_at = UTC_TIMESTAMP()
+               WHERE status = 'queued'
+                 AND available_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %s SECOND)
+                 AND locked_by IS NULL""",
+            (safe,),
+        )
+
     def count_active_workers(self, queue_name: str | None = None) -> dict[str, int]:
         """Count distinct workers that have claimed jobs in the last 10 minutes, by queue."""
         rows = self.fetch_all(

--- a/python/orchestrator/worker_pool.py
+++ b/python/orchestrator/worker_pool.py
@@ -416,6 +416,9 @@ def main(argv: list[str] | None = None) -> int:
             reaped = db.reap_stale_running_jobs()
             if reaped > 0:
                 logger.info("reaped stale running jobs", payload={"event": "worker_pool.reaped_stale", "worker_id": worker_id, "reaped": reaped})
+            reaped_queued = db.reap_stale_queued_jobs(stale_seconds=3600)
+            if reaped_queued > 0:
+                logger.info("reaped stale queued jobs", payload={"event": "worker_pool.reaped_stale_queued", "worker_id": worker_id, "reaped": reaped_queued})
 
             # ── Scope job definitions to this worker's queues ─────────
             # Each worker instance (sync vs compute) must only queue and

--- a/src/db.php
+++ b/src/db.php
@@ -9097,12 +9097,21 @@ function db_sync_schedule_mark_success(int $scheduleId, ?array $runtime = null):
     if ($updated && $jobKey !== '') {
         $finishedAt = gmdate('Y-m-d H:i:s');
         $isSkipLike = in_array($lastResult, ['skipped', 'skipped_no_change', 'skipped_within_freshness_window'], true);
+        // Preserve last_success_at for skip-like results so the change-aware
+        // freshness ceiling (requires_forced_periodic_refresh) eventually
+        // triggers.  Previously skips reset last_success_at to now(), which
+        // prevented the forced-refresh safety net from ever firing — jobs
+        // with unchanging upstream data would be skipped indefinitely.
+        $currentStatus = db_scheduler_job_current_status_fetch_map([$jobKey])[$jobKey] ?? [];
+        $lastSuccessAtValue = $isSkipLike
+            ? ($currentStatus['last_success_at'] ?? $finishedAt)
+            : $finishedAt;
         db_scheduler_job_current_status_upsert($jobKey, [
             'latest_status' => $lastResult,
             'latest_event_type' => 'completion',
             'last_started_at' => $schedule['last_started_at'] ?? null,
             'last_finished_at' => $finishedAt,
-            'last_success_at' => $finishedAt,
+            'last_success_at' => $lastSuccessAtValue,
             'last_failure_at' => $isSkipLike ? ($runtime['last_failure_at'] ?? null) : null,
             'last_failure_message' => null,
             'current_pressure_state' => $runtime['current_pressure_state'] ?? ($schedule['current_pressure_state'] ?? 'healthy'),


### PR DESCRIPTION
…eaper

Two additional issues found while tracing market_comparison_summary_sync:

1. Change-aware jobs (market_comparison_summary_sync, deal_alerts_sync, etc.) stuck in a permanent skip loop. When the PHP scheduler detected no upstream data change, scheduler_record_change_aware_skip() called db_sync_schedule_mark_success() which set last_success_at = NOW() even for skips. This reset the freshness clock, so the requires_forced_periodic_refresh safety ceiling (e.g. 45 min) could never trigger — the job was indefinitely skipped despite having a staleness safety net configured.

   Fix: preserve the existing last_success_at for skip-like results so the freshness age keeps growing until the ceiling forces a real execution.

2. Stale worker_jobs rows from the previous cross-queue bug sit in 'queued' status forever. The existing-check in queue_due_recurring_jobs finds them and skips re-evaluation, while the DAG scheduler treats them as unsatisfied dependencies. No reaper existed for orphaned queued rows.

   Fix: add reap_stale_queued_jobs() that marks jobs queued for >1 hour without being claimed as failed, allowing re-evaluation on the next cycle.

https://claude.ai/code/session_01ACJdFvCZLxUkAEpoU6KqTe