### PR TITLE
Drop item_role='fitted' filter in auto doctrine detector

### DIFF
--- a/python/orchestrator/jobs/compute_auto_doctrines.py
+++ b/python/orchestrator/jobs/compute_auto_doctrines.py
@@ -82,6 +82,12 @@ def _extract_our_losses(db: Any, window_days: int) -> dict[int, dict]:
     (``killmail_persist_r2z2_payload``) and is authoritative for "this is
     one of ours".
     """
+    # The ``item_flag`` slot ranges are authoritative for "fitted module"
+    # on their own — those EVE flags map exclusively to high/mid/low/rig/
+    # subsystem slots. Some ingest classifiers only ever write
+    # ``'destroyed'`` / ``'dropped'`` into ``item_role`` and never tag
+    # anything ``'fitted'``, which previously caused this query to return
+    # zero rows even when thousands of loss killmails were in-window.
     sql = """
         SELECT ke.sequence_id, ke.victim_ship_type_id, ke.victim_alliance_id,
                ki.item_type_id, ki.item_flag
@@ -92,7 +98,6 @@ def _extract_our_losses(db: Any, window_days: int) -> dict[int, dict]:
           AND (ki.item_flag BETWEEN 11 AND 34
                OR ki.item_flag BETWEEN 92 AND 94
                OR ki.item_flag BETWEEN 125 AND 132)
-          AND ki.item_role = 'fitted'
         ORDER BY ke.sequence_id
     """
     # Use _fit_clustering.flag_category via local import to avoid a


### PR DESCRIPTION
## Summary

`compute_auto_doctrines` was returning zero rows on a live install with 10k+ loss killmails in-window because some EVE killmail ingest classifiers only ever write `'destroyed'` or `'dropped'` into `killmail_items.item_role` and never tag anything as `'fitted'`. My extractor query filtered on `item_role = 'fitted'` which killed every matching row.

Drilled down through five diagnostic queries on the affected server:

| filter | rows |
|---|---|
| A. `mail_type='loss'` + 90d window | **10,296** |
| B. + joined with `killmail_items` | 7,189 |
| C. + `item_flag` in fitted slot ranges (11-34, 92-94, 125-132) | 6,143 |
| D. + `item_role = 'fitted'` | **0** ← everything killed here |
| E. `SELECT item_role, COUNT(*) FROM killmail_items` | `destroyed: 555,220` / `dropped: 474,176` (no `'fitted'` rows) |

## Fix

Drop the `AND ki.item_role = 'fitted'` filter. The `item_flag` slot ranges are already authoritative for "fitted module":

- **11-34** → high/mid/low slots, turret hardpoints, launcher hardpoints
- **92-94** → rigs
- **125-132** → T3 subsystems

Everything outside those ranges is cargo bay, drone bay, fuel bay, ship maintenance bay, etc. The `item_role` filter was belt-and-suspenders that the classifier on this (and probably most) servers doesn't produce. Cluster quality is unchanged — the slot-range gate still only admits actual fitted modules.

## Test plan

- [ ] `python -m orchestrator run-job --job-key compute_auto_doctrines` returns `rows_seen > 0` and `doctrines_upserted > 0`
- [ ] `SELECT COUNT(*) FROM auto_doctrines WHERE is_active=1` returns a non-zero count
- [ ] `/doctrines/` page lists detected hulls with core module sets
- [ ] `compute_auto_buyall` chains on success and populates `auto_buyall_summary` / `auto_buyall_items`
- [ ] Revert the debug thresholds once real data is flowing:
  ```sql
  UPDATE app_settings SET setting_value = '5'  WHERE setting_key = 'auto_doctrines.min_losses_threshold';
  UPDATE app_settings SET setting_value = '30' WHERE setting_key = 'auto_doctrines.window_days';
  ```

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw