### PR TITLE
compute_auto_buyall: look up summary id by computed_at, not LAST_INSERT_ID

### DIFF
--- a/python/orchestrator/jobs/compute_auto_buyall.py
+++ b/python/orchestrator/jobs/compute_auto_buyall.py
@@ -290,7 +290,18 @@ def run_compute_auto_buyall(db: Any) -> dict[str, Any]:
             json.dumps(payload, separators=(",", ":")),
         ),
     )
-    summary_row = db.fetch_one("SELECT LAST_INSERT_ID() AS id")
+    # ``SupplyCoreDb.execute`` and ``fetch_one`` each open their own
+    # short-lived connection, so ``SELECT LAST_INSERT_ID()`` from a
+    # separate call returns 0 — the session it belonged to has already
+    # been returned to the pool. Look the row up by ``computed_at``
+    # instead; we just wrote it and it is a datetime that we control.
+    summary_row = db.fetch_one(
+        """SELECT id FROM auto_buyall_summary
+            WHERE computed_at = %s
+            ORDER BY id DESC
+            LIMIT 1""",
+        (computed_at,),
+    )
     summary_id = int((summary_row or {}).get("id") or 0)
 
     if summary_id > 0 and items:


### PR DESCRIPTION
## The bug

```json
{
  "summary": "Auto buy-all: 8 items, 2,170,559,256 ISK.",
  "rows_written": 9,
  "meta": {
    "summary_id": 0,          ← should be the real auto-increment id
    "doctrine_count": 27,
    "total_isk": 2170559256.0
  }
}
```

The job computes 2.17B ISK of demand across 8 items and reports success. But `/buy-all/` still renders empty with "Alliance stock covers every active doctrine — nothing to buy right now".

## Root cause

```python
db.execute("INSERT INTO auto_buyall_summary ...")
summary_row = db.fetch_one("SELECT LAST_INSERT_ID() AS id")  # ← returns 0
summary_id = int((summary_row or {}).get("id") or 0)

if summary_id > 0 and items:          # ← guard fails
    for item in items:
        db.execute("INSERT INTO auto_buyall_items ...")   # ← never runs
```

`SupplyCoreDb.execute` and `SupplyCoreDb.fetch_one` each open **their own short-lived connection**. `LAST_INSERT_ID()` in MySQL/MariaDB is **session-scoped** — it reports the most recent id inserted *in the current session*. When `fetch_one` opens a fresh connection, that session has never inserted anything, so `LAST_INSERT_ID()` returns `0`.

The `if summary_id > 0` guard then skips the items loop entirely. The summary row exists with a real auto-increment id (that's how the page can read "Deterministic from 27 active doctrines × runway"), but no `auto_buyall_items` rows were written for it. The page reads the summary, queries items by `summary_id`, gets zero rows, and renders empty.

`rows_written: 9` is a lie — that value is `1 + len(items)` computed in Python, not the actual DB rowcount.

## Fix

Look up the summary row by `computed_at` instead of `LAST_INSERT_ID()`. `computed_at` is a datetime the Python job generates and writes, so it's unique per run and doesn't depend on session state:

```python
summary_row = db.fetch_one(
    """SELECT id FROM auto_buyall_summary
        WHERE computed_at = %s
        ORDER BY id DESC
        LIMIT 1""",
    (computed_at,),
)
summary_id = int((summary_row or {}).get("id") or 0)
```

One deterministic SELECT, no cross-session gymnastics. Works regardless of whether the pool hands out the same or different connection.

## Test plan

```bash
git pull
python -m orchestrator run-job --app-root /var/www/SupplyCore --job-key compute_auto_buyall
```

Expected meta change: `summary_id` is now a real non-zero id. Reload `/buy-all/` and you should see the 8-item, 2.17B ISK buy list populated for real.

```sql
-- Verify items now persist
SELECT s.id, s.computed_at, s.total_items, s.total_isk,
       (SELECT COUNT(*) FROM auto_buyall_items WHERE summary_id = s.id) AS item_rows
  FROM auto_buyall_summary s
 ORDER BY s.computed_at DESC
 LIMIT 3;
-- For the newest row, item_rows should equal total_items (8).
-- Earlier rows from before this fix will have item_rows = 0 (orphans from the bug).
```

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw