### PR TITLE
activity-priority: stock-aware readiness labels

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -22422,6 +22422,109 @@ function activity_priority_module_loss_windows(array $hullTypeIds): array
     return $out;
 }
 
+/**
+ * For every active doctrine in ``$doctrineIds`` compute how many
+ * complete fits the current alliance stock can already cover.
+ *
+ * The bottleneck is the minimum across every module in the fit:
+ *     fits_per_module   = floor(alliance_stock[type_id] / per_fit_qty)
+ *     fits_covered      = min(fits_per_module across all modules)
+ *
+ * Returns ``{doctrine_id: {covered, bottleneck_type_id, bottleneck_fits}}``.
+ * Two batched queries regardless of how many doctrines or modules —
+ * one to load all modules, one to load all alliance stock snapshots.
+ *
+ * Doctrines whose core module set is empty return ``covered = 0``
+ * (nothing to stock, so no coverage signal).
+ */
+function activity_priority_stock_coverage(array $doctrineIds): array
+{
+    $doctrineIds = array_values(array_unique(array_filter(array_map('intval', $doctrineIds), static fn (int $id): bool => $id > 0)));
+    if ($doctrineIds === []) {
+        return [];
+    }
+
+    // Step 1: pull every module row for the target doctrines in one go.
+    $placeholders = implode(',', array_fill(0, count($doctrineIds), '?'));
+    $moduleRows = db_select(
+        "SELECT doctrine_id, type_id, quantity
+           FROM auto_doctrine_modules
+          WHERE doctrine_id IN ({$placeholders})",
+        $doctrineIds
+    );
+
+    // Group modules by doctrine and collect every unique type_id.
+    $modulesByDoctrine = [];
+    $typeIdSet = [];
+    foreach ($moduleRows as $row) {
+        $doctrineId = (int) ($row['doctrine_id'] ?? 0);
+        $typeId = (int) ($row['type_id'] ?? 0);
+        $qty = max(1, (int) ($row['quantity'] ?? 1));
+        if ($doctrineId <= 0 || $typeId <= 0) {
+            continue;
+        }
+        $modulesByDoctrine[$doctrineId][] = ['type_id' => $typeId, 'quantity' => $qty];
+        $typeIdSet[$typeId] = true;
+    }
+
+    // Step 2: latest alliance-structure stock snapshot per type_id.
+    $stockByType = [];
+    if ($typeIdSet !== []) {
+        $typeIds = array_keys($typeIdSet);
+        $typePlaceholders = implode(',', array_fill(0, count($typeIds), '?'));
+        $stockRows = db_select(
+            "SELECT mss.type_id,
+                    COALESCE(mss.total_sell_volume, 0) AS stock_qty
+               FROM market_order_snapshots_summary mss
+               JOIN (
+                   SELECT type_id, MAX(observed_at) AS latest_at
+                     FROM market_order_snapshots_summary
+                    WHERE source_type = 'alliance_structure'
+                      AND type_id IN ({$typePlaceholders})
+                    GROUP BY type_id
+               ) latest
+                 ON latest.type_id = mss.type_id
+                AND latest.latest_at = mss.observed_at
+              WHERE mss.source_type = 'alliance_structure'",
+            $typeIds
+        );
+        foreach ($stockRows as $row) {
+            $stockByType[(int) ($row['type_id'] ?? 0)] = (int) ($row['stock_qty'] ?? 0);
+        }
+    }
+
+    // Step 3: compute the bottleneck per doctrine.
+    $out = [];
+    foreach ($doctrineIds as $doctrineId) {
+        $modules = $modulesByDoctrine[$doctrineId] ?? [];
+        if ($modules === []) {
+            $out[$doctrineId] = ['covered' => 0, 'bottleneck_type_id' => 0];
+            continue;
+        }
+        $bottleneckFits = PHP_INT_MAX;
+        $bottleneckTypeId = 0;
+        foreach ($modules as $m) {
+            $typeId = (int) $m['type_id'];
+            $perFitQty = max(1, (int) $m['quantity']);
+            $stock = (int) ($stockByType[$typeId] ?? 0);
+            $fitsForThisModule = intdiv($stock, $perFitQty);
+            if ($fitsForThisModule < $bottleneckFits) {
+                $bottleneckFits = $fitsForThisModule;
+                $bottleneckTypeId = $typeId;
+            }
+        }
+        if ($bottleneckFits === PHP_INT_MAX) {
+            $bottleneckFits = 0;
+        }
+        $out[$doctrineId] = [
+            'covered'             => $bottleneckFits,
+            'bottleneck_type_id'  => $bottleneckTypeId,
+        ];
+    }
+
+    return $out;
+}
+
 function activity_priority_page_data(): array
 {
     // The legacy snapshot flow populated doctrine_activity_snapshots from
@@ -22445,6 +22548,14 @@ function activity_priority_page_data(): array
     $hullTypeIds = array_values(array_unique(array_map(static fn (array $d): int => (int) ($d['hull_type_id'] ?? 0), $active)));
     $hullWindows = activity_priority_hull_loss_windows($hullTypeIds);
     $moduleWindows = activity_priority_module_loss_windows($hullTypeIds);
+
+    // Stock coverage per doctrine: how many complete fits the current
+    // alliance-structure snapshot can cover, bottlenecked by the most
+    // constrained module in each fit. Used to override the readiness
+    // label and resupply pressure tier so "Critical gap · Urgent
+    // resupply" does not fire on doctrines whose stock is fine.
+    $activeDoctrineIds = array_map(static fn (array $d): int => (int) ($d['id'] ?? 0), $active);
+    $stockCoverage = activity_priority_stock_coverage($activeDoctrineIds);
 
     $windowDays = max(1, (int) $settings['window_days']);
     $defaultRunway = max(1, (int) $settings['default_runway_days']);
@@ -22493,19 +22604,38 @@ function activity_priority_page_data(): array
         $runwayDays = $s['runway_days'];
         $activityScore = $s['score'];
 
+        // Stock-aware readiness: subtract how many complete fits the
+        // current alliance-structure stock can already cover from the
+        // per-fingerprint target. ``realGap`` is the number of fits
+        // we STILL need after stock is counted — that's what actually
+        // drives whether operators should be alarmed.
+        $coveredFits = (int) ($stockCoverage[(int) ($d['id'] ?? 0)]['covered'] ?? 0);
+        $realGap = max(0, $targetFits - $coveredFits);
+
+        // Activity level stays loss-driven — it's a signal about how
+        // actively the fit is being burned, independent of stock.
         $activityLevel = match (true) {
             $targetFits >= 10 => 'critical',
             $targetFits >= 3  => 'elevated',
             default            => 'low',
         };
-        $readinessLabel = $targetFits > 0 ? 'Critical gap' : 'Market ready';
-        // Resupply pressure must agree with the readiness gap: no gap
-        // means no urgency regardless of historical loss count.
-        $resupplyPressure = match (true) {
-            $targetFits >= 10 => 'Urgent resupply',
-            $targetFits >= 3  => 'Moderate pressure',
-            default            => 'Stable',
-        };
+
+        // Readiness / resupply tier, on the other hand, only fires
+        // when stock cannot cover the demand. Thresholds are scaled
+        // against target_fits so a proportional shortfall (roughly a
+        // third of the target) still trips the "Critical gap" label
+        // even on low-volume doctrines.
+        $criticalCut = max(3, (int) ceil($targetFits / 3));
+        if ($realGap <= 0) {
+            $readinessLabel = 'Market ready';
+            $resupplyPressure = 'Stable';
+        } elseif ($realGap >= $criticalCut) {
+            $readinessLabel = 'Critical gap';
+            $resupplyPressure = 'Urgent resupply';
+        } else {
+            $readinessLabel = 'Partial gap';
+            $resupplyPressure = 'Moderate pressure';
+        }
 
         $row = [
             'entity_id'          => (int) ($d['id'] ?? 0),
@@ -22523,14 +22653,14 @@ function activity_priority_page_data(): array
             'rank_delta'         => 0,
             'movement_label'     => '—',
             'explanation'        => sprintf(
-                '%d losses for this fit in the last %dd · daily rate %.2f · target %d fits over %dd runway (hull-level: %d in 7d, %d in 24h)',
+                '%d losses for this fit in the last %dd · daily rate %.2f · target %d fits, %d covered by stock, %d still needed (runway %dd)',
                 $windowLosses,
                 $windowDays,
                 $dailyRate,
                 $targetFits,
-                $runwayDays,
-                $hullW['h7d'],
-                $hullW['h24']
+                $coveredFits,
+                $realGap,
+                $runwayDays
             ),
             // "hull_losses_*" are the hull-level windows shared across
             // every fingerprint on the same hull. The template labels
@@ -22545,11 +22675,16 @@ function activity_priority_page_data(): array
             'fit_equivalent_losses_7d'     => (float) $hullW['h7d'],
             'readiness_label'              => $readinessLabel,
             'resupply_pressure'            => $resupplyPressure,
-            'readiness_gap_count'          => $targetFits,
+            // Surface the REAL gap (after subtracting stock) instead
+            // of the raw target_fits so the "X fit gaps" text in the
+            // template agrees with the readiness label.
+            'readiness_gap_count'          => $realGap,
             'score_components'             => [
                 sprintf('Fit losses (%dd)', $windowDays)  => (string) $windowLosses,
                 'Daily rate'                               => number_format($dailyRate, 2),
                 'Target fits'                              => (string) $targetFits,
+                'Covered by stock'                         => (string) $coveredFits,
+                'Real gap (needed)'                        => (string) $realGap,
                 'Runway (days)'                            => (string) $runwayDays,
                 'Hull total (7d)'                          => (string) $hullW['h7d'],
             ],
@@ -22581,9 +22716,9 @@ function activity_priority_page_data(): array
             'context' => 'Auto-detected doctrines with fit gaps right now',
         ],
         [
-            'label'   => 'Highly Active Fits',
-            'value'   => (string) count(array_filter($activeDoctrines, static fn (array $r): bool => (string) $r['activity_level'] === 'critical')),
-            'context' => 'Doctrine fits with urgent resupply pressure',
+            'label'   => 'Fits Needing Stock',
+            'value'   => (string) count(array_filter($activeDoctrines, static fn (array $r): bool => (string) $r['resupply_pressure'] === 'Urgent resupply')),
+            'context' => 'Doctrines where alliance stock cannot cover the target fit count',
         ],
         [
             'label'   => 'Total Window Losses',


### PR DESCRIPTION
## The contradiction

- **`/buy-all/`**: "Alliance stock covers every active doctrine — nothing to buy right now"
- **`/activity-priority/`** (same doctrines): `Critical gap · Urgent resupply · 119 fit gaps`

Both were internally correct, but measured different things. `activity_priority_page_data` tiered its readiness labels purely on `target_fits = loss_rate × runway`, never consulting alliance stock. So any fit with 10+ target fits screamed "Urgent resupply" even when stock fully covered it.

## The fix

### New helper `activity_priority_stock_coverage($doctrineIds)`

Two batched queries regardless of doctrine count:
1. Pull every `auto_doctrine_modules` row for the active doctrine set
2. Pull the latest alliance-structure snapshot for every referenced `type_id`

Per doctrine, compute `covered_fits` as the bottleneck across modules:
```
covered_fits = min(floor(alliance_stock[type_id] / per_fit_quantity))
```

Returns `{doctrine_id: {covered, bottleneck_type_id}}`.

### Page-loop rewrite

Per row:
```php
$realGap = max(0, $targetFits - $coveredFits);
$criticalCut = max(3, (int) ceil($targetFits / 3));

if ($realGap <= 0) {
    Market ready / Stable
} elseif ($realGap >= $criticalCut) {
    Critical gap / Urgent resupply
} else {
    Partial gap / Moderate pressure
}
```

- `activity_level` stays loss-driven (it's a demand signal independent of stock)
- `readiness_gap_count` = `realGap` (not raw `targetFits`), so "X fit gaps" agrees with the label
- `explanation` shows "target N, M covered by stock, K still needed"
- `score_components` gains `Covered by stock` and `Real gap (needed)` rows
- Summary card **"Highly Active Fits"** renamed to **"Fits Needing Stock"** and counts by `resupply_pressure = 'Urgent resupply'` — the buy-list driver operators actually care about

## Expected after merge + pull

For your well-stocked alliance:

| Doctrine | Before | After |
|---|---|---|
| Zealot 72 target, stock covers all | Critical gap · Urgent resupply · 72 fit gaps | **Market ready · Stable** |
| Retribution 59 target, stock covers 40 | Critical gap · Urgent resupply · 59 fit gaps | **Partial gap · Moderate pressure · 19 fit gaps** |
| Caracal 45 target, stock covers 3 | Critical gap · Urgent resupply · 45 fit gaps | **Critical gap · Urgent resupply · 42 fit gaps** (agrees with buy-all listing it) |

If buy-all is empty (stock covers everything), activity-priority will show all doctrines as `Market ready · Stable`. If buy-all starts producing a list, activity-priority will tier the doctrines by how much of their runway target is uncovered.

## Test plan

1. Merge + pull
2. Clean up the duplicate-cluster ghosts from the flag-map transition (separate issue):
   ```sql
   DELETE FROM auto_doctrine_fit_demand_1d;
   DELETE FROM auto_doctrine_modules;
   DELETE FROM auto_doctrines;
   ```
3. ```bash
   python -m orchestrator run-job --job-key compute_auto_doctrines
   python -m orchestrator run-job --job-key compute_auto_buyall
   ```
4. Verify on `/activity-priority/`:
   - Rows where alliance has plenty of stock show "Market ready · Stable"
   - Rows where alliance has a genuine shortage show "Critical gap · Urgent resupply"
   - The "Fits Needing Stock" KPI matches the count of rows `/buy-all/` is actually buying for

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw