### PR TITLE
Fix scheduler: switch to worker-pool, fix OOM, DAG blockage, change-aware skips

### DIFF
--- a/ops/systemd/supplycore-compute-worker.service
+++ b/ops/systemd/supplycore-compute-worker.service
@@ -15,7 +15,7 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=1G
+MemoryMax=2G
 StandardOutput=append:/var/www/SupplyCore/storage/logs/compute.log
 StandardError=append:/var/www/SupplyCore/storage/logs/compute.log
 

--- a/ops/systemd/supplycore-compute-worker@.service
+++ b/ops/systemd/supplycore-compute-worker@.service
@@ -15,7 +15,7 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=1G
+MemoryMax=2G
 StandardOutput=append:/var/www/SupplyCore/storage/logs/compute.log
 StandardError=append:/var/www/SupplyCore/storage/logs/compute.log
 

--- a/ops/systemd/supplycore-loop-runner.service
+++ b/ops/systemd/supplycore-loop-runner.service
@@ -19,5 +19,9 @@ MemoryMax=5G
 StandardOutput=append:/var/www/SupplyCore/storage/logs/worker.log
 StandardError=append:/var/www/SupplyCore/storage/logs/worker.log
 
+# NOTE: Disabled in favour of supplycore-sync-worker + supplycore-compute-worker.
+# The loop-runner runs all ~64 jobs in a single process with thread pools,
+# which causes OOM kills even at MemoryMax=5G.  The worker-pool model runs
+# one job at a time per process with proper memory isolation.
 [Install]
-WantedBy=multi-user.target
+# WantedBy=multi-user.target

--- a/ops/systemd/supplycore-sync-worker.service
+++ b/ops/systemd/supplycore-sync-worker.service
@@ -15,7 +15,7 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=768M
+MemoryMax=2G
 StandardOutput=append:/var/www/SupplyCore/storage/logs/worker.log
 StandardError=append:/var/www/SupplyCore/storage/logs/worker.log
 

--- a/ops/systemd/supplycore-sync-worker@.service
+++ b/ops/systemd/supplycore-sync-worker@.service
@@ -15,7 +15,7 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=768M
+MemoryMax=2G
 StandardOutput=append:/var/www/SupplyCore/storage/logs/worker.log
 StandardError=append:/var/www/SupplyCore/storage/logs/worker.log
 


### PR DESCRIPTION
## Summary

- **Switch from loop-runner to worker-pool**: The loop-runner runs all ~64 jobs in a single process with thread pools (fast + background = up to 2*N concurrent jobs). This OOM-killed every ~90 seconds regardless of MemoryMax tuning. The worker-pool model runs ONE job at a time per process — natural memory isolation, no OOM cascades.
- **Fix loop-runner OOM settings**: `--max-parallel` 6→2, `MemoryMax` 2G→5G, added 4 GiB soft memory abort (kept as fallback if loop-runner is re-enabled).
- **Raise worker-pool MemoryMax**: compute 1G→2G, sync 768M→2G (heaviest jobs declare 1024MB).
- **Fix worker-pool cross-queue DAG blockage**: Each worker queued ALL job definitions regardless of queue affinity, leaving cross-queue jobs stuck in 'queued' status and permanently blocking downstream DAG dependencies.
- **Fix loop-runner not advancing `next_due_at`**: After commit 581f1bf the loop-runner never advanced `next_due_at`, leaving all jobs perpetually "overdue" in the PHP scheduler's view.
- **Fix change-aware skip resetting freshness clock**: `db_sync_schedule_mark_success()` set `last_success_at = NOW()` even for skip-like results, preventing the `requires_forced_periodic_refresh` safety ceiling from ever firing. Jobs like `market_comparison_summary_sync` and `deal_alerts_sync` were indefinitely skipped.
- **Add stale queue reaper**: Orphaned `worker_jobs` rows stuck in 'queued' for >1hr are now cleaned up.
- **Remove `enabled=1` filter from completed-keys**: Disabled jobs in `sync_schedules` can still satisfy DAG dependencies.

## Deploy steps

```bash
systemctl stop supplycore-loop-runner.service
systemctl disable supplycore-loop-runner.service
cp /var/www/SupplyCore/ops/systemd/supplycore-*.service /etc/systemd/system/
systemctl daemon-reload
systemctl enable --now supplycore-sync-worker.service
systemctl enable --now supplycore-compute-worker.service
systemctl status supplycore-sync-worker.service supplycore-compute-worker.service
```

## Test plan

- [ ] Verify sync-worker and compute-worker stay alive (no OOM)
- [ ] Verify "Healthy Overdue" jobs start completing within a few minutes
- [ ] Verify `market_comparison_summary_sync` and `deal_alerts_sync` run within 45 minutes (freshness ceiling)
- [ ] Monitor memory: `systemctl status supplycore-sync-worker supplycore-compute-worker`

https://claude.ai/code/session_01ACJdFvCZLxUkAEpoU6KqTe