### PR TITLE
Fix evetech.net icon size=24 → size=32 on /buy-all/

### DIFF
--- a/public/buy-all/index.php
+++ b/public/buy-all/index.php
@@ -84,7 +84,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <tr class="border-b border-white/5">
                         <td class="px-3 py-2">
                             <div class="flex items-center gap-2">
-                                <img src="https://images.evetech.net/types/<?= (int) $item['type_id'] ?>/icon?size=24" width="24" height="24" alt="" loading="lazy" class="rounded">
+                                <img src="https://images.evetech.net/types/<?= (int) $item['type_id'] ?>/icon?size=32" width="24" height="24" alt="" loading="lazy" class="rounded">
                                 <span><?= htmlspecialchars((string) $item['type_name']) ?></span>
                             </div>
                         </td>


### PR DESCRIPTION
EVE's image CDN (images.evetech.net) only accepts a fixed set of icon sizes: 32, 64, 128, 256, 512, 1024. Requesting ``?size=24`` returns an HTTP error and the browser renders a broken image placeholder next to every row on /buy-all/.

Fix: request ``?size=32`` from the CDN but keep the rendered ``width="24"`` / ``height="24"`` so the visual density of the list is unchanged. The browser downscales the 32px icon to 24px on paint.

Verified every other icon emitter in ``public/`` already uses a valid size (32 or 64) — /buy-all/ was the only caller of the broken 24.

https://claude.ai/code/session_01DeQoyDiHzd3jR4vYu9hwLw