### PR TITLE
Fix NameError: add missing json import in compute_economic_warfare

### DIFF
--- a/python/orchestrator/jobs/compute_economic_warfare.py
+++ b/python/orchestrator/jobs/compute_economic_warfare.py
@@ -9,6 +9,7 @@ Phase 4: Write composite economic_warfare_score for each module
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import time


### PR DESCRIPTION
The job referenced json.dumps() when serializing fit family alliance and module set data, but the json module was never imported, causing scheduler.job.compute_economic_warfare to fail with NameError.