### PR TITLE
Use float for DECIMAL market fields in Influx dual-write

### DIFF
--- a/python/orchestrator/jobs/analytics_bucket_1d_sync.py
+++ b/python/orchestrator/jobs/analytics_bucket_1d_sync.py
@@ -21,6 +21,11 @@ def _dual_write_stock(db: SupplyCoreDb, bridge: RollupInfluxBridge) -> None:
         "WHERE bucket_start >= DATE_SUB(UTC_DATE(), INTERVAL 14 DAY)"
     )
     for row in rows:
+        # ``stock_units_sum`` and ``listing_count_sum`` are DECIMAL(20, 2)
+        # in MariaDB and have already been registered as ``float`` in
+        # Influx by the legacy influx_export.py. Writing them as ``int``
+        # here would trigger a field-type conflict and InfluxDB rejects
+        # the whole batch with HTTP 422. Keep them floats to match.
         bridge.enqueue_market_stock(
             bucket_start=row["bucket_start"],
             source_type=row["source_type"],
@@ -29,8 +34,8 @@ def _dual_write_stock(db: SupplyCoreDb, bridge: RollupInfluxBridge) -> None:
             window="1d",
             fields={
                 "sample_count": int(row.get("sample_count") or 0),
-                "stock_units_sum": int(row.get("stock_units_sum") or 0),
-                "listing_count_sum": int(row.get("listing_count_sum") or 0),
+                "stock_units_sum": float(row.get("stock_units_sum") or 0),
+                "listing_count_sum": float(row.get("listing_count_sum") or 0),
                 "local_stock_units": int(row.get("local_stock_units") or 0),
                 "listing_count": int(row.get("listing_count") or 0),
             },
@@ -57,7 +62,8 @@ def _dual_write_price(db: SupplyCoreDb, bridge: RollupInfluxBridge) -> None:
             window="1d",
             fields={
                 "sample_count": int(row.get("sample_count") or 0),
-                "listing_count_sum": int(row.get("listing_count_sum") or 0),
+                # listing_count_sum is DECIMAL in MariaDB → float in Influx.
+                "listing_count_sum": float(row.get("listing_count_sum") or 0),
                 "avg_price_sum": float(row.get("avg_price_sum") or 0),
                 "weighted_price_numerator": float(row.get("weighted_price_numerator") or 0),
                 "weighted_price_denominator": float(row.get("weighted_price_denominator") or 0),

--- a/python/orchestrator/jobs/analytics_bucket_1h_sync.py
+++ b/python/orchestrator/jobs/analytics_bucket_1h_sync.py
@@ -20,6 +20,9 @@ def _dual_write_stock(db: SupplyCoreDb, bridge: RollupInfluxBridge) -> None:
         "WHERE bucket_start >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 48 HOUR)"
     )
     for row in rows:
+        # DECIMAL(20,2) columns must be floats in Influx to match the
+        # existing legacy-exporter schema. See the daily job for the
+        # full explanation.
         bridge.enqueue_market_stock(
             bucket_start=row["bucket_start"],
             source_type=row["source_type"],
@@ -28,8 +31,8 @@ def _dual_write_stock(db: SupplyCoreDb, bridge: RollupInfluxBridge) -> None:
             window="1h",
             fields={
                 "sample_count": int(row.get("sample_count") or 0),
-                "stock_units_sum": int(row.get("stock_units_sum") or 0),
-                "listing_count_sum": int(row.get("listing_count_sum") or 0),
+                "stock_units_sum": float(row.get("stock_units_sum") or 0),
+                "listing_count_sum": float(row.get("listing_count_sum") or 0),
                 "local_stock_units": int(row.get("local_stock_units") or 0),
                 "listing_count": int(row.get("listing_count") or 0),
             },
@@ -56,7 +59,7 @@ def _dual_write_price(db: SupplyCoreDb, bridge: RollupInfluxBridge) -> None:
             window="1h",
             fields={
                 "sample_count": int(row.get("sample_count") or 0),
-                "listing_count_sum": int(row.get("listing_count_sum") or 0),
+                "listing_count_sum": float(row.get("listing_count_sum") or 0),
                 "avg_price_sum": float(row.get("avg_price_sum") or 0),
                 "weighted_price_numerator": float(row.get("weighted_price_numerator") or 0),
                 "weighted_price_denominator": float(row.get("weighted_price_denominator") or 0),


### PR DESCRIPTION
## Summary

Analytics jobs were hitting a wall of HTTP 422 errors from InfluxDB:

```
failure writing points to database: partial write: field type conflict:
input field "stock_units_sum" on measurement "market_item_stock" is type
integer, already exists as type float  dropped=500
```

…repeated for every 500-point batch, and the same pattern for `listing_count_sum` on `market_item_price`.

## Root cause

The dual-write helpers I added in PR #750 cast every numeric field with `int()`. But `stock_units_sum` and `listing_count_sum` are `DECIMAL(20, 2)` in MariaDB, and the legacy `influx_export.py` had already registered them as **float** in Influx. InfluxDB is strict: once a field is registered as one type on a measurement, writes of a different type get rejected wholesale.

## Fix

Align the Python casts with the MariaDB column semantics:

| Field | MariaDB | Influx cast |
|---|---|---|
| `stock_units_sum` | DECIMAL(20,2) | **float** (was int) |
| `listing_count_sum` | DECIMAL(20,2) | **float** (was int) |
| `sample_count` | INT UNSIGNED | int (unchanged) |
| `listing_count` | INT UNSIGNED | int (unchanged) |
| `local_stock_units` | BIGINT | int (unchanged) |
| `avg_price_sum`, `weighted_price_*`, `min_price`, `max_price`, `avg_price`, `weighted_price` | DECIMAL | float (already correct) |

The killmail dual-write helpers were already correct — all the killmail rollup fields (`loss_count`, `quantity_lost`, `victim_count`, `killmail_count`) are true integer columns. That's why the last job run reported **`InfluxDB: 336301 points`** successfully for the item-loss hourly rollup while the market half of the same run was dropping everything.

Applied to both `analytics_bucket_1d_sync.py` and `analytics_bucket_1h_sync.py`.

## Test plan

```bash
python -m orchestrator run-job --app-root /var/www/SupplyCore --job-key analytics_bucket_1d_sync
python -m orchestrator run-job --app-root /var/www/SupplyCore --job-key analytics_bucket_1h_sync
```

Expected: no `[influx_writer] Dual-write flush failed` lines in the output. The job summary should report non-zero Influx point counts for the **market** measurements too, not just killmail.

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw