### PR TITLE
Per-provider capability tier + fix opposition button label

### DIFF
--- a/public/opposition-intelligence/index.php
+++ b/public/opposition-intelligence/index.php
@@ -103,9 +103,16 @@ include __DIR__ . '/../../src/views/partials/header.php';
                   onsubmit="this.querySelector('button').disabled=true;this.querySelector('button').innerText='Generating…';">
                 <input type="hidden" name="_token" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
                 <input type="hidden" name="date" value="<?= htmlspecialchars($date, ENT_QUOTES) ?>">
+                <?php
+                $oppoProviderLabel = ollama_provider_options()[(string) ($ollamaConfig['provider'] ?? 'local')] ?? 'AI';
+                $oppoFeatureProvider = get_setting('ai_provider_opposition_global', 'default');
+                if ($oppoFeatureProvider !== 'default' && isset(ollama_provider_options()[$oppoFeatureProvider])) {
+                    $oppoProviderLabel = ollama_provider_options()[$oppoFeatureProvider];
+                }
+                ?>
                 <button type="submit" class="btn-primary"
-                        title="Generate a SITREP for this date using local Ollama (gemma4:e2b). May take several minutes.">
-                    Generate Intel (local gemma4:e2b)
+                        title="Queue a SITREP generation job for this date. Runs in the background via the AI worker.">
+                    Generate Intel (<?= htmlspecialchars($oppoProviderLabel, ENT_QUOTES) ?>)
                 </button>
             </form>
         </div>

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -1752,26 +1752,17 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     </span>
                 </label>
 
-                <!-- Global provider + capability tier -->
+                <!-- Global default provider -->
                 <div class="rounded-2xl border border-white/8 bg-white/[0.03] p-4">
-                    <p class="text-sm font-medium text-slate-100">Global defaults</p>
-                    <p class="mt-1 text-xs text-muted">Picks which provider handles AI jobs by default. Per-feature routing below can override this on a per-job-type basis.</p>
-                    <div class="mt-3 grid gap-4 md:grid-cols-2">
+                    <p class="text-sm font-medium text-slate-100">Global default provider</p>
+                    <p class="mt-1 text-xs text-muted">Picks which provider handles AI jobs by default. Per-feature routing below can override this on a per-job-type basis. Each provider card has its own capability tier.</p>
+                    <div class="mt-3">
                         <label class="block space-y-2">
                             <span class="text-sm text-muted">Default AI Provider</span>
                             <select name="ollama_provider" class="w-full field-input">
                                 <?php $selectedProvider = (string) ($settingValues['ollama_provider'] ?? ($ollamaConfig['provider'] ?? 'local')); ?>
                                 <?php foreach (ollama_provider_options() as $value => $label): ?>
                                     <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $selectedProvider === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
-                                <?php endforeach; ?>
-                            </select>
-                        </label>
-                        <label class="block space-y-2">
-                            <span class="text-sm text-muted">Capability Tier</span>
-                            <select name="ollama_capability_tier" class="w-full field-input">
-                                <?php $selectedTier = (string) ($settingValues['ollama_capability_tier'] ?? ($ollamaConfig['capability_override'] ?? 'auto')); ?>
-                                <?php foreach (['auto' => 'Auto-detect from model', 'small' => 'Small', 'medium' => 'Medium', 'large' => 'Large'] as $value => $label): ?>
-                                    <option value="<?= htmlspecialchars($value, ENT_QUOTES) ?>" <?= $selectedTier === $value ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES) ?></option>
                                 <?php endforeach; ?>
                             </select>
                         </label>
@@ -1799,6 +1790,15 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             <label class="block space-y-1.5">
                                 <span class="text-xs uppercase tracking-wider text-muted">Request Timeout (s)</span>
                                 <input type="number" min="1" max="600" step="1" name="ollama_timeout" value="<?= htmlspecialchars($settingValues['ollama_timeout'] ?? (string) ($ollamaConfig['local_ollama_timeout'] ?? 20), ENT_QUOTES) ?>" class="w-full field-input" />
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Capability Tier</span>
+                                <?php $localTier = (string) ($settingValues['ollama_capability_tier'] ?? ($ollamaConfig['local_ollama_capability_tier'] ?? 'auto')); ?>
+                                <select name="ollama_capability_tier" class="w-full field-input">
+                                    <?php foreach (['auto' => 'Auto-detect', 'small' => 'Small', 'medium' => 'Medium', 'large' => 'Large'] as $v => $l): ?>
+                                        <option value="<?= $v ?>" <?= $localTier === $v ? 'selected' : '' ?>><?= $l ?></option>
+                                    <?php endforeach; ?>
+                                </select>
                             </label>
                         </div>
                     </section>
@@ -1833,6 +1833,15 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 <input type="number" min="5" max="900" step="1" name="runpod_timeout" value="<?= htmlspecialchars($settingValues['runpod_timeout'] ?? (string) ($ollamaConfig['runpod_timeout'] ?? 120), ENT_QUOTES) ?>" class="w-full field-input" />
                                 <p class="text-xs text-muted">Caps individual /run and /status calls. Total polling budget is controlled by the AI worker's lease (~14 minutes).</p>
                             </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Capability Tier</span>
+                                <?php $runpodTier = (string) ($settingValues['runpod_capability_tier'] ?? ($ollamaConfig['runpod_capability_tier'] ?? 'auto')); ?>
+                                <select name="runpod_capability_tier" class="w-full field-input">
+                                    <?php foreach (['auto' => 'Auto-detect', 'small' => 'Small', 'medium' => 'Medium', 'large' => 'Large'] as $v => $l): ?>
+                                        <option value="<?= $v ?>" <?= $runpodTier === $v ? 'selected' : '' ?>><?= $l ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </label>
                         </div>
                     </section>
 
@@ -1860,6 +1869,15 @@ include __DIR__ . '/../../src/views/partials/header.php';
                                 <span class="text-xs uppercase tracking-wider text-muted">Request Timeout (s)</span>
                                 <input type="number" min="5" max="600" step="1" name="claude_timeout" value="<?= htmlspecialchars($settingValues['claude_timeout'] ?? (string) ($ollamaConfig['claude_timeout'] ?? 60), ENT_QUOTES) ?>" class="w-full field-input" />
                             </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Capability Tier</span>
+                                <?php $claudeTier = (string) ($settingValues['claude_capability_tier'] ?? ($ollamaConfig['claude_capability_tier'] ?? 'large')); ?>
+                                <select name="claude_capability_tier" class="w-full field-input">
+                                    <?php foreach (['auto' => 'Auto-detect', 'small' => 'Small', 'medium' => 'Medium', 'large' => 'Large'] as $v => $l): ?>
+                                        <option value="<?= $v ?>" <?= $claudeTier === $v ? 'selected' : '' ?>><?= $l ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </label>
                         </div>
                     </section>
 
@@ -1886,6 +1904,15 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             <label class="block space-y-1.5">
                                 <span class="text-xs uppercase tracking-wider text-muted">Request Timeout (s)</span>
                                 <input type="number" min="5" max="300" step="1" name="groq_timeout" value="<?= htmlspecialchars($settingValues['groq_timeout'] ?? (string) ($ollamaConfig['groq_timeout'] ?? 30), ENT_QUOTES) ?>" class="w-full field-input" />
+                            </label>
+                            <label class="block space-y-1.5">
+                                <span class="text-xs uppercase tracking-wider text-muted">Capability Tier</span>
+                                <?php $groqTier = (string) ($settingValues['groq_capability_tier'] ?? ($ollamaConfig['groq_capability_tier'] ?? 'auto')); ?>
+                                <select name="groq_capability_tier" class="w-full field-input">
+                                    <?php foreach (['auto' => 'Auto-detect', 'small' => 'Small', 'medium' => 'Medium', 'large' => 'Large'] as $v => $l): ?>
+                                        <option value="<?= $v ?>" <?= $groqTier === $v ? 'selected' : '' ?>><?= $l ?></option>
+                                    <?php endforeach; ?>
+                                </select>
                             </label>
                         </div>
                     </section>

--- a/src/functions.php
+++ b/src/functions.php
@@ -880,16 +880,19 @@ function ai_briefing_setting_defaults(): array
         'ollama_runpod_api_key' => '',
         'runpod_model' => 'gemma4:26b-a4b-it-q4_K_M',
         'runpod_timeout' => '120',
+        'runpod_capability_tier' => 'auto',
 
         // --- Claude (Anthropic) ---
         'claude_api_key' => '',
         'claude_model' => 'claude-sonnet-4-20250514',
         'claude_timeout' => '60',
+        'claude_capability_tier' => 'large',
 
         // --- Groq ---
         'groq_api_key' => '',
         'groq_model' => 'meta-llama/llama-4-scout-17b-16e-instruct',
         'groq_timeout' => '30',
+        'groq_capability_tier' => 'auto',
 
         // --- Prompts ---
         'theater_aar_prompt' => '',
@@ -1182,16 +1185,19 @@ function ai_briefing_settings_from_request(array $request): array
         'ollama_runpod_api_key' => sanitize_ollama_runpod_api_key($request['ollama_runpod_api_key'] ?? null),
         'runpod_model' => sanitize_runpod_model($request['runpod_model'] ?? null),
         'runpod_timeout' => sanitize_provider_timeout($request['runpod_timeout'] ?? null, 120, 900),
+        'runpod_capability_tier' => sanitize_ollama_capability_tier($request['runpod_capability_tier'] ?? null),
 
         // Claude
         'claude_api_key' => trim((string) ($request['claude_api_key'] ?? '')),
         'claude_model' => sanitize_ai_model_name($request['claude_model'] ?? null, 'claude-sonnet-4-20250514'),
         'claude_timeout' => sanitize_provider_timeout($request['claude_timeout'] ?? null, 60, 600),
+        'claude_capability_tier' => sanitize_ollama_capability_tier($request['claude_capability_tier'] ?? null),
 
         // Groq
         'groq_api_key' => trim((string) ($request['groq_api_key'] ?? '')),
         'groq_model' => sanitize_ai_model_name($request['groq_model'] ?? null, 'meta-llama/llama-4-scout-17b-16e-instruct'),
         'groq_timeout' => sanitize_provider_timeout($request['groq_timeout'] ?? null, 30, 300),
+        'groq_capability_tier' => sanitize_ollama_capability_tier($request['groq_capability_tier'] ?? null),
 
         // Prompts
         'theater_aar_prompt' => mb_substr(trim((string) ($request['theater_aar_prompt'] ?? '')), 0, 8000),
@@ -21011,13 +21017,29 @@ function supplycore_ai_ollama_config(): array
         default => $localModel,
     };
 
+    // Per-provider capability tier overrides. Each provider can have its
+    // own tier pinned so a tiny local model ('small') doesn't drag down
+    // the prompt strategy when the operator also runs a large Runpod
+    // model. 'auto' infers from the provider's model name.
+    $localCapTier = sanitize_ollama_capability_tier($settings['ollama_capability_tier'] ?? $defaults['ollama_capability_tier']);
+    $runpodCapTier = sanitize_ollama_capability_tier($settings['runpod_capability_tier'] ?? $defaults['runpod_capability_tier']);
+    $claudeCapTier = sanitize_ollama_capability_tier($settings['claude_capability_tier'] ?? $defaults['claude_capability_tier']);
+    $groqCapTier = sanitize_ollama_capability_tier($settings['groq_capability_tier'] ?? $defaults['groq_capability_tier']);
+
+    $activeCapTier = match ($provider) {
+        'runpod' => $runpodCapTier,
+        'claude' => $claudeCapTier,
+        'groq' => $groqCapTier,
+        default => $localCapTier,
+    };
+
     $config = [
         'enabled' => (($settings['ollama_enabled'] ?? $defaults['ollama_enabled']) === '1'),
         'provider' => $provider,
         'url' => sanitize_ollama_url($settings['ollama_url'] ?? $defaults['ollama_url']),
         'model' => $activeModel,
         'timeout' => $activeTimeout,
-        'capability_override' => sanitize_ollama_capability_tier($settings['ollama_capability_tier'] ?? $defaults['ollama_capability_tier']),
+        'capability_override' => $activeCapTier,
 
         // Per-provider resolved values. Callers targeting a specific
         // provider should read these rather than the active 'model' /
@@ -21025,21 +21047,25 @@ function supplycore_ai_ollama_config(): array
         // when the global provider is different.
         'local_ollama_model' => $localModel,
         'local_ollama_timeout' => $localTimeout,
+        'local_ollama_capability_tier' => $localCapTier,
         'runpod_url' => sanitize_ollama_runpod_url($settings['ollama_runpod_url'] ?? $defaults['ollama_runpod_url']),
         'runpod_api_key' => sanitize_ollama_runpod_api_key($settings['ollama_runpod_api_key'] ?? $defaults['ollama_runpod_api_key']),
         'runpod_model' => $runpodModel,
         'runpod_timeout' => $runpodTimeout,
+        'runpod_capability_tier' => $runpodCapTier,
         'claude_api_key' => trim((string) ($settings['claude_api_key'] ?? $defaults['claude_api_key'])),
         'claude_model' => trim((string) ($settings['claude_model'] ?? $defaults['claude_model'])),
         'claude_timeout' => $claudeTimeout,
+        'claude_capability_tier' => $claudeCapTier,
         'groq_api_key' => trim((string) ($settings['groq_api_key'] ?? $defaults['groq_api_key'])),
         'groq_model' => trim((string) ($settings['groq_model'] ?? $defaults['groq_model'])),
         'groq_timeout' => $groqTimeout,
+        'groq_capability_tier' => $groqCapTier,
     ];
 
     $inferredTier = supplycore_ai_infer_model_capability_tier((string) ($config['model'] ?? ''));
-    $effectiveTier = ($config['capability_override'] ?? 'auto') !== 'auto'
-        ? (string) $config['capability_override']
+    $effectiveTier = ($activeCapTier !== 'auto')
+        ? $activeCapTier
         : $inferredTier;
     $strategy = supplycore_ai_capability_strategy($effectiveTier);
 
@@ -21049,22 +21075,26 @@ function supplycore_ai_ollama_config(): array
         'url' => (string) ($config['url'] ?? $defaults['ollama_url']),
         'model' => (string) ($config['model'] ?? $defaults['ollama_model']),
         'timeout' => max(1, (int) ($config['timeout'] ?? (int) $defaults['ollama_timeout'])),
-        'capability_override' => (string) ($config['capability_override'] ?? 'auto'),
+        'capability_override' => (string) ($activeCapTier),
         'local_ollama_model' => (string) ($config['local_ollama_model'] ?? $defaults['ollama_model']),
         'local_ollama_timeout' => max(1, (int) ($config['local_ollama_timeout'] ?? (int) $defaults['ollama_timeout'])),
+        'local_ollama_capability_tier' => (string) ($config['local_ollama_capability_tier'] ?? 'auto'),
         'runpod_url' => (string) ($config['runpod_url'] ?? ''),
         'runpod_api_key' => (string) ($config['runpod_api_key'] ?? ''),
         'runpod_api_key_masked' => supplycore_mask_secret((string) ($config['runpod_api_key'] ?? '')),
         'runpod_model' => (string) ($config['runpod_model'] ?? ''),
         'runpod_timeout' => max(1, (int) ($config['runpod_timeout'] ?? (int) $defaults['runpod_timeout'])),
+        'runpod_capability_tier' => (string) ($config['runpod_capability_tier'] ?? 'auto'),
         'claude_api_key' => (string) ($config['claude_api_key'] ?? ''),
         'claude_api_key_masked' => supplycore_mask_secret((string) ($config['claude_api_key'] ?? '')),
         'claude_model' => (string) ($config['claude_model'] ?? 'claude-sonnet-4-20250514'),
         'claude_timeout' => max(1, (int) ($config['claude_timeout'] ?? (int) $defaults['claude_timeout'])),
+        'claude_capability_tier' => (string) ($config['claude_capability_tier'] ?? 'large'),
         'groq_api_key' => (string) ($config['groq_api_key'] ?? ''),
         'groq_api_key_masked' => supplycore_mask_secret((string) ($config['groq_api_key'] ?? '')),
         'groq_model' => (string) ($config['groq_model'] ?? 'meta-llama/llama-4-scout-17b-16e-instruct'),
         'groq_timeout' => max(1, (int) ($config['groq_timeout'] ?? (int) $defaults['groq_timeout'])),
+        'groq_capability_tier' => (string) ($config['groq_capability_tier'] ?? 'auto'),
         'inferred_tier' => $inferredTier,
         'capability_tier' => $effectiveTier,
         'strategy' => $strategy,
@@ -21789,13 +21819,20 @@ function supplycore_ai_resolve_feature_config(string $feature, ?string $explicit
         default => (int) ($config['local_ollama_timeout'] ?? $config['timeout'] ?? 20),
     });
 
-    // Re-compute the capability tier against the now-resolved model so
-    // features running on a different provider (e.g. local defaults to
-    // a small qwen but a feature routes to Runpod gemma4:26b-a4b) get
-    // the tier/strategy that actually matches their runtime model.
+    // Re-compute the capability tier against the now-resolved provider's
+    // model and tier override so features running on a different provider
+    // (e.g. local defaults to a small qwen but a feature routes to
+    // Runpod gemma4:26b-a4b) get the tier/strategy that actually matches.
+    $providerCapTier = match ($provider) {
+        'runpod' => (string) ($config['runpod_capability_tier'] ?? 'auto'),
+        'claude' => (string) ($config['claude_capability_tier'] ?? 'large'),
+        'groq' => (string) ($config['groq_capability_tier'] ?? 'auto'),
+        default => (string) ($config['local_ollama_capability_tier'] ?? $config['capability_override'] ?? 'auto'),
+    };
+    $config['capability_override'] = $providerCapTier;
     $inferredTier = supplycore_ai_infer_model_capability_tier((string) ($config['model'] ?? ''));
-    $effectiveTier = ($config['capability_override'] ?? 'auto') !== 'auto'
-        ? (string) $config['capability_override']
+    $effectiveTier = ($providerCapTier !== 'auto')
+        ? $providerCapTier
         : $inferredTier;
     $config['inferred_tier'] = $inferredTier;
     $config['capability_tier'] = $effectiveTier;


### PR DESCRIPTION
## Summary

Two things that were missing after #769:

### 1. Per-provider capability tier selector

The capability tier dropdown was still global — one setting shared across all providers. Now each provider card has its own tier dropdown:

| Provider | Default | Why |
|---|---|---|
| Local Ollama | Auto-detect | Infers from model name (e.g. qwen2.5:1.5b → small) |
| Runpod | Auto-detect | gemma4:26b-a4b → large |
| Claude | Large | Cloud models are always capable |
| Groq | Auto-detect | Infers from model name |

The config resolver picks the active provider's tier. `supplycore_ai_resolve_feature_config()` also reads the correct per-provider tier when a feature is routed to a different provider than the global default.

New settings keys: `runpod_capability_tier`, `claude_capability_tier`, `groq_capability_tier`. The existing `ollama_capability_tier` stays as the Local Ollama tier.

### 2. Opposition Intel button label

The "Generate Intel (local gemma4:e2b)" button was hardcoded from the old pre-queue flow. It now dynamically reads the configured provider (or per-feature override) and renders the actual name: "Generate Intel (Groq)", "Generate Intel (Runpod Serverless)", etc.

## Test plan

- [ ] Each provider card shows its own Capability Tier dropdown
- [ ] Changing Runpod's tier to "Medium" while Local Ollama stays "Small" → theater-lock job routed to Runpod uses medium strategy
- [ ] Opposition Intel page shows the correct provider name on the Generate button
- [ ] Per-feature override to a different provider shows that provider's name on the button

https://claude.ai/code/session_01PYdPoUa3UgyVArQLufSViC