### PR TITLE
Add inflicted damage tracking per side in battle reports

### DIFF
--- a/public-proxy/partials/_battle_report_classic.php
+++ b/public-proxy/partials/_battle_report_classic.php
@@ -133,15 +133,26 @@ $groupedThirdParty = $isThreeColumn ? $_classicGroupParticipants($classicSides['
 
 // Compute summary stats per side
 $classicStats = [];
+// When we collapse the third-party column into opponent (two-column view),
+// the side_panels value for opponent has already been merged server-side.
+// We still add third_party's damage locally for the classic two-column view
+// since _battle_report_classic.php merges participants the same way.
+$mergeThirdPartyIntoOpponent = !$isThreeColumn;
 foreach (['friendly', 'opponent', 'third_party'] as $side) {
-    $pilots = 0; $shipsLost = 0; $dmgInflicted = 0.0;
+    $pilots = 0; $shipsLost = 0;
     foreach ($classicSides[$side] as $p) {
         $pilots++;
         $shipsLost += (int) ($p['deaths'] ?? $p['loss_count'] ?? 0);
-        $dmgInflicted += (float) ($p['damage_done'] ?? 0);
     }
     $totalIskK = (float) ($sidePanels[$side]['isk_killed'] ?? 0);
     $totalIskL = (float) ($sidePanels[$side]['isk_lost'] ?? 0);
+    // Inflicted damage is fed from the server-side raw killmail_attackers
+    // rollup (sidePanels[$side]['damage_inflicted']) so NPC/structure damage
+    // stays accounted for and this metric is independent from ISK values.
+    $dmgInflicted = (float) ($sidePanels[$side]['damage_inflicted'] ?? 0);
+    if ($mergeThirdPartyIntoOpponent && $side === 'opponent') {
+        $dmgInflicted += (float) ($sidePanels['third_party']['damage_inflicted'] ?? 0);
+    }
     $classicStats[$side] = [
         'pilots' => $pilots,
         'isk_destroyed' => $totalIskK,

--- a/public/api/public/theater.php
+++ b/public/api/public/theater.php
@@ -496,6 +496,54 @@ if (!isset($classifyAlliance)) {
     };
 }
 
+// ── Inflicted Damage per side (raw attacker damage, separate from ISK) ──
+// Sum killmail_attackers.damage_done directly rather than relying on the
+// character-keyed theater_participants rollup so NPC/structure damage and
+// attackers without a character_id are accounted for in the reconciliation.
+$damageByGroup = db_theater_damage_by_attacker_group($theaterId);
+$sideDamageInflicted = ['friendly' => 0.0, 'opponent' => 0.0, 'third_party' => 0.0];
+$unattributedDamage = 0.0;
+$totalDamage = 0.0;
+foreach ($damageByGroup as $_dmgRow) {
+    $_dmgAid = (int) ($_dmgRow['alliance_id'] ?? 0);
+    $_dmgCid = (int) ($_dmgRow['corporation_id'] ?? 0);
+    $_dmgAmt = (float) ($_dmgRow['total_damage'] ?? 0);
+    $totalDamage += $_dmgAmt;
+    if ($_dmgAid === 0 && $_dmgCid === 0) {
+        $unattributedDamage += $_dmgAmt;
+        continue;
+    }
+    $_dmgSide = $classifyAlliance($_dmgAid, $_dmgCid);
+    if (isset($sideDamageInflicted[$_dmgSide])) {
+        $sideDamageInflicted[$_dmgSide] += $_dmgAmt;
+    }
+}
+unset($_dmgRow, $_dmgAid, $_dmgCid, $_dmgAmt, $_dmgSide);
+foreach (['friendly', 'opponent', 'third_party'] as $_side) {
+    if (!isset($sidePanels[$_side])) continue;
+    $sidePanels[$_side]['damage_inflicted'] = $sideDamageInflicted[$_side];
+}
+unset($_side);
+$attributedDamage = $totalDamage - $unattributedDamage;
+$damageReconciliation = [
+    'total_damage'        => $totalDamage,
+    'attributed_damage'   => $attributedDamage,
+    'unattributed_damage' => $unattributedDamage,
+    'unattributed_pct'    => $totalDamage > 0 ? ($unattributedDamage / $totalDamage) * 100.0 : 0.0,
+    'friendly'            => $sideDamageInflicted['friendly'],
+    'opponent'            => $sideDamageInflicted['opponent'],
+    'third_party'         => $sideDamageInflicted['third_party'],
+];
+if ($totalDamage > 0 && ($unattributedDamage / $totalDamage) >= 0.01) {
+    if (!isset($dataQualityNotes) || !is_array($dataQualityNotes)) $dataQualityNotes = [];
+    $dataQualityNotes[] = sprintf(
+        'Inflicted damage reconciliation: %s HP unattributed (NPC/structure/unknown attackers), %.1f%% of %s total.',
+        number_format($unattributedDamage, 0),
+        $damageReconciliation['unattributed_pct'],
+        number_format($totalDamage, 0)
+    );
+}
+
 // No final-blows correction needed — all stats are derived from the
 // per-character ledger via alliance_summary.
 
@@ -606,6 +654,7 @@ $response = [
     'side_labels'           => $sideLabels,
     'side_alliances_by_pilots' => $sideAlliancesByPilots,
     'side_panels'           => $sidePanels,
+    'damage_reconciliation' => $damageReconciliation,
     'opponent_model'        => $opponentModel,
     'data_quality_notes'    => $dataQualityNotes,
     'tracked_alliance_ids'  => $trackedAllianceIds,

--- a/public/theater-intelligence/partials/_battle_report_classic.php
+++ b/public/theater-intelligence/partials/_battle_report_classic.php
@@ -138,15 +138,22 @@ $groupedThirdParty = $isThreeColumn ? _classic_group_participants($classicSides[
 
 // Compute summary stats per side
 $classicStats = [];
+$mergeThirdPartyIntoOpponent = !$isThreeColumn;
 foreach (['friendly', 'opponent', 'third_party'] as $side) {
-    $pilots = 0; $shipsLost = 0; $dmgInflicted = 0.0;
+    $pilots = 0; $shipsLost = 0;
     foreach ($classicSides[$side] as $p) {
         $pilots++;
         $shipsLost += (int) ($p['deaths'] ?? 0);
-        $dmgInflicted += (float) ($p['damage_done'] ?? 0);
     }
     $totalIskK = (float) ($sidePanels[$side]['isk_killed'] ?? 0);
     $totalIskL = (float) ($sidePanels[$side]['isk_lost'] ?? 0);
+    // Inflicted damage comes from the server-side raw killmail_attackers
+    // rollup — independent from ISK values and including attackers without
+    // a character_id (NPCs/structures) via the unattributed bucket.
+    $dmgInflicted = (float) ($sidePanels[$side]['damage_inflicted'] ?? 0);
+    if ($mergeThirdPartyIntoOpponent && $side === 'opponent') {
+        $dmgInflicted += (float) ($sidePanels['third_party']['damage_inflicted'] ?? 0);
+    }
     $classicStats[$side] = [
         'pilots' => $pilots,
         'isk_destroyed' => $totalIskK,

--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -872,6 +872,54 @@ if ($viewSnapshot !== null && !$pendingLock) {
 // ledger processes each killmail exactly once, crediting the victim with
 // losses/isk_lost and the final-blow attacker with kills/isk_killed.
 
+// ── Inflicted Damage per side (raw attacker damage, separate from ISK) ──
+// Sum killmail_attackers.damage_done directly rather than rely on the
+// character-keyed theater_participants rollup so NPC/structure damage and
+// attackers without a character_id land in the reconciliation bucket
+// instead of silently disappearing.
+$damageByGroup = db_theater_damage_by_attacker_group($theaterId);
+$sideDamageInflicted = ['friendly' => 0.0, 'opponent' => 0.0, 'third_party' => 0.0];
+$unattributedDamage = 0.0;
+$totalDamage = 0.0;
+foreach ($damageByGroup as $_dmgRow) {
+    $_dmgAid = (int) ($_dmgRow['alliance_id'] ?? 0);
+    $_dmgCid = (int) ($_dmgRow['corporation_id'] ?? 0);
+    $_dmgAmt = (float) ($_dmgRow['total_damage'] ?? 0);
+    $totalDamage += $_dmgAmt;
+    if ($_dmgAid === 0 && $_dmgCid === 0) {
+        $unattributedDamage += $_dmgAmt;
+        continue;
+    }
+    $_dmgSide = $classifyAlliance($_dmgAid, $_dmgCid);
+    if (isset($sideDamageInflicted[$_dmgSide])) {
+        $sideDamageInflicted[$_dmgSide] += $_dmgAmt;
+    }
+}
+unset($_dmgRow, $_dmgAid, $_dmgCid, $_dmgAmt, $_dmgSide);
+foreach (['friendly', 'opponent', 'third_party'] as $_dmgSideKey) {
+    if (!isset($sidePanels[$_dmgSideKey])) continue;
+    $sidePanels[$_dmgSideKey]['damage_inflicted'] = $sideDamageInflicted[$_dmgSideKey];
+}
+unset($_dmgSideKey);
+$damageReconciliation = [
+    'total_damage'        => $totalDamage,
+    'attributed_damage'   => $totalDamage - $unattributedDamage,
+    'unattributed_damage' => $unattributedDamage,
+    'unattributed_pct'    => $totalDamage > 0 ? ($unattributedDamage / $totalDamage) * 100.0 : 0.0,
+    'friendly'            => $sideDamageInflicted['friendly'],
+    'opponent'            => $sideDamageInflicted['opponent'],
+    'third_party'         => $sideDamageInflicted['third_party'],
+];
+if ($totalDamage > 0 && ($unattributedDamage / $totalDamage) >= 0.01) {
+    if (!isset($dataQualityNotes) || !is_array($dataQualityNotes)) $dataQualityNotes = [];
+    $dataQualityNotes[] = sprintf(
+        'Inflicted damage reconciliation: %s HP unattributed (NPC/structure/unknown attackers), %.1f%% of %s total.',
+        number_format($unattributedDamage, 0),
+        $damageReconciliation['unattributed_pct'],
+        number_format($totalDamage, 0)
+    );
+}
+
 // ── Promote third-party to opponent when no opponents are configured ─────────
 // Handles both fresh renders and locked snapshots saved before this logic existed.
 // The sideAlliancesByPilots promotion may have already run in the live path —

--- a/src/db.php
+++ b/src/db.php
@@ -15403,6 +15403,33 @@ function db_theater_fleet_composition(string $theaterId): array
 }
 
 /**
+ * Sum attacker damage_done per (alliance_id, corporation_id) across every
+ * killmail in a theater.
+ *
+ * Aggregates the raw killmail_attackers rows so the caller can classify each
+ * group to a side using the same closure as other per-side rollups. Rows with
+ * no alliance and no corporation (NPCs, structures) fall into the (0,0) group
+ * and should be reported as "unattributed" rather than silently dropped.
+ *
+ * @return list<array{alliance_id: int, corporation_id: int, total_damage: float}>
+ */
+function db_theater_damage_by_attacker_group(string $theaterId): array
+{
+    return db_select(
+        "SELECT
+            COALESCE(ka.alliance_id, 0) AS alliance_id,
+            COALESCE(ka.corporation_id, 0) AS corporation_id,
+            COALESCE(SUM(ka.damage_done), 0) AS total_damage
+         FROM killmail_attackers ka
+         INNER JOIN killmail_events ke ON ke.sequence_id = ka.sequence_id
+         INNER JOIN theater_battles tb ON tb.battle_id = ke.battle_id
+         WHERE tb.theater_id = ?
+         GROUP BY COALESCE(ka.alliance_id, 0), COALESCE(ka.corporation_id, 0)",
+        [$theaterId]
+    );
+}
+
+/**
  * Count final blows per attacker alliance/corporation for a theater.
  *
  * Returns raw per-group counts so the caller can classify sides consistently


### PR DESCRIPTION
## Summary
This change adds raw inflicted damage metrics to battle reports, tracked separately from ISK values. The implementation aggregates damage directly from killmail attacker records to account for NPC/structure damage and attackers without character IDs, which would otherwise be silently dropped.

## Key Changes

- **New database function** (`db_theater_damage_by_attacker_group`): Aggregates `killmail_attackers.damage_done` grouped by alliance/corporation, including unattributed damage (NPCs/structures) in a (0,0) group for reconciliation.

- **Damage reconciliation logic**: Added to both `public/api/public/theater.php` and `public/theater-intelligence/view.php`:
  - Classifies damage by side (friendly/opponent/third_party) using existing alliance classification
  - Tracks total, attributed, and unattributed damage
  - Generates data quality notes when unattributed damage exceeds 1% of total
  - Populates `sidePanels[$side]['damage_inflicted']` for API/template consumption

- **Battle report display**: Updated both classic battle report partials to:
  - Display inflicted damage alongside ISK metrics
  - Format damage with human-readable units (b/M/k for billions/millions/thousands)
  - Merge third-party damage into opponent column in two-column view (matching participant grouping behavior)

- **API response**: Added `damage_reconciliation` object to theater API response containing total/attributed/unattributed damage breakdown and per-side damage values.

## Implementation Details

- Damage aggregation bypasses the character-keyed `theater_participants` rollup to preserve NPC/structure damage that would otherwise be lost
- Unattributed damage (alliance_id=0, corporation_id=0) is tracked separately and reported in data quality notes when significant
- The same `$classifyAlliance()` closure used for other per-side metrics ensures consistent side classification
- Damage metrics are independent from ISK values, providing a complementary view of combat intensity

https://claude.ai/code/session_01A3MsgaPaKLN6M2LwMWcBqF