### PR TITLE
Battle reports: structure kills, opponent-aware splitting, auto-lock

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -578,10 +578,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         $unlockCount++;
                     }
                 }
-                // Trigger clustering + analysis jobs
+                // Trigger clustering first, then analysis — both are needed
+                // for theaters to appear in the overview (which INNER JOINs
+                // theater_alliance_summary, populated by analysis).
                 run_data_sync_now('theater_clustering');
+                run_data_sync_now('theater_analysis');
                 $saved = true;
-                $saveMessage = "Unlocked {$unlockCount} theater(s) and triggered recalculation. Theaters will auto-lock again once analysis completes.";
+                $saveMessage = "Unlocked {$unlockCount} theater(s) and queued clustering + analysis. Allow a minute for jobs to run — theaters will auto-lock again once analysis completes.";
             } elseif ($unlockTheaterId !== '') {
                 $unlockResult = theater_unlock_report($unlockTheaterId);
                 $saved = (bool) ($unlockResult['ok'] ?? false);

--- a/python/orchestrator/jobs/theater_clustering.py
+++ b/python/orchestrator/jobs/theater_clustering.py
@@ -751,10 +751,39 @@ def _flush_theaters(
             cursor.execute(f"DELETE FROM theater_systems WHERE theater_id NOT IN ({id_placeholders})", tuple(preserve_ids))
             cursor.execute(f"DELETE FROM theater_battles WHERE theater_id NOT IN ({id_placeholders})", tuple(preserve_ids))
             cursor.execute(f"DELETE FROM theaters WHERE theater_id NOT IN ({id_placeholders})", tuple(preserve_ids))
+            # Clean up orphaned analysis rows from tables populated by
+            # theater_analysis.  These tables are keyed by theater_id and
+            # would otherwise leave dangling rows when a theater is split
+            # or its battle composition changes (producing a new theater_id).
+            for tbl in (
+                "theater_alliance_summary",
+                "theater_participants",
+                "theater_timeline",
+                "theater_turning_points",
+                "theater_structure_kills",
+                "theater_side_composition",
+            ):
+                try:
+                    cursor.execute(f"DELETE FROM {tbl} WHERE theater_id NOT IN ({id_placeholders})", tuple(preserve_ids))
+                except Exception:
+                    # Table may not exist on older schemas — skip silently
+                    pass
         else:
             cursor.execute("DELETE FROM theater_systems")
             cursor.execute("DELETE FROM theater_battles")
             cursor.execute("DELETE FROM theaters")
+            for tbl in (
+                "theater_alliance_summary",
+                "theater_participants",
+                "theater_timeline",
+                "theater_turning_points",
+                "theater_structure_kills",
+                "theater_side_composition",
+            ):
+                try:
+                    cursor.execute(f"DELETE FROM {tbl}")
+                except Exception:
+                    pass
 
         # Delete existing battle/system rows for theaters we're re-inserting
         if new_theater_ids:


### PR DESCRIPTION
## Summary

Several improvements to theater battle reports:

### Structure kills now count toward coalition ISK totals
Structures (Astrahus, Raitaru, etc.) have no victim character, so they were excluded from the per-character ledger that powers coalition stats. Now:
- `isk_lost` is credited to the victim alliance's side
- `isk_killed` is credited to the **final-blow attacker's side** (tracked via new `killer_alliance_id` / `killer_corporation_id` columns on `theater_structure_kills`)
- Applied to both `view.php` and the public API (slow path + snapshot path)

### Opponent-aware theater splitting
When clustering produced a theater containing battles against distinct opponent groups (e.g. first fight vs Goons, second vs Init), they were lumped together because friendly pilots overlapped. New post-processing step:
- Loads non-friendly alliances per battle from `battle_participants`
- Union-find: battles sharing a **significant** opponent alliance (≥5 pilots) stay together
- Stragglers from a previous fight no longer bridge two otherwise-separate engagements
- Disjoint components → split into separate theaters

### Auto-lock + recalculate button
- Theaters whose last battle ended >1 hour ago are auto-locked after analysis, so re-runs skip them (saves compute)
- Both clustering and analysis skip locked theaters; clustering preserves their rows in the flush
- New **Recalculate All Theaters** button in Settings → AI Report Management unlocks everything, runs clustering + analysis, and lets auto-lock re-freeze them

### Bug fixes
- `db_theaters_list` uses `INNER JOIN theater_alliance_summary`, so when clustering produced new theater_ids (from splits), old rows were orphaned and new ones didn't exist until analysis ran. Clustering flush now cleans orphaned rows from `theater_alliance_summary`, `theater_participants`, `theater_timeline`, `theater_turning_points`, `theater_structure_kills`, and `theater_side_composition`.
- Recalculate button now triggers `theater_analysis` after `theater_clustering` (previously only clustering ran).

## Commits
- `0a0df7e` Include structure kills (Astrahus, etc.) in battle report ISK totals
- `51f30b6` Attribute structure kill ISK to final-blow attacker's side
- `f5901e8` Split theaters when constituent battles face disjoint opponent groups
- `2cb583a` Auto-lock theaters after 1 hour, add recalculate button, skip locked theaters
- `e27341b` Fix missing theaters after recalculate — clean orphans + run analysis

## Migration
- `database/migrations/20260414_theater_structure_kills_killer_columns.sql` — adds `killer_alliance_id` / `killer_corporation_id` columns to `theater_structure_kills`

## Test plan
- [ ] Run the new migration
- [ ] Click **Recalculate All Theaters** in Settings → AI Report Management
- [ ] Wait ~1 minute for clustering + analysis to complete
- [ ] Verify theaters appear in the overview
- [ ] Verify a theater with structure losses (e.g. Astrahus kills) now reflects those losses in coalition ISK Lost and the opposite side's ISK Killed
- [ ] Verify a theater previously merging two engagements against different opponents now splits into two separate theater entries
- [ ] Verify theaters auto-lock ~1 hour after their last battle

https://claude.ai/code/session_01DS2PpHNLuySBR9uLoZQEpB