### PR TITLE
Fix auto-doctrine migrations: settings table is app_settings

### DIFF
--- a/database/migrations/20260415_create_auto_doctrines.sql
+++ b/database/migrations/20260415_create_auto_doctrines.sql
@@ -101,7 +101,7 @@ CREATE TABLE IF NOT EXISTS auto_buyall_items (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ── Settings defaults (tunable at runtime) ──────────────────────────────
-INSERT INTO settings (setting_key, setting_value) VALUES
+INSERT INTO app_settings (setting_key, setting_value) VALUES
     ('auto_doctrines.window_days',           '30'),
     ('auto_doctrines.min_losses_threshold',  '5'),
     ('auto_doctrines.default_runway_days',   '14'),

--- a/database/migrations/20260415_drop_legacy_doctrines_buyall.sql
+++ b/database/migrations/20260415_drop_legacy_doctrines_buyall.sql
@@ -48,6 +48,6 @@ DELETE FROM sync_schedules WHERE job_key IN (
 );
 
 -- ── Retire obsolete settings keys ───────────────────────────────────────
-DELETE FROM settings WHERE setting_key IN (
+DELETE FROM app_settings WHERE setting_key IN (
     'doctrine.default_group'
 );

--- a/python/orchestrator/jobs/compute_auto_buyall.py
+++ b/python/orchestrator/jobs/compute_auto_buyall.py
@@ -35,7 +35,7 @@ _PRUNE_SUMMARIES_OLDER_THAN_DAYS = 7
 
 def _load_settings(db: Any) -> dict[str, int]:
     rows = db.fetch_all(
-        """SELECT setting_key, setting_value FROM settings
+        """SELECT setting_key, setting_value FROM app_settings
             WHERE setting_key IN (
                 'auto_doctrines.default_runway_days',
                 'auto_doctrines.window_days'

--- a/python/orchestrator/jobs/compute_auto_doctrines.py
+++ b/python/orchestrator/jobs/compute_auto_doctrines.py
@@ -45,7 +45,7 @@ _CORE_FREQUENCY_THRESHOLD = 0.80
 
 def _load_settings(db: Any) -> dict[str, Any]:
     rows = db.fetch_all(
-        """SELECT setting_key, setting_value FROM settings
+        """SELECT setting_key, setting_value FROM app_settings
             WHERE setting_key IN (
                 'auto_doctrines.window_days',
                 'auto_doctrines.min_losses_threshold',

--- a/src/auto_doctrines.php
+++ b/src/auto_doctrines.php
@@ -197,7 +197,7 @@ function auto_doctrine_settings(): array
     }
     $pdo = db();
     $stmt = $pdo->query(
-        "SELECT setting_key, setting_value FROM settings
+        "SELECT setting_key, setting_value FROM app_settings
           WHERE setting_key IN (
               'auto_doctrines.window_days',
               'auto_doctrines.min_losses_threshold',


### PR DESCRIPTION
## Summary

Migrations `20260415_create_auto_doctrines.sql` and `20260415_drop_legacy_doctrines_buyall.sql` were failing with:

```
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'supplycore.settings' doesn't exist
```

Root cause: both migrations — and the three runtime readers for the new `auto_doctrines.*` config keys — referenced a `settings` table. The correct table name in SupplyCore is `app_settings` (defined in `database/schema.sql:245`).

## Fixes

- `database/migrations/20260415_create_auto_doctrines.sql` — `INSERT INTO settings ...` → `INSERT INTO app_settings ...`
- `database/migrations/20260415_drop_legacy_doctrines_buyall.sql` — `DELETE FROM settings ...` → `DELETE FROM app_settings ...`
- `src/auto_doctrines.php::auto_doctrine_settings()` — `SELECT ... FROM settings` → `FROM app_settings`
- `python/orchestrator/jobs/compute_auto_doctrines.py::_load_settings` — same
- `python/orchestrator/jobs/compute_auto_buyall.py::_load_settings` — same

All five files now read/write from `app_settings` consistently.

## Test plan

- [ ] `php bin/run_migrations.php` runs `20260415_*` migrations cleanly
- [ ] `bin/python_compute_auto_doctrines.py` loads the four `auto_doctrines.*` defaults without error
- [ ] `/doctrines/` page renders settings-derived threshold labels correctly

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw