### PR TITLE
Split AI provider settings: per-provider model + timeout, cleaner UI

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1752,82 +1752,143 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     </span>
                 </label>
 
+                <!-- Global provider + capability tier -->
+                <div class="rounded-2xl border border-white/8 bg-white/[0.03] p-4">
+                    <p class="text-sm font-medium text-slate-100">Global defaults</p>
+                    <p class="mt-1 text-xs text-muted">Picks which provider handles AI jobs by default. Per-feature routing below can override this on a per-job-type basis.</p>
+                    <div class="mt-3 grid gap-4 md:grid-cols-2">
+                        <label class="block space-y-2">
+                            <span class="text-sm text-muted">Default AI Provider</span>
+                            <select name="ollama_provider" class="w-full field-input">
+                                <?php $selectedProvider = (string) ($settingValues['ollama_provider'] ?? ($ollamaConfig['provider'] ?? 'local')); ?>
+                                <?php foreach (ollama_provider_options() as $value => $label): ?>
+                                    <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $selectedProvider === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </label>
+                        <label class="block space-y-2">
+                            <span class="text-sm text-muted">Capability Tier</span>
+                            <select name="ollama_capability_tier" class="w-full field-input">
+                                <?php $selectedTier = (string) ($settingValues['ollama_capability_tier'] ?? ($ollamaConfig['capability_override'] ?? 'auto')); ?>
+                                <?php foreach (['auto' => 'Auto-detect from model', 'small' => 'Small', 'medium' => 'Medium', 'large' => 'Large'] as $value => $label): ?>
+                                    <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $selectedTier === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </label>
+                    </div>
+                </div>
+
+                <!-- Provider cards: each provider has its own isolated settings. -->
                 <div class="grid gap-4 md:grid-cols-2">
-                    <label class="block space-y-2 md:col-span-2">
-                        <span class="text-sm text-muted">AI Provider</span>
-                        <select name="ollama_provider" class="w-full field-input">
-                            <?php $selectedProvider = (string) ($settingValues['ollama_provider'] ?? ($ollamaConfig['provider'] ?? 'local')); ?>
-                            <?php foreach (ollama_provider_options() as $value => $label): ?>
-                                <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $selectedProvider === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
-                            <?php endforeach; ?>
-                        </select>
-                        <p class="text-xs text-muted">Use <span class="font-medium text-slate-100">Local Ollama</span> for self-hosted CPU/GPU inference, <span class="font-medium text-slate-100">Runpod Serverless</span> for async GPU jobs, or <span class="font-medium text-slate-100">Claude API</span> for fast hosted inference (requires separate API billing at <span class="font-medium text-slate-100">console.anthropic.com</span>).</p>
-                    </label>
-                    <label class="block space-y-2 md:col-span-2">
-                        <span class="text-sm text-muted">Local Ollama API URL</span>
-                        <input name="ollama_url" value="<?= htmlspecialchars($settingValues['ollama_url'] ?? ($ollamaConfig['url'] ?? 'http://localhost:11434/api'), ENT_QUOTES) ?>" class="w-full field-input" />
-                        <p class="text-xs text-muted">Use the API base URL, for example <span class="font-medium text-slate-100">http://localhost:11434/api</span>.</p>
-                    </label>
-                    <label class="block space-y-2 md:col-span-2">
-                        <span class="text-sm text-muted">Runpod Serverless Endpoint</span>
-                        <input name="ollama_runpod_url" value="<?= htmlspecialchars($settingValues['ollama_runpod_url'] ?? ($ollamaConfig['runpod_url'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="https://api.runpod.ai/v2/.../run" />
-                        <p class="text-xs text-muted">Paste the full Runpod async request URL, for example <span class="font-medium text-slate-100">https://api.runpod.ai/v2/58qz2qbho8h3f1/run</span>. Existing <span class="font-medium text-slate-100">/runsync</span> URLs are converted automatically.</p>
-                    </label>
-                    <label class="block space-y-2 md:col-span-2">
-                        <span class="text-sm text-muted">Runpod API Key</span>
-                        <input name="ollama_runpod_api_key" type="password" value="<?= htmlspecialchars($settingValues['ollama_runpod_api_key'] ?? ($ollamaConfig['runpod_api_key'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="Bearer token for the Runpod endpoint" />
-                        <?php if (($ollamaConfig['runpod_api_key_masked'] ?? '') !== ''): ?>
-                            <p class="text-xs text-muted">Saved key preview: <span class="font-medium text-slate-100"><?= htmlspecialchars((string) $ollamaConfig['runpod_api_key_masked'], ENT_QUOTES) ?></span>.</p>
-                        <?php else: ?>
-                            <p class="text-xs text-muted">Stored only when you save settings. Leave blank if you are staying on the local provider.</p>
-                        <?php endif; ?>
-                    </label>
-                    <label class="block space-y-2 md:col-span-2">
-                        <span class="text-sm text-muted">Claude API Key</span>
-                        <input name="claude_api_key" type="password" value="<?= htmlspecialchars($settingValues['claude_api_key'] ?? ($ollamaConfig['claude_api_key'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="sk-ant-api03-..." />
-                        <?php if (($ollamaConfig['claude_api_key_masked'] ?? '') !== ''): ?>
-                            <p class="text-xs text-muted">Saved key preview: <span class="font-medium text-slate-100"><?= htmlspecialchars((string) $ollamaConfig['claude_api_key_masked'], ENT_QUOTES) ?></span>.</p>
-                        <?php else: ?>
-                            <p class="text-xs text-muted">Get your API key from <span class="font-medium text-slate-100">console.anthropic.com</span>. API usage is billed separately from Claude Pro subscriptions.</p>
-                        <?php endif; ?>
-                    </label>
-                    <label class="block space-y-2 md:col-span-2">
-                        <span class="text-sm text-muted">Claude Model</span>
-                        <input name="claude_model" value="<?= htmlspecialchars($settingValues['claude_model'] ?? ($ollamaConfig['claude_model'] ?? 'claude-sonnet-4-20250514'), ENT_QUOTES) ?>" class="w-full field-input" />
-                        <p class="text-xs text-muted">Recommended: <span class="font-medium text-slate-100">claude-sonnet-4-20250514</span> (fast, cheap) or <span class="font-medium text-slate-100">claude-haiku-4-5-20251001</span> (fastest, cheapest).</p>
-                    </label>
-                    <label class="block space-y-2 md:col-span-2">
-                        <span class="text-sm text-muted">Groq API Key</span>
-                        <input name="groq_api_key" type="password" value="<?= htmlspecialchars($settingValues['groq_api_key'] ?? ($ollamaConfig['groq_api_key'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="gsk_..." />
-                        <?php if (($ollamaConfig['groq_api_key_masked'] ?? '') !== ''): ?>
-                            <p class="text-xs text-muted">Saved key preview: <span class="font-medium text-slate-100"><?= htmlspecialchars((string) $ollamaConfig['groq_api_key_masked'], ENT_QUOTES) ?></span>.</p>
-                        <?php else: ?>
-                            <p class="text-xs text-muted">Free tier at <span class="font-medium text-slate-100">console.groq.com</span>. Fast inference — great for CPU-only machines.</p>
-                        <?php endif; ?>
-                    </label>
-                    <label class="block space-y-2 md:col-span-2">
-                        <span class="text-sm text-muted">Groq Model</span>
-                        <input name="groq_model" value="<?= htmlspecialchars($settingValues['groq_model'] ?? ($ollamaConfig['groq_model'] ?? 'meta-llama/llama-4-scout-17b-16e-instruct'), ENT_QUOTES) ?>" class="w-full field-input" />
-                        <p class="text-xs text-muted">Recommended: <span class="font-medium text-slate-100">meta-llama/llama-4-scout-17b-16e-instruct</span> (500K TPD) or <span class="font-medium text-slate-100">llama-3.3-70b-versatile</span> (best quality, 100K TPD).</p>
-                    </label>
-                    <label class="block space-y-2">
-                        <span class="text-sm text-muted">Model Name (Ollama/Runpod)</span>
-                        <input name="ollama_model" value="<?= htmlspecialchars($settingValues['ollama_model'] ?? ($ollamaConfig['model'] ?? 'qwen2.5:1.5b-instruct'), ENT_QUOTES) ?>" class="w-full field-input" />
-                    </label>
-                    <label class="block space-y-2">
-                        <span class="text-sm text-muted">Request Timeout (seconds)</span>
-                        <input type="number" min="1" max="600" step="1" name="ollama_timeout" value="<?= htmlspecialchars($settingValues['ollama_timeout'] ?? (string) ($ollamaConfig['timeout'] ?? 20), ENT_QUOTES) ?>" class="w-full field-input" />
-                    </label>
-                    <label class="block space-y-2 md:col-span-2">
-                        <span class="text-sm text-muted">Capability Tier</span>
-                        <select name="ollama_capability_tier" class="w-full field-input">
-                            <?php $selectedTier = (string) ($settingValues['ollama_capability_tier'] ?? ($ollamaConfig['capability_override'] ?? 'auto')); ?>
-                            <?php foreach (['auto' => 'Auto-detect from model', 'small' => 'Small', 'medium' => 'Medium', 'large' => 'Large'] as $value => $label): ?>
-                                <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $selectedTier === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
-                            <?php endforeach; ?>
-                        </select>
-                        <p class="text-xs text-muted">Leave this on auto to infer capability from the configured model name, or pin a tier if the model naming does not include parameter size.</p>
-                    </label>
+                    <!-- Local Ollama -->
+                    <section class="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                        <header class="flex items-center justify-between">
+                            <h3 class="text-sm font-semibold text-slate-100">Local Ollama</h3>
+                            <span class="badge border-white/10 bg-white/5 text-xs text-muted">self-hosted</span>
+                        </header>
+                        <p class="mt-1 text-xs text-muted">Self-hosted CPU/GPU inference. Configure the API base URL and model you want to run against your local Ollama daemon.</p>
+                        <div class="mt-3 space-y-3">
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">API URL</span>
+                                <input name="ollama_url" value="<?= htmlspecialchars($settingValues['ollama_url'] ?? ($ollamaConfig['url'] ?? 'http://localhost:11434/api'), ENT_QUOTES) ?>" class="w-full field-input" placeholder="http://localhost:11434/api" />
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Model</span>
+                                <input name="ollama_model" value="<?= htmlspecialchars($settingValues['ollama_model'] ?? ($ollamaConfig['local_ollama_model'] ?? 'qwen2.5:1.5b-instruct'), ENT_QUOTES) ?>" class="w-full field-input" placeholder="qwen2.5:1.5b-instruct" />
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Request Timeout (s)</span>
+                                <input type="number" min="1" max="600" step="1" name="ollama_timeout" value="<?= htmlspecialchars($settingValues['ollama_timeout'] ?? (string) ($ollamaConfig['local_ollama_timeout'] ?? 20), ENT_QUOTES) ?>" class="w-full field-input" />
+                            </label>
+                        </div>
+                    </section>
+
+                    <!-- Runpod Serverless -->
+                    <section class="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                        <header class="flex items-center justify-between">
+                            <h3 class="text-sm font-semibold text-slate-100">Runpod Serverless</h3>
+                            <span class="badge border-sky-400/20 bg-sky-500/10 text-xs text-sky-100">async GPU</span>
+                        </header>
+                        <p class="mt-1 text-xs text-muted">Async GPU inference. Runs through the <span class="font-medium text-slate-100">ai_jobs</span> queue — the browser never waits on a cold start.</p>
+                        <div class="mt-3 space-y-3">
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Endpoint URL</span>
+                                <input name="ollama_runpod_url" value="<?= htmlspecialchars($settingValues['ollama_runpod_url'] ?? ($ollamaConfig['runpod_url'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="https://api.runpod.ai/v2/<id>/run" />
+                                <p class="text-xs text-muted">Accepts either <span class="font-medium text-slate-100">/run</span> or <span class="font-medium text-slate-100">/runsync</span> — the worker normalises it automatically.</p>
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">API Key</span>
+                                <input name="ollama_runpod_api_key" type="password" value="<?= htmlspecialchars($settingValues['ollama_runpod_api_key'] ?? ($ollamaConfig['runpod_api_key'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="Bearer token" />
+                                <?php if (($ollamaConfig['runpod_api_key_masked'] ?? '') !== ''): ?>
+                                    <p class="text-xs text-muted">Saved: <span class="font-medium text-slate-100"><?= htmlspecialchars((string) $ollamaConfig['runpod_api_key_masked'], ENT_QUOTES) ?></span></p>
+                                <?php endif; ?>
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Model</span>
+                                <input name="runpod_model" value="<?= htmlspecialchars($settingValues['runpod_model'] ?? ($ollamaConfig['runpod_model'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="llama3.1:70b (or leave blank if your worker hard-codes the model)" />
+                                <p class="text-xs text-muted">Independent of the Local Ollama model. Leave blank if your Runpod worker image has the model baked in.</p>
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Per-HTTP Timeout (s)</span>
+                                <input type="number" min="5" max="900" step="1" name="runpod_timeout" value="<?= htmlspecialchars($settingValues['runpod_timeout'] ?? (string) ($ollamaConfig['runpod_timeout'] ?? 120), ENT_QUOTES) ?>" class="w-full field-input" />
+                                <p class="text-xs text-muted">Caps individual /run and /status calls. Total polling budget is controlled by the AI worker's lease (~14 minutes).</p>
+                            </label>
+                        </div>
+                    </section>
+
+                    <!-- Claude API -->
+                    <section class="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                        <header class="flex items-center justify-between">
+                            <h3 class="text-sm font-semibold text-slate-100">Claude API (Anthropic)</h3>
+                            <span class="badge border-amber-400/20 bg-amber-500/10 text-xs text-amber-100">hosted</span>
+                        </header>
+                        <p class="mt-1 text-xs text-muted">Fast hosted inference billed separately from Claude Pro. Get an API key from <span class="font-medium text-slate-100">console.anthropic.com</span>.</p>
+                        <div class="mt-3 space-y-3">
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">API Key</span>
+                                <input name="claude_api_key" type="password" value="<?= htmlspecialchars($settingValues['claude_api_key'] ?? ($ollamaConfig['claude_api_key'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="sk-ant-api03-..." />
+                                <?php if (($ollamaConfig['claude_api_key_masked'] ?? '') !== ''): ?>
+                                    <p class="text-xs text-muted">Saved: <span class="font-medium text-slate-100"><?= htmlspecialchars((string) $ollamaConfig['claude_api_key_masked'], ENT_QUOTES) ?></span></p>
+                                <?php endif; ?>
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Model</span>
+                                <input name="claude_model" value="<?= htmlspecialchars($settingValues['claude_model'] ?? ($ollamaConfig['claude_model'] ?? 'claude-sonnet-4-20250514'), ENT_QUOTES) ?>" class="w-full field-input" placeholder="claude-sonnet-4-20250514" />
+                                <p class="text-xs text-muted">Recommended: <span class="font-medium text-slate-100">claude-sonnet-4-20250514</span> or <span class="font-medium text-slate-100">claude-haiku-4-5-20251001</span>.</p>
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Request Timeout (s)</span>
+                                <input type="number" min="5" max="600" step="1" name="claude_timeout" value="<?= htmlspecialchars($settingValues['claude_timeout'] ?? (string) ($ollamaConfig['claude_timeout'] ?? 60), ENT_QUOTES) ?>" class="w-full field-input" />
+                            </label>
+                        </div>
+                    </section>
+
+                    <!-- Groq -->
+                    <section class="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                        <header class="flex items-center justify-between">
+                            <h3 class="text-sm font-semibold text-slate-100">Groq</h3>
+                            <span class="badge border-emerald-400/20 bg-emerald-500/10 text-xs text-emerald-100">free tier</span>
+                        </header>
+                        <p class="mt-1 text-xs text-muted">Fast hosted inference with a generous free tier at <span class="font-medium text-slate-100">console.groq.com</span>. Great for CPU-only boxes.</p>
+                        <div class="mt-3 space-y-3">
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">API Key</span>
+                                <input name="groq_api_key" type="password" value="<?= htmlspecialchars($settingValues['groq_api_key'] ?? ($ollamaConfig['groq_api_key'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="gsk_..." />
+                                <?php if (($ollamaConfig['groq_api_key_masked'] ?? '') !== ''): ?>
+                                    <p class="text-xs text-muted">Saved: <span class="font-medium text-slate-100"><?= htmlspecialchars((string) $ollamaConfig['groq_api_key_masked'], ENT_QUOTES) ?></span></p>
+                                <?php endif; ?>
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Model</span>
+                                <input name="groq_model" value="<?= htmlspecialchars($settingValues['groq_model'] ?? ($ollamaConfig['groq_model'] ?? 'meta-llama/llama-4-scout-17b-16e-instruct'), ENT_QUOTES) ?>" class="w-full field-input" placeholder="meta-llama/llama-4-scout-17b-16e-instruct" />
+                                <p class="text-xs text-muted">Recommended: <span class="font-medium text-slate-100">meta-llama/llama-4-scout-17b-16e-instruct</span> (500K TPD) or <span class="font-medium text-slate-100">llama-3.3-70b-versatile</span> (best quality, 100K TPD).</p>
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Request Timeout (s)</span>
+                                <input type="number" min="5" max="300" step="1" name="groq_timeout" value="<?= htmlspecialchars($settingValues['groq_timeout'] ?? (string) ($ollamaConfig['groq_timeout'] ?? 30), ENT_QUOTES) ?>" class="w-full field-input" />
+                            </label>
+                        </div>
+                    </section>
                 </div>
 
                 <div class="mt-4 rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3">

--- a/src/functions.php
+++ b/src/functions.php
@@ -860,23 +860,41 @@ function ai_briefing_setting_defaults(): array
     return [
         'ollama_enabled' => '0',
         'ollama_provider' => 'local',
+
+        // --- Local Ollama ---
         'ollama_url' => 'http://localhost:11434/api',
         'ollama_model' => 'qwen2.5:1.5b-instruct',
         'ollama_timeout' => '20',
         'ollama_capability_tier' => 'auto',
+
+        // --- Runpod Serverless ---
+        // ollama_runpod_url / ollama_runpod_api_key retain their legacy
+        // names so existing installs keep working without a data
+        // migration. runpod_model and runpod_timeout are new: Runpod and
+        // Local Ollama no longer share model/timeout settings.
         'ollama_runpod_url' => '',
         'ollama_runpod_api_key' => '',
+        'runpod_model' => '',
+        'runpod_timeout' => '120',
+
+        // --- Claude (Anthropic) ---
         'claude_api_key' => '',
         'claude_model' => 'claude-sonnet-4-20250514',
+        'claude_timeout' => '60',
+
+        // --- Groq ---
         'groq_api_key' => '',
         'groq_model' => 'meta-llama/llama-4-scout-17b-16e-instruct',
+        'groq_timeout' => '30',
+
+        // --- Prompts ---
         'theater_aar_prompt' => '',
-        // Per-feature provider overrides. Each takes one of:
-        //   'default' — use ollama_provider
-        //   'local' | 'runpod' | 'claude' | 'groq'
-        // This lets operators pick different providers per use case (e.g.
-        // cheap local Ollama for theater summaries, RunPod for opposition
-        // briefings). Resolved by supplycore_ai_resolve_config().
+
+        // --- Per-feature provider routing ---
+        // Each takes: 'default' (inherit ollama_provider) | 'local' |
+        // 'runpod' | 'claude' | 'groq'. Lets operators pick different
+        // providers per use case. Resolved by
+        // supplycore_ai_resolve_feature_config().
         'ai_provider_theater_lock' => 'default',
         'ai_provider_opposition_global' => 'default',
         'ai_provider_opposition_alliance' => 'default',
@@ -1117,22 +1135,64 @@ function sanitize_ollama_runpod_api_key(?string $value): string
     return mb_substr(trim((string) $value), 0, 255);
 }
 
+function sanitize_runpod_model(?string $value): string
+{
+    // Empty string is intentional: some Runpod workers ignore the model
+    // field entirely (it's baked into the worker image). Leaving it
+    // blank tells the prompt builder to fall back to ollama_model.
+    return mb_substr(trim((string) $value), 0, 120);
+}
+
+function sanitize_provider_timeout(mixed $value, int $default, int $max = 900): string
+{
+    $timeout = (int) $value;
+    if ($timeout < 1) {
+        $timeout = $default;
+    }
+    return (string) max(1, min($max, $timeout));
+}
+
+function sanitize_ai_model_name(?string $value, string $default = ''): string
+{
+    $model = trim((string) $value);
+    if ($model === '') {
+        return $default;
+    }
+    return mb_substr($model, 0, 200);
+}
+
 function ai_briefing_settings_from_request(array $request): array
 {
     return [
         'ollama_enabled' => sanitize_enabled_flag($request['ollama_enabled'] ?? null),
         'ollama_provider' => sanitize_ollama_provider($request['ollama_provider'] ?? null),
+
+        // Local Ollama
         'ollama_url' => sanitize_ollama_url($request['ollama_url'] ?? null),
         'ollama_model' => sanitize_ollama_model($request['ollama_model'] ?? null),
         'ollama_timeout' => sanitize_ollama_timeout($request['ollama_timeout'] ?? null),
         'ollama_capability_tier' => sanitize_ollama_capability_tier($request['ollama_capability_tier'] ?? null),
+
+        // Runpod
         'ollama_runpod_url' => sanitize_ollama_runpod_url($request['ollama_runpod_url'] ?? null),
         'ollama_runpod_api_key' => sanitize_ollama_runpod_api_key($request['ollama_runpod_api_key'] ?? null),
+        'runpod_model' => sanitize_runpod_model($request['runpod_model'] ?? null),
+        'runpod_timeout' => sanitize_provider_timeout($request['runpod_timeout'] ?? null, 120, 900),
+
+        // Claude
         'claude_api_key' => trim((string) ($request['claude_api_key'] ?? '')),
-        'claude_model' => trim((string) ($request['claude_model'] ?? 'claude-sonnet-4-20250514')),
+        'claude_model' => sanitize_ai_model_name($request['claude_model'] ?? null, 'claude-sonnet-4-20250514'),
+        'claude_timeout' => sanitize_provider_timeout($request['claude_timeout'] ?? null, 60, 600),
+
+        // Groq
         'groq_api_key' => trim((string) ($request['groq_api_key'] ?? '')),
-        'groq_model' => trim((string) ($request['groq_model'] ?? 'meta-llama/llama-4-scout-17b-16e-instruct')),
+        'groq_model' => sanitize_ai_model_name($request['groq_model'] ?? null, 'meta-llama/llama-4-scout-17b-16e-instruct'),
+        'groq_timeout' => sanitize_provider_timeout($request['groq_timeout'] ?? null, 30, 300),
+
+        // Prompts
         'theater_aar_prompt' => mb_substr(trim((string) ($request['theater_aar_prompt'] ?? '')), 0, 8000),
+
+        // Per-feature provider routing
         'ai_provider_theater_lock' => sanitize_ai_feature_provider($request['ai_provider_theater_lock'] ?? null),
         'ai_provider_opposition_global' => sanitize_ai_feature_provider($request['ai_provider_opposition_global'] ?? null),
         'ai_provider_opposition_alliance' => sanitize_ai_feature_provider($request['ai_provider_opposition_alliance'] ?? null),
@@ -20916,19 +20976,61 @@ function supplycore_ai_ollama_config(): array
     $settings = get_settings(ai_briefing_setting_keys());
     $provider = sanitize_ollama_provider($settings['ollama_provider'] ?? $defaults['ollama_provider']);
 
+    $localModel = sanitize_ollama_model($settings['ollama_model'] ?? $defaults['ollama_model']);
+    $runpodModel = sanitize_runpod_model($settings['runpod_model'] ?? $defaults['runpod_model']);
+    // If no Runpod-specific model is configured, fall back to the local
+    // Ollama model. Pre-split installs stored a single model shared
+    // across both providers; preserving that fallback avoids breaking
+    // existing deployments.
+    if ($runpodModel === '') {
+        $runpodModel = $localModel;
+    }
+
+    $localTimeout = max(1, (int) sanitize_ollama_timeout($settings['ollama_timeout'] ?? $defaults['ollama_timeout']));
+    $runpodTimeout = (int) sanitize_provider_timeout($settings['runpod_timeout'] ?? $defaults['runpod_timeout'], 120, 900);
+    $claudeTimeout = (int) sanitize_provider_timeout($settings['claude_timeout'] ?? $defaults['claude_timeout'], 60, 600);
+    $groqTimeout = (int) sanitize_provider_timeout($settings['groq_timeout'] ?? $defaults['groq_timeout'], 30, 300);
+
+    // `timeout` and `model` resolve to the *active* provider's values
+    // so existing callers that read $config['timeout'] / $config['model']
+    // keep working without branching on provider everywhere.
+    $activeTimeout = match ($provider) {
+        'runpod' => $runpodTimeout,
+        'claude' => $claudeTimeout,
+        'groq' => $groqTimeout,
+        default => $localTimeout,
+    };
+    $activeModel = match ($provider) {
+        'runpod' => $runpodModel,
+        'claude' => trim((string) ($settings['claude_model'] ?? $defaults['claude_model'])),
+        'groq' => trim((string) ($settings['groq_model'] ?? $defaults['groq_model'])),
+        default => $localModel,
+    };
+
     $config = [
         'enabled' => (($settings['ollama_enabled'] ?? $defaults['ollama_enabled']) === '1'),
         'provider' => $provider,
         'url' => sanitize_ollama_url($settings['ollama_url'] ?? $defaults['ollama_url']),
-        'model' => sanitize_ollama_model($settings['ollama_model'] ?? $defaults['ollama_model']),
-        'timeout' => max(1, (int) sanitize_ollama_timeout($settings['ollama_timeout'] ?? $defaults['ollama_timeout'])),
+        'model' => $activeModel,
+        'timeout' => $activeTimeout,
         'capability_override' => sanitize_ollama_capability_tier($settings['ollama_capability_tier'] ?? $defaults['ollama_capability_tier']),
+
+        // Per-provider resolved values. Callers targeting a specific
+        // provider should read these rather than the active 'model' /
+        // 'timeout' fields so they always see the right setting even
+        // when the global provider is different.
+        'local_ollama_model' => $localModel,
+        'local_ollama_timeout' => $localTimeout,
         'runpod_url' => sanitize_ollama_runpod_url($settings['ollama_runpod_url'] ?? $defaults['ollama_runpod_url']),
         'runpod_api_key' => sanitize_ollama_runpod_api_key($settings['ollama_runpod_api_key'] ?? $defaults['ollama_runpod_api_key']),
+        'runpod_model' => $runpodModel,
+        'runpod_timeout' => $runpodTimeout,
         'claude_api_key' => trim((string) ($settings['claude_api_key'] ?? $defaults['claude_api_key'])),
         'claude_model' => trim((string) ($settings['claude_model'] ?? $defaults['claude_model'])),
+        'claude_timeout' => $claudeTimeout,
         'groq_api_key' => trim((string) ($settings['groq_api_key'] ?? $defaults['groq_api_key'])),
         'groq_model' => trim((string) ($settings['groq_model'] ?? $defaults['groq_model'])),
+        'groq_timeout' => $groqTimeout,
     ];
 
     $inferredTier = supplycore_ai_infer_model_capability_tier((string) ($config['model'] ?? ''));
@@ -20944,15 +21046,21 @@ function supplycore_ai_ollama_config(): array
         'model' => (string) ($config['model'] ?? $defaults['ollama_model']),
         'timeout' => max(1, (int) ($config['timeout'] ?? (int) $defaults['ollama_timeout'])),
         'capability_override' => (string) ($config['capability_override'] ?? 'auto'),
+        'local_ollama_model' => (string) ($config['local_ollama_model'] ?? $defaults['ollama_model']),
+        'local_ollama_timeout' => max(1, (int) ($config['local_ollama_timeout'] ?? (int) $defaults['ollama_timeout'])),
         'runpod_url' => (string) ($config['runpod_url'] ?? ''),
         'runpod_api_key' => (string) ($config['runpod_api_key'] ?? ''),
         'runpod_api_key_masked' => supplycore_mask_secret((string) ($config['runpod_api_key'] ?? '')),
+        'runpod_model' => (string) ($config['runpod_model'] ?? ''),
+        'runpod_timeout' => max(1, (int) ($config['runpod_timeout'] ?? (int) $defaults['runpod_timeout'])),
         'claude_api_key' => (string) ($config['claude_api_key'] ?? ''),
         'claude_api_key_masked' => supplycore_mask_secret((string) ($config['claude_api_key'] ?? '')),
         'claude_model' => (string) ($config['claude_model'] ?? 'claude-sonnet-4-20250514'),
+        'claude_timeout' => max(1, (int) ($config['claude_timeout'] ?? (int) $defaults['claude_timeout'])),
         'groq_api_key' => (string) ($config['groq_api_key'] ?? ''),
         'groq_api_key_masked' => supplycore_mask_secret((string) ($config['groq_api_key'] ?? '')),
         'groq_model' => (string) ($config['groq_model'] ?? 'meta-llama/llama-4-scout-17b-16e-instruct'),
+        'groq_timeout' => max(1, (int) ($config['groq_timeout'] ?? (int) $defaults['groq_timeout'])),
         'inferred_tier' => $inferredTier,
         'capability_tier' => $effectiveTier,
         'strategy' => $strategy,
@@ -21357,8 +21465,16 @@ function supplycore_ai_runpod_prompt(array $config, string $systemPrompt, string
         $schemaJson = '{}';
     }
 
+    // Prefer the Runpod-specific model if one is configured, otherwise
+    // fall back to the active/local model name. Pre-split installs only
+    // had a single shared field.
+    $model = (string) ($config['runpod_model'] ?? '');
+    if ($model === '') {
+        $model = (string) ($config['model'] ?? '');
+    }
+
     return trim(implode("\n\n", [
-        'You are using the model "' . (string) ($config['model'] ?? '') . '" through a Runpod serverless endpoint.',
+        'You are using the model "' . $model . '" through a Runpod serverless endpoint.',
         'SYSTEM INSTRUCTIONS',
         $systemPrompt,
         'USER REQUEST',
@@ -21400,9 +21516,13 @@ function supplycore_ai_runpod_status_url(string $url, string $jobId): string
 
 function supplycore_ai_runpod_request_timeout(array $config): int
 {
-    $configuredTimeout = max(1, (int) ($config['timeout'] ?? 20));
+    // Prefer the Runpod-specific per-HTTP-call timeout if configured.
+    // Fall back to the active/local 'timeout' for pre-split installs.
+    $configuredTimeout = max(1, (int) ($config['runpod_timeout'] ?? $config['timeout'] ?? 20));
 
-    return min(15, $configuredTimeout);
+    // Per-HTTP cap — individual /run and /status calls should be quick;
+    // this is NOT the total polling budget.
+    return min(30, $configuredTimeout);
 }
 
 function supplycore_ai_runpod_poll_budget_seconds(array $config): int
@@ -21414,7 +21534,9 @@ function supplycore_ai_runpod_poll_budget_seconds(array $config): int
         return max(30, (int) $config['runpod_poll_budget_seconds']);
     }
 
-    $configuredTimeout = max(1, (int) ($config['timeout'] ?? 20));
+    // Prefer the Runpod-specific timeout if configured. Pre-split
+    // installs fall back to the active 'timeout' field.
+    $configuredTimeout = max(1, (int) ($config['runpod_timeout'] ?? $config['timeout'] ?? 20));
 
     // Floor of 2 minutes as a safety net when called outside the worker
     // (e.g. from bin/ai_briefing_worker.php --once debugging).
@@ -21588,6 +21710,28 @@ function supplycore_ai_resolve_feature_config(string $feature, ?string $explicit
     }
 
     $config['provider'] = $provider;
+
+    // Re-point the active 'model' and 'timeout' at the chosen provider's
+    // fields so generic callers that read $config['timeout'] / ['model']
+    // see the right value for this feature. The per-provider fields
+    // (runpod_model, claude_timeout, …) still carry the full picture for
+    // providers that need them.
+    $runpodModel = (string) ($config['runpod_model'] ?? '');
+    if ($runpodModel === '') {
+        $runpodModel = (string) ($config['local_ollama_model'] ?? $config['model'] ?? '');
+    }
+    $config['model'] = match ($provider) {
+        'runpod' => $runpodModel,
+        'claude' => (string) ($config['claude_model'] ?? ''),
+        'groq' => (string) ($config['groq_model'] ?? ''),
+        default => (string) ($config['local_ollama_model'] ?? $config['model'] ?? ''),
+    };
+    $config['timeout'] = max(1, (int) match ($provider) {
+        'runpod' => (int) ($config['runpod_timeout'] ?? $config['timeout'] ?? 120),
+        'claude' => (int) ($config['claude_timeout'] ?? $config['timeout'] ?? 60),
+        'groq' => (int) ($config['groq_timeout'] ?? $config['timeout'] ?? 30),
+        default => (int) ($config['local_ollama_timeout'] ?? $config['timeout'] ?? 20),
+    });
 
     return $config;
 }
@@ -21958,7 +22102,7 @@ function supplycore_ai_claude_generate_json(array $config, string $systemPrompt,
             'anthropic-version: 2023-06-01',
         ],
         $requestPayload,
-        max(120, (int) ($config['timeout'] ?? 60))
+        max(30, (int) ($config['claude_timeout'] ?? $config['timeout'] ?? 60))
     );
 
     $status = (int) ($response['status'] ?? 0);
@@ -22020,7 +22164,7 @@ function supplycore_ai_groq_generate_json(array $config, string $systemPrompt, s
             'Authorization: Bearer ' . $apiKey,
         ],
         $requestPayload,
-        max(120, (int) ($config['timeout'] ?? 60))
+        max(15, (int) ($config['groq_timeout'] ?? $config['timeout'] ?? 30))
     );
 
     $status = (int) ($response['status'] ?? 0);


### PR DESCRIPTION
## Summary

Local Ollama and Runpod previously shared a single `ollama_model` and `ollama_timeout` setting, and every provider's fields were crammed into one mixed grid on the settings page. You couldn't, for example, point Local Ollama at a tiny qwen model while pointing Runpod at a 70B llama.

This PR gives each provider its own model + timeout fields and reorganises the settings UI into per-provider cards.

> **Stacked on top of `claude/check-runpod-async-EgMDi`** (the ai_jobs + CLI worker work). Merge that one first, then this.

## New per-provider settings

| Key | Default | Range | Notes |
|---|---|---|---|
| `runpod_model` | `""` | up to 120 chars | Independent of `ollama_model`. Blank → falls back to `ollama_model` to preserve pre-split installs. |
| `runpod_timeout` | `120` | 1–900 s | Per-HTTP cap for `/run` and `/status` calls. Total polling budget is still controlled by the ai_jobs worker lease (~14 min). |
| `claude_timeout` | `60` | 1–600 s | |
| `groq_timeout` | `30` | 1–300 s | |

`ollama_model` / `ollama_timeout` remain the **Local Ollama** fields. `ollama_runpod_url` / `ollama_runpod_api_key` keep their legacy names so existing installs don't need a data migration.

## Config resolver

`supplycore_ai_ollama_config()` now returns:

- Active-provider aliases (`model`, `timeout`) resolved from whichever provider is currently selected — existing generic callers keep working
- Per-provider fields alongside: `local_ollama_model`, `local_ollama_timeout`, `runpod_model`, `runpod_timeout`, `claude_model`, `claude_timeout`, `groq_model`, `groq_timeout`

`supplycore_ai_resolve_feature_config()` re-points the active fields when a feature override selects a different provider, so the ai_jobs worker always runs with the right model and timeout for the feature's chosen provider.

## Provider helpers

- `supplycore_ai_runpod_prompt` uses `runpod_model` (fallback to `model`)
- `supplycore_ai_runpod_request_timeout` reads `runpod_timeout`
- `supplycore_ai_runpod_poll_budget_seconds` reads `runpod_timeout`
- `supplycore_ai_claude_generate_json` reads `claude_timeout`
- `supplycore_ai_groq_generate_json` reads `groq_timeout`

## UI

Before: one big mixed grid with all providers' fields stacked together and a shared "Model Name (Ollama/Runpod)" input.

After:
- **Global defaults** card — provider selector + capability tier
- **Local Ollama** card — API URL, Model, Timeout
- **Runpod Serverless** card — Endpoint URL, API Key, Model, Per-HTTP Timeout
- **Claude API** card — API Key, Model, Timeout
- **Groq** card — API Key, Model, Timeout
- **Per-feature routing** card (unchanged)

Each provider card is self-contained — operators only see the fields relevant to that provider, and the dual Local Ollama ↔ Runpod model field is gone.

## Migration

None required. New keys default to sane values; read-side fallbacks handle pre-split data (empty `runpod_model` → `ollama_model`, empty `*_timeout` → active `timeout`).

## Test plan

- [ ] Save settings with Runpod selected, confirm `runpod_model` and `runpod_timeout` persist independently of `ollama_model` / `ollama_timeout`
- [ ] Leave `runpod_model` blank → Runpod calls still work using `ollama_model` as a fallback
- [ ] Switch global provider between Local / Runpod / Claude / Groq and verify the capability tier auto-detection still picks the right model
- [ ] Enqueue a theater-lock job with a per-feature provider override and confirm the worker picks up the feature provider's model and timeout (not the global one)
- [ ] Settings "Test connection" still works for each provider

https://claude.ai/code/session_01PYdPoUa3UgyVArQLufSViC