### PR TITLE
Add command ship / command destroyer doctrine tier with 2-loss floor

### DIFF
--- a/database/migrations/20260416_command_min_losses_threshold.sql
+++ b/database/migrations/20260416_command_min_losses_threshold.sql
@@ -1,0 +1,11 @@
+-- Seed the new ``auto_doctrines.command_min_losses_threshold`` setting.
+--
+-- Command Ships (group 540) and Command Destroyers (group 1534) almost
+-- always fly in pairs (one shield/info, one armor/skirmish) and die
+-- rarely. The 30-loss subcap floor hides them entirely and even the
+-- 5-loss capital floor is too strict — a single lost pair is enough
+-- signal that a booster doctrine is being actively fielded. Default
+-- to 2 so one bad fight flips the pair into an active doctrine.
+INSERT INTO app_settings (setting_key, setting_value) VALUES
+    ('auto_doctrines.command_min_losses_threshold', '2')
+ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value);

--- a/python/orchestrator/jobs/compute_auto_doctrines.py
+++ b/python/orchestrator/jobs/compute_auto_doctrines.py
@@ -44,6 +44,12 @@ _DEFAULT_MIN_LOSSES = 30
 # titans, and force auxiliaries — tunable via the
 # ``auto_doctrines.capital_min_losses_threshold`` setting.
 _DEFAULT_CAPITAL_MIN_LOSSES = 5
+# Fleet command/boost ships almost always fly in pairs (one shield/info,
+# one armor/skirmish) so even the 5-loss capital floor hides real
+# doctrines early in their adoption curve. 2 losses — i.e. one bad fight
+# — is enough signal that the booster pair is a real doctrine. Tunable
+# via ``auto_doctrines.command_min_losses_threshold``.
+_DEFAULT_COMMAND_MIN_LOSSES = 2
 # 0.65 merges clusters that share roughly two-thirds of their modules.
 # The original 0.80 value (inherited from the opponent-kill economic
 # warfare clusterer) was too strict for our own losses: incomplete
@@ -58,20 +64,14 @@ _DEFAULT_JACCARD = 0.65
 # do not need to appear here.
 _CAPITAL_HULL_GROUPS: frozenset[int] = frozenset({485, 547, 659, 30, 1538})
 
-# EVE group IDs for fleet-support hulls that die rarely but are always
-# in real doctrines: Command Ships (Astarte, Sleipnir, Nighthawk,
-# Absolution, Claymore, Damnation, Eos, Vulture — group 540) and
-# Command Destroyers (Bifrost, Stork, Magus, Pontifex — group 1534).
-# These carry the fleet Command Bursts (shield / armor / info /
-# skirmish links) and almost never fly alone, but at the 30-loss
-# subcap floor they never accumulate enough losses to activate. Share
-# the capital 5-loss floor so they surface as doctrine ships.
+# EVE group IDs for fleet-support hulls that die rarely and are always
+# fielded in pairs (one shield/info, one armor/skirmish): Command
+# Ships (Astarte, Sleipnir, Nighthawk, Absolution, Claymore, Damnation,
+# Eos, Vulture — group 540) and Command Destroyers (Bifrost, Stork,
+# Magus, Pontifex — group 1534). These get their own 2-loss floor via
+# ``_DEFAULT_COMMAND_MIN_LOSSES`` — lower than capitals because a
+# single lost pair already signals an active doctrine.
 _COMMAND_HULL_GROUPS: frozenset[int] = frozenset({540, 1534})
-
-# Convenience: the union of every hull group that uses the low
-# activation floor. Used by the extractor's threshold tiering and the
-# is_active sweep so the two can't drift.
-_LOW_VOLUME_HULL_GROUPS: frozenset[int] = _CAPITAL_HULL_GROUPS | _COMMAND_HULL_GROUPS
 
 # Hull groups that must never appear as doctrines. The extractor SQL
 # filters by this list, and ``_purge_excluded_hull_rows`` deletes any
@@ -102,6 +102,7 @@ def _load_settings(db: Any) -> dict[str, Any]:
                 'auto_doctrines.window_days',
                 'auto_doctrines.min_losses_threshold',
                 'auto_doctrines.capital_min_losses_threshold',
+                'auto_doctrines.command_min_losses_threshold',
                 'auto_doctrines.default_runway_days',
                 'auto_doctrines.jaccard_threshold'
             )"""
@@ -125,6 +126,9 @@ def _load_settings(db: Any) -> dict[str, Any]:
         "min_losses": _int("auto_doctrines.min_losses_threshold", _DEFAULT_MIN_LOSSES),
         "capital_min_losses": _int(
             "auto_doctrines.capital_min_losses_threshold", _DEFAULT_CAPITAL_MIN_LOSSES
+        ),
+        "command_min_losses": _int(
+            "auto_doctrines.command_min_losses_threshold", _DEFAULT_COMMAND_MIN_LOSSES
         ),
         "default_runway_days": _int("auto_doctrines.default_runway_days", 14),
         "jaccard_threshold": _float("auto_doctrines.jaccard_threshold", _DEFAULT_JACCARD),
@@ -294,6 +298,7 @@ def _upsert_doctrines(
     window_days: int,
     min_losses: int,
     capital_min_losses: int,
+    command_min_losses: int,
 ) -> dict[tuple[int, str], int]:
     """Upsert every family whose core set is non-empty. Returns a map
     ``(hull_type_id, canonical_fingerprint) -> doctrine_id``.
@@ -343,15 +348,19 @@ def _upsert_doctrines(
             hull_names.get(hull_type_id, ""), core, alliance_label=alliance_label
         )
 
-        # Tier the activation threshold: capitals AND command/boost
-        # hulls (Command Ships + Command Destroyers) use the lower
-        # capital_min_losses floor because they die rarely enough that
-        # the 30-loss subcap default would hide every real doctrine
-        # fit. See ``_LOW_VOLUME_HULL_GROUPS``.
+        # Tier the activation threshold in three tiers:
+        #   - Command ships / command destroyers: 2-loss floor (they
+        #     fly in pairs and a single lost pair is enough signal).
+        #   - Capitals (dread / carrier / super / titan / FAX): 5-loss
+        #     floor.
+        #   - Everything else: subcap 30-loss floor.
         hull_group_id = int(hull_meta.get(hull_type_id, {}).get("group_id") or 0)
-        effective_min_losses = (
-            capital_min_losses if hull_group_id in _LOW_VOLUME_HULL_GROUPS else min_losses
-        )
+        if hull_group_id in _COMMAND_HULL_GROUPS:
+            effective_min_losses = command_min_losses
+        elif hull_group_id in _CAPITAL_HULL_GROUPS:
+            effective_min_losses = capital_min_losses
+        else:
+            effective_min_losses = min_losses
 
         existing = db.fetch_one(
             """SELECT id, loss_count_total, is_pinned
@@ -458,9 +467,14 @@ def _purge_excluded_hull_rows(db: Any) -> int:
     )
 
 
-def _sweep_is_active(db: Any, min_losses: int, capital_min_losses: int) -> int:
+def _sweep_is_active(
+    db: Any,
+    min_losses: int,
+    capital_min_losses: int,
+    command_min_losses: int,
+) -> int:
     """Recompute ``is_active`` for every non-pinned row against the
-    current thresholds.
+    current three-tier thresholds (command < capital < subcap).
 
     Without this sweep a row only gets its ``is_active`` flag updated
     when the detector's clustering pass touches it — i.e. when a
@@ -472,17 +486,20 @@ def _sweep_is_active(db: Any, min_losses: int, capital_min_losses: int) -> int:
     re-evaluates every non-pinned row in one shot, tiered by hull
     class.
     """
-    low_volume_list = ",".join(str(g) for g in sorted(_LOW_VOLUME_HULL_GROUPS))
+    cap_list = ",".join(str(g) for g in sorted(_CAPITAL_HULL_GROUPS))
+    cmd_list = ",".join(str(g) for g in sorted(_COMMAND_HULL_GROUPS))
     return db.execute(
         f"""UPDATE auto_doctrines ad
               JOIN ref_item_types rit ON rit.type_id = ad.hull_type_id
                SET ad.is_active = CASE
-                   WHEN rit.group_id IN ({low_volume_list})
+                   WHEN rit.group_id IN ({cmd_list})
                        THEN IF(ad.loss_count_window >= %s, 1, 0)
-                       ELSE IF(ad.loss_count_window >= %s, 1, 0)
+                   WHEN rit.group_id IN ({cap_list})
+                       THEN IF(ad.loss_count_window >= %s, 1, 0)
+                   ELSE IF(ad.loss_count_window >= %s, 1, 0)
                END
              WHERE ad.is_pinned = 0""",
-        (capital_min_losses, min_losses),
+        (command_min_losses, capital_min_losses, min_losses),
     )
 
 
@@ -643,6 +660,7 @@ def run_compute_auto_doctrines(db: Any) -> dict[str, Any]:
         window_days=settings["window_days"],
         min_losses=settings["min_losses"],
         capital_min_losses=settings["capital_min_losses"],
+        command_min_losses=settings["command_min_losses"],
     )
 
     # Recompute is_active for every non-pinned row against the current
@@ -654,6 +672,7 @@ def run_compute_auto_doctrines(db: Any) -> dict[str, Any]:
         db,
         min_losses=settings["min_losses"],
         capital_min_losses=settings["capital_min_losses"],
+        command_min_losses=settings["command_min_losses"],
     )
     logger.info("auto_doctrines: is_active sweep touched %d rows", reactivated)
 
@@ -681,6 +700,7 @@ def run_compute_auto_doctrines(db: Any) -> dict[str, Any]:
             "window_days": settings["window_days"],
             "min_losses_threshold": settings["min_losses"],
             "capital_min_losses_threshold": settings["capital_min_losses"],
+            "command_min_losses_threshold": settings["command_min_losses"],
             "families_clustered": len(families),
             "doctrines_upserted": len(id_map),
             "demand_rows": demand_rows,


### PR DESCRIPTION
## Context

Operator reported that fleet boost / command hulls (Sleipnir, Nighthawk, Damnation, Eos, Absolution, Claymore, Vulture, Astarte — plus the Command Destroyer family Bifrost / Stork / Magus / Pontifex) never show up on `/doctrines/` even though they're always present in real fleet compositions. They die rarely enough that the 30-loss subcap floor filters them out, and even the 5-loss capital floor is too strict — **fleet boosters fly in pairs** (one shield/info, one armor/skirmish), so a single lost pair already signals an active doctrine.

## Fix

Three-tier activation threshold instead of two:

| Tier | Default | Setting key | Hulls |
|---|---|---|---|
| Subcap | 30 | `auto_doctrines.min_losses_threshold` | everything not below |
| Capital | 5 | `auto_doctrines.capital_min_losses_threshold` | Dread (485), Carrier (547), Super (659), Titan (30), FAX (1538) |
| **Command/Boost** | **2** | **`auto_doctrines.command_min_losses_threshold`** | **Command Ship (540), Command Destroyer (1534)** |

The picker in `_upsert_doctrines` is a three-way `if/elif`:
```python
if hull_group_id in _COMMAND_HULL_GROUPS:
    effective_min_losses = command_min_losses
elif hull_group_id in _CAPITAL_HULL_GROUPS:
    effective_min_losses = capital_min_losses
else:
    effective_min_losses = min_losses
```

And `_sweep_is_active` builds a three-branch `CASE WHEN` over the two group lists so the bulk re-activation pass stays consistent with the per-cluster tiering.

## Migration

`20260416_command_min_losses_threshold.sql` seeds `auto_doctrines.command_min_losses_threshold = 2` in `app_settings` so existing installs pick it up on `php bin/run-migrations.php`. Operators can tweak the value without a restart — the Python job reads it every run.

## Test plan

```bash
git pull && php bin/run-migrations.php

mysql supplycore -e "SELECT setting_key, setting_value FROM app_settings WHERE setting_key LIKE 'auto_doctrines.%';"
# Expected: now 6 keys including command_min_losses_threshold = 2

python -m orchestrator run-job --job-key compute_auto_doctrines
# meta should now include command_min_losses_threshold: 2
```

```sql
-- Any command ships with >=2 losses should now be active
SELECT ad.id, ad.canonical_name, ad.loss_count_window, ad.is_active,
       rit.type_name, rit.group_id
  FROM auto_doctrines ad
  JOIN ref_item_types rit ON rit.type_id = ad.hull_type_id
 WHERE rit.group_id IN (540, 1534)
 ORDER BY ad.loss_count_window DESC;
-- Expected: any cluster with >=2 window losses is is_active=1
```

Load `/doctrines/` — command ships (Sleipnir, Damnation, Eos, Bifrost, Stork, etc) should now appear if your alliance has lost any in the last 30 days.

## Tuning

If 2 is still too generous or too strict for your data, tune without a code change:
```sql
UPDATE app_settings SET setting_value = '3' WHERE setting_key = 'auto_doctrines.command_min_losses_threshold';
```

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw