### PR TITLE
Separate AI provider cards + size prompts for gemma4:26b-a4b

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1825,8 +1825,8 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             </label>
                             <label class="block space-y-1.5">
                                 <span class="text-xs uppercase tracking-wider text-muted">Model</span>
-                                <input name="runpod_model" value="<?= htmlspecialchars($settingValues['runpod_model'] ?? ($ollamaConfig['runpod_model'] ?? ''), ENT_QUOTES) ?>" class="w-full field-input" placeholder="llama3.1:70b (or leave blank if your worker hard-codes the model)" />
-                                <p class="text-xs text-muted">Independent of the Local Ollama model. Leave blank if your Runpod worker image has the model baked in.</p>
+                                <input name="runpod_model" value="<?= htmlspecialchars($settingValues['runpod_model'] ?? ($ollamaConfig['runpod_model'] ?? 'gemma4:26b-a4b-it-q4_K_M'), ENT_QUOTES) ?>" class="w-full field-input" placeholder="gemma4:26b-a4b-it-q4_K_M" />
+                                <p class="text-xs text-muted">Independent of the Local Ollama model. Default is <span class="font-medium text-slate-100">gemma4:26b-a4b-it-q4_K_M</span> — the MoE variant with 25.2B total / 3.8B active params and a 256K context window, which auto-detects as the <span class="font-medium text-slate-100">large</span> capability tier. Leave blank if your Runpod worker image has the model baked in.</p>
                             </label>
                             <label class="block space-y-1.5">
                                 <span class="text-xs uppercase tracking-wider text-muted">Per-HTTP Timeout (s)</span>

--- a/src/functions.php
+++ b/src/functions.php
@@ -872,9 +872,13 @@ function ai_briefing_setting_defaults(): array
         // names so existing installs keep working without a data
         // migration. runpod_model and runpod_timeout are new: Runpod and
         // Local Ollama no longer share model/timeout settings.
+        //
+        // Default model is gemma4:26b-a4b-it-q4_K_M — the MoE variant
+        // with 25.2B total / 3.8B active params and a 256K context
+        // window. Sized to the current reference Runpod worker image.
         'ollama_runpod_url' => '',
         'ollama_runpod_api_key' => '',
-        'runpod_model' => '',
+        'runpod_model' => 'gemma4:26b-a4b-it-q4_K_M',
         'runpod_timeout' => '120',
 
         // --- Claude (Anthropic) ---
@@ -21067,6 +21071,58 @@ function supplycore_ai_ollama_config(): array
     ];
 }
 
+/**
+ * Build the Ollama /generate 'options' object sized to the active model
+ * and capability tier. Centralises temperature, num_predict and num_ctx
+ * so the theater and opposition call sites don't drift apart, and so
+ * large-context models (e.g. Gemma 4 26B A4B with a 256K window) get a
+ * context allocation that actually lets their quality show.
+ *
+ * Passing $overrides lets individual callers bump creativity / output
+ * length for their specific prompt (e.g. long AAR summaries).
+ *
+ * NOTE: num_ctx is also the KV-cache size on the Ollama daemon side, so
+ * we deliberately DON'T max out model capability — 32K on a 26B model
+ * already costs several GB of VRAM. Operators on beefier hardware can
+ * pin the tier to 'large' to get the bigger context.
+ */
+function supplycore_ai_ollama_request_options(array $config, array $overrides = []): array
+{
+    $tier = (string) ($config['capability_tier'] ?? 'small');
+
+    // Per-tier defaults:
+    //   small  — tiny models (qwen 1.5B, gemma e4b): compact prompts
+    //   medium — 7-8B dense models: room for one long section
+    //   large  — 13B+ dense, or MoE like gemma4:26b-a4b: deep briefings
+    $defaults = match ($tier) {
+        'large' => [
+            'temperature' => 0.2,
+            'num_predict' => 6144,
+            'num_ctx' => 32768,
+        ],
+        'medium' => [
+            'temperature' => 0.2,
+            'num_predict' => 4096,
+            'num_ctx' => 16384,
+        ],
+        default => [
+            'temperature' => 0.2,
+            'num_predict' => 2048,
+            'num_ctx' => 8192,
+        ],
+    };
+
+    // Allow the configured timeout to pull num_ctx down — tiny request
+    // timeouts on weak hardware shouldn't be promised a 32K context
+    // they can't serve inside the window.
+    $timeoutSeconds = (int) ($config['timeout'] ?? ($config['local_ollama_timeout'] ?? 20));
+    if ($timeoutSeconds > 0 && $timeoutSeconds < 30 && $defaults['num_ctx'] > 8192) {
+        $defaults['num_ctx'] = 8192;
+    }
+
+    return $overrides + $defaults;
+}
+
 function supplycore_mask_secret(string $value): string
 {
     $trimmed = trim($value);
@@ -21733,6 +21789,18 @@ function supplycore_ai_resolve_feature_config(string $feature, ?string $explicit
         default => (int) ($config['local_ollama_timeout'] ?? $config['timeout'] ?? 20),
     });
 
+    // Re-compute the capability tier against the now-resolved model so
+    // features running on a different provider (e.g. local defaults to
+    // a small qwen but a feature routes to Runpod gemma4:26b-a4b) get
+    // the tier/strategy that actually matches their runtime model.
+    $inferredTier = supplycore_ai_infer_model_capability_tier((string) ($config['model'] ?? ''));
+    $effectiveTier = ($config['capability_override'] ?? 'auto') !== 'auto'
+        ? (string) $config['capability_override']
+        : $inferredTier;
+    $config['inferred_tier'] = $inferredTier;
+    $config['capability_tier'] = $effectiveTier;
+    $config['strategy'] = supplycore_ai_capability_strategy($effectiveTier);
+
     return $config;
 }
 
@@ -22275,11 +22343,7 @@ function theater_ai_summary_generate(string $theaterId, bool $forceRegenerate = 
                 'system' => $systemPrompt,
                 'prompt' => $userPrompt,
                 'format' => $schema,
-                'options' => [
-                    'temperature' => 0.2,
-                    'num_predict' => 4096,
-                    'num_ctx' => 8192,
-                ],
+                'options' => supplycore_ai_ollama_request_options($config),
             ];
             $response = http_post_json($endpoint, [], $requestPayload, max(300, $config['timeout']));
             $status = (int) ($response['status'] ?? 0);
@@ -26806,11 +26870,9 @@ function opposition_ai_call_provider(string $systemPrompt, string $userPrompt, a
         'system' => $systemPrompt,
         'prompt' => $userPrompt,
         'format' => $schema,
-        'options' => [
-            'temperature' => 0.3,
-            'num_predict' => 4096,
-            'num_ctx' => 8192,
-        ],
+        // Opposition briefings historically used a slightly higher
+        // temperature (0.3) for more varied phrasing.
+        'options' => supplycore_ai_ollama_request_options($config, ['temperature' => 0.3]),
     ];
     $response = http_post_json($endpoint, [], $requestPayload, max(300, $config['timeout']));
     $status = (int) ($response['status'] ?? 0);


### PR DESCRIPTION
## Summary

Replaces the flat mixed-field AI settings grid with four isolated per-provider cards and properly sizes prompt/context for the Runpod gemma4:26b-a4b-it-q4_K_M model.

**Before:** All provider fields (URLs, API keys, models, timeouts) were crammed into one long grid. Runpod and Local Ollama shared a single "Model Name (Ollama/Runpod)" field and a single "Request Timeout" field.

**After:**

```
┌─ Global defaults ─────────────────────────────────┐
│  Default AI Provider [dropdown]                    │
│  Capability Tier     [dropdown]                    │
└────────────────────────────────────────────────────┘

┌─ Local Ollama ──────────┐  ┌─ Runpod Serverless ───┐
│  API URL                │  │  Endpoint URL          │
│  Model                  │  │  API Key               │
│  Timeout (s)            │  │  Model (gemma4:26b-…)  │
│                         │  │  Per-HTTP Timeout (s)   │
└─────────────────────────┘  └────────────────────────┘

┌─ Claude API ────────────┐  ┌─ Groq ────────────────┐
│  API Key                │  │  API Key               │
│  Model                  │  │  Model                 │
│  Timeout (s)            │  │  Timeout (s)           │
└─────────────────────────┘  └────────────────────────┘

┌─ Per-feature provider routing ─────────────────────┐
│  ...                                               │
└────────────────────────────────────────────────────┘
```

## Per-provider storage (new settings keys)

| Key | Default | Notes |
|---|---|---|
| `runpod_model` | `gemma4:26b-a4b-it-q4_K_M` | Independent of `ollama_model`. 25.2B total / 3.8B active MoE, 256K context, Q4_K_M (~18 GB). Auto-detects as **large** tier. |
| `runpod_timeout` | `120` s | Per-HTTP cap for /run and /status calls. |
| `claude_timeout` | `60` s | |
| `groq_timeout` | `30` s | |

`ollama_model` / `ollama_timeout` are now strictly Local Ollama fields. Zero migration needed — blank `runpod_model` falls back to `ollama_model` for pre-split installs.

## Prompt sizing for gemma4:26b-a4b-it-q4_K_M

New `supplycore_ai_ollama_request_options()` helper picks `num_ctx`, `num_predict`, `temperature` from the capability tier:

| Tier | num_ctx | num_predict | Example models |
|---|---|---|---|
| small | 8 192 | 2 048 | qwen2.5:1.5b, gemma4:e4b |
| medium | 16 384 | 4 096 | llama3.1:8b, qwen2.5:7b |
| **large** | **32 768** | **6 144** | **gemma4:26b-a4b**, llama3.3:70b |

32K is deliberately capped below the model's 256K headroom — `num_ctx` = KV-cache size on the Ollama daemon, and 32K already costs several GB of VRAM. Timeouts < 30 s force `num_ctx` back to 8 192 as a safety net.

Both local Ollama call sites (`theater_ai_summary_generate`, `opposition_ai_call_provider`) now use the helper.

## Feature-router tier fix

`supplycore_ai_resolve_feature_config()` now recomputes `capability_tier` / `inferred_tier` / `strategy` after swapping the provider and model. Previously a feature routed to Runpod gemma4 (large tier) would inherit the global provider's small tier if the global was qwen 1.5B.

## Config resolver

`supplycore_ai_ollama_config()` exposes active-provider aliases (`model`, `timeout`) plus per-provider fields (`runpod_model`, `runpod_timeout`, `claude_timeout`, `groq_timeout`, etc.). Generic callers keep working; provider-specific callers read their own fields.

## Test plan

- [ ] Settings page shows four separate provider cards, no shared "Model Name (Ollama/Runpod)" field
- [ ] Save settings with different models per provider — confirm they persist independently
- [ ] `runpod_model` defaults to `gemma4:26b-a4b-it-q4_K_M` and auto-detects as large tier
- [ ] Theater-lock job with `ai_provider_theater_lock=runpod` uses the large tier and gemma4 model even when global is small local qwen
- [ ] Local Ollama calls get `num_ctx=32768` for large-tier models

https://claude.ai/code/session_01PYdPoUa3UgyVArQLufSViC