### PR TITLE
Replace opponent-split with boundary-scored theater splitting

### DIFF
--- a/python/orchestrator/jobs/theater_clustering.py
+++ b/python/orchestrator/jobs/theater_clustering.py
@@ -568,12 +568,17 @@ OPPONENT_SPLIT_PRIMARY_MIN_SHARE = 0.30
 #   Primary opponent change    +2  dominant non-friendly alliance flipped
 #   Time gap                   +1  gap between battles > 5 minutes
 #
-# A boundary with score >= BOUNDARY_SPLIT_THRESHOLD (default 5) becomes a
+# A boundary with score >= BOUNDARY_SPLIT_THRESHOLD (default 6) becomes a
 # split point.  Hard floor: battles in the same system with <30 min gap
 # never split (keeps in-system grinds together).  Safety valve: same-system
 # battles with >=30 min gap CAN split (catches downtime/reform cases).
+#
+# Threshold 6 is intentionally conservative: it requires either two strong
+# signals (3+3) or a strong signal plus supporting evidence, rather than
+# firing on any two weak signals.  Lower to 5 only if real data shows
+# persistent under-splitting.
 
-BOUNDARY_SPLIT_THRESHOLD = 5
+BOUNDARY_SPLIT_THRESHOLD = 6
 
 BOUNDARY_WEIGHT_GEO_PIVOT = 3
 BOUNDARY_WEIGHT_SCALE_JUMP = 3
@@ -591,6 +596,12 @@ BOUNDARY_FRIENDLY_OVERLAP_THRESHOLD = 0.40
 
 # Command roster Jaccard below this fires the command-change signal.
 BOUNDARY_COMMAND_OVERLAP_THRESHOLD = 0.50
+
+# Minimum number of command-tagged pilots required in BOTH battles before
+# the command-change signal can fire.  With only 1 command pilot on either
+# side the Jaccard becomes a single-pilot artifact (0 or 1), which is too
+# noisy to be trustworthy — skip the signal in that case.
+BOUNDARY_COMMAND_MIN_PILOTS = 2
 
 # Time gap in seconds that fires the time-gap signal.
 BOUNDARY_TIME_GAP_SECONDS = 5 * 60
@@ -736,10 +747,12 @@ def _boundary_score(
         score += BOUNDARY_WEIGHT_SCALE_JUMP
         reasons.append("scale_jump_mega")
 
-    # Command roster change
+    # Command roster change — only trust the signal when both battles have
+    # enough command-tagged pilots that the Jaccard isn't a single-pilot
+    # statistical artifact.
     prev_cmd = command_chars.get(prev_bid, set())
     curr_cmd = command_chars.get(curr_bid, set())
-    if prev_cmd or curr_cmd:
+    if len(prev_cmd) >= BOUNDARY_COMMAND_MIN_PILOTS and len(curr_cmd) >= BOUNDARY_COMMAND_MIN_PILOTS:
         cmd_jaccard = _jaccard(prev_cmd, curr_cmd)
         if cmd_jaccard < BOUNDARY_COMMAND_OVERLAP_THRESHOLD:
             score += BOUNDARY_WEIGHT_COMMAND_CHANGE


### PR DESCRIPTION
## Summary

Replaces the primary-opponent union-find split with a multi-signal boundary scoring model. The old approach failed on the K42-IE case because Init and Goons were both present throughout the engagement — no single signal could cleanly separate them. This PR walks each theater's chronologically sorted battles and scores each gap between consecutive battles using multiple weighted signals.

## Scoring model

| Signal | Weight | Trigger |
|---|---|---|
| Geographic pivot | +3 | Different system and not directly adjacent (1 gate) |
| Scale jump to/from mega | +3 | One side ≥200 pilots and the other isn't |
| Command roster change | +3 | Jaccard of `is_command` pilots < 0.50 |
| Friendly overlap drop | +2 | Jaccard of friendly character sets < 0.40 |
| Primary opponent change | +2 | Dominant non-friendly alliance flips |
| Time gap | +1 | Gap between battles > 5 minutes |

**Split threshold:** 5

**Hard floor:** Same system with <30 min gap never splits — prevents in-system fight breakup.

**Safety valve:** Same system with ≥30 min gap *can* still split — catches downtime/reform cases.

## Why this works for the K42-IE case

Running the scorer on the 6L78-1 → K42-IE boundary from the frustrating test case:
- Geographic pivot (6L78-1 ≠ K42-IE, non-adjacent): **+3**
- Scale jump (23 pilots → 443 pilots): **+3**
- Primary opponent change (Goons → Init): **+2**
- Time gap (313s): **+1**
- **Total: 9** → split fires cleanly

The K42-IE mega → K42-IE mega transition (6-second gap, same system) hits the same-system floor and scores 0 — stays together.

The K42-IE mega → K42-IE small 35 minutes later with a different fleet scores 11 via scale jump, command change, friendly overlap drop, opponent change, and time gap — the safety valve correctly catches the reform.

## Infrastructure

No new tables or columns — the command roster signal reuses the existing `battle_participants.is_command` flag. Friendly character sets are computed from `battle_participants` filtered by the tracked alliance/corporation lists.

## Files changed

- `python/orchestrator/jobs/theater_clustering.py` — removed `_split_by_opponent_composition`, added `_load_battle_friendly_characters`, `_battle_primary_opponent`, `_jaccard`, `_boundary_score`, `_split_by_boundary_scoring`. Wired into `run_theater_clustering` at step 4c.

## Known limitations

- Weights and thresholds are first-pass values and will likely need tuning against real data. Every split logs its reasons to the theater log (`theater_clustering.boundary_split` events) so tuning can be data-driven.
- Multi-signal scoring will occasionally split things humans would keep together and vice versa. A manual merge/split UI on the theater detail page is the right long-term escape hatch.

## Test plan
- [ ] Run the new migration (none needed — reuses existing tables)
- [ ] Click **Recalculate All Theaters** in Settings
- [ ] Verify the K42-IE fight now exists as its own theater with just the 2 K42-IE megas (and any adjacent-system follow-ups)
- [ ] Verify the preceding Goons run-up (O-VWPB, LX-ZOJ, VSJ-PP, 6L78-1) is in a separate theater
- [ ] Verify single-system grinds (e.g. a long I6-SYN sequence) don't get over-split
- [ ] Check theater logs for `boundary_split` events to review which signals fired

https://claude.ai/code/session_01DS2PpHNLuySBR9uLoZQEpB