### PR TITLE
Retire straggler legacy jobs and rewire activity-priority to auto_doctrines

### DIFF
--- a/database/migrations/20260416_retire_straggler_legacy_jobs.sql
+++ b/database/migrations/20260416_retire_straggler_legacy_jobs.sql
@@ -1,0 +1,48 @@
+-- Stragglers from the auto-doctrine migration.
+--
+-- The original drop migration (20260415_drop_legacy_doctrines_buyall.sql)
+-- retired compute_buy_all, doctrine_intelligence_sync, loss_demand_summary_sync,
+-- and rebuild_ai_briefings. Production logs show these job keys are still
+-- present in sync_schedules and firing — either the schema bootstrap
+-- re-seeded them or the DELETE ran before the last ON DUPLICATE KEY
+-- bootstrap reinserted them.
+--
+-- This migration re-applies the cleanup and also scrubs the legacy
+-- doctrine rollup tables if any survived on upgraded servers. It is
+-- idempotent (DROP TABLE IF EXISTS, DELETE WHERE key IN).
+
+-- ── Retire scheduler slots for retired jobs ─────────────────────────────
+DELETE FROM sync_schedules WHERE job_key IN (
+    'doctrine_intelligence_sync',
+    'loss_demand_summary_sync',
+    'rebuild_ai_briefings',
+    'compute_buy_all'
+);
+
+-- ── Drop legacy doctrine rollup + precompute tables (idempotent) ────────
+DROP TABLE IF EXISTS doctrine_fit_stock_pressure_1d;
+DROP TABLE IF EXISTS doctrine_group_activity_1d;
+DROP TABLE IF EXISTS doctrine_fit_activity_1d;
+DROP TABLE IF EXISTS doctrine_item_stock_1d;
+DROP TABLE IF EXISTS killmail_doctrine_activity_1d;
+DROP TABLE IF EXISTS doctrine_activity_snapshots;
+DROP TABLE IF EXISTS doctrine_fit_snapshots;
+DROP TABLE IF EXISTS doctrine_ai_briefings;
+DROP TABLE IF EXISTS doctrine_readiness;
+DROP TABLE IF EXISTS doctrine_dependency_depth;
+
+-- ── Drop legacy doctrine core (items → fit_groups → fits → groups) ─────
+DROP TABLE IF EXISTS doctrine_fit_items;
+DROP TABLE IF EXISTS doctrine_fit_groups;
+DROP TABLE IF EXISTS doctrine_fits;
+DROP TABLE IF EXISTS doctrine_groups;
+
+-- ── Drop legacy buy_all precompute (idempotent) ─────────────────────────
+DROP TABLE IF EXISTS buy_all_items;
+DROP TABLE IF EXISTS buy_all_summary;
+DROP TABLE IF EXISTS buy_all_precomputed_payloads;
+
+-- ── Scrub retired settings keys ─────────────────────────────────────────
+DELETE FROM app_settings WHERE setting_key IN (
+    'doctrine.default_group'
+);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -3062,13 +3062,8 @@ INSERT INTO app_settings (setting_key, setting_value) VALUES
     ('ollama_url', 'http://localhost:11434/api'),
     ('ollama_model', 'qwen2.5:1.5b-instruct'),
     ('ollama_timeout', '20'),
-    ('ollama_capability_tier', 'auto'),
-    ('doctrine.default_group', 'SupplyCore Doctrine')
+    ('ollama_capability_tier', 'auto')
 ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value);
-
-INSERT INTO doctrine_groups (group_name, description) VALUES
-    ('SupplyCore Doctrine', 'Baseline doctrine fits used for gap detection, restock generation, and hauling prep.')
-ON DUPLICATE KEY UPDATE description = VALUES(description);
 
 INSERT INTO sync_schedules (
     job_key,
@@ -3096,11 +3091,8 @@ INSERT INTO sync_schedules (
     ('alliance_current_sync', 0, 4, 240, 120, 2, 'medium', 'single', 'python', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
     ('current_state_refresh_sync', 0, 12, 720, 360, 6, 'medium', 'single', 'python', 120, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
     ('market_hub_local_history_sync', 0, 20, 1200, 840, 14, 'normal', 'background', 'python', 1800, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('doctrine_intelligence_sync', 0, 15, 900, 480, 8, 'normal', 'single', 'python', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
     ('market_comparison_summary_sync', 0, 15, 900, 540, 9, 'normal', 'single', 'python', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('loss_demand_summary_sync', 0, 15, 900, 600, 10, 'normal', 'single', 'python', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
     ('dashboard_summary_sync', 0, 15, 900, 660, 11, 'normal', 'single', 'python', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
-    ('rebuild_ai_briefings', 0, 20, 1200, 720, 12, 'normal', 'background', 'python', 300, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
     ('killmail_r2z2_sync', 0, 1, 180, 300, 3, 'highest', 'single', 'python', 180, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
     ('alliance_historical_sync', 0, 360, 21600, 300, 5, 'normal', 'background', 'python', 3600, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),
     ('market_hub_historical_sync', 0, 360, 21600, 0, 0, 'normal', 'background', 'python', 3600, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'waiting', 'automatic', 1, 1, NULL, NULL, NULL, NULL),

--- a/public/activity-priority/index.php
+++ b/public/activity-priority/index.php
@@ -53,7 +53,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             <div class="flex flex-wrap items-center gap-2">
                                 <?php $doctrineGroupId = (int) ($row['entity_id'] ?? 0); ?>
                                 <?php if ($doctrineGroupId > 0): ?>
-                                    <a href="/doctrine/group?group_id=<?= $doctrineGroupId ?>" class="truncate text-lg font-semibold text-cyan-100 transition hover:text-cyan-50 hover:underline">
+                                    <a href="/doctrines/#doctrine-<?= $doctrineGroupId ?>" class="truncate text-lg font-semibold text-cyan-100 transition hover:text-cyan-50 hover:underline">
                                         <?= htmlspecialchars((string) ($row['doctrine_name'] ?? ''), ENT_QUOTES) ?>
                                     </a>
                                 <?php else: ?>
@@ -142,7 +142,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
             </div>
             <div class="mt-4 space-y-3">
                 <?php foreach ($activeFits as $fit): ?>
-                    <a href="/doctrine/fit?fit_id=<?= (int) ($fit['entity_id'] ?? 0) ?>" class="intelligence-row group">
+                    <a href="/doctrines/#doctrine-<?= (int) ($fit['entity_id'] ?? 0) ?>" class="intelligence-row group">
                         <div class="min-w-0 flex-1">
                             <p class="truncate text-sm font-semibold text-slate-100"><?= htmlspecialchars((string) ($fit['doctrine_name'] ?? ''), ENT_QUOTES) ?></p>
                             <p class="mt-1 text-xs text-slate-500"><?= htmlspecialchars((string) ($fit['readiness_label'] ?? 'Market ready'), ENT_QUOTES) ?> · <?= htmlspecialchars((string) ($fit['resupply_pressure'] ?? 'Stable'), ENT_QUOTES) ?></p>

--- a/python/orchestrator/influx_export.py
+++ b/python/orchestrator/influx_export.py
@@ -108,84 +108,6 @@ def _killmail_hull_fields(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _killmail_doctrine_tags(row: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "window": row.get("_window"),
-        "doctrine_fit_id": row.get("doctrine_fit_id") or 0,
-        "doctrine_group_id": row.get("doctrine_group_id") or 0,
-        "hull_type_id": row.get("hull_type_id") or 0,
-    }
-
-
-def _killmail_doctrine_fields(row: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "loss_count": row.get("loss_count"),
-        "quantity_lost": row.get("quantity_lost"),
-        "victim_count": row.get("victim_count"),
-        "killmail_count": row.get("killmail_count"),
-    }
-
-
-def _doctrine_fit_activity_tags(row: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "window": row.get("_window"),
-        "fit_id": row.get("fit_id"),
-        "doctrine_group_id": row.get("doctrine_group_id") or 0,
-        "hull_type_id": row.get("hull_type_id") or 0,
-    }
-
-
-def _doctrine_fit_activity_fields(row: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "hull_loss_count": row.get("hull_loss_count"),
-        "doctrine_item_loss_count": row.get("doctrine_item_loss_count"),
-        "complete_fits_available": row.get("complete_fits_available"),
-        "target_fits": row.get("target_fits"),
-        "fit_gap": row.get("fit_gap"),
-        "priority_score": row.get("priority_score"),
-        "readiness_state": row.get("readiness_state"),
-        "resupply_pressure": row.get("resupply_pressure"),
-    }
-
-
-def _doctrine_group_activity_tags(row: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "window": row.get("_window"),
-        "group_id": row.get("group_id"),
-    }
-
-
-def _doctrine_group_activity_fields(row: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "hull_loss_count": row.get("hull_loss_count"),
-        "doctrine_item_loss_count": row.get("doctrine_item_loss_count"),
-        "complete_fits_available": row.get("complete_fits_available"),
-        "target_fits": row.get("target_fits"),
-        "fit_gap": row.get("fit_gap"),
-        "priority_score": row.get("priority_score"),
-        "readiness_state": row.get("readiness_state"),
-        "resupply_pressure": row.get("resupply_pressure"),
-    }
-
-
-def _doctrine_stock_pressure_tags(row: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "window": row.get("_window"),
-        "fit_id": row.get("fit_id"),
-        "doctrine_group_id": row.get("doctrine_group_id") or 0,
-        "bottleneck_type_id": row.get("bottleneck_type_id") or 0,
-    }
-
-
-def _doctrine_stock_pressure_fields(row: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "complete_fits_available": row.get("complete_fits_available"),
-        "target_fits": row.get("target_fits"),
-        "fit_gap": row.get("fit_gap"),
-        "bottleneck_quantity": row.get("bottleneck_quantity"),
-        "readiness_state": row.get("readiness_state"),
-        "resupply_pressure": row.get("resupply_pressure"),
-    }
 
 
 DATASETS: tuple[RollupDataset, ...] = (
@@ -196,10 +118,9 @@ DATASETS: tuple[RollupDataset, ...] = (
     RollupDataset("killmail_item_loss_1h", "killmail_item_loss_1h", "killmail_item_loss", "bucket_start", ("updated_at", "bucket_start", "type_id", "doctrine_fit_key", "doctrine_group_key", "hull_type_key"), _killmail_item_tags, _killmail_item_fields),
     RollupDataset("killmail_item_loss_1d", "killmail_item_loss_1d", "killmail_item_loss", "bucket_start", ("updated_at", "bucket_start", "type_id", "doctrine_fit_key", "doctrine_group_key", "hull_type_key"), _killmail_item_tags, _killmail_item_fields),
     RollupDataset("killmail_hull_loss_1d", "killmail_hull_loss_1d", "killmail_hull_loss", "bucket_start", ("updated_at", "bucket_start", "hull_type_id", "doctrine_fit_key", "doctrine_group_key"), _killmail_hull_tags, _killmail_hull_fields),
-    RollupDataset("killmail_doctrine_activity_1d", "killmail_doctrine_activity_1d", "killmail_doctrine_activity", "bucket_start", ("updated_at", "bucket_start", "doctrine_fit_key", "doctrine_group_key", "hull_type_key"), _killmail_doctrine_tags, _killmail_doctrine_fields),
-    RollupDataset("doctrine_fit_activity_1d", "doctrine_fit_activity_1d", "doctrine_fit_activity", "bucket_start", ("updated_at", "bucket_start", "fit_id"), _doctrine_fit_activity_tags, _doctrine_fit_activity_fields),
-    RollupDataset("doctrine_group_activity_1d", "doctrine_group_activity_1d", "doctrine_group_activity", "bucket_start", ("updated_at", "bucket_start", "group_id"), _doctrine_group_activity_tags, _doctrine_group_activity_fields),
-    RollupDataset("doctrine_fit_stock_pressure_1d", "doctrine_fit_stock_pressure_1d", "doctrine_fit_stock_pressure", "bucket_start", ("updated_at", "bucket_start", "fit_id"), _doctrine_stock_pressure_tags, _doctrine_stock_pressure_fields),
+    # killmail_doctrine_activity_1d, doctrine_fit_activity_1d,
+    # doctrine_group_activity_1d, and doctrine_fit_stock_pressure_1d have
+    # been retired along with the hand-maintained doctrine pipeline.
 )
 DATASET_MAP = {dataset.key: dataset for dataset in DATASETS}
 

--- a/python/orchestrator/influx_inspect.py
+++ b/python/orchestrator/influx_inspect.py
@@ -90,10 +90,6 @@ def _normalize_dataset_filters(filters: list[str], available_measurements: list[
         "killmail_item_loss_1h": "killmail_item_loss",
         "killmail_item_loss_1d": "killmail_item_loss",
         "killmail_hull_loss_1d": "killmail_hull_loss",
-        "killmail_doctrine_activity_1d": "killmail_doctrine_activity",
-        "doctrine_fit_activity_1d": "doctrine_fit_activity",
-        "doctrine_group_activity_1d": "doctrine_group_activity",
-        "doctrine_fit_stock_pressure_1d": "doctrine_fit_stock_pressure",
     }
     normalized: list[str] = []
     seen: set[str] = set()

--- a/python/orchestrator/jobs/activity_priority_summary_sync.py
+++ b/python/orchestrator/jobs/activity_priority_summary_sync.py
@@ -6,89 +6,36 @@ from .sync_runtime import run_sync_phase_job
 
 
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
-    rows_processed = db.fetch_scalar("SELECT COUNT(*) FROM doctrine_fit_activity_1d WHERE bucket_start = CURDATE()")
-    rows_written = db.execute(
-        """INSERT INTO doctrine_activity_snapshots (
-                entity_type, entity_id, entity_name, snapshot_time, rank_position, activity_score, activity_level,
-                hull_losses_24h, hull_losses_3d, hull_losses_7d, module_losses_24h, module_losses_3d, module_losses_7d,
-                fit_equivalent_losses_24h, fit_equivalent_losses_3d, fit_equivalent_losses_7d,
-                readiness_state, resupply_pressure_state, resupply_pressure, readiness_gap_count, explanation_text
-            )
-            SELECT
-                'fit' AS entity_type,
-                fa.fit_id AS entity_id,
-                COALESCE(f.fit_name, CONCAT('fit-', fa.fit_id)) AS entity_name,
-                UTC_TIMESTAMP() AS snapshot_time,
-                ROW_NUMBER() OVER (ORDER BY fa.priority_score DESC, fa.fit_gap DESC, fa.fit_id ASC) AS rank_position,
-                fa.priority_score AS activity_score,
-                CASE WHEN fa.priority_score >= 100 THEN 'critical' WHEN fa.priority_score >= 25 THEN 'elevated' ELSE 'low' END AS activity_level,
-                fa.hull_loss_count,
-                fa.hull_loss_count,
-                fa.hull_loss_count,
-                LEAST(999999.99, fa.doctrine_item_loss_count) AS module_losses_24h,
-                LEAST(999999.99, fa.doctrine_item_loss_count) AS module_losses_3d,
-                LEAST(999999.99, fa.doctrine_item_loss_count) AS module_losses_7d,
-                LEAST(999999.99, fa.doctrine_item_loss_count) AS fit_equivalent_losses_24h,
-                LEAST(999999.99, fa.doctrine_item_loss_count) AS fit_equivalent_losses_3d,
-                LEAST(999999.99, fa.doctrine_item_loss_count) AS fit_equivalent_losses_7d,
-                fa.readiness_state,
-                fa.resupply_pressure,
-                fa.resupply_pressure,
-                fa.fit_gap,
-                CONCAT('fit_gap=', fa.fit_gap, ', complete_fits_available=', fa.complete_fits_available)
-            FROM doctrine_fit_activity_1d fa
-            LEFT JOIN doctrine_fits f ON f.id = fa.fit_id
-            WHERE fa.bucket_start = CURDATE()
-            ON DUPLICATE KEY UPDATE
-                rank_position = VALUES(rank_position), activity_score = VALUES(activity_score), activity_level = VALUES(activity_level),
-                hull_losses_24h = VALUES(hull_losses_24h), module_losses_24h = VALUES(module_losses_24h),
-                fit_equivalent_losses_24h = VALUES(fit_equivalent_losses_24h), readiness_state = VALUES(readiness_state),
-                resupply_pressure_state = VALUES(resupply_pressure_state), resupply_pressure = VALUES(resupply_pressure),
-                readiness_gap_count = VALUES(readiness_gap_count), explanation_text = VALUES(explanation_text)"""
-    )
-    # Build a lightweight summary for the intelligence_snapshots table
-    # so the freshness system can track this job's output.
-    top_fits = db.fetch_all(
-        """SELECT das.entity_id AS fit_id, das.entity_name, das.activity_score, das.activity_level,
-                  das.readiness_state, das.resupply_pressure, das.readiness_gap_count, das.rank_position
-           FROM doctrine_activity_snapshots das
-           WHERE das.entity_type = 'fit'
-           ORDER BY das.activity_score DESC
-           LIMIT 100"""
-    )
+    """Retired — this sync used to fan doctrine_fit_activity_1d rows out
+    into doctrine_activity_snapshots, both of which have been dropped.
+    It is replaced by the auto doctrine pipeline (compute_auto_doctrines +
+    the auto_doctrine_fit_demand_1d rollup).
+
+    We still materialise an empty intelligence_snapshots row so the
+    freshness tracker keeps a heartbeat for activity_priority consumers.
+    """
     snapshot_payload = {
-        "active_doctrines": [
-            {
-                "fit_id": int(r.get("fit_id") or 0),
-                "entity_name": str(r.get("entity_name") or ""),
-                "activity_score": float(r.get("activity_score") or 0),
-                "activity_level": str(r.get("activity_level") or "low"),
-                "readiness_state": str(r.get("readiness_state") or ""),
-                "resupply_pressure": str(r.get("resupply_pressure") or ""),
-                "readiness_gap_count": int(r.get("readiness_gap_count") or 0),
-                "rank_position": int(r.get("rank_position") or 0),
-            }
-            for r in top_fits
-        ],
-        "total_rows": rows_written,
+        "active_doctrines": [],
+        "total_rows": 0,
+        "retired": True,
     }
     db.upsert_intelligence_snapshot(
         snapshot_key="doctrine_activity_db_state",
         payload_json=json_dumps_safe(snapshot_payload),
         metadata_json=json_dumps_safe({
-            "source": "doctrine_activity_snapshots",
+            "source": "retired",
             "reason": "scheduler:python",
-            "row_count": len(top_fits),
+            "row_count": 0,
         }),
         expires_seconds=900,
     )
 
     return {
-        "rows_processed": rows_processed,
-        "rows_written": rows_written,
-        "warnings": [] if rows_processed > 0 else ["No doctrine fit activity rows available for today."],
-        "summary": f"Refreshed doctrine activity snapshots with {rows_written} upserts.",
-        "meta": {"entity_type": "fit", "snapshot_key": "activity_priority_summaries"},
+        "rows_processed": 0,
+        "rows_written": 0,
+        "warnings": ["activity_priority_summary_sync is retired; auto_doctrines feeds /doctrines/ directly."],
+        "summary": "activity_priority_summary_sync retired — no-op.",
+        "meta": {"entity_type": "fit", "snapshot_key": "activity_priority_summaries", "retired": True},
     }
 
 

--- a/python/orchestrator/jobs/compute_signals.py
+++ b/python/orchestrator/jobs/compute_signals.py
@@ -56,155 +56,24 @@ from(bucket: "{config.bucket}")
 
 
 def run_compute_signals(db: SupplyCoreDb, influx_raw: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Retired — compute_signals originally materialised enriched signal rows
+    out of the old ``buy_all_items`` / ``buy_all_summary`` precompute tables.
+    Those tables have been dropped along with the hand-maintained buy-all
+    pipeline. The auto buy-all job (``compute_auto_buyall``) now materialises
+    its own deterministic list. This function is kept as a no-op so the
+    scheduler keeps its slot without erroring on missing tables."""
     _started_at = datetime.now(UTC)
-    _start_mono = time.monotonic()
-    computed_at = _started_at.strftime("%Y-%m-%d %H:%M:%S")
-    rows = db.fetch_all(
-        """
-        SELECT
-            bai.type_id,
-            MAX(bai.mode_rank_score) AS mode_rank_score,
-            MAX(bai.necessity_score) AS necessity_score,
-            MAX(bai.profit_score) AS profit_score,
-            MAX(CASE WHEN rit.type_name IS NULL OR rit.type_name = '' THEN CONCAT('Type #', bai.type_id) ELSE rit.type_name END) AS type_name,
-            MAX(COALESCE(bai.quantity, 0)) AS planner_qty,
-            MAX(COALESCE(mh.hub_price, 0)) AS hub_price,
-            MAX(COALESCE(asrc.alliance_price, 0)) AS alliance_price,
-            MAX(COALESCE(asrc.total_sell_volume, 0)) AS alliance_volume,
-            MAX(COALESCE(ids.dependency_score, 0.0)) AS dependency_score,
-            MAX(COALESCE(ids.doctrine_count, 0)) AS doctrine_count,
-            MAX(COALESCE(ids.fit_count, 0)) AS dependency_fit_count
-        FROM buy_all_items bai
-        INNER JOIN buy_all_summary bas ON bas.id = bai.summary_id
-        LEFT JOIN ref_item_types rit ON rit.type_id = bai.type_id
-        LEFT JOIN (
-            SELECT type_id,
-                   MAX(COALESCE(best_sell_price, best_buy_price, 0)) AS hub_price
-            FROM market_order_snapshots_summary
-            WHERE source_type = 'market_hub'
-              AND observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 24 HOUR)
-            GROUP BY type_id
-        ) mh ON mh.type_id = bai.type_id
-        LEFT JOIN (
-            SELECT type_id,
-                   MAX(COALESCE(best_sell_price, best_buy_price, 0)) AS alliance_price,
-                   MAX(COALESCE(total_sell_volume, 0)) AS total_sell_volume
-            FROM market_order_snapshots_summary
-            WHERE source_type = 'alliance_structure'
-              AND observed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 24 HOUR)
-            GROUP BY type_id
-        ) asrc ON asrc.type_id = bai.type_id
-        LEFT JOIN item_dependency_score ids ON ids.type_id = bai.type_id
-        WHERE bas.computed_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 24 HOUR)
-        GROUP BY bai.type_id
-        ORDER BY mode_rank_score DESC
-        LIMIT 250
-        """
-    )
-
-    type_ids = [int(row.get("type_id") or 0) for row in rows if int(row.get("type_id") or 0) > 0]
-    historical = _historical_mean_by_type(influx_raw or {}, type_ids)
-
-    created = 0
-    with db.transaction() as (_, cursor):
-        cursor.execute("DELETE FROM signals WHERE computed_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL 30 DAY)")
-
-        for row in rows:
-            type_id = int(row.get("type_id") or 0)
-            if type_id <= 0:
-                continue
-            title = str(row.get("type_name") or f"Type #{type_id}")
-            hub_price = to_decimal(row.get("hub_price"))
-            alliance_volume = int(row.get("alliance_volume") or 0)
-            necessity = to_decimal(row.get("necessity_score"))
-            dependency_score = to_decimal(row.get("dependency_score"))
-            doctrine_count = int(row.get("doctrine_count") or 0)
-            dependency_fit_count = int(row.get("dependency_fit_count") or 0)
-
-            signal_type = "market_spike"
-            severity = "medium"
-            mode_rank_score = to_decimal(row.get("mode_rank_score"))
-            signal_text = f"Planner rank {mode_rank_score:.1f} with alliance volume {alliance_volume}."
-
-            hist = to_decimal(historical.get(type_id))
-            price_worsening = bool(hist > DECIMAL_ZERO and hub_price > (hist * Decimal("1.10")))
-            low_supply = alliance_volume < 20
-            high_dependency = dependency_score >= Decimal("30") or doctrine_count >= 3
-
-            if high_dependency and low_supply and price_worsening:
-                signal_type = "high_dependency_low_supply"
-                severity = "critical"
-                signal_text = (
-                    f"Dependency score {dependency_score:.1f} across {doctrine_count} doctrines with low alliance volume {alliance_volume}; "
-                    f"hub price {hub_price:.2f} is above 14d mean {hist:.2f}."
-                )
-            elif high_dependency and low_supply:
-                signal_type = "critical_shared_dependency"
-                severity = "critical"
-                signal_text = (
-                    f"Shared dependency risk: score {dependency_score:.1f}, doctrines {doctrine_count}, fits {dependency_fit_count}, "
-                    f"alliance volume {alliance_volume}."
-                )
-            elif high_dependency and necessity >= Decimal("60"):
-                signal_type = "doctrine_bottleneck"
-                severity = "high"
-                signal_text = (
-                    f"Doctrine bottleneck candidate with dependency score {dependency_score:.1f}, necessity {necessity:.1f}, "
-                    f"used by {doctrine_count} doctrines."
-                )
-            elif hist > DECIMAL_ZERO and hub_price > DECIMAL_ZERO and hub_price <= hist * Decimal("0.9"):
-                signal_type = "undervalued_item"
-                severity = "high"
-                signal_text = f"Hub price {hub_price:.2f} is below 14d mean {hist:.2f}."
-            elif alliance_volume < 25 and necessity >= Decimal("55"):
-                signal_type = "supply_shortage"
-                severity = "critical"
-                signal_text = f"Alliance volume {alliance_volume} is low for necessity score {necessity:.1f}."
-            elif necessity >= Decimal("70"):
-                signal_type = "doctrine_blocking_item"
-                severity = "high"
-                signal_text = f"Necessity score {necessity:.1f} indicates doctrine blocking risk."
-
-            payload = {
-                "hub_price": hub_price,
-                "historical_mean": hist if hist > DECIMAL_ZERO else None,
-                "alliance_volume": alliance_volume,
-                "planner_qty": int(row.get("planner_qty") or 0),
-                "mode_rank_score": mode_rank_score,
-                "necessity_score": necessity,
-                "profit_score": to_decimal(row.get("profit_score")),
-                "dependency_score": dependency_score,
-                "doctrine_count": doctrine_count,
-                "dependency_fit_count": dependency_fit_count,
-            }
-            signal_key = f"{signal_type}:{type_id}"
-            cursor.execute(
-                """
-                INSERT INTO signals (signal_key, signal_type, severity, type_id, doctrine_fit_id, signal_title, signal_text, signal_payload_json, computed_at)
-                VALUES (%s, %s, %s, %s, NULL, %s, %s, %s, %s)
-                ON DUPLICATE KEY UPDATE
-                    severity = VALUES(severity),
-                    signal_title = VALUES(signal_title),
-                    signal_text = VALUES(signal_text),
-                    signal_payload_json = VALUES(signal_payload_json),
-                    computed_at = VALUES(computed_at)
-                """,
-                (signal_key, signal_type, severity, type_id, title, signal_text, json.dumps(payload, separators=(",", ":"), ensure_ascii=False, default=_decimal_json_default), computed_at),
-            )
-            created += 1
-
-    _finished_at = datetime.now(UTC)
-    return JobResult.success(
-        job_key="compute_signals",
-        summary=f"Generated {created} intelligence signals from {len(rows)} buy-all items.",
-        rows_processed=len(rows),
-        rows_written=created,
-        started_at=_started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        finished_at=_finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        duration_ms=int((time.monotonic() - _start_mono) * 1000),
-        meta={"computed_at": computed_at, "signals_created": created},
-    ).to_dict()
-
+    return {
+        "status": "success",
+        "summary": "compute_signals retired — buy_all_items dropped.",
+        "started_at": _started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "finished_at": _started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "duration_ms": 0,
+        "rows_seen": 0,
+        "rows_processed": 0,
+        "rows_written": 0,
+        "meta": {"retired": True},
+    }
 
 def _decimal_json_default(value: Any) -> Any:
     if isinstance(value, Decimal):

--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -256,122 +256,18 @@ def _snapshot_graph_health(client: Neo4jClient) -> dict[str, Any]:
 
 
 def run_compute_graph_sync_doctrine_dependency(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Retired — legacy doctrine_fits / doctrine_fit_items / doctrine_groups tables
+    no longer exist. The auto doctrine pipeline does not yet project into Neo4j,
+    so this job is a no-op and should be removed from the scheduler once all
+    downstream graph consumers migrate off the Doctrine/Fit/Item node labels."""
     started = time.perf_counter()
-    job_name = "compute_graph_sync_doctrine_dependency"
-    config = Neo4jConfig.from_runtime(neo4j_raw or {})
-    if not config.enabled:
-        return _job_payload(job_name, started, "skipped", error_text="neo4j disabled")
-
-    client = Neo4jClient(config)
-    _ensure_constraints_and_indexes(client)
-
-    runtime = neo4j_raw or {}
-    batch_size = _coerce_batch_size(runtime.get("sync_doctrine_batch_size") or runtime.get("batch_size"))
-    max_batches = max(1, int(runtime.get("sync_doctrine_max_batches_per_run") or 6))
-    cursor_row = _sync_state_get(db, GRAPH_BATCH_STATE_KEYS["doctrine_cursor"]) or {}
-    cursor_id = _parse_int_cursor(cursor_row.get("last_cursor"))
-    rows_processed = 0
-    rows_written = 0
-    batch_count = 0
-    latest_checkpoint = cursor_id
-    while batch_count < max_batches:
-        batch_started = time.perf_counter()
-        rows = db.fetch_all(
-            """
-            SELECT
-                dfi.id AS doctrine_item_id,
-                dg.id AS doctrine_id,
-                dg.group_name AS doctrine_name,
-                df.id AS fit_id,
-                df.fit_name,
-                dfi.type_id,
-                COALESCE(rit.type_name, CONCAT('Type #', dfi.type_id)) AS item_name,
-                GREATEST(COALESCE(df.updated_at, '1970-01-01 00:00:00'), COALESCE(dfi.updated_at, '1970-01-01 00:00:00')) AS changed_at
-            FROM doctrine_fit_items dfi
-            INNER JOIN doctrine_fits df ON df.id = dfi.doctrine_fit_id
-            INNER JOIN doctrine_fit_groups dfg ON dfg.doctrine_fit_id = df.id
-            INNER JOIN doctrine_groups dg ON dg.id = dfg.doctrine_group_id
-            LEFT JOIN ref_item_types rit ON rit.type_id = dfi.type_id
-            WHERE dfi.id > %s
-            ORDER BY dfi.id ASC
-            LIMIT %s
-            """,
-            (cursor_id, batch_size),
-        )
-        if not rows:
-            cursor_id = 0
-            break
-
-        client.query(
-            """
-            UNWIND $rows AS row
-            MERGE (d:Doctrine {doctrine_id: toInteger(row.doctrine_id)})
-              SET d.name = row.doctrine_name
-            MERGE (f:Fit {fit_id: toInteger(row.fit_id)})
-              SET f.name = row.fit_name
-            MERGE (i:Item {type_id: toInteger(row.type_id)})
-              SET i.name = row.item_name
-            MERGE (d)-[:USES]->(f)
-            MERGE (f)-[:CONTAINS]->(i)
-            """,
-            {"rows": rows},
-        )
-
-        cursor_id = int(rows[-1].get("doctrine_item_id") or cursor_id)
-        latest_checkpoint = cursor_id
-        batch_count += 1
-        rows_processed += len(rows)
-        rows_written += len(rows)
-        _sync_state_upsert(
-            db,
-            GRAPH_BATCH_STATE_KEYS["doctrine_cursor"],
-            sync_mode="incremental",
-            status="running",
-            last_success_at=None,
-            last_cursor=_format_int_cursor(cursor_id),
-            last_row_count=rows_written,
-            last_error_message=None,
-        )
-        _emit_batch_telemetry(
-            config.log_file,
-            job_name,
-            {
-                "batch_start": batch_count,
-                "batch_end": batch_count,
-                "rows_processed": len(rows),
-                "rows_written": len(rows),
-                "duration_ms": int((time.perf_counter() - batch_started) * 1000),
-                "checkpoint_after": _format_int_cursor(cursor_id),
-                "errors": "",
-            },
-        )
-
-    _sync_state_upsert(
-        db,
-        GRAPH_BATCH_STATE_KEYS["doctrine_cursor"],
-        sync_mode="incremental",
-        status="success",
-        last_success_at=_utc_now_sql(),
-        last_cursor=_format_int_cursor(cursor_id),
-        last_row_count=rows_written,
-        last_error_message=None,
-    )
-
-    result = _job_payload(
-        job_name,
+    return _job_payload(
+        "compute_graph_sync_doctrine_dependency",
         started,
-        "success",
-        rows_processed=rows_processed,
-        rows_written=rows_written,
-        nodes_merged=rows_written * 3,
-        relationships_merged=rows_written * 2,
-        checkpoint_cursor=_format_int_cursor(latest_checkpoint),
-        batch_count=batch_count,
-        batch_size=batch_size,
-        has_more=cursor_id > 0,
+        "skipped",
+        error_text="retired: legacy doctrine tables dropped",
     )
-    _write_graph_log(config.log_file, "graph.sync.doctrine.completed", result)
-    return result
+
 
 
 def run_compute_graph_sync_battle_intelligence(db: SupplyCoreDb, neo4j_raw: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -1009,54 +905,6 @@ def _upsert_table(db: SupplyCoreDb, table_name: str, columns: str, placeholders:
             )
         )
 
-
-def _ensure_doctrine_dependency_depth_schema(db: SupplyCoreDb) -> None:
-    expected_columns: list[tuple[str, str, str]] = [
-        ("doctrine_name", "VARCHAR(191) NOT NULL DEFAULT ''", "doctrine_id"),
-        ("fit_count", "INT UNSIGNED NOT NULL DEFAULT 0", "doctrine_id"),
-        ("item_count", "INT UNSIGNED NOT NULL DEFAULT 0", "fit_count"),
-        ("unique_item_count", "INT UNSIGNED NOT NULL DEFAULT 0", "item_count"),
-        ("dependency_depth_score", "DECIMAL(12,4) NOT NULL DEFAULT 0.0000", "unique_item_count"),
-        ("computed_at", "DATETIME NOT NULL", "dependency_depth_score"),
-    ]
-    for column_name, definition, after_column in expected_columns:
-        row = db.fetch_one(
-            """
-            SELECT COLUMN_NAME
-            FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE TABLE_SCHEMA = DATABASE()
-              AND TABLE_NAME = 'doctrine_dependency_depth'
-              AND COLUMN_NAME = %s
-            LIMIT 1
-            """,
-            (column_name,),
-        )
-        if row:
-            continue
-        db.execute(
-            f"ALTER TABLE doctrine_dependency_depth ADD COLUMN {column_name} {definition} AFTER {after_column}"
-        )
-
-    for index_name, index_cols in (
-        ("idx_doctrine_dependency_depth_score", "dependency_depth_score, computed_at"),
-        ("idx_doctrine_dependency_depth_computed", "computed_at"),
-    ):
-        index_row = db.fetch_one(
-            """
-            SELECT 1
-            FROM INFORMATION_SCHEMA.STATISTICS
-            WHERE TABLE_SCHEMA = DATABASE()
-              AND TABLE_NAME = 'doctrine_dependency_depth'
-              AND INDEX_NAME = %s
-            LIMIT 1
-            """,
-            (index_name,),
-        )
-        if index_row:
-            continue
-        db.execute(
-            f"ALTER TABLE doctrine_dependency_depth ADD KEY {index_name} ({index_cols})"
-        )
 
 
 def _table_has_column(db: SupplyCoreDb, table_name: str, column_name: str) -> bool:
@@ -1751,66 +1599,12 @@ def _run_compute_graph_insights_inner(
     _vlog(f"connected to neo4j ({config.url}), batch_size={batch_size}")
 
     # ── Step 1: Base item dependency scores from Neo4j ──
-    _vlog("step 1/8: querying item dependency scores from Neo4j ...")
-    item_rows = client.query(
-        """
-        MATCH (d:Doctrine)-[:USES]->(f:Fit)-[:CONTAINS]->(i:Item)
-        WITH i, count(DISTINCT d) AS doctrine_count, count(DISTINCT f) AS fit_count
-        RETURN toInteger(i.type_id) AS type_id,
-               toInteger(doctrine_count) AS doctrine_count,
-               toInteger(fit_count) AS fit_count,
-               toFloat((doctrine_count * 10) + fit_count) AS dependency_score
-        ORDER BY dependency_score DESC, type_id ASC
-        """
-    )
-    _vlog(f"step 1/8: got {len(item_rows)} item rows, querying doctrine dependency depth ...")
-
-    doctrine_rows = client.query(
-        """
-        MATCH (d:Doctrine)
-        OPTIONAL MATCH (d)-[:USES]->(f:Fit)
-        OPTIONAL MATCH (f)-[:CONTAINS]->(i:Item)
-        WITH d, count(DISTINCT f) AS fit_count, count(i) AS item_count, count(DISTINCT i) AS unique_item_count
-        RETURN toInteger(d.doctrine_id) AS doctrine_id,
-               toString(COALESCE(d.name, '')) AS doctrine_name,
-               toInteger(fit_count) AS fit_count,
-               toInteger(item_count) AS item_count,
-               toInteger(unique_item_count) AS unique_item_count,
-               toFloat(unique_item_count + (fit_count * 5)) AS dependency_depth_score
-        ORDER BY dependency_depth_score DESC, doctrine_id ASC
-        """
-    )
-
-    _ensure_doctrine_dependency_depth_schema(db)
-
-    _upsert_table(
-        db,
-        "item_dependency_score",
-        "type_id, doctrine_count, fit_count, dependency_score, computed_at",
-        "%s, %s, %s, %s, %s",
-        [(int(r["type_id"]), int(r["doctrine_count"]), int(r["fit_count"]), float(r["dependency_score"]), computed_at) for r in item_rows if int(r.get("type_id") or 0) > 0],
-    )
-    _vlog(f"step 1/8: got {len(doctrine_rows)} doctrine rows, upserting to MariaDB ...")
-
-    doctrine_dependency_rows = [r for r in doctrine_rows if int(r.get("doctrine_id") or 0) > 0]
-    _upsert_table(
-        db,
-        "doctrine_dependency_depth",
-        "doctrine_id, doctrine_name, fit_count, item_count, unique_item_count, dependency_depth_score, computed_at",
-        "%s, %s, %s, %s, %s, %s, %s",
-        [
-            (
-                int(r["doctrine_id"]),
-                str(r.get("doctrine_name") or f"Doctrine #{int(r['doctrine_id'])}"),
-                int(r["fit_count"]),
-                int(r["item_count"]),
-                int(r["unique_item_count"]),
-                float(r["dependency_depth_score"]),
-                computed_at,
-            )
-            for r in doctrine_dependency_rows
-        ],
-    )
+    # Legacy Doctrine nodes no longer exist in Neo4j (the sync job that
+    # produced them has been retired). Skip steps that depend on them so
+    # the rest of the graph-insights pipeline still runs.
+    _vlog("step 1/8: doctrine dependency scoring retired — skipping Doctrine-based rollups")
+    item_rows: list[dict[str, Any]] = []
+    doctrine_rows: list[dict[str, Any]] = []
 
     # ── Step 2: Critical edge ratio from Neo4j ──
     _vlog("step 2/8: querying critical edge ratios from Neo4j ...")

--- a/python/orchestrator/jobs/rebuild_ai_briefings.py
+++ b/python/orchestrator/jobs/rebuild_ai_briefings.py
@@ -6,47 +6,24 @@ from .sync_runtime import run_sync_phase_job
 
 
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
-    rows_processed = db.fetch_scalar("SELECT COUNT(*) FROM doctrine_fit_activity_1d WHERE bucket_start = CURDATE()")
-    rows_written = db.execute(
-        """INSERT INTO doctrine_ai_briefings (
-                entity_type, entity_id, fit_id, group_id, generation_status, computed_at, model_name,
-                headline, summary, action_text, priority_level, source_payload_json, response_json, error_message
-            )
-            SELECT
-                'fit' AS entity_type,
-                fa.fit_id AS entity_id,
-                fa.fit_id,
-                fa.doctrine_group_id,
-                'ready' AS generation_status,
-                UTC_TIMESTAMP() AS computed_at,
-                'deterministic-briefing-v1' AS model_name,
-                CONCAT('Doctrine fit ', COALESCE(f.fit_name, fa.fit_id), ' readiness: ', fa.readiness_state) AS headline,
-                CONCAT('Fit gap=', fa.fit_gap, ', complete fits available=', fa.complete_fits_available, ', item-loss-24h=', fa.doctrine_item_loss_count) AS summary,
-                CASE WHEN fa.fit_gap > 0 THEN 'Restock constrained doctrine items and prioritize missing fits.' ELSE 'Maintain current supply posture.' END AS action_text,
-                CASE WHEN fa.fit_gap > 20 THEN 'critical' WHEN fa.fit_gap > 5 THEN 'high' ELSE 'medium' END AS priority_level,
-                JSON_OBJECT('fit_gap', fa.fit_gap, 'complete_fits_available', fa.complete_fits_available, 'loss_24h', fa.doctrine_item_loss_count),
-                JSON_OBJECT('pipeline', 'python.rebuild_ai_briefings', 'kind', 'deterministic'),
-                NULL
-            FROM doctrine_fit_activity_1d fa
-            LEFT JOIN doctrine_fits f ON f.id = fa.fit_id
-            WHERE fa.bucket_start = CURDATE()
-            ON DUPLICATE KEY UPDATE
-                generation_status = VALUES(generation_status), computed_at = VALUES(computed_at), model_name = VALUES(model_name),
-                headline = VALUES(headline), summary = VALUES(summary), action_text = VALUES(action_text), priority_level = VALUES(priority_level),
-                source_payload_json = VALUES(source_payload_json), response_json = VALUES(response_json), error_message = VALUES(error_message)"""
-    )
+    """Retired — doctrine AI briefings were sourced from
+    ``doctrine_fit_activity_1d`` and written into ``doctrine_ai_briefings``,
+    both of which have been dropped along with the hand-maintained doctrine
+    system. We keep a heartbeat intelligence_snapshots row so downstream
+    freshness probes stay green.
+    """
     db.upsert_intelligence_snapshot(
         snapshot_key="doctrine_ai_briefings_status",
-        payload_json=json_dumps_safe({"row_count": rows_processed}),
-        metadata_json=json_dumps_safe({"source": "doctrine_fit_activity_1d", "job": "rebuild_ai_briefings"}),
+        payload_json=json_dumps_safe({"row_count": 0, "retired": True}),
+        metadata_json=json_dumps_safe({"source": "retired", "job": "rebuild_ai_briefings"}),
         expires_seconds=1200,
     )
     return {
-        "rows_processed": rows_processed,
-        "rows_written": rows_written,
-        "warnings": [] if rows_processed > 0 else ["No doctrine_fit_activity_1d rows available for AI briefing generation."],
-        "summary": f"Rebuilt {rows_written} doctrine AI briefings from deterministic fit activity inputs.",
-        "meta": {"entity_type": "fit", "snapshot_key": "doctrine_ai_briefings_status"},
+        "rows_processed": 0,
+        "rows_written": 0,
+        "warnings": ["rebuild_ai_briefings is retired; doctrine AI briefings are no longer generated."],
+        "summary": "rebuild_ai_briefings retired — no-op.",
+        "meta": {"entity_type": "fit", "snapshot_key": "doctrine_ai_briefings_status", "retired": True},
     }
 
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -403,14 +403,13 @@ function nav_items(): array
             ],
         ],
         [
-            'label' => 'Doctrine Fits',
-            'path' => '/doctrine',
+            'label' => 'Doctrines',
+            'path' => '/doctrines/',
             'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 5h14v14H5z"/><path stroke-linecap="round" stroke-linejoin="round" d="M9 9h6M9 13h6M9 17h4"/></svg>',
-            'badge_tooltip' => 'Doctrine management views',
+            'badge_tooltip' => 'Auto-detected doctrines from killmails',
             'children' => [
-                ['label' => 'Doctrine Groups', 'path' => '/doctrine'],
-                ['label' => 'Fit Overview', 'path' => '/doctrine/fits'],
-                ['label' => 'Bulk Import', 'path' => '/doctrine/import'],
+                ['label' => 'Detected Doctrines', 'path' => '/doctrines/'],
+                ['label' => 'Buy-all', 'path' => '/buy-all/'],
             ],
         ],
         [
@@ -22326,12 +22325,127 @@ function activity_priority_refresh_summary_job_result(string $reason = 'manual')
 
 function activity_priority_page_data(): array
 {
-    $snapshot = activity_priority_snapshot_payload();
-    if (!activity_priority_snapshot_has_computed_metrics($snapshot)) {
-        $snapshot = activity_priority_refresh_summary('page-contract-repair');
+    // The legacy snapshot flow populated doctrine_activity_snapshots from
+    // doctrine_fit_activity_1d — both dropped. We now reshape the auto
+    // doctrine list into the key-shape the existing template expects so
+    // the page renders without template changes.
+    $doctrines = function_exists('auto_doctrine_list') ? auto_doctrine_list(['include_hidden' => false]) : [];
+    $settings = function_exists('auto_doctrine_settings') ? auto_doctrine_settings() : [
+        'window_days' => 30,
+        'default_runway_days' => 14,
+    ];
+
+    $active = array_values(array_filter($doctrines, static fn (array $d): bool => (bool) ($d['is_active'] ?? false) || (bool) ($d['is_pinned'] ?? false)));
+    usort($active, static fn (array $a, array $b): int => ((float) ($b['priority_score'] ?? 0.0)) <=> ((float) ($a['priority_score'] ?? 0.0)));
+
+    $activeDoctrines = [];
+    $activeFits = [];
+    foreach ($active as $index => $d) {
+        $lossWindow = (int) ($d['loss_count_window'] ?? 0);
+        $dailyRate = (float) ($d['daily_loss_rate'] ?? 0.0);
+        $targetFits = (int) ($d['target_fits'] ?? 0);
+        $activityScore = (float) ($d['priority_score'] ?? 0.0);
+        $activityLevel = match (true) {
+            $targetFits >= 10 => 'critical',
+            $targetFits >= 3  => 'elevated',
+            default            => 'low',
+        };
+        $readinessLabel = $targetFits > 0 ? 'Critical gap' : 'Market ready';
+        $resupplyPressure = $lossWindow >= 5 ? 'Urgent resupply' : 'Stable';
+
+        $row = [
+            'entity_id'          => (int) ($d['id'] ?? 0),
+            'rank_position'      => $index + 1,
+            'doctrine_name'      => (string) ($d['canonical_name'] ?? ''),
+            'activity_level'     => $activityLevel,
+            'activity_score'     => $activityScore,
+            'score_delta'        => 0.0,
+            'rank_delta'         => 0,
+            'movement_label'     => 'Holding',
+            'explanation'        => sprintf(
+                '%d hull losses in the last %dd · daily rate %.2f · target %d fits over %dd runway',
+                $lossWindow,
+                (int) ($d['window_days'] ?? $settings['window_days']),
+                $dailyRate,
+                $targetFits,
+                (int) ($d['runway_days_effective'] ?? $settings['default_runway_days'])
+            ),
+            'hull_losses_24h'              => 0,
+            'hull_losses_3d'               => 0,
+            'hull_losses_7d'               => $lossWindow,
+            'module_losses_24h'            => 0,
+            'module_losses_3d'             => 0,
+            'module_losses_7d'             => 0,
+            'fit_equivalent_losses_24h'    => 0.0,
+            'fit_equivalent_losses_7d'     => (float) $lossWindow,
+            'readiness_label'              => $readinessLabel,
+            'resupply_pressure'            => $resupplyPressure,
+            'readiness_gap_count'          => $targetFits,
+            'score_components'             => [
+                'Daily loss rate' => number_format($dailyRate, 2),
+                'Target fits'     => (string) $targetFits,
+                'Window losses'   => (string) $lossWindow,
+            ],
+            'top_fits' => [
+                [
+                    'fit_name'       => (string) ($d['canonical_name'] ?? ''),
+                    'activity_level' => $activityLevel,
+                    'activity_score' => $activityScore,
+                ],
+            ],
+        ];
+        $activeDoctrines[] = $row;
+
+        $activeFits[] = [
+            'entity_id'        => (int) ($d['id'] ?? 0),
+            'doctrine_name'    => (string) ($d['canonical_name'] ?? ''),
+            'readiness_label'  => $readinessLabel,
+            'resupply_pressure' => $resupplyPressure,
+            'activity_score'   => $activityScore,
+            'movement_label'   => 'Holding',
+        ];
     }
 
-    return $snapshot;
+    // Summary cards: keep labels stable for any dashboard consumers.
+    $summaryCards = [
+        [
+            'label'   => 'Active Doctrines',
+            'value'   => (string) count($active),
+            'context' => 'Auto-detected doctrines with fit gaps right now',
+        ],
+        [
+            'label'   => 'Highly Active Fits',
+            'value'   => (string) count(array_filter($activeDoctrines, static fn (array $r): bool => (string) $r['activity_level'] === 'critical')),
+            'context' => 'Doctrine fits with urgent resupply pressure',
+        ],
+        [
+            'label'   => 'Total Window Losses',
+            'value'   => (string) array_sum(array_column($active, 'loss_count_window')),
+            'context' => sprintf('Killmail losses over the last %d days', (int) $settings['window_days']),
+        ],
+        [
+            'label'   => 'Runway (days)',
+            'value'   => (string) (int) $settings['default_runway_days'],
+            'context' => 'Default buy-all runway (override per doctrine)',
+        ],
+    ];
+
+    return [
+        'summary_cards'    => $summaryCards,
+        'active_doctrines' => $activeDoctrines,
+        'active_fits'      => array_slice($activeFits, 0, 25),
+        'priority_items'   => [],
+        'trend_movement'   => [
+            'doctrines_moving_up'  => [],
+            'items_newly_elevated' => [],
+            'items_cooling_down'   => [],
+        ],
+        '_freshness'       => [
+            'computed_at'      => gmdate(DATE_ATOM),
+            'freshness_state'  => 'fresh',
+            'freshness_label'  => 'Fresh',
+        ],
+    ];
 }
 
 function activity_priority_snapshot_has_computed_metrics(array $snapshot): bool


### PR DESCRIPTION
## What the user saw

1. `/activity-priority/` was still showing rich pre-cleanup doctrine data ("30 Active Doctrines", "60 Highly Active Fits", "12 tracked groups") — the page was reading a **stale materialized snapshot** populated before the auto-doctrine cutover. The underlying tables that built that snapshot are dropped, so the numbers were permanent ghost data.
2. Nav bar still had `Doctrine Fits / Doctrine Groups / Fit Overview / Bulk Import` entries pointing at `/doctrine/*` — all 404.
3. Scheduler logs showed **seven** job families firing against dropped tables (`doctrine_fit_items`, `doctrine_fit_activity_1d`, `buy_all_items`, `doctrine_dependency_depth`, `killmail_doctrine_activity_1d`, etc.) plus `doctrine_intelligence_sync` and `compute_buy_all` still in `sync_schedules`.

## Why the stale snapshot

`activity_priority_snapshot_payload()` first reads from two JSON caches; if those are empty it falls back to the materialized snapshot; if that's missing it bootstraps via `activity_priority_summary_build()` (which I already neutered in #743). In production the JSON caches were populated before cleanup and never got overwritten, because the scheduler jobs that refresh them (`activity_priority_summary_sync`, `rebuild_ai_briefings`) now error out on dropped tables instead of writing empty payloads to the cache. Result: the page just keeps serving the pre-cleanup payload forever.

## Fixes

### 1. Rewire `/activity-priority/` to read from `auto_doctrines`
`activity_priority_page_data()` now pulls from `auto_doctrine_list()` and reshapes into the template's expected keys (`summary_cards`, `active_doctrines`, `active_fits`, `priority_items`, `trend_movement`, `_freshness`). No template changes needed. The two deep-links in `public/activity-priority/index.php` that went to `/doctrine/group?...` and `/doctrine/fit?...` now point at `/doctrines/#doctrine-<id>`.

### 2. Nav bar
Replaced the `Doctrine Fits` dropdown in `scheduler_nav_items()` (`src/functions.php:405`) with a single `Doctrines` entry pointing at `/doctrines/` and a `Buy-all` child at `/buy-all/`.

### 3. Python scheduler jobs that still touched dropped tables
- **`compute_graph_sync_doctrine_dependency`** (`graph_pipeline.py`) — replaced body with a `skipped` no-op; the function had a Neo4j sync that drove upserts from `doctrine_fit_items` / `doctrine_fits` / `doctrine_groups`.
- **`run_compute_graph_topology_metrics`** (`graph_pipeline.py`) — Step 1/8 originally queried `MATCH (d:Doctrine)-[:USES]->(f:Fit)-[:CONTAINS]->(i:Item)` from Neo4j and upserted to `item_dependency_score` / `doctrine_dependency_depth`. Doctrine nodes are no longer projected to Neo4j (that sync retired above) and `doctrine_dependency_depth` is dropped, so I stubbed `item_rows` / `doctrine_rows` to empty lists, removed the upsert block, and deleted the now-unused `_ensure_doctrine_dependency_depth_schema` helper.
- **`compute_signals`** (`compute_signals.py`) — whole body replaced with a success-shape no-op. The original query was a join on `buy_all_items` + `buy_all_summary`, both dropped.
- **`activity_priority_summary_sync`** + **`rebuild_ai_briefings`** — reduced to heartbeat no-ops that still write an `intelligence_snapshots` row so freshness probes stay green.
- **Influx rollup export** (`influx_export.py`, `influx_inspect.py`) — dropped `killmail_doctrine_activity_1d`, `doctrine_fit_activity_1d`, `doctrine_group_activity_1d`, `doctrine_fit_stock_pressure_1d` from the dataset list and alias map; deleted the unused tag/field helpers.

### 4. Straggler `sync_schedules` rows
The original #743 drop migration did `DELETE FROM sync_schedules WHERE job_key IN ('doctrine_intelligence_sync', 'compute_buy_all', …)` but the `schema.sql` bootstrap still had `INSERT INTO sync_schedules` rows for the retired keys and an `INSERT INTO doctrine_groups` seed. Every schema re-apply was re-seeding the rows the migration had just deleted.

Fixes:
- **`database/schema.sql`**: removed the `doctrine_groups` seed insert, the `doctrine.default_group` `app_settings` seed, and the `doctrine_intelligence_sync` / `loss_demand_summary_sync` / `rebuild_ai_briefings` rows from the `sync_schedules` seed block.
- **New migration `20260416_retire_straggler_legacy_jobs.sql`** — idempotent cleanup that re-deletes the straggler `sync_schedules` rows, `DROP TABLE IF EXISTS` for every legacy doctrine/buy_all table (in case any survived on upgraded servers), and scrubs the retired `app_settings` key.

## Test plan

- [ ] Run `20260416_retire_straggler_legacy_jobs.sql` migration
- [ ] `SELECT job_key FROM sync_schedules WHERE job_key IN ('doctrine_intelligence_sync', 'compute_buy_all', 'loss_demand_summary_sync', 'rebuild_ai_briefings')` returns 0 rows
- [ ] Load `/activity-priority/` — renders auto-doctrine data, KPIs match `auto_doctrine_list()` counts
- [ ] Nav bar: `Doctrines` menu shows `Detected Doctrines` → `/doctrines/` and `Buy-all` → `/buy-all/`
- [ ] Scheduler log: `compute_graph_sync_doctrine_dependency`, `compute_signals`, `activity_priority_summary_sync`, `rebuild_ai_briefings` all complete successfully (no more `ProgrammingError: Table ... doesn't exist`)
- [ ] Influx rollup export: `killmail_doctrine_activity_1d` no longer in the dataset list
- [ ] `/doctrines/` still lists detected doctrines with hide/pin/runway controls

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw