### PR TITLE
Restore doctrine_format_quantity shim and fix allowedPageSizes closure

### DIFF
--- a/src/auto_doctrines.php
+++ b/src/auto_doctrines.php
@@ -187,6 +187,17 @@ function db_auto_doctrine_fit_demand_latest(): array
     return $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
 }
 
+// ─── Legacy formatter shim ─────────────────────────────────────────────────
+// ``doctrine_format_quantity`` is still called from several view templates
+// (dashboard, activity-priority). It is a pure formatter with no table
+// dependency, so we keep it alive here to avoid view-level fatals.
+if (!function_exists('doctrine_format_quantity')) {
+    function doctrine_format_quantity(int $value): string
+    {
+        return number_format(max(0, $value));
+    }
+}
+
 // ─── Settings helpers ──────────────────────────────────────────────────────
 
 function auto_doctrine_settings(): array

--- a/src/functions.php
+++ b/src/functions.php
@@ -9618,7 +9618,7 @@ function current_alliance_market_status_data(): array
     $page = max(1, (int) ($_GET['page'] ?? 1));
     $cacheParts = ['current-alliance', $sort, $pageSize, $page, $search];
     $useCache = $search === '' && $page === 1 && $pageSize === 25 && $sort === 'urgency';
-    $resolver = static function () use ($search, $sort, $pageSize, $page): array {
+    $resolver = static function () use ($search, $sort, $pageSize, $page, $allowedPageSizes): array {
         $outcomes = market_comparison_outcomes();
         $thresholds = $outcomes['thresholds'] ?? [];
         $lowStockThreshold = max(1, (int) ($thresholds['min_alliance_sell_volume'] ?? 25));


### PR DESCRIPTION
## Summary

Two regressions from the legacy doctrine purge (#743) surfaced in production logs:

### 1. `FATAL` in `public/index.php:331`

```
PHP Fatal error: Uncaught Error: Call to undefined function doctrine_format_quantity()
```

The mass-delete script in #743 swept `doctrine_format_quantity()` along with the rest of the `doctrine_*` helpers, but it's still referenced from ~20 view templates (`public/index.php`, `public/activity-priority/index.php`, internal functions.php reason-builders) and is a pure formatter with no table dependency:

```php
function doctrine_format_quantity(int $value): string
{
    return number_format(max(0, $value));
}
```

**Fix:** re-add it in `src/auto_doctrines.php` behind `function_exists()` so the dashboard renders again. This is a shim — no new table dependency, no new behavior.

### 2. `WARNING` in `src/functions.php:9707`

```
PHP Warning: Undefined variable $allowedPageSizes in current_alliance_market_status_data()
```

`current_alliance_market_status_data()` declares `$allowedPageSizes = [25, 50, 100]` in the outer scope (line 9612), but the inner resolver closure at line 9621 doesn't import it via `use()`. The view template reads `$data['pagination']['page_size_options']` and gets `null` → warning.

**Fix:** add `$allowedPageSizes` to the closure's `use()` list. This is a pre-existing scoping bug (not introduced by #743) that only started surfacing now that the dashboard is actively rendering this section again.

## Not in scope

A third warning in the original log dump (`public/log-viewer/index.php:30` headers-already-sent) is unrelated to this cleanup chain and predates the auto-doctrines redesign — the `api/ui-refresh-fragment.php` endpoint appears to include a page script that emits output before its own headers are set. Left for a separate fix.

## Test plan

- [ ] Load `/` — dashboard renders, no `doctrine_format_quantity` fatal
- [ ] Load `/market-status/current-alliance` — no `Undefined variable $allowedPageSizes` warning, page-size dropdown populates
- [ ] Load `/activity-priority/` — quantity labels render using the shim

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw