### PR TITLE
Fix inverted high/low slot labels in ITEM_FLAG_CATEGORY

### DIFF
--- a/python/orchestrator/eve_constants.py
+++ b/python/orchestrator/eve_constants.py
@@ -156,9 +156,19 @@ ROLE_MULTIPLIER_WEIGHT: dict[str, float] = {
 # ── Economic Warfare: item flag → slot category mapping (ESI standard) ────────
 
 ITEM_FLAG_CATEGORY: dict[int, str] = {
-    **{f: "high" for f in range(11, 19)},       # high slots (11-18)
+    # EVE ``invFlags`` IDs (verified against the SDE):
+    #   LoSlot0..LoSlot7  = 11..18
+    #   MedSlot0..MedSlot7 = 19..26
+    #   HiSlot0..HiSlot7  = 27..34
+    # An earlier version of this map had the 11-18 and 27-34 ranges
+    # swapped — clustering still worked because the labels were
+    # consistently wrong, but the human-readable slot category and the
+    # ``_canonical_name`` heuristic that picks the "dominant high-slot
+    # module" were both inverted. Fixing the labels here re-anchors
+    # every downstream consumer to reality.
+    **{f: "low" for f in range(11, 19)},         # low slots (11-18)
     **{f: "medium" for f in range(19, 27)},      # mid slots (19-26)
-    **{f: "low" for f in range(27, 35)},         # low slots (27-34)
+    **{f: "high" for f in range(27, 35)},        # high slots (27-34)
     **{f: "rig" for f in range(92, 95)},         # rig slots (92-94)
     87: "drone",                                  # drone bay
     **{f: "subsystem" for f in range(125, 133)},  # T3 subsystems (125-132)


### PR DESCRIPTION
## Summary

`ITEM_FLAG_CATEGORY` in `python/orchestrator/eve_constants.py` had the high/low slot ranges **swapped** relative to EVE's actual `invFlags` table:

```python
# BEFORE (wrong)
**{f: "high" for f in range(11, 19)},   # ← actually LOW slots
**{f: "low" for f in range(27, 35)},    # ← actually HIGH slots

# AFTER (correct)
**{f: "low" for f in range(11, 19)},    # LoSlot0..LoSlot7
**{f: "high" for f in range(27, 35)},   # HiSlot0..HiSlot7
```

## Symptoms

Operator reported the `/doctrines/` expand panel showing:

```
Retribution — auto (top: type 2605)
  2× Nanofiber Internal Structure II        high · 100%    ← actually low-slot
  4× Small Focused Beam Laser II            low  · 100%    ← actually high-slot
  1× Small Coaxial Compact Remote Rep       low  · 100%    ← actually high-slot
```

Every hi-slot weapon showed as "low" and every low-slot module showed as "high".

## Downstream consequences

1. **`_canonical_name` picked the wrong "top" module.** The heuristic filters `m[1] in {"high", "high_slot", "turret", "launcher"}` to find the dominant weapon for the doctrine label. With the map inverted it was matching LOW-slot modules (damage mods, armor plates, reps) and labelling doctrines with those instead of the actual weapon. That's why you've been seeing `(top: type 2605)` — 2605 is "Heat Sink II", a low-slot damage mod — when the real dominant high-slot item is the laser.

2. **Clustering was *consistently* wrong, so it still worked.** Every kill got hashed with the same inverted labels, so the Jaccard clustering produced the right groups — just with misleading labels. No re-fragmentation from this bug alone.

3. **Human-readable slot column was confusing.** Operators looking at the expand panel couldn't trust the slot labels.

## Data migration impact

The `fingerprint_hash` in `auto_doctrines` is built from `(type_id, flag_category)` tuples. Every existing row on disk was hashed with the inverted labels. After this fix deploys, the next `compute_auto_doctrines` run will produce **different** fingerprint hashes for the same underlying kills → all existing rows become orphans (eventually demoted via `last_seen_at < window_days` cleanup).

## Cleanup SQL (run once after merge + pull)

```sql
-- Drop everything and let the detector rebuild with correct labels.
-- You haven't pinned any doctrines yet so there's no state to preserve.
DELETE FROM auto_doctrine_fit_demand_1d;
DELETE FROM auto_doctrine_modules;
DELETE FROM auto_doctrines;

-- Then rerun:
--   python -m orchestrator run-job --job-key compute_auto_doctrines
--   python -m orchestrator run-job --job-key compute_auto_buyall
```

After rebuild, the `/doctrines/` expand panel should show sensible slot labels:
```
Retribution — auto (top: type <real laser type_id>)
  2× Nanofiber Internal Structure II        low  · 100%    ✓
  4× Small Focused Beam Laser II            high · 100%    ✓
  1× Small Coaxial Compact Remote Rep       high · 100%    ✓
```

## About the `Imperial Navy Standard S` and `Scan Resolution Script` charges you saw

Those are categoryID 8 (Charge) and **should** be filtered by the extractor's `rit.category_id IN (7, 32)` clause. Please verify on your server:

```sql
SELECT type_id, type_name, category_id, group_id
  FROM ref_item_types
 WHERE type_name IN ('Imperial Navy Standard S', 'Scan Resolution Script');
```

If `category_id = 8` for both, then the filter *is* working and any charges in your current `auto_doctrine_modules` are stale rows from a pre-#749 run that weren't rewritten (the DELETE-from-`auto_doctrines` in the cleanup SQL above takes them out too). If `category_id ≠ 8`, your SDE has them miscategorized and we need a type_id override list similar to the Venture fix.

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw