### PR TITLE
Send model name in RunPod input payload

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -21528,9 +21528,20 @@ function supplycore_ai_ollama_generate_json(array $sourcePayload): array
 function supplycore_ai_runpod_generate_json(array $config, string $systemPrompt, string $userPrompt, array $schema): array
 {
     $headers = ['Authorization: Bearer ' . (string) ($config['runpod_api_key'] ?? '')];
+
+    // Resolve the model that should actually run on the RunPod worker.
+    $runpodModel = (string) ($config['runpod_model'] ?? '');
+    if ($runpodModel === '') {
+        $runpodModel = (string) ($config['model'] ?? '');
+    }
+
     $requestPayload = [
         'input' => [
             'prompt' => supplycore_ai_runpod_prompt($config, $systemPrompt, $userPrompt, $schema),
+            // Tell the RunPod worker which Ollama model to load. Without
+            // this, the worker defaults to whatever model is baked into
+            // its Docker image (often a tiny model like qwen2.5:1.5b).
+            'model' => $runpodModel,
         ],
     ];
     $response = http_post_json(
@@ -21871,6 +21882,7 @@ function supplycore_ai_jobs_enqueue(
     $config = supplycore_ai_resolve_feature_config($feature, $providerOverride);
     $provider = (string) ($config['provider'] ?? 'local');
     $model = match ($provider) {
+        'runpod' => (string) ($config['runpod_model'] ?? $config['model'] ?? ''),
         'claude' => (string) ($config['claude_model'] ?? ''),
         'groq' => (string) ($config['groq_model'] ?? ''),
         default => (string) ($config['model'] ?? ''),
@@ -22410,6 +22422,7 @@ function theater_ai_summary_generate(string $theaterId, bool $forceRegenerate = 
         }
 
         $modelLabel = match ($provider) {
+            'runpod' => (string) ($config['runpod_model'] ?? $config['model'] ?? ''),
             'claude' => (string) ($config['claude_model'] ?? 'claude-sonnet-4-20250514'),
             'groq' => (string) ($config['groq_model'] ?? 'llama-4-scout'),
             default => (string) $config['model'],


### PR DESCRIPTION
## Summary

The RunPod worker was ignoring `runpod_model` and running `qwen2.5:1.5b-instruct` because we never sent the model name in the input payload — only embedded it in the prompt text (cosmetic). The worker's Ollama daemon defaulted to its baked-in model.

From the RunPod logs:
```
'input': {'prompt': 'You are using the model "qwen2.5:1.5b-instruct" through a Runpod serverless endpoint...'}
```
Result: "AI response is missing the summary field" — qwen 1.5B can't follow complex JSON schemas.

## Fix

1. **`supplycore_ai_runpod_generate_json()`** now sends `model` in the input payload:
   ```json
   {"input": {"prompt": "...", "model": "gemma4:26b-a4b-it-q4_K_M"}}
   ```

2. **`supplycore_ai_jobs_enqueue()`** — explicit `'runpod'` match case reads `$config['runpod_model']` instead of falling to `default` which read the generic `model` field.

3. **`theater_ai_summary_store()`** — same explicit `'runpod'` case so stored summaries credit the correct model.

## Test plan

- [ ] Trigger a RunPod briefing job and confirm the RunPod logs show `"model": "gemma4:26b-a4b-it-q4_K_M"` in the input
- [ ] Verify the worker's Ollama responds with valid JSON matching the schema
- [ ] Check ai_jobs.model column shows `gemma4:26b-a4b-it-q4_K_M` not `qwen2.5:1.5b-instruct`

> **Note:** Your RunPod worker code must also read the `model` field from the input and pass it to Ollama. If it ignores it, the worker image needs updating.

https://claude.ai/code/session_01PYdPoUa3UgyVArQLufSViC