### PR TITLE
Fix SQL placeholder generation for theater deletion queries

### DIFF
--- a/python/orchestrator/jobs/theater_clustering.py
+++ b/python/orchestrator/jobs/theater_clustering.py
@@ -758,8 +758,9 @@ def _flush_theaters(
 
         # Delete existing battle/system rows for theaters we're re-inserting
         if new_theater_ids:
-            cursor.execute(f"DELETE FROM theater_systems WHERE theater_id IN ({id_placeholders})", tuple(new_theater_ids))
-            cursor.execute(f"DELETE FROM theater_battles WHERE theater_id IN ({id_placeholders})", tuple(new_theater_ids))
+            new_id_placeholders = ",".join(["%s"] * len(new_theater_ids))
+            cursor.execute(f"DELETE FROM theater_systems WHERE theater_id IN ({new_id_placeholders})", tuple(new_theater_ids))
+            cursor.execute(f"DELETE FROM theater_battles WHERE theater_id IN ({new_id_placeholders})", tuple(new_theater_ids))
 
         # Upsert theaters — preserve analysis fields (total_kills, total_isk, anomaly_score)
         for t in theaters:


### PR DESCRIPTION
## Summary
Fixed a bug in the theater clustering job where SQL DELETE queries were using an incorrect placeholder variable when deleting theater systems and battles.

## Key Changes
- Created a new `new_id_placeholders` variable that correctly generates the appropriate number of `%s` placeholders based on the length of `new_theater_ids`
- Updated both DELETE queries to use `new_id_placeholders` instead of the previously used `id_placeholders` variable
- This ensures the number of SQL placeholders matches the number of theater IDs being passed to the query

## Implementation Details
The original code was reusing `id_placeholders` which may have been defined with a different count or scope. By generating `new_id_placeholders` with `",".join(["%s"] * len(new_theater_ids))`, we guarantee the correct number of placeholders for the current batch of theater IDs being deleted, preventing potential SQL errors or incorrect query execution.

https://claude.ai/code/session_01LojuzKzQZPJPNboGp8d1tX