### PR TITLE
Tighten auto doctrine noise floor: 30-loss threshold, module-only fingerprints, hide inactive by default

### DIFF
--- a/database/migrations/20260416_raise_auto_doctrine_threshold.sql
+++ b/database/migrations/20260416_raise_auto_doctrine_threshold.sql
@@ -1,0 +1,15 @@
+-- Raise the default auto-doctrine activation threshold from 5 → 30.
+--
+-- Field experience with live killmail data shows that a threshold of 5
+-- produces large amounts of noise: coincidental loadout overlaps
+-- between 2-3 kills start registering as "doctrines". 30 losses in the
+-- 30-day window is a much stronger signal that a fit is actually being
+-- repeatedly fielded by the alliance.
+--
+-- Only update the default if the setting is still at the old shipped
+-- value — servers that already hand-tuned to something else keep their
+-- local preference.
+UPDATE app_settings
+   SET setting_value = '30'
+ WHERE setting_key = 'auto_doctrines.min_losses_threshold'
+   AND setting_value = '5';

--- a/public/doctrines/index.php
+++ b/public/doctrines/index.php
@@ -52,7 +52,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 // ─── GET: render the list ──────────────────────────────────────────────────
 $title = 'Doctrines';
 $includeHidden = isset($_GET['include_hidden']) && $_GET['include_hidden'] === '1';
-$doctrines = auto_doctrine_list(['include_hidden' => $includeHidden]);
+$includeInactive = isset($_GET['include_inactive']) && $_GET['include_inactive'] === '1';
+$doctrines = auto_doctrine_list([
+    'include_hidden'   => $includeHidden,
+    'include_inactive' => $includeInactive,
+]);
 $settings = auto_doctrine_settings();
 $flashOk = flash('doctrines_ok');
 $flashErr = flash('doctrines_error');
@@ -92,7 +96,20 @@ include __DIR__ . '/../../src/views/partials/header.php';
             <p class="text-sm text-white/60">Pin critical fits so they always drive buy-all. Hide noisy ones. Adjust runway per doctrine.</p>
         </div>
         <div class="flex items-center gap-3">
-            <a href="/doctrines/?include_hidden=<?= $includeHidden ? '0' : '1' ?>" class="text-sm text-cyan-300 hover:text-cyan-200">
+            <?php
+                $toggleInactiveQuery = http_build_query([
+                    'include_inactive' => $includeInactive ? '0' : '1',
+                    'include_hidden'   => $includeHidden ? '1' : '0',
+                ]);
+                $toggleHiddenQuery = http_build_query([
+                    'include_inactive' => $includeInactive ? '1' : '0',
+                    'include_hidden'   => $includeHidden ? '0' : '1',
+                ]);
+            ?>
+            <a href="/doctrines/?<?= htmlspecialchars($toggleInactiveQuery, ENT_QUOTES) ?>" class="text-sm text-cyan-300 hover:text-cyan-200">
+                <?= $includeInactive ? 'Hide inactive' : 'Show inactive' ?>
+            </a>
+            <a href="/doctrines/?<?= htmlspecialchars($toggleHiddenQuery, ENT_QUOTES) ?>" class="text-sm text-cyan-300 hover:text-cyan-200">
                 <?= $includeHidden ? 'Hide hidden' : 'Show hidden' ?>
             </a>
             <a href="/buy-all/" class="text-sm text-cyan-300 hover:text-cyan-200">Buy-all →</a>

--- a/python/orchestrator/jobs/compute_auto_doctrines.py
+++ b/python/orchestrator/jobs/compute_auto_doctrines.py
@@ -38,7 +38,7 @@ from ._fit_clustering import (
 logger = logging.getLogger("supplycore.auto_doctrines")
 
 _DEFAULT_WINDOW_DAYS = 30
-_DEFAULT_MIN_LOSSES = 5
+_DEFAULT_MIN_LOSSES = 30
 _DEFAULT_JACCARD = 0.80
 _CORE_FREQUENCY_THRESHOLD = 0.80
 
@@ -88,16 +88,28 @@ def _extract_our_losses(db: Any, window_days: int) -> dict[int, dict]:
     # ``'destroyed'`` / ``'dropped'`` into ``item_role`` and never tag
     # anything ``'fitted'``, which previously caused this query to return
     # zero rows even when thousands of loss killmails were in-window.
+    #
+    # We additionally filter to ``ref_item_types.category_id IN (7, 32)``
+    # so that charges loaded into turret / launcher hardpoints
+    # (category 8 — ammo, missiles, crystals, scripts) and any stray
+    # booster / implant rows do not enter the fingerprint. Including
+    # charges fragments clusters heavily because the same Caracal fit
+    # with Scourge Fury vs Mjolnir Fury would otherwise hash to two
+    # different doctrines.
+    #
+    # EVE category IDs: 7 = Module, 32 = Subsystem.
     sql = """
         SELECT ke.sequence_id, ke.victim_ship_type_id, ke.victim_alliance_id,
                ki.item_type_id, ki.item_flag
         FROM killmail_events ke
         INNER JOIN killmail_items ki ON ki.sequence_id = ke.sequence_id
+        INNER JOIN ref_item_types rit ON rit.type_id = ki.item_type_id
         WHERE ke.mail_type = 'loss'
           AND ke.killmail_time >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL %s DAY)
           AND (ki.item_flag BETWEEN 11 AND 34
                OR ki.item_flag BETWEEN 92 AND 94
                OR ki.item_flag BETWEEN 125 AND 132)
+          AND rit.category_id IN (7, 32)
         ORDER BY ke.sequence_id
     """
     # Use _fit_clustering.flag_category via local import to avoid a

--- a/src/auto_doctrines.php
+++ b/src/auto_doctrines.php
@@ -19,11 +19,25 @@ declare(strict_types=1);
 
 // ─── DB layer ──────────────────────────────────────────────────────────────
 
-/** Fetch every auto-doctrine row joined with today's demand rollup. */
-function db_auto_doctrine_fetch_all(bool $includeHidden = false): array
+/** Fetch every auto-doctrine row joined with today's demand rollup.
+ *
+ * By default only active-or-pinned, non-hidden rows are returned so the
+ * /doctrines/ page doesn't drown in single-kill cluster fragments. Pass
+ * ``includeInactive=true`` to pull the long tail (inactive clusters
+ * still live in the table for history) and ``includeHidden=true`` to
+ * also show rows the operator explicitly hid.
+ */
+function db_auto_doctrine_fetch_all(bool $includeHidden = false, bool $includeInactive = false): array
 {
     $pdo = db();
-    $where = $includeHidden ? '1 = 1' : 'ad.is_hidden = 0';
+    $clauses = [];
+    if (!$includeHidden) {
+        $clauses[] = 'ad.is_hidden = 0';
+    }
+    if (!$includeInactive) {
+        $clauses[] = '(ad.is_active = 1 OR ad.is_pinned = 1)';
+    }
+    $where = $clauses === [] ? '1 = 1' : implode(' AND ', $clauses);
     $sql = "SELECT ad.id, ad.hull_type_id, ad.fingerprint_hash, ad.canonical_name,
                    ad.first_seen_at, ad.last_seen_at,
                    ad.loss_count_window, ad.loss_count_total,
@@ -241,7 +255,8 @@ function auto_doctrine_settings(): array
 function auto_doctrine_list(array $opts = []): array
 {
     $includeHidden = (bool) ($opts['include_hidden'] ?? false);
-    $rows = db_auto_doctrine_fetch_all($includeHidden);
+    $includeInactive = (bool) ($opts['include_inactive'] ?? false);
+    $rows = db_auto_doctrine_fetch_all($includeHidden, $includeInactive);
     $settings = auto_doctrine_settings();
     $defaultRunway = (int) $settings['default_runway_days'];
 


### PR DESCRIPTION
## Summary

Field data on a live install produced **3,470 cluster families from 6,147 loss killmails** — 1.77 kills per cluster on average. That's mostly noise, driven by three compounding issues that this PR fixes together.

## 1. Charges were contaminating the fingerprint

The extractor joined `killmail_items` on the fitted-slot flag ranges (11-34 / 92-94 / 125-132) without checking item category. Missile charges, hybrid / laser / projectile ammo, scripts, probes, and any boosters loaded into hardpoint slots were all hashed into the "fitted module" multiset. Same Caracal fit running **Scourge Fury Heavy Missile** vs **Mjolnir Fury Heavy Missile** → two separate "doctrines".

**Fix:** inner-join `ref_item_types` and require `category_id IN (7, 32)` — EVE's Module and Subsystem categories. Charges (cat 8), Implants/Boosters (cat 20), Drones (cat 18), Fighters (cat 87), and everything else are excluded. The fingerprint now sees only actual fitted modules, so loadout variance in ammo no longer fragments clusters.

## 2. Activation threshold was too permissive

5 losses in 30 days is low enough for coincidental 2-3 kill overlaps to register as doctrines. Bump the shipped default to **30**.

- New migration `20260416_raise_auto_doctrine_threshold.sql` — updates existing installs **only if** the operator hasn't already hand-tuned the value (`WHERE setting_value = '5'`).
- `_DEFAULT_MIN_LOSSES` Python constant bumped to 30 for cold bootstraps.

## 3. The `/doctrines/` page listed inactive clusters by default

Even with a strict threshold, the 3,470 cluster rows still sit in `auto_doctrines` — the detector upserts every family regardless of activation so history is preserved. The list was showing all of them.

**Fix:** `auto_doctrine_list()` now filters to `(is_active = 1 OR is_pinned = 1) AND is_hidden = 0` by default. New `include_inactive` opt plumbed through `db_auto_doctrine_fetch_all()` and a "Show inactive" toggle added to the page header next to "Show hidden". Operators can still drill into the long tail when they want to investigate a fringe fit.

## Test plan

- [ ] Run `20260416_raise_auto_doctrine_threshold.sql` → `auto_doctrines.min_losses_threshold` becomes `30` on installs that hadn't hand-tuned it
- [ ] `python -m orchestrator run-job --job-key compute_auto_doctrines` — `rows_seen` should drop from ~6,143 to somewhere lower once charges are excluded, `doctrines_upserted` should drop markedly (fewer ammo-driven splits)
- [ ] `SELECT COUNT(*) FROM auto_doctrines WHERE is_active = 1` — order-of-magnitude smaller than before (only fits with ≥30 window losses stay active)
- [ ] Load `/doctrines/` → shows only active+pinned rows by default; "Show inactive" toggle reveals the tail; "Show hidden" toggle still works
- [ ] Revert the debug threshold that was set manually on the live install:
  ```sql
  UPDATE app_settings SET setting_value = '30' WHERE setting_key = 'auto_doctrines.min_losses_threshold';
  UPDATE app_settings SET setting_value = '30' WHERE setting_key = 'auto_doctrines.window_days';
  ```
- [ ] Spot-check `SELECT * FROM auto_doctrine_modules WHERE type_id IN (SELECT type_id FROM ref_item_types WHERE category_id = 8)` returns 0 rows (no charges in the module set)

## Follow-up (not in this PR)

If clusters are still over-fragmenting after this lands, the Jaccard threshold (default 0.80) is the next knob. Opponent-kill economic warfare tuned it at 0.80 against hostile fits; our-losses may benefit from 0.65-0.70 since friendly fits have more meta variance. Wait and see first.

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw