### PR TITLE
Fix dupe-key crash in loss rollup attribution + forward Influx write_on_rollup to Python

### DIFF
--- a/python/orchestrator/jobs/compute_auto_doctrines.py
+++ b/python/orchestrator/jobs/compute_auto_doctrines.py
@@ -428,11 +428,32 @@ def _repopulate_loss_aggregates(db: Any) -> int:
     and compute_auto_buyall only needs a per-doctrine loss rate — which
     we can derive by redistributing hull totals when needed.
     """
-    # Wipe any previous attribution so stale ids don't linger.
-    db.execute("UPDATE killmail_hull_loss_1d SET doctrine_fit_id = NULL")
-    db.execute("UPDATE killmail_item_loss_1d SET doctrine_fit_id = NULL")
+    # The unique keys on killmail_hull_loss_1d / killmail_item_loss_1d
+    # are built on GENERATED columns:
+    #
+    #     UNIQUE (bucket_start, hull_type_id,
+    #             doctrine_fit_key    -- COALESCE(doctrine_fit_id, 0)
+    #             doctrine_group_key) -- COALESCE(doctrine_group_id, 0)
+    #
+    # A naive ``UPDATE ... SET doctrine_fit_id = NULL`` collapses every
+    # stale row for the same ``(bucket_start, hull_type_id)`` into the
+    # same key (0, 0) and fails with a duplicate-key error. Instead we
+    # DELETE the rows that currently hold a non-NULL attribution — the
+    # analytics bucket job re-writes the canonical NULL row every run,
+    # so the delete is safe: we are only removing stale carbon copies,
+    # not historical data.
+    db.execute(
+        "DELETE FROM killmail_hull_loss_1d WHERE doctrine_fit_id IS NOT NULL OR doctrine_group_id IS NOT NULL"
+    )
+    db.execute(
+        "DELETE FROM killmail_item_loss_1d WHERE doctrine_fit_id IS NOT NULL OR doctrine_group_id IS NOT NULL"
+    )
 
     # Match: hulls that currently have exactly one active doctrine.
+    # We can't UPDATE in place for the same reason (flipping the NULL
+    # canonical row to a non-NULL id would produce a new (bucket, hull,
+    # id, 0) tuple that collides with nothing, so that path IS safe,
+    # but only because we just deleted the stale non-NULL rows above).
     rows = db.fetch_all(
         """SELECT hull_type_id, MIN(id) AS doctrine_id, COUNT(*) AS cnt
              FROM auto_doctrines
@@ -445,11 +466,13 @@ def _repopulate_loss_aggregates(db: Any) -> int:
         hull_type_id = int(row["hull_type_id"])
         doctrine_id = int(row["doctrine_id"])
         updated += db.execute(
-            "UPDATE killmail_hull_loss_1d SET doctrine_fit_id = %s WHERE hull_type_id = %s",
+            "UPDATE killmail_hull_loss_1d SET doctrine_fit_id = %s "
+            "WHERE hull_type_id = %s AND doctrine_fit_id IS NULL",
             (doctrine_id, hull_type_id),
         )
         updated += db.execute(
-            "UPDATE killmail_item_loss_1d SET doctrine_fit_id = %s WHERE hull_type_id = %s",
+            "UPDATE killmail_item_loss_1d SET doctrine_fit_id = %s "
+            "WHERE hull_type_id = %s AND doctrine_fit_id IS NULL",
             (doctrine_id, hull_type_id),
         )
     return updated

--- a/src/functions.php
+++ b/src/functions.php
@@ -4118,6 +4118,8 @@ function orchestrator_runtime_config_export(): array
         'influxdb' => [
             'enabled' => (bool) config('influxdb.enabled', false),
             'read_enabled' => (bool) config('influxdb.read_enabled', false),
+            'read_mode' => (string) config('influxdb.read_mode', 'disabled'),
+            'write_on_rollup' => (bool) config('influxdb.write_on_rollup', false),
             'url' => rtrim((string) config('influxdb.url', 'http://127.0.0.1:8086'), '/'),
             'org' => (string) config('influxdb.org', ''),
             'bucket' => (string) config('influxdb.bucket', 'supplycore_rollups'),
@@ -4125,6 +4127,7 @@ function orchestrator_runtime_config_export(): array
             'timeout_seconds' => max(3, (int) config('influxdb.timeout_seconds', 15)),
             'export_batch_size' => max(100, (int) config('influxdb.export_batch_size', 1000)),
             'export_overlap_seconds' => max(0, (int) config('influxdb.export_overlap_seconds', 21600)),
+            'rollup_write_batch_size' => max(100, (int) config('influxdb.rollup_write_batch_size', 500)),
             'export_log_file' => supplycore_worker_log_path('influx-rollup-export.log', (string) config('influxdb.export_log_file', 'storage/logs/influx-rollup-export.log')),
         ],
         'redis' => [


### PR DESCRIPTION
## Two bugs found while deploying the auto-doctrine pipeline on a live server

### 1. `IntegrityError` crash in `_repopulate_loss_aggregates`

```
(1062, "Duplicate entry '2026-03-16-582-0-0' for key 'uniq_killmail_hull_loss_1d_dimensions'")
  File ".../compute_auto_doctrines.py", line 432, in _repopulate_loss_aggregates
    db.execute("UPDATE killmail_hull_loss_1d SET doctrine_fit_id = NULL")
```

**Root cause:** the unique key on `killmail_hull_loss_1d` is built from **generated** columns:

```sql
UNIQUE (bucket_start, hull_type_id,
        doctrine_fit_key,    -- GENERATED ALWAYS AS (COALESCE(doctrine_fit_id, 0))
        doctrine_group_key)  -- GENERATED ALWAYS AS (COALESCE(doctrine_group_id, 0))
```

Earlier detector runs left behind multiple rows with non-NULL `doctrine_fit_id` values for the same `(bucket_start, hull_type_id)` tuple. The bulk `UPDATE ... SET doctrine_fit_id = NULL` collapsed every one of those into the same `(bucket, hull, 0, 0)` key and collided with the canonical NULL row the analytics bucket job had just rewritten.

**Fix:** `DELETE` the stale non-NULL attribution rows instead of `UPDATE`-ing them. The canonical NULL rows are rewritten every analytics run, so the delete only removes carbon copies — no historical counts are lost. The per-hull UPDATE that attaches `doctrine_fit_id` to a single active `auto_doctrines` row now also filters `WHERE doctrine_fit_id IS NULL` so it stays idempotent across re-runs.

### 2. `influxdb.write_on_rollup` + `influxdb.read_mode` never reached Python

The operator ticked both checkboxes in the settings UI, but the analytics job output showed `InfluxDB: 0 points`. 

**Root cause:** `src/config/runtime_settings.php` registers both keys as `database_backed`, and the PHP `config()` lookup reads them correctly — but `orchestrator_runtime_config_export()` in `src/functions.php` only forwarded `enabled` / `read_enabled` / `url` / `org` / `bucket` / `token` into the exported `influxdb` dict. Python's `RollupInfluxBridge.from_config` read the missing `write_on_rollup` as `False` (the default), disabled itself, and every analytics job silently reported zero Influx writes.

**Fix:** add `read_mode`, `write_on_rollup`, and `rollup_write_batch_size` to the exported `influxdb` block. `_load_live_php_runtime_config` shells out to PHP on every orchestrator invocation so there's no cache bust — the next job run sees the new values.

## Test plan

On the server after pull + deploy (no migrations needed for this PR):

```bash
# 1. Detector now completes without the dupe-key error
python -m orchestrator run-job --app-root /var/www/SupplyCore --job-key compute_auto_doctrines
# Expected: status=success, doctrines_upserted > 0

# 2. Analytics job now dual-writes to Influx (assuming both checkboxes are on)
python -m orchestrator run-job --app-root /var/www/SupplyCore --job-key analytics_bucket_1d_sync
# Expected in summary: "InfluxDB: <N> points" where N > 0
```

```sql
-- 3. No stale attribution carbon copies remain
SELECT COUNT(*) FROM killmail_hull_loss_1d WHERE doctrine_fit_id IS NOT NULL;
-- Expected: small (= count of hulls with exactly one active auto-doctrine)

-- 4. Unique key no longer contested
SELECT bucket_start, hull_type_id, COUNT(*)
  FROM killmail_hull_loss_1d
 GROUP BY bucket_start, hull_type_id
HAVING COUNT(*) > 1;
-- Expected: 0 rows
```

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw