### PR TITLE
Size AI prompts for Runpod gemma4:26b-a4b-it-q4_K_M

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1825,8 +1825,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             </label>
                             <label class="block space-y-1.5">
                                 <span class="text-xs uppercase tracking-wider text-muted">Model</span>
-                                <input name="runpod_model" value="<?= htmlspecialchars($settingValues['runpod_model'] ?? ($ollamaConfig['runpod_model'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="llama3.1:70b (or leave blank if your worker hard-codes the model)" />
-                                <p class="text-xs text-muted">Independent of the Local Ollama model. Leave blank if your Runpod worker image has the model baked in.</p>
+                                <input name="runpod_model" value="<?= htmlspecialchars($settingValues['runpod_model'] ?? ($ollamaConfig['runpod_model'] ?? 'gemma4:26b-a4b-it-q4_K_M'), ENT_QUOTES) ?>" class="w-full field-input" placeholder="gemma4:26b-a4b-it-q4_K_M" />
+                                <p class="text-xs text-muted">Independent of the Local Ollama model. Default is <span class="font-medium text-slate-100">gemma4:26b-a4b-it-q4_K_M</span> — the MoE variant with 25.2B total / 3.8B active params and a 256K context window, which auto-detects as the <span class="font-medium text-slate-100">large</span> capability tier. Leave blank if your Runpod worker image has the model baked in.</p>
                             </label>
                             <label class="block space-y-1.5">
                                 <span class="text-xs uppercase tracking-wider text-muted">Per-HTTP Timeout (s)</span>

--- a/src/functions.php
+++ b/src/functions.php
@@ -872,9 +872,13 @@ function ai_briefing_setting_defaults(): array
         // names so existing installs keep working without a data
         // migration. runpod_model and runpod_timeout are new: Runpod and
         // Local Ollama no longer share model/timeout settings.
+        //
+        // Default model is gemma4:26b-a4b-it-q4_K_M — the MoE variant
+        // with 25.2B total / 3.8B active params and a 256K context
+        // window. Sized to the current reference Runpod worker image.
         'ollama_runpod_url' => '',
         'ollama_runpod_api_key' => '',
-        'runpod_model' => '',
+        'runpod_model' => 'gemma4:26b-a4b-it-q4_K_M',
         'runpod_timeout' => '120',
 
         // --- Claude (Anthropic) ---
@@ -21067,6 +21071,58 @@ function supplycore_ai_ollama_config(): array
     ];
 }
 
+/**
+ * Build the Ollama /generate 'options' object sized to the active model
+ * and capability tier. Centralises temperature, num_predict and num_ctx
+ * so the theater and opposition call sites don't drift apart, and so
+ * large-context models (e.g. Gemma 4 26B A4B with a 256K window) get a
+ * context allocation that actually lets their quality show.
+ *
+ * Passing $overrides lets individual callers bump creativity / output
+ * length for their specific prompt (e.g. long AAR summaries).
+ *
+ * NOTE: num_ctx is also the KV-cache size on the Ollama daemon side, so
+ * we deliberately DON'T max out model capability — 32K on a 26B model
+ * already costs several GB of VRAM. Operators on beefier hardware can
+ * pin the tier to 'large' to get the bigger context.
+ */
+function supplycore_ai_ollama_request_options(array $config, array $overrides = []): array
+{
+    $tier = (string) ($config['capability_tier'] ?? 'small');
+
+    // Per-tier defaults:
+    //   small  — tiny models (qwen 1.5B, gemma e4b): compact prompts
+    //   medium — 7-8B dense models: room for one long section
+    //   large  — 13B+ dense, or MoE like gemma4:26b-a4b: deep briefings
+    $defaults = match ($tier) {
+        'large' => [
+            'temperature' => 0.2,
+            'num_predict' => 6144,
+            'num_ctx' => 32768,
+        ],
+        'medium' => [
+            'temperature' => 0.2,
+            'num_predict' => 4096,
+            'num_ctx' => 16384,
+        ],
+        default => [
+            'temperature' => 0.2,
+            'num_predict' => 2048,
+            'num_ctx' => 8192,
+        ],
+    };
+
+    // Allow the configured timeout to pull num_ctx down — tiny request
+    // timeouts on weak hardware shouldn't be promised a 32K context
+    // they can't serve inside the window.
+    $timeoutSeconds = (int) ($config['timeout'] ?? ($config['local_ollama_timeout'] ?? 20));
+    if ($timeoutSeconds > 0 && $timeoutSeconds < 30 && $defaults['num_ctx'] > 8192) {
+        $defaults['num_ctx'] = 8192;
+    }
+
+    return $overrides + $defaults;
+}
+
 function supplycore_mask_secret(string $value): string
 {
     $trimmed = trim($value);
@@ -21733,6 +21789,18 @@ function supplycore_ai_resolve_feature_config(string $feature, ?string $explicit
         default => (int) ($config['local_ollama_timeout'] ?? $config['timeout'] ?? 20),
     });
 
+    // Re-compute the capability tier against the now-resolved model so
+    // features running on a different provider (e.g. local defaults to
+    // a small qwen but a feature routes to Runpod gemma4:26b-a4b) get
+    // the tier/strategy that actually matches their runtime model.
+    $inferredTier = supplycore_ai_infer_model_capability_tier((string) ($config['model'] ?? ''));
+    $effectiveTier = ($config['capability_override'] ?? 'auto') !== 'auto'
+        ? (string) $config['capability_override']
+        : $inferredTier;
+    $config['inferred_tier'] = $inferredTier;
+    $config['capability_tier'] = $effectiveTier;
+    $config['strategy'] = supplycore_ai_capability_strategy($effectiveTier);
+
     return $config;
 }
 
@@ -22275,11 +22343,7 @@ function theater_ai_summary_generate(string $theaterId, bool $forceRegenerate = 
                 'system' => $systemPrompt,
                 'prompt' => $userPrompt,
                 'format' => $schema,
-                'options' => [
-                    'temperature' => 0.2,
-                    'num_predict' => 4096,
-                    'num_ctx' => 8192,
-                ],
+                'options' => supplycore_ai_ollama_request_options($config),
             ];
             $response = http_post_json($endpoint, [], $requestPayload, max(300, $config['timeout']));
             $status = (int) ($response['status'] ?? 0);
@@ -26806,11 +26870,9 @@ function opposition_ai_call_provider(string $systemPrompt, string $userPrompt, a
         'system' => $systemPrompt,
         'prompt' => $userPrompt,
         'format' => $schema,
-        'options' => [
-            'temperature' => 0.3,
-            'num_predict' => 4096,
-            'num_ctx' => 8192,
-        ],
+        // Opposition briefings historically used a slightly higher
+        // temperature (0.3) for more varied phrasing.
+        'options' => supplycore_ai_ollama_request_options($config, ['temperature' => 0.3]),
     ];
     $response = http_post_json($endpoint, [], $requestPayload, max(300, $config['timeout']));
     $status = (int) ($response['status'] ?? 0);


### PR DESCRIPTION
## Summary

Runpod's reference worker image is **Gemma 4 26B A4B** — an MoE with **25.2B total / 3.8B active params**, a **256K context window**, Q4_K_M quantization (~18GB on disk). Our previous defaults undersized everything for this model.

Three problems this fixes:

1. `runpod_model` was blank, so operators had to know and type the exact tag themselves
2. The local Ollama `options` object was hardcoded to `num_ctx=8192` regardless of which model was loaded — a 26B-class model with 256K headroom was being asked to operate on 8K context even when the user-facing capability tier said "large"
3. `supplycore_ai_resolve_feature_config()` was swapping the provider and model for per-feature routing but **not recomputing the capability tier**. A feature routed to Runpod's large gemma4 would inherit the global tier (e.g. "small" if the global provider is a tiny local qwen) and run with the compact prompt strategy against a model that can handle far richer input.

> Stacked on `claude/split-ai-provider-settings`. Merge that one first.

## What changed

### Default model

```php
'runpod_model' => 'gemma4:26b-a4b-it-q4_K_M',
```

The name parser already extracts `26B` from the tag and maps it to the **large** capability tier, which unlocks the rich prompt strategy (wider `candidate_limit`, deeper history, extra output sections like `operator_briefing_max_chars` and `trend_max_chars`).

Verified:
```
infer_model_capacity_billions("gemma4:26b-a4b-it-q4_K_M") -> 26.0
infer_model_capability_tier  ("gemma4:26b-a4b-it-q4_K_M") -> "large"
```

### New sizing helper

```php
supplycore_ai_ollama_request_options(array $config, array $overrides = []): array
```

Picks `num_ctx`, `num_predict`, `temperature` from the active capability tier:

| Tier   | num_ctx | num_predict | Example models |
|--------|---------|-------------|----------------|
| small  | 8 192   | 2 048       | qwen2.5:1.5b, gemma4:e4b |
| medium | 16 384  | 4 096       | llama3.1:8b, qwen2.5:7b |
| large  | 32 768  | 6 144       | gemma4:26b-a4b, llama3.3:70b |

**32K is deliberately capped far below the model's 256K headroom.** `num_ctx` is also the KV-cache size on the Ollama daemon side, and 32K already costs several GB of VRAM on a 26B-class model — promising 256K would OOM most realistic deployments. Short request timeouts (< 30 s) force `num_ctx` back to 8 192 as a safety net so weak hardware isn't handed a context it can't serve in time.

Both existing call sites (`theater_ai_summary_generate` and `opposition_ai_call_provider`) now use the helper instead of hardcoding the options object. The opposition path keeps its historical `temperature=0.3` via the `overrides` arg.

### Feature-router tier fix

`supplycore_ai_resolve_feature_config()` now re-runs `supplycore_ai_infer_model_capability_tier()` against the resolved model after swapping the provider, so the `capability_tier`, `inferred_tier`, and `strategy` fields match the model that will actually run — not the global default's model.

### UI

The Runpod model field now shows the new default with a help text explaining the provenance (MoE, 256K context, large-tier auto-detection).

## Migration

None. Existing installs with a blank `runpod_model` will pick up the new default on the next settings save, and installs with an explicit value keep it unchanged.

## Test plan

- [ ] Default `runpod_model` is `gemma4:26b-a4b-it-q4_K_M` on a fresh install
- [ ] `supplycore_ai_ollama_request_options()` returns `num_ctx=32768` for the large tier and falls back to 8192 when timeout < 30 s
- [ ] A theater-lock job with `ai_provider_theater_lock=runpod` resolves the large tier against `gemma4:26b-a4b-it-q4_K_M` even when global provider is local qwen
- [ ] Theater AAR generation on a local Ollama daemon picks up the larger `num_ctx` for 13B+ models without OOMing

## Sources
- [Gemma 4 model card — Google AI for Developers](https://ai.google.dev/gemma/docs/core/model_card_4)
- [gemma4:26b-a4b-it-q4_K_M — Ollama library](https://ollama.com/library/gemma4:26b-a4b-it-q4_K_M)
- [Gemma 4 Complete Guide: Architecture, Models, and Deployment in 2026](https://dev.to/linnn_charm_2e397112f3b51/gemma-4-complete-guide-architecture-models-and-deployment-in-2026-3m5b)

https://claude.ai/code/session_01PYdPoUa3UgyVArQLufSViC