### PR TITLE
Aggregate Top Hulls by ship type, not per alliance

### DIFF
--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -387,9 +387,31 @@ if ($viewSnapshot !== null) {
         }
     }
     foreach ($sidePanels as $side => $data) {
-        usort($data['ships'], static fn(array $l, array $r): int => $r['pilots'] <=> $l['pilots']);
-        $sidePanels[$side]['ships'] = array_slice($data['ships'], 0, 12);
+        // Aggregate ships by type_id (fleet_composition is grouped per
+        // alliance/corp, so the same hull appears multiple times — one per
+        // alliance fielding it).  Collapse to a single entry per ship type.
+        $_agg = [];
+        foreach ($data['ships'] as $_sh) {
+            $_key = (int) ($_sh['type_id'] ?? 0) > 0
+                ? 't:' . (int) $_sh['type_id']
+                : 'n:' . strtolower(trim((string) ($_sh['name'] ?? '')));
+            if (!isset($_agg[$_key])) {
+                $_agg[$_key] = [
+                    'name' => (string) ($_sh['name'] ?? ''),
+                    'type_id' => (int) ($_sh['type_id'] ?? 0),
+                    'pilots' => 0,
+                ];
+            }
+            $_agg[$_key]['pilots'] += (int) ($_sh['pilots'] ?? 0);
+            if ($_agg[$_key]['name'] === '' && ($_sh['name'] ?? '') !== '') {
+                $_agg[$_key]['name'] = (string) $_sh['name'];
+            }
+        }
+        $_aggList = array_values($_agg);
+        usort($_aggList, static fn(array $l, array $r): int => $r['pilots'] <=> $l['pilots']);
+        $sidePanels[$side]['ships'] = array_slice($_aggList, 0, 12);
     }
+    unset($_agg, $_sh, $_key, $_aggList);
 
     // Resolve ship type names
     $allShipTypeIds = [];

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -313,10 +313,32 @@ if ($viewSnapshot !== null && !$pendingLock) {
     unset($_podTypeIdsFC, $extraShipCounts, $_p, $_flyId, $_pSide, $_lostJson, $_lostArr, $_nonPod, $_bestId, $_side, $_ships, $_entry);
 
     foreach ($sidePanels as $_side => $_data) {
-        usort($_data['ships'], static fn(array $l, array $r): int => $r['pilots'] <=> $l['pilots']);
-        $sidePanels[$_side]['ships'] = array_slice($_data['ships'], 0, 12);
+        // Aggregate ships by type_id (fleet_composition is grouped per
+        // alliance/corp, so the same hull appears multiple times — one per
+        // alliance fielding it).  Collapse to a single entry per ship type.
+        $_agg = [];
+        foreach ($_data['ships'] as $_sh) {
+            $_key = (int) ($_sh['type_id'] ?? 0) > 0
+                ? 't:' . (int) $_sh['type_id']
+                : 'n:' . strtolower(trim((string) ($_sh['name'] ?? '')));
+            if (!isset($_agg[$_key])) {
+                $_agg[$_key] = [
+                    'name' => (string) ($_sh['name'] ?? ''),
+                    'type_id' => (int) ($_sh['type_id'] ?? 0),
+                    'pilots' => 0,
+                ];
+            }
+            $_agg[$_key]['pilots'] += (int) ($_sh['pilots'] ?? 0);
+            // Prefer a non-empty name if any variant has it
+            if ($_agg[$_key]['name'] === '' && ($_sh['name'] ?? '') !== '') {
+                $_agg[$_key]['name'] = (string) $_sh['name'];
+            }
+        }
+        $_aggList = array_values($_agg);
+        usort($_aggList, static fn(array $l, array $r): int => $r['pilots'] <=> $l['pilots']);
+        $sidePanels[$_side]['ships'] = array_slice($_aggList, 0, 12);
     }
-    unset($_side, $_data);
+    unset($_side, $_data, $_agg, $_sh, $_key, $_aggList);
 
     $sideColorClass = [
         'friendly' => 'text-blue-300',
@@ -728,9 +750,31 @@ if ($viewSnapshot !== null && !$pendingLock) {
     }
 
     foreach ($sidePanels as $side => $data) {
-        usort($data['ships'], static fn(array $l, array $r): int => $r['pilots'] <=> $l['pilots']);
-        $sidePanels[$side]['ships'] = array_slice($data['ships'], 0, 12);
+        // Aggregate ships by type_id (fleet_composition is grouped per
+        // alliance/corp, so the same hull appears multiple times — one per
+        // alliance fielding it).  Collapse to a single entry per ship type.
+        $_agg = [];
+        foreach ($data['ships'] as $_sh) {
+            $_key = (int) ($_sh['type_id'] ?? 0) > 0
+                ? 't:' . (int) $_sh['type_id']
+                : 'n:' . strtolower(trim((string) ($_sh['name'] ?? '')));
+            if (!isset($_agg[$_key])) {
+                $_agg[$_key] = [
+                    'name' => (string) ($_sh['name'] ?? ''),
+                    'type_id' => (int) ($_sh['type_id'] ?? 0),
+                    'pilots' => 0,
+                ];
+            }
+            $_agg[$_key]['pilots'] += (int) ($_sh['pilots'] ?? 0);
+            if ($_agg[$_key]['name'] === '' && ($_sh['name'] ?? '') !== '') {
+                $_agg[$_key]['name'] = (string) $_sh['name'];
+            }
+        }
+        $_aggList = array_values($_agg);
+        usort($_aggList, static fn(array $l, array $r): int => $r['pilots'] <=> $l['pilots']);
+        $sidePanels[$side]['ships'] = array_slice($_aggList, 0, 12);
     }
+    unset($_agg, $_sh, $_key, $_aggList);
 
     // ── Resolve ship type names for participant table ──────────────────────
     $allShipTypeIds = [];


### PR DESCRIPTION
## Summary

The "Top Hulls (by appearances)" panel shows the same ship listed multiple times with different counts (e.g. `Muninn x9, Muninn x4, Muninn x4, Muninn x4…`) instead of a single aggregated entry (`Muninn x21`).

## Root cause

`db_theater_fleet_composition` in `src/db.php:17307` groups by:

```sql
GROUP BY tp.flying_ship_type_id, rit.type_name, rig.group_name,
         tp.side, COALESCE(tp.alliance_id, 0), COALESCE(tp.corporation_id, 0)
```

So a single hull type produces one row per alliance+corp fielding it. The PHP then appends every row to `sidePanels[$side]['ships'][]` without collapsing by ship type, so the UI renders three Muninn entries instead of one.

## Fix

The query can't change — the code immediately after it reclassifies sides against live standings, which needs the per-alliance grain. Instead, collapse in PHP right before the sort+slice: aggregate by `type_id` (falling back to lowercased name when `type_id` is missing), summing pilot counts.

Applied to all three code paths that build `sidePanels['ships']`:

- `public/theater-intelligence/view.php` — snapshot fast path
- `public/theater-intelligence/view.php` — live slow path
- `public/api/public/theater.php` — public API endpoint

## Test plan
- [ ] Open any battle report with multiple friendly alliances fielding the same hull type
- [ ] Verify "Top Hulls" shows one entry per ship type with the total pilot count across alliances
- [ ] Verify ordering is still by pilot count descending, truncated to top 12

https://claude.ai/code/session_01DS2PpHNLuySBR9uLoZQEpB