### PR TITLE
Restore missing math import in compute_economic_warfare

### DIFF
--- a/python/orchestrator/jobs/compute_economic_warfare.py
+++ b/python/orchestrator/jobs/compute_economic_warfare.py
@@ -10,6 +10,7 @@ Phase 4: Write composite economic_warfare_score for each module
 from __future__ import annotations
 
 import logging
+import math
 import time
 from collections import defaultdict
 from datetime import UTC, datetime
@@ -24,9 +25,7 @@ from ._fit_clustering import (
     JACCARD_MERGE_THRESHOLD as _JACCARD_MERGE_THRESHOLD,
     cluster_fit_families,
     confidence as _confidence,
-    fingerprint as _fingerprint,
     flag_category as _flag_category,
-    jaccard as _jaccard,
 )
 
 logger = logging.getLogger("supplycore.economic_warfare")


### PR DESCRIPTION
## Summary

`python -m orchestrator run-job --job-key compute_economic_warfare` crashes with:

```
NameError: name 'math' is not defined. Did you forget to import 'math'
  File ".../jobs/compute_economic_warfare.py", line 241, in _score_modules
    price_factor = min(1.0, math.log10(max(price, 1.0)) / 10.0)
```

## Root cause

PR #743 extracted the Jaccard clustering helpers out of `compute_economic_warfare.py` into the shared `_fit_clustering` module and removed the local `_confidence` helper (which was the only caller of `math.exp`). The `import math` statement was removed along with it, but `_score_modules` at line 241 still calls `math.log10` for the price_factor calculation — a quiet survivor the refactor missed.

## Fix

- Re-add `import math` (one line).
- Drop the two now-unused imports (`fingerprint as _fingerprint`, `jaccard as _jaccard`) from the `_fit_clustering` import block — both names were only referenced by the old inline `_cluster_fit_families` which PR #743 replaced with a thin wrapper around `cluster_fit_families()`.

## Test plan

- [ ] `python -m orchestrator run-job --app-root /var/www/SupplyCore --job-key compute_economic_warfare` completes with `status: success`
- [ ] `economic_warfare_scores` receives fresh rows

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw