### PR TITLE
Add AI-powered intel generation and improve ISK formatting

### DIFF
--- a/public/opposition-intelligence/generate.php
+++ b/public/opposition-intelligence/generate.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    header('Allow: POST');
+    exit('Method Not Allowed');
+}
+
+if (!validate_csrf($_POST['_token'] ?? null)) {
+    http_response_code(419);
+    exit('Invalid CSRF token');
+}
+
+$date = trim((string) ($_POST['date'] ?? ''));
+if ($date === '' || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
+    $date = gmdate('Y-m-d');
+}
+
+// Generation can take several minutes on a local GPU/CPU — remove PHP timeout
+// and make sure the HTTP stack won't cut us off either.
+@set_time_limit(0);
+@ini_set('max_execution_time', '0');
+ignore_user_abort(false);
+
+// Force the AI pipeline to use local Ollama with the gemma4:e2b model at the
+// default local URL, regardless of whatever provider is configured in settings.
+$GLOBALS['supplycore_ai_ollama_runtime_override'] = [
+    'enabled' => true,
+    'provider' => 'local',
+    'url' => 'http://localhost:11434/api',
+    'model' => 'gemma4:e2b',
+    // Allow up to ~15 minutes for a single model call (gemma on local hardware
+    // can be slow, especially on first load).
+    'timeout' => 900,
+    'capability_override' => 'auto',
+    'runpod_url' => '',
+    'runpod_api_key' => '',
+    'runpod_api_key_masked' => '',
+    'claude_api_key' => '',
+    'claude_api_key_masked' => '',
+    'claude_model' => '',
+    'groq_api_key' => '',
+    'groq_api_key_masked' => '',
+    'groq_model' => '',
+    'inferred_tier' => 'small',
+    'capability_tier' => 'small',
+    'strategy' => supplycore_ai_capability_strategy('small'),
+];
+
+$error = null;
+$generated = 0;
+try {
+    $generated = opposition_ai_generate_daily_briefings($date);
+} catch (Throwable $e) {
+    error_log('[opposition-intel-generate] ' . $e->getMessage());
+    $error = $e->getMessage();
+}
+
+$status = $error !== null ? 'error' : 'ok';
+$flash = [
+    'status' => $status,
+    'generated' => $generated,
+    'error' => $error,
+    'date' => $date,
+];
+if (session_status() === PHP_SESSION_NONE) {
+    @session_start();
+}
+$_SESSION['opposition_intel_flash'] = $flash;
+
+header('Location: /opposition-intelligence/?date=' . urlencode($date));
+exit;

--- a/public/opposition-intelligence/index.php
+++ b/public/opposition-intelligence/index.php
@@ -48,6 +48,38 @@ $totalLosses = array_sum(array_column($snapshots, 'losses'));
 $totalIskDestroyed = array_sum(array_column($snapshots, 'isk_destroyed'));
 $activeAlliances = count(array_filter($snapshots, static fn ($s): bool => ((int) $s['kills'] > 0 || (int) $s['losses'] > 0)));
 
+// Human-readable ISK formatter: M (millions), B (billions), T (trillions).
+$formatIsk = static function (float $value): string {
+    if ($value <= 0) return '0';
+    if ($value >= 1_000_000_000_000) return number_format($value / 1_000_000_000_000, 2) . 'T';
+    if ($value >= 1_000_000_000) return number_format($value / 1_000_000_000, 2) . 'B';
+    if ($value >= 1_000_000) return number_format($value / 1_000_000, 1) . 'M';
+    if ($value >= 1_000) return number_format($value / 1_000, 1) . 'K';
+    return number_format($value, 0);
+};
+
+// Resolve solar system names in bulk so the table shows "Jita" instead of "System #30000142".
+$systemIdsToResolve = [];
+foreach ($snapshots as $s) {
+    $systems = $s['active_systems_json'] ?? [];
+    if (is_string($systems)) $systems = json_decode($systems, true) ?: [];
+    foreach ($systems as $sys) {
+        if (isset($sys['system_id'])) {
+            $systemIdsToResolve[(int) $sys['system_id']] = true;
+        }
+    }
+}
+$systemNameMap = [];
+if ($systemIdsToResolve !== []) {
+    try {
+        foreach (db_ref_systems_by_ids(array_keys($systemIdsToResolve)) as $row) {
+            $systemNameMap[(int) $row['system_id']] = (string) $row['system_name'];
+        }
+    } catch (Throwable $e) {
+        // Non-fatal: fall back to whatever name is in the snapshot JSON.
+    }
+}
+
 include __DIR__ . '/../../src/views/partials/header.php';
 ?>
 
@@ -67,9 +99,46 @@ include __DIR__ . '/../../src/views/partials/header.php';
             <?php endif; ?>
             <a href="/alliance-dossiers" class="btn-secondary">Alliance Dossiers</a>
             <a href="/theater-intelligence" class="btn-secondary">Theater Intel</a>
+            <form method="post" action="/opposition-intelligence/generate.php" class="inline"
+                  onsubmit="this.querySelector('button').disabled=true;this.querySelector('button').innerText='Generating…';">
+                <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
+                <input type="hidden" name="date" value="<?= htmlspecialchars($date, ENT_QUOTES) ?>">
+                <button type="submit" class="btn-primary"
+                        title="Generate a SITREP for this date using local Ollama (gemma4:e2b). May take several minutes.">
+                    Generate Intel (local gemma4:e2b)
+                </button>
+            </form>
         </div>
     </div>
 </section>
+
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    @session_start();
+}
+$flash = $_SESSION['opposition_intel_flash'] ?? null;
+if ($flash !== null) {
+    unset($_SESSION['opposition_intel_flash']);
+}
+?>
+<?php if ($flash): ?>
+    <?php if (($flash['status'] ?? '') === 'ok'): ?>
+        <section class="surface-primary mt-4 border border-emerald-500/30 bg-emerald-500/10">
+            <p class="text-sm text-emerald-200">
+                <strong>Intel generation complete.</strong>
+                Generated <?= (int) ($flash['generated'] ?? 0) ?> briefing(s) for <?= htmlspecialchars((string) ($flash['date'] ?? ''), ENT_QUOTES) ?>
+                using local Ollama (gemma4:e2b).
+            </p>
+        </section>
+    <?php else: ?>
+        <section class="surface-primary mt-4 border border-red-500/30 bg-red-500/10">
+            <p class="text-sm text-red-200">
+                <strong>Intel generation failed.</strong>
+                <?= htmlspecialchars((string) ($flash['error'] ?? 'Unknown error'), ENT_QUOTES) ?>
+            </p>
+        </section>
+    <?php endif; ?>
+<?php endif; ?>
 
 <?php if ($tablesReadyError !== null): ?>
 <section class="surface-primary mt-4 border border-amber-500/30 bg-amber-500/10">
@@ -112,7 +181,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
     </div>
     <div class="surface-primary text-center">
         <p class="text-xs uppercase tracking-wider text-muted">ISK Destroyed</p>
-        <p class="mt-1 text-2xl font-bold text-amber-300"><?= number_format($totalIskDestroyed / 1_000_000, 0) ?>M</p>
+        <p class="mt-1 text-2xl font-bold text-amber-300"><?= htmlspecialchars($formatIsk((float) $totalIskDestroyed)) ?></p>
     </div>
 </section>
 
@@ -195,7 +264,11 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         $aid = (int) $s['alliance_id'];
                         $systems = $s['active_systems_json'] ?? [];
                         if (is_string($systems)) $systems = json_decode($systems, true) ?: [];
-                        $topSystems = array_slice(array_column($systems, 'system_name'), 0, 3);
+                        $topSystems = [];
+                        foreach (array_slice($systems, 0, 3) as $sys) {
+                            $sid = isset($sys['system_id']) ? (int) $sys['system_id'] : 0;
+                            $topSystems[] = $systemNameMap[$sid] ?? (string) ($sys['system_name'] ?? ('System #' . $sid));
+                        }
 
                         // Find alliance briefing if any
                         $allianceBriefing = null;
@@ -228,8 +301,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             </td>
                             <td class="px-3 py-2 text-sm text-right font-mono text-red-300"><?= number_format($kills) ?></td>
                             <td class="px-3 py-2 text-sm text-right font-mono text-emerald-300"><?= number_format($losses) ?></td>
-                            <td class="px-3 py-2 text-sm text-right font-mono"><?= number_format((float) $s['isk_destroyed'] / 1_000_000, 0) ?>M</td>
-                            <td class="px-3 py-2 text-sm text-right font-mono"><?= number_format((float) $s['isk_lost'] / 1_000_000, 0) ?>M</td>
+                            <td class="px-3 py-2 text-sm text-right font-mono"><?= htmlspecialchars($formatIsk((float) $s['isk_destroyed'])) ?></td>
+                            <td class="px-3 py-2 text-sm text-right font-mono"><?= htmlspecialchars($formatIsk((float) $s['isk_lost'])) ?></td>
                             <td class="px-3 py-2 text-sm text-right font-mono"><?= (int) $s['active_pilots'] ?></td>
                             <td class="px-3 py-2 text-xs text-muted"><?= htmlspecialchars(implode(', ', $topSystems)) ?></td>
                             <td class="px-3 py-2 text-xs">

--- a/python/orchestrator/jobs/compute_opposition_daily_snapshots.py
+++ b/python/orchestrator/jobs/compute_opposition_daily_snapshots.py
@@ -129,10 +129,11 @@ def _load_daily_geography_bulk(db: SupplyCoreDb, alliance_ids: list[int], target
     system_rows = db.fetch_all(
         f"""
         SELECT ka.alliance_id, ke.solar_system_id AS system_id,
-               COALESCE(emc.entity_name, CONCAT('System #', ke.solar_system_id)) AS system_name,
+               COALESCE(NULLIF(rs.system_name, ''), emc.entity_name, CONCAT('System #', ke.solar_system_id)) AS system_name,
                COUNT(DISTINCT ka.sequence_id) AS killmail_count
         FROM killmail_attackers ka
         INNER JOIN killmail_events ke ON ke.sequence_id = ka.sequence_id
+        LEFT JOIN ref_systems rs ON rs.system_id = ke.solar_system_id
         LEFT JOIN entity_metadata_cache emc
              ON emc.entity_type = 'solar_system' AND emc.entity_id = ke.solar_system_id
         WHERE ka.alliance_id IN ({placeholders})

--- a/src/functions.php
+++ b/src/functions.php
@@ -25968,6 +25968,14 @@ function supplycore_ai_ollama_config(): array
 {
     static $config = null;
 
+    // Runtime override (e.g. "Generate Intel" button forcing local Ollama + model).
+    // Set $GLOBALS['supplycore_ai_ollama_runtime_override'] to an assoc array before
+    // calling into the AI pipeline to force specific config values for this request.
+    $override = $GLOBALS['supplycore_ai_ollama_runtime_override'] ?? null;
+    if (is_array($override) && $override !== []) {
+        return $override;
+    }
+
     if (is_array($config)) {
         return $config;
     }


### PR DESCRIPTION
## Summary
This PR adds the ability to generate AI-powered intelligence briefings for opposition alliances using local Ollama, improves ISK value formatting across the opposition intelligence dashboard, and enhances solar system name resolution.

## Key Changes

- **AI Intel Generation**: Added a new "Generate Intel (local gemma4:e2b)" button that triggers AI-powered briefing generation for a selected date using local Ollama with the gemma4:e2b model
  - New endpoint: `public/opposition-intelligence/generate.php` handles POST requests with CSRF protection
  - Removes PHP execution timeout to allow long-running AI model inference (up to 15 minutes)
  - Displays success/error flash messages after generation completes

- **ISK Formatting**: Implemented a human-readable ISK formatter that displays values in K/M/B/T notation
  - Replaces hardcoded million-based formatting with dynamic `$formatIsk()` function
  - Applies to dashboard summary stats and alliance activity table
  - Handles edge cases (zero values, very large numbers)

- **Solar System Name Resolution**: Enhanced system name display in the activity table
  - Bulk-resolves system IDs to names from `ref_systems` table at page load
  - Falls back to cached entity metadata or system ID if resolution fails
  - Prevents "System #30000142" from appearing in the UI when proper names are available

- **AI Pipeline Override**: Added runtime configuration override mechanism in `supplycore_ai_ollama_config()` to allow forcing specific AI provider settings per-request

- **Database Query Improvement**: Updated `compute_opposition_daily_snapshots.py` to prefer `ref_systems.system_name` over entity metadata cache for more reliable system naming

## Implementation Details

- CSRF token validation on generation endpoint
- Non-fatal error handling for system name resolution (graceful fallback)
- Session-based flash messaging for user feedback
- Proper HTML escaping for all user-facing output

https://claude.ai/code/session_013Lh1AUWLoVNR54uwcUeFWN