### PR TITLE
Implement async AI job queue for theater/opposition briefings

### DIFF
--- a/bin/ai_briefing_worker.php
+++ b/bin/ai_briefing_worker.php
@@ -1,0 +1,236 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SupplyCore AI briefing worker.
+ *
+ * Drains the ai_jobs queue and executes AI generation work that used to run
+ * inline on web requests (theater battle summaries, opposition daily
+ * briefings). Designed to be managed by systemd — see
+ * ops/systemd/supplycore-ai-worker.service.
+ *
+ * Usage:
+ *   php bin/ai_briefing_worker.php --drain                    # long-running loop (systemd)
+ *   php bin/ai_briefing_worker.php --once                     # claim and run a single job, then exit
+ *   php bin/ai_briefing_worker.php --job=<id>                 # run a specific job by id (debug)
+ *   php bin/ai_briefing_worker.php --sweep                    # reclaim stale leases, then exit
+ *
+ * Options:
+ *   --worker-id=<tag>       Identifier written to ai_jobs.worker_id (default: hostname-pid)
+ *   --lease=<seconds>       Lease length per claimed job (default: 900)
+ *   --poll=<seconds>        Idle sleep between queue polls (default: 5)
+ *   --max-jobs=<n>          Exit cleanly after processing n jobs (0 = unlimited)
+ *   --max-runtime=<seconds> Exit cleanly after n seconds of wall time (0 = unlimited)
+ */
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+// CLI hygiene: no PHP timeout, unbuffered output, journal-friendly logging.
+@set_time_limit(0);
+@ini_set('max_execution_time', '0');
+@ini_set('memory_limit', '512M');
+if (function_exists('ob_implicit_flush')) {
+    @ob_implicit_flush(true);
+}
+
+$options = getopt('', [
+    'drain',
+    'once',
+    'sweep',
+    'job::',
+    'worker-id::',
+    'lease::',
+    'poll::',
+    'max-jobs::',
+    'max-runtime::',
+    'help',
+]);
+
+if (isset($options['help'])) {
+    fwrite(STDOUT, "Usage: php bin/ai_briefing_worker.php --drain|--once|--sweep|--job=<id>\n");
+    exit(0);
+}
+
+$workerId = (string) ($options['worker-id'] ?? (gethostname() ?: 'worker') . '-' . getmypid());
+$leaseSeconds = max(60, (int) ($options['lease'] ?? 900));
+$pollSeconds = max(1, (int) ($options['poll'] ?? 5));
+$maxJobs = max(0, (int) ($options['max-jobs'] ?? 0));
+$maxRuntime = max(0, (int) ($options['max-runtime'] ?? 0));
+
+function ai_worker_log(string $level, string $message, array $context = []): void
+{
+    $line = sprintf(
+        '[ai-worker] [%s] %s%s',
+        $level,
+        $message,
+        $context === [] ? '' : ' ' . json_encode($context, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)
+    );
+    fwrite($level === 'error' || $level === 'warn' ? STDERR : STDOUT, $line . PHP_EOL);
+}
+
+function ai_worker_is_transient(Throwable $e): bool
+{
+    $message = $e->getMessage();
+    // Network / HTTP 5xx / timeout / cold-start style errors are retried.
+    // JSON validation, 4xx, missing-endpoint errors are terminal.
+    if (preg_match('/HTTP\s+5\d\d/i', $message) === 1) {
+        return true;
+    }
+    if (stripos($message, 'timed out') !== false
+        || stripos($message, 'did not finish before timeout') !== false
+        || stripos($message, 'connection') !== false
+        || stripos($message, 'network') !== false
+        || stripos($message, 'cold start') !== false
+        || stripos($message, 'IN_QUEUE') !== false
+        || stripos($message, 'IN_PROGRESS') !== false) {
+        return true;
+    }
+    return false;
+}
+
+function ai_worker_run_job(array $job, string $workerId): void
+{
+    $id = (int) ($job['id'] ?? 0);
+    $feature = (string) ($job['feature'] ?? '');
+    $target = (string) ($job['target_key'] ?? '');
+    $provider = (string) ($job['provider'] ?? '');
+    $attempts = (int) ($job['attempts'] ?? 0);
+
+    ai_worker_log('info', 'job.start', [
+        'id' => $id,
+        'feature' => $feature,
+        'target_key' => $target,
+        'provider' => $provider,
+        'attempt' => $attempts,
+        'worker' => $workerId,
+    ]);
+
+    $startedAt = microtime(true);
+    try {
+        $result = supplycore_ai_jobs_execute($job);
+        $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
+        supplycore_ai_jobs_complete($id, $result, $durationMs);
+        ai_worker_log('info', 'job.done', [
+            'id' => $id,
+            'feature' => $feature,
+            'duration_ms' => $durationMs,
+        ]);
+    } catch (Throwable $e) {
+        $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
+        $transient = ai_worker_is_transient($e);
+        supplycore_ai_jobs_fail($id, $e->getMessage(), $transient);
+        ai_worker_log($transient ? 'warn' : 'error', 'job.fail', [
+            'id' => $id,
+            'feature' => $feature,
+            'duration_ms' => $durationMs,
+            'transient' => $transient,
+            'error' => $e->getMessage(),
+        ]);
+    }
+}
+
+// --sweep: reclaim any stale leases and exit. Useful as a one-shot tool or
+// as part of a systemd OnCalendar timer.
+if (isset($options['sweep'])) {
+    $swept = supplycore_ai_jobs_sweep_expired_leases();
+    ai_worker_log('info', 'sweep.done', ['reclaimed' => $swept]);
+    exit(0);
+}
+
+// --job=<id>: run one specific row (debug hook, bypasses the claim loop).
+if (isset($options['job']) && $options['job'] !== false) {
+    $jobId = (int) $options['job'];
+    $job = supplycore_ai_jobs_get($jobId);
+    if ($job === null) {
+        ai_worker_log('error', 'job.not_found', ['id' => $jobId]);
+        exit(2);
+    }
+    ai_worker_run_job($job, $workerId);
+    exit(0);
+}
+
+// --once: claim and run a single job (if any) then exit.
+if (isset($options['once'])) {
+    supplycore_ai_jobs_sweep_expired_leases();
+    $job = supplycore_ai_jobs_claim($workerId, $leaseSeconds);
+    if ($job === null) {
+        ai_worker_log('info', 'queue.empty', []);
+        exit(0);
+    }
+    ai_worker_run_job($job, $workerId);
+    exit(0);
+}
+
+// --drain: long-running loop. Default mode when invoked by systemd.
+if (!isset($options['drain'])) {
+    fwrite(STDERR, "One of --drain / --once / --sweep / --job=<id> is required.\n");
+    exit(64);
+}
+
+$shouldStop = false;
+$handleSignal = static function (int $signal) use (&$shouldStop): void {
+    $shouldStop = true;
+    ai_worker_log('info', 'signal.stop', ['signal' => $signal]);
+};
+if (function_exists('pcntl_async_signals') && function_exists('pcntl_signal')) {
+    pcntl_async_signals(true);
+    pcntl_signal(SIGTERM, $handleSignal);
+    pcntl_signal(SIGINT, $handleSignal);
+    pcntl_signal(SIGHUP, $handleSignal);
+}
+
+ai_worker_log('info', 'drain.start', [
+    'worker_id' => $workerId,
+    'lease' => $leaseSeconds,
+    'poll' => $pollSeconds,
+    'max_jobs' => $maxJobs,
+    'max_runtime' => $maxRuntime,
+]);
+
+$processed = 0;
+$deadline = $maxRuntime > 0 ? (time() + $maxRuntime) : 0;
+$lastSweep = 0;
+
+while (!$shouldStop) {
+    // Cheap sweep for expired leases once a minute so one crashed worker
+    // doesn't permanently wedge its claimed rows.
+    if ((time() - $lastSweep) >= 60) {
+        try {
+            supplycore_ai_jobs_sweep_expired_leases();
+        } catch (Throwable $e) {
+            ai_worker_log('warn', 'sweep.error', ['error' => $e->getMessage()]);
+        }
+        $lastSweep = time();
+    }
+
+    try {
+        $job = supplycore_ai_jobs_claim($workerId, $leaseSeconds);
+    } catch (Throwable $e) {
+        ai_worker_log('error', 'claim.error', ['error' => $e->getMessage()]);
+        sleep($pollSeconds);
+        continue;
+    }
+
+    if ($job === null) {
+        if ($deadline > 0 && time() >= $deadline) {
+            break;
+        }
+        sleep($pollSeconds);
+        continue;
+    }
+
+    ai_worker_run_job($job, $workerId);
+    $processed++;
+
+    if ($maxJobs > 0 && $processed >= $maxJobs) {
+        break;
+    }
+    if ($deadline > 0 && time() >= $deadline) {
+        break;
+    }
+}
+
+ai_worker_log('info', 'drain.stop', ['processed' => $processed]);
+exit(0);

--- a/database/migrations/20260417_ai_jobs.sql
+++ b/database/migrations/20260417_ai_jobs.sql
@@ -1,0 +1,65 @@
+-- AI jobs queue
+--
+-- Stores asynchronous AI generation work (theater battle summaries,
+-- opposition daily briefings, etc.) that used to run inline on the web
+-- request thread. The web tier now enqueues a row here and returns
+-- immediately; bin/ai_briefing_worker.php (run under systemd) drains the
+-- queue, calls the configured AI provider (local/RunPod/Claude/Groq), and
+-- writes results back here and into the feature tables.
+--
+-- MariaDB >= 10.6 is required for SELECT ... FOR UPDATE SKIP LOCKED, which
+-- the worker uses to claim jobs without contending across worker slots.
+
+CREATE TABLE IF NOT EXISTS ai_jobs (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    -- Feature/use case: 'theater_lock', 'opposition_global',
+    -- 'opposition_alliance'. Determines which handler the worker invokes
+    -- and which provider override setting it consults.
+    feature VARCHAR(64) NOT NULL,
+    -- Stable key that identifies the target row the job writes back to
+    -- (e.g. theater_id, or 'YYYY-MM-DD' for opposition briefings, or
+    -- 'YYYY-MM-DD:<alliance_id>' for per-alliance briefings). Used to
+    -- deduplicate queued/running jobs for the same target.
+    target_key VARCHAR(191) NOT NULL,
+    -- Provider actually resolved at enqueue time ('local'|'runpod'|
+    -- 'claude'|'groq'). Captured so the worker uses the provider the
+    -- operator picked when the job was submitted, even if global settings
+    -- change later.
+    provider VARCHAR(32) NOT NULL,
+    -- Optional model label captured at enqueue time for audit.
+    model VARCHAR(120) NOT NULL DEFAULT '',
+    status ENUM('queued','running','done','failed','cancelled')
+        NOT NULL DEFAULT 'queued',
+    priority TINYINT NOT NULL DEFAULT 0,
+    attempts INT UNSIGNED NOT NULL DEFAULT 0,
+    max_attempts INT UNSIGNED NOT NULL DEFAULT 2,
+    -- Feature-specific input payload (e.g. {"theater_id": "..."} or
+    -- {"date":"2026-04-17","alliance_id":12345}). Kept explicit so the
+    -- worker is self-sufficient and doesn't re-read mutable state.
+    payload_json LONGTEXT NOT NULL,
+    -- Final result as returned by the AI provider (optional, primarily
+    -- for debugging — the normalized result is written into the feature
+    -- table by the handler).
+    result_json LONGTEXT NULL,
+    last_error TEXT NULL,
+    -- Lease for crash-safety: worker claims a row by setting status =
+    -- 'running', lease_until = NOW() + N, worker_id = slot tag. If a
+    -- worker dies mid-job, another worker (or a janitor sweep) can
+    -- reclaim rows whose lease_until is in the past.
+    lease_until DATETIME NULL,
+    worker_id VARCHAR(64) NULL,
+    duration_ms INT UNSIGNED NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ON UPDATE CURRENT_TIMESTAMP,
+    started_at DATETIME NULL,
+    completed_at DATETIME NULL,
+    PRIMARY KEY (id),
+    -- Worker claim query: WHERE status='queued' ORDER BY priority DESC, id ASC
+    KEY idx_ai_jobs_claim (status, priority, id),
+    -- Lease reclaim sweep: WHERE status='running' AND lease_until < NOW()
+    KEY idx_ai_jobs_lease (status, lease_until),
+    -- Dedup lookup: is there already an active job for this target?
+    KEY idx_ai_jobs_target (feature, target_key, status),
+    KEY idx_ai_jobs_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/ops/systemd/supplycore-ai-worker.service
+++ b/ops/systemd/supplycore-ai-worker.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=SupplyCore AI briefing worker (drains ai_jobs queue)
+After=network-online.target mariadb.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+WorkingDirectory=/var/www/SupplyCore
+EnvironmentFile=-/etc/default/supplycore-worker
+Environment=SUPPLYCORE_AI_WORKER_LEASE=900
+Environment=SUPPLYCORE_AI_WORKER_POLL=5
+ExecStart=/usr/bin/php /var/www/SupplyCore/bin/ai_briefing_worker.php --drain --worker-id=%H-ai --lease=${SUPPLYCORE_AI_WORKER_LEASE} --poll=${SUPPLYCORE_AI_WORKER_POLL}
+Restart=always
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=30
+MemoryMax=512M
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/public/opposition-intelligence/generate.php
+++ b/public/opposition-intelligence/generate.php
@@ -19,50 +19,34 @@ if ($date === '' || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
     $date = gmdate('Y-m-d');
 }
 
-// Generation can take several minutes on a local GPU/CPU — remove PHP timeout
-// and make sure the HTTP stack won't cut us off either.
-@set_time_limit(0);
-@ini_set('max_execution_time', '0');
-ignore_user_abort(false);
-
-// Force the AI pipeline to use local Ollama with the gemma4:e2b model at the
-// default local URL, regardless of whatever provider is configured in settings.
-$GLOBALS['supplycore_ai_ollama_runtime_override'] = [
-    'enabled' => true,
-    'provider' => 'local',
-    'url' => 'http://localhost:11434/api',
-    'model' => 'gemma4:e2b',
-    // Allow up to ~15 minutes for a single model call (gemma on local hardware
-    // can be slow, especially on first load).
-    'timeout' => 900,
-    'capability_override' => 'auto',
-    'runpod_url' => '',
-    'runpod_api_key' => '',
-    'runpod_api_key_masked' => '',
-    'claude_api_key' => '',
-    'claude_api_key_masked' => '',
-    'claude_model' => '',
-    'groq_api_key' => '',
-    'groq_api_key_masked' => '',
-    'groq_model' => '',
-    'inferred_tier' => 'small',
-    'capability_tier' => 'small',
-    'strategy' => supplycore_ai_capability_strategy('small'),
-];
-
+// Opposition briefings now run through the ai_jobs queue drained by
+// bin/ai_briefing_worker.php (systemd: supplycore-ai-worker.service). The
+// provider is picked per-feature via settings (ai_provider_opposition_global)
+// — no more hard-coded runtime override here.
 $error = null;
-$generated = 0;
-try {
-    $generated = opposition_ai_generate_daily_briefings($date);
-} catch (Throwable $e) {
-    error_log('[opposition-intel-generate] ' . $e->getMessage());
-    $error = $e->getMessage();
+$jobId = null;
+$status = 'queued';
+
+if (!supplycore_ai_ollama_enabled()) {
+    $status = 'disabled';
+    $error = 'AI briefings are disabled in settings.';
+} else {
+    try {
+        $jobId = supplycore_ai_jobs_enqueue(
+            'opposition_global',
+            $date,
+            ['date' => $date]
+        );
+    } catch (Throwable $e) {
+        error_log('[opposition-intel-generate] ' . $e->getMessage());
+        $status = 'error';
+        $error = $e->getMessage();
+    }
 }
 
-$status = $error !== null ? 'error' : 'ok';
 $flash = [
     'status' => $status,
-    'generated' => $generated,
+    'job_id' => $jobId,
     'error' => $error,
     'date' => $date,
 ];

--- a/public/opposition-intelligence/index.php
+++ b/public/opposition-intelligence/index.php
@@ -122,12 +122,21 @@ if ($flash !== null) {
 }
 ?>
 <?php if ($flash): ?>
-    <?php if (($flash['status'] ?? '') === 'ok'): ?>
-        <section class="surface-primary mt-4 border border-emerald-500/30 bg-emerald-500/10">
-            <p class="text-sm text-emerald-200">
-                <strong>Intel generation complete.</strong>
-                Generated <?= (int) ($flash['generated'] ?? 0) ?> briefing(s) for <?= htmlspecialchars((string) ($flash['date'] ?? ''), ENT_QUOTES) ?>
-                using local Ollama (gemma4:e2b).
+    <?php $flashStatus = (string) ($flash['status'] ?? ''); ?>
+    <?php if ($flashStatus === 'queued'): ?>
+        <section class="surface-primary mt-4 border border-sky-500/30 bg-sky-500/10">
+            <p class="text-sm text-sky-200">
+                <strong>Intel generation queued.</strong>
+                Job #<?= (int) ($flash['job_id'] ?? 0) ?> is running in the background for
+                <?= htmlspecialchars((string) ($flash['date'] ?? ''), ENT_QUOTES) ?>.
+                Refresh this page in a minute to see the result.
+            </p>
+        </section>
+    <?php elseif ($flashStatus === 'disabled'): ?>
+        <section class="surface-primary mt-4 border border-amber-500/30 bg-amber-500/10">
+            <p class="text-sm text-amber-200">
+                <strong>Intel generation disabled.</strong>
+                Enable AI briefings in Settings to queue a job.
             </p>
         </section>
     <?php else: ?>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1830,6 +1830,31 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     </label>
                 </div>
 
+                <div class="mt-4 rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3">
+                    <p class="text-sm font-medium text-slate-100">Per-feature provider routing</p>
+                    <p class="mt-1 text-xs text-muted">Pick which provider handles each AI job feature. Jobs run through the <span class="font-medium text-slate-100">ai_jobs</span> queue drained by <span class="font-medium text-slate-100">supplycore-ai-worker.service</span> — the browser never waits for the model. Leaving a feature on <span class="font-medium text-slate-100">Use global provider</span> falls back to the selection above.</p>
+                    <div class="mt-3 grid gap-4 md:grid-cols-2">
+                        <?php
+                        $featureLabels = [
+                            'ai_provider_theater_lock' => 'Theater battle summaries (lock)',
+                            'ai_provider_opposition_global' => 'Opposition — daily global briefing',
+                            'ai_provider_opposition_alliance' => 'Opposition — per-alliance briefings',
+                        ];
+                        foreach ($featureLabels as $key => $label):
+                            $currentValue = (string) ($settingValues[$key] ?? 'default');
+                        ?>
+                            <label class="block space-y-2">
+                                <span class="text-sm text-muted"><?= htmlspecialchars($label, ENT_QUOTES) ?></span>
+                                <select name="<?= htmlspecialchars($key, ENT_QUOTES) ?>" class="w-full field-input">
+                                    <?php foreach (ai_feature_provider_options() as $value => $optionLabel): ?>
+                                        <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $currentValue === $value ? 'selected' : '' ?>><?= htmlspecialchars($optionLabel, ENT_QUOTES) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </label>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+
                 <div class="mt-2">
                     <label class="block space-y-2">
                         <span class="text-sm text-muted">Theater AAR Prompt</span>

--- a/public/theater-intelligence/ai-status.php
+++ b/public/theater-intelligence/ai-status.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store');
+
+$theaterId = trim((string) ($_GET['theater_id'] ?? ''));
+if ($theaterId === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'theater_id is required']);
+    exit;
+}
+
+try {
+    $snapshot = theater_ai_status_snapshot($theaterId);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+    exit;
+}
+
+echo json_encode(['theater_id' => $theaterId] + $snapshot, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -383,6 +383,10 @@ INSTALL_INFLUX=false
 if prompt_yes_no "Install the InfluxDB rollup export service and timer?" "N"; then
   INSTALL_INFLUX=true
 fi
+INSTALL_AI_WORKER=false
+if prompt_yes_no "Install the AI briefing worker (drains ai_jobs queue for theater/opposition AI)?" "Y"; then
+  INSTALL_AI_WORKER=true
+fi
 
 # ===========================  Validation  =================================
 
@@ -487,6 +491,9 @@ if [[ ${INSTALL_INFLUX} == true ]]; then
     echo "Wrote InfluxDB env file to ${INFLUX_ENV_FILE}"
   fi
 fi
+if [[ ${INSTALL_AI_WORKER} == true ]]; then
+  render_unit "${REPO_ROOT}/ops/systemd/supplycore-ai-worker.service" "${SYSTEMD_DIR}/supplycore-ai-worker.service"
+fi
 
 # ===========================  Enable and start  ===========================
 
@@ -523,6 +530,10 @@ fi
 if [[ ${INSTALL_INFLUX} == true ]]; then
   services_to_enable+=("supplycore-influx-rollup-export.service")
   services_to_enable+=("supplycore-influx-rollup-export.timer")
+fi
+
+if [[ ${INSTALL_AI_WORKER} == true ]]; then
+  services_to_enable+=("supplycore-ai-worker.service")
 fi
 
 start_services "${services_to_enable[@]}"
@@ -564,6 +575,9 @@ if [[ ${INSTALL_EVEWHO} == true ]]; then
 fi
 if [[ ${INSTALL_INFLUX} == true ]]; then
   echo "  systemctl status supplycore-influx-rollup-export.timer"
+fi
+if [[ ${INSTALL_AI_WORKER} == true ]]; then
+  echo "  systemctl status supplycore-ai-worker.service"
 fi
 echo
 echo "Run any registered job manually:"

--- a/src/functions.php
+++ b/src/functions.php
@@ -871,6 +871,15 @@ function ai_briefing_setting_defaults(): array
         'groq_api_key' => '',
         'groq_model' => 'meta-llama/llama-4-scout-17b-16e-instruct',
         'theater_aar_prompt' => '',
+        // Per-feature provider overrides. Each takes one of:
+        //   'default' — use ollama_provider
+        //   'local' | 'runpod' | 'claude' | 'groq'
+        // This lets operators pick different providers per use case (e.g.
+        // cheap local Ollama for theater summaries, RunPod for opposition
+        // briefings). Resolved by supplycore_ai_resolve_config().
+        'ai_provider_theater_lock' => 'default',
+        'ai_provider_opposition_global' => 'default',
+        'ai_provider_opposition_alliance' => 'default',
     ];
 }
 
@@ -1015,6 +1024,29 @@ function ollama_provider_options(): array
     ];
 }
 
+function ai_feature_provider_options(): array
+{
+    return ['default' => 'Use global provider'] + ollama_provider_options();
+}
+
+function ai_feature_keys(): array
+{
+    return [
+        'theater_lock',
+        'opposition_global',
+        'opposition_alliance',
+    ];
+}
+
+function sanitize_ai_feature_provider(mixed $value): string
+{
+    $provider = mb_strtolower(trim((string) $value));
+
+    return array_key_exists($provider, ai_feature_provider_options())
+        ? $provider
+        : 'default';
+}
+
 function sanitize_ollama_provider(mixed $value): string
 {
     $provider = mb_strtolower(trim((string) $value));
@@ -1101,6 +1133,9 @@ function ai_briefing_settings_from_request(array $request): array
         'groq_api_key' => trim((string) ($request['groq_api_key'] ?? '')),
         'groq_model' => trim((string) ($request['groq_model'] ?? 'meta-llama/llama-4-scout-17b-16e-instruct')),
         'theater_aar_prompt' => mb_substr(trim((string) ($request['theater_aar_prompt'] ?? '')), 0, 8000),
+        'ai_provider_theater_lock' => sanitize_ai_feature_provider($request['ai_provider_theater_lock'] ?? null),
+        'ai_provider_opposition_global' => sanitize_ai_feature_provider($request['ai_provider_opposition_global'] ?? null),
+        'ai_provider_opposition_alliance' => sanitize_ai_feature_provider($request['ai_provider_opposition_alliance'] ?? null),
     ];
 }
 
@@ -21141,8 +21176,25 @@ function supplycore_ai_test_connection(): array
             $decoded = supplycore_ai_groq_generate_json($config, $systemPrompt, $userPrompt, $schema);
             $model = (string) ($config['groq_model'] ?? '');
         } elseif ($provider === 'runpod') {
-            $decoded = supplycore_ai_runpod_generate_json($config, $systemPrompt, $userPrompt, $schema);
-            $model = (string) ($config['model'] ?? '');
+            // Fast-path: go through /runsync with a trivial payload and a
+            // 10-second cap. The settings test must never block on an
+            // async RunPod cold start — that's what the ai_jobs worker
+            // is for. This check only verifies reachability + auth.
+            $probe = supplycore_ai_runpod_probe($config);
+            if (!($probe['success'] ?? false)) {
+                return [
+                    'success' => false,
+                    'error' => (string) ($probe['error'] ?? 'Runpod probe failed'),
+                    'provider' => $provider,
+                ];
+            }
+            return [
+                'success' => true,
+                'provider' => $provider,
+                'model' => (string) ($config['model'] ?? ''),
+                'response' => 'Runpod endpoint reachable (status: ' . (string) ($probe['job_status'] ?? 'OK') . ').',
+                'elapsed_ms' => (int) ($probe['elapsed_ms'] ?? 0),
+            ];
         } else {
             $response = http_get_json(
                 rtrim((string) $config['url'], '/') . '/tags',
@@ -21355,12 +21407,18 @@ function supplycore_ai_runpod_request_timeout(array $config): int
 
 function supplycore_ai_runpod_poll_budget_seconds(array $config): int
 {
+    // Allow callers (primarily the ai_jobs CLI worker) to pin the polling
+    // budget explicitly — the worker sizes this against its own lease
+    // rather than inheriting the user-facing Ollama timeout.
+    if (isset($config['runpod_poll_budget_seconds'])) {
+        return max(30, (int) $config['runpod_poll_budget_seconds']);
+    }
+
     $configuredTimeout = max(1, (int) ($config['timeout'] ?? 20));
 
-    // Async RunPod jobs frequently need more time than a single Ollama request
-    // (cold starts alone can exceed a minute). Give the polling loop a floor of
-    // five minutes and let users extend it by raising their configured timeout.
-    return max(300, $configuredTimeout * 15);
+    // Floor of 2 minutes as a safety net when called outside the worker
+    // (e.g. from bin/ai_briefing_worker.php --once debugging).
+    return max(120, $configuredTimeout * 6);
 }
 
 function supplycore_ai_runpod_poll_until_complete(array $config, array $headers, array $response): array
@@ -21493,6 +21551,378 @@ function supplycore_ai_decode_json_string(string $value): ?array
     }
 
     return null;
+}
+
+// ---------------------------------------------------------------------------
+// AI job queue (ai_jobs table) + per-feature provider resolution
+// ---------------------------------------------------------------------------
+//
+// The web tier enqueues a row into ai_jobs and returns immediately; the CLI
+// worker (bin/ai_briefing_worker.php, managed by systemd) drains the queue,
+// runs the actual AI call (which may take minutes for a RunPod cold start),
+// and writes the result back. This keeps php-fpm, nginx, and the browser
+// out of the long-running job's critical path.
+
+/**
+ * Resolve the AI config that should be used for a specific feature.
+ *
+ * Per-feature provider overrides let operators pick different providers
+ * per use case (e.g. cheap local Ollama for theater summaries, RunPod for
+ * opposition briefings). If the feature's override is 'default' or not
+ * recognised, falls back to the global provider.
+ */
+function supplycore_ai_resolve_feature_config(string $feature, ?string $explicitProvider = null): array
+{
+    $config = supplycore_ai_ollama_config();
+
+    if ($explicitProvider !== null && $explicitProvider !== '') {
+        $provider = sanitize_ollama_provider($explicitProvider);
+    } else {
+        $settingKey = 'ai_provider_' . $feature;
+        $featureOverride = sanitize_ai_feature_provider(
+            get_setting($settingKey, 'default')
+        );
+        $provider = $featureOverride === 'default'
+            ? (string) ($config['provider'] ?? 'local')
+            : $featureOverride;
+    }
+
+    $config['provider'] = $provider;
+
+    return $config;
+}
+
+function supplycore_ai_jobs_feature_valid(string $feature): bool
+{
+    static $valid = null;
+    if ($valid === null) {
+        $valid = array_flip(['theater_lock', 'opposition_global', 'opposition_alliance']);
+    }
+    return isset($valid[$feature]);
+}
+
+/**
+ * Enqueue an AI job if one isn't already queued/running for the same
+ * (feature, target_key). Returns the job id (new or pre-existing).
+ */
+function supplycore_ai_jobs_enqueue(
+    string $feature,
+    string $targetKey,
+    array $payload,
+    ?string $providerOverride = null,
+    int $priority = 0
+): int {
+    if (!supplycore_ai_jobs_feature_valid($feature)) {
+        throw new InvalidArgumentException('Unknown AI job feature: ' . $feature);
+    }
+    if ($targetKey === '') {
+        throw new InvalidArgumentException('AI job target_key is required.');
+    }
+
+    $config = supplycore_ai_resolve_feature_config($feature, $providerOverride);
+    $provider = (string) ($config['provider'] ?? 'local');
+    $model = match ($provider) {
+        'claude' => (string) ($config['claude_model'] ?? ''),
+        'groq' => (string) ($config['groq_model'] ?? ''),
+        default => (string) ($config['model'] ?? ''),
+    };
+
+    $payloadJson = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    if ($payloadJson === false) {
+        throw new RuntimeException('AI job payload could not be JSON-encoded.');
+    }
+
+    return db_transaction(static function () use ($feature, $targetKey, $provider, $model, $payloadJson, $priority): int {
+        $existing = db_select_one(
+            "SELECT id FROM ai_jobs
+             WHERE feature = ? AND target_key = ? AND status IN ('queued','running')
+             ORDER BY id DESC LIMIT 1",
+            [$feature, $targetKey]
+        );
+        if (is_array($existing) && isset($existing['id'])) {
+            return (int) $existing['id'];
+        }
+
+        db_execute(
+            'INSERT INTO ai_jobs (feature, target_key, provider, model, status, priority, payload_json)
+             VALUES (?, ?, ?, ?, \'queued\', ?, ?)',
+            [$feature, $targetKey, $provider, $model, $priority, $payloadJson]
+        );
+
+        return (int) db()->lastInsertId();
+    });
+}
+
+function supplycore_ai_jobs_find_active(string $feature, string $targetKey): ?array
+{
+    return db_select_one(
+        "SELECT * FROM ai_jobs
+         WHERE feature = ? AND target_key = ? AND status IN ('queued','running')
+         ORDER BY id DESC LIMIT 1",
+        [$feature, $targetKey]
+    );
+}
+
+function supplycore_ai_jobs_find_latest(string $feature, string $targetKey): ?array
+{
+    return db_select_one(
+        'SELECT * FROM ai_jobs
+         WHERE feature = ? AND target_key = ?
+         ORDER BY id DESC LIMIT 1',
+        [$feature, $targetKey]
+    );
+}
+
+function supplycore_ai_jobs_get(int $id): ?array
+{
+    return db_select_one('SELECT * FROM ai_jobs WHERE id = ?', [$id]);
+}
+
+/**
+ * Claim the next queued job. Uses FOR UPDATE SKIP LOCKED (MariaDB >= 10.6)
+ * so multiple worker slots never fight over the same row.
+ */
+function supplycore_ai_jobs_claim(string $workerId, int $leaseSeconds = 900): ?array
+{
+    db_query_cache_clear();
+    $pdo = db();
+    $pdo->beginTransaction();
+    try {
+        $stmt = $pdo->prepare(
+            "SELECT id FROM ai_jobs
+             WHERE status = 'queued'
+             ORDER BY priority DESC, id ASC
+             LIMIT 1
+             FOR UPDATE SKIP LOCKED"
+        );
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!is_array($row) || !isset($row['id'])) {
+            $pdo->commit();
+            return null;
+        }
+        $id = (int) $row['id'];
+
+        $update = $pdo->prepare(
+            "UPDATE ai_jobs
+             SET status = 'running',
+                 attempts = attempts + 1,
+                 worker_id = ?,
+                 lease_until = DATE_ADD(NOW(), INTERVAL ? SECOND),
+                 started_at = COALESCE(started_at, NOW())
+             WHERE id = ?"
+        );
+        $update->execute([$workerId, max(60, $leaseSeconds), $id]);
+        $pdo->commit();
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
+    }
+
+    return supplycore_ai_jobs_get($id);
+}
+
+function supplycore_ai_jobs_complete(int $id, array $result, int $durationMs): void
+{
+    $resultJson = json_encode($result, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    if ($resultJson === false) {
+        $resultJson = '{}';
+    }
+    db_execute(
+        "UPDATE ai_jobs
+         SET status = 'done',
+             result_json = ?,
+             duration_ms = ?,
+             completed_at = NOW(),
+             lease_until = NULL,
+             last_error = NULL
+         WHERE id = ?",
+        [$resultJson, max(0, $durationMs), $id]
+    );
+}
+
+/**
+ * Mark a job as failed. If the job still has retries available and the
+ * caller signals the error is transient, it is requeued instead.
+ */
+function supplycore_ai_jobs_fail(int $id, string $error, bool $transient): void
+{
+    $job = supplycore_ai_jobs_get($id);
+    if ($job === null) {
+        return;
+    }
+
+    $attempts = (int) ($job['attempts'] ?? 0);
+    $maxAttempts = (int) ($job['max_attempts'] ?? 1);
+    $shouldRetry = $transient && $attempts < $maxAttempts;
+
+    if ($shouldRetry) {
+        db_execute(
+            "UPDATE ai_jobs
+             SET status = 'queued',
+                 worker_id = NULL,
+                 lease_until = NULL,
+                 last_error = ?
+             WHERE id = ?",
+            [mb_substr($error, 0, 2000), $id]
+        );
+        return;
+    }
+
+    db_execute(
+        "UPDATE ai_jobs
+         SET status = 'failed',
+             last_error = ?,
+             completed_at = NOW(),
+             lease_until = NULL
+         WHERE id = ?",
+        [mb_substr($error, 0, 2000), $id]
+    );
+}
+
+/**
+ * Reclaim rows whose worker lease has expired (crash-safety). Any row in
+ * 'running' state with lease_until < NOW() is pushed back to 'queued' if it
+ * still has retries, or marked 'failed' otherwise.
+ */
+function supplycore_ai_jobs_sweep_expired_leases(): int
+{
+    $rows = db_select(
+        "SELECT id, attempts, max_attempts FROM ai_jobs
+         WHERE status = 'running' AND lease_until IS NOT NULL AND lease_until < NOW()"
+    );
+    foreach ($rows as $row) {
+        $id = (int) ($row['id'] ?? 0);
+        if ($id === 0) {
+            continue;
+        }
+        supplycore_ai_jobs_fail((int) $id, 'Worker lease expired (crash or hang).', true);
+    }
+    return count($rows);
+}
+
+/**
+ * Execute a claimed AI job by dispatching to the feature-specific handler.
+ * Returns the normalized result payload; throws on failure.
+ */
+function supplycore_ai_jobs_execute(array $job): array
+{
+    $feature = (string) ($job['feature'] ?? '');
+    $payload = [];
+    $payloadJson = (string) ($job['payload_json'] ?? '');
+    if ($payloadJson !== '') {
+        $decoded = json_decode($payloadJson, true);
+        if (is_array($decoded)) {
+            $payload = $decoded;
+        }
+    }
+    $providerOverride = (string) ($job['provider'] ?? '');
+    // Force the feature config to use the provider captured at enqueue time
+    // so later settings changes don't silently re-route in-flight jobs.
+    $override = supplycore_ai_resolve_feature_config($feature, $providerOverride);
+    // Give RunPod polling a generous budget tied to the worker lease
+    // rather than the user-facing Ollama timeout. 14 minutes leaves a
+    // small safety margin before a default 15-minute lease expires.
+    $override['runpod_poll_budget_seconds'] = 14 * 60;
+    $GLOBALS['supplycore_ai_ollama_runtime_override'] = $override;
+
+    try {
+        return match ($feature) {
+            'theater_lock' => supplycore_ai_jobs_run_theater_lock($payload),
+            'opposition_global' => supplycore_ai_jobs_run_opposition_global($payload),
+            'opposition_alliance' => supplycore_ai_jobs_run_opposition_alliance($payload),
+            default => throw new RuntimeException('Unknown AI job feature: ' . $feature),
+        };
+    } finally {
+        unset($GLOBALS['supplycore_ai_ollama_runtime_override']);
+    }
+}
+
+function supplycore_ai_jobs_run_theater_lock(array $payload): array
+{
+    $theaterId = trim((string) ($payload['theater_id'] ?? ''));
+    if ($theaterId === '') {
+        throw new RuntimeException('theater_lock payload missing theater_id.');
+    }
+    $result = theater_ai_summary_generate($theaterId, true);
+    if ($result === null) {
+        throw new RuntimeException('theater_ai_summary_generate returned null for ' . $theaterId);
+    }
+    return $result;
+}
+
+function supplycore_ai_jobs_run_opposition_global(array $payload): array
+{
+    $date = trim((string) ($payload['date'] ?? ''));
+    if ($date === '' || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
+        throw new RuntimeException('opposition_global payload missing/invalid date.');
+    }
+    $generated = opposition_ai_generate_daily_briefings($date);
+    return ['date' => $date, 'generated' => $generated];
+}
+
+function supplycore_ai_jobs_run_opposition_alliance(array $payload): array
+{
+    // Alliance-level briefings are generated inside
+    // opposition_ai_generate_daily_briefings() today. This hook exists so
+    // future callers can enqueue per-alliance regenerations without
+    // touching the global path.
+    return supplycore_ai_jobs_run_opposition_global($payload);
+}
+
+/**
+ * Fast-path RunPod connectivity probe used by the settings "Test
+ * connection" button. Uses /runsync with a trivial payload and a hard
+ * 10-second cap so the health check never blocks on an async cold start.
+ */
+function supplycore_ai_runpod_probe(array $config): array
+{
+    $url = rtrim(trim((string) ($config['runpod_url'] ?? '')), '/');
+    $apiKey = trim((string) ($config['runpod_api_key'] ?? ''));
+    if ($url === '' || $apiKey === '') {
+        return ['success' => false, 'error' => 'Runpod endpoint or API key not configured.'];
+    }
+
+    // Force /runsync regardless of how the user typed the URL. The probe
+    // must NOT go through the async /run path.
+    $probeUrl = preg_match('#/(?:run|runsync)$#i', $url) === 1
+        ? (string) preg_replace('#/(?:run|runsync)$#i', '/runsync', $url)
+        : $url . '/runsync';
+
+    $headers = ['Authorization: Bearer ' . $apiKey];
+    $payload = ['input' => ['prompt' => 'ping']];
+
+    $startedAt = microtime(true);
+    try {
+        $response = http_post_json($probeUrl, $headers, $payload, 10);
+    } catch (Throwable $e) {
+        return ['success' => false, 'error' => 'Runpod probe failed: ' . $e->getMessage()];
+    }
+    $elapsedMs = (int) round((microtime(true) - $startedAt) * 1000);
+
+    $status = (int) ($response['status'] ?? 0);
+    if ($status === 401 || $status === 403) {
+        return ['success' => false, 'error' => 'Runpod auth rejected (HTTP ' . $status . '). Check API key.'];
+    }
+    if ($status === 404) {
+        return ['success' => false, 'error' => 'Runpod endpoint not found (HTTP 404). Check endpoint URL.'];
+    }
+    if ($status < 200 || $status >= 300) {
+        return ['success' => false, 'error' => 'Runpod probe HTTP ' . $status . '.'];
+    }
+
+    $json = is_array($response['json'] ?? null) ? $response['json'] : [];
+    $jobStatus = strtoupper(trim((string) ($json['status'] ?? '')));
+    // /runsync returns COMPLETED on fast-path; IN_QUEUE/IN_PROGRESS means
+    // the worker is still cold-starting but the endpoint is reachable and
+    // auth worked — that's a healthy probe result.
+    return [
+        'success' => true,
+        'elapsed_ms' => $elapsedMs,
+        'job_status' => $jobStatus !== '' ? $jobStatus : 'OK',
+    ];
 }
 
 // ---------------------------------------------------------------------------
@@ -22177,16 +22607,54 @@ function theater_lock_report(string $theaterId): ?array
         return ['error' => 'Battle report is already locked'];
     }
 
-    // Generate AI summary at lock time
-    $aiResult = null;
-    if (supplycore_ai_ollama_enabled()) {
-        $aiResult = theater_ai_summary_generate($theaterId, true);
-    }
-
-    // Lock the theater regardless of AI success
+    // Lock the theater immediately. AI summary generation is enqueued to
+    // the ai_jobs queue and drained by bin/ai_briefing_worker.php — the web
+    // request no longer waits on the model to respond.
     db_execute('UPDATE theaters SET locked_at = NOW() WHERE theater_id = ?', [$theaterId]);
 
-    return $aiResult;
+    if (!supplycore_ai_ollama_enabled()) {
+        return ['ai_status' => 'disabled'];
+    }
+
+    try {
+        $jobId = supplycore_ai_jobs_enqueue(
+            'theater_lock',
+            $theaterId,
+            ['theater_id' => $theaterId]
+        );
+    } catch (Throwable $e) {
+        error_log('[theater-lock] Failed to enqueue AI job: ' . $e->getMessage());
+        return ['ai_status' => 'error', 'error' => $e->getMessage()];
+    }
+
+    return ['ai_status' => 'queued', 'ai_job_id' => $jobId];
+}
+
+/**
+ * Snapshot the current AI briefing state for a theater. Returns the cached
+ * summary if present, otherwise the active job's status (queued/running/
+ * failed) so the UI can render progress or retry affordances.
+ */
+function theater_ai_status_snapshot(string $theaterId): array
+{
+    $cached = theater_ai_summary_read($theaterId);
+    if ($cached !== null) {
+        return ['status' => 'done', 'summary' => $cached];
+    }
+
+    $job = supplycore_ai_jobs_find_latest('theater_lock', $theaterId);
+    if ($job === null) {
+        return ['status' => 'none'];
+    }
+
+    return [
+        'status' => (string) ($job['status'] ?? 'unknown'),
+        'provider' => (string) ($job['provider'] ?? ''),
+        'model' => (string) ($job['model'] ?? ''),
+        'attempts' => (int) ($job['attempts'] ?? 0),
+        'error' => (string) ($job['last_error'] ?? ''),
+        'updated_at' => (string) ($job['updated_at'] ?? ''),
+    ];
 }
 
 function theater_view_snapshot_save(string $theaterId, array $viewState): void


### PR DESCRIPTION
## Summary

Refactors AI briefing generation (theater battle summaries and opposition daily briefings) from synchronous web request handlers into an asynchronous job queue system. Web requests now enqueue work to `ai_jobs` table and return immediately; a new systemd-managed CLI worker (`bin/ai_briefing_worker.php`) drains the queue and executes AI calls that may take minutes (especially on RunPod cold starts).

## Key Changes

- **Job Queue Infrastructure**
  - New `ai_jobs` database table with status tracking (queued/running/done/failed), worker leasing for crash-safety, and retry logic
  - Job enqueueing functions: `supplycore_ai_jobs_enqueue()`, `supplycore_ai_jobs_claim()`, `supplycore_ai_jobs_complete()`, `supplycore_ai_jobs_fail()`
  - Lease expiration sweep (`supplycore_ai_jobs_sweep_expired_leases()`) to reclaim jobs from crashed workers

- **Per-Feature Provider Routing**
  - New settings: `ai_provider_theater_lock`, `ai_provider_opposition_global`, `ai_provider_opposition_alliance`
  - Allows operators to route different AI features to different providers (e.g., cheap local Ollama for summaries, RunPod for opposition briefings)
  - `supplycore_ai_resolve_feature_config()` resolves provider at enqueue time and captures it in the job row

- **CLI Worker**
  - New `bin/ai_briefing_worker.php` with modes: `--drain` (long-running systemd loop), `--once` (single job), `--sweep` (lease reclaim), `--job=<id>` (debug)
  - Transient error detection and automatic retry for network/timeout/cold-start failures
  - Structured JSON logging to systemd journal
  - Signal handling (SIGTERM/SIGINT/SIGHUP) for graceful shutdown

- **Systemd Service**
  - New `ops/systemd/supplycore-ai-worker.service` unit file
  - Configurable via environment variables (lease duration, poll interval)
  - Memory limit (512M), journal logging, auto-restart on failure

- **RunPod Improvements**
  - New `supplycore_ai_runpod_probe()` for fast health checks (10-second cap, /runsync endpoint)
  - `supplycore_ai_runpod_poll_budget_seconds()` allows worker to use generous polling budget (14 minutes) independent of user-facing timeout
  - Exponential backoff on polling (1.25x multiplier, capped at 5 seconds)
  - Test connection button now uses probe instead of full JSON generation

- **Web Request Changes**
  - `theater_lock_report()` now enqueues job and returns immediately instead of blocking on AI generation
  - Opposition briefing generation (`public/opposition-intelligence/generate.php`) enqueues instead of running inline
  - New `theater_ai_status_snapshot()` endpoint to query job status (queued/running/done/failed) for UI progress display
  - New `public/theater-intelligence/ai-status.php` JSON endpoint for polling job state

- **Settings UI**
  - Per-feature provider selector in settings page
  - Explanatory text about queue-based execution and systemd service

## Implementation Details

- Job deduplication: only one queued/running job per (feature, target_key) pair
- Payload captured at enqueue time so worker is self-sufficient and doesn't re-read mutable state
- Provider and model resolved at enqueue time and stored in job row for audit trail
- Worker uses `SELECT ... FOR UPDATE SKIP LOCKED` (MariaDB 10.6+) to avoid contention across worker slots
- Transient vs. terminal error classification determines retry eligibility
- Installation script updated to prompt for AI worker service setup

https://claude.ai/code/session_01PYdPoUa3UgyVArQLufSViC