### PR TITLE
Switch RunPod to OpenAI messages format for correct model routing

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -21535,15 +21535,39 @@ function supplycore_ai_runpod_generate_json(array $config, string $systemPrompt,
         $runpodModel = (string) ($config['model'] ?? '');
     }
 
+    $schemaJson = json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    if (!is_string($schemaJson)) {
+        $schemaJson = '{}';
+    }
+
+    // Build an OpenAI-compatible messages payload. Most RunPod Ollama
+    // workers route messages-style input through their OpenAI engine
+    // which forwards to Ollama's /v1/chat/completions — including the
+    // model name. Raw prompt-only payloads often lose the model field
+    // because the legacy OllamaEngine path may not forward it.
+    $schemaInstruction = "Return valid JSON only. Do not include markdown fences or any commentary outside the JSON object.\n"
+        . "The JSON object must match this schema exactly:\n" . $schemaJson;
+
     $requestPayload = [
         'input' => [
-            'prompt' => supplycore_ai_runpod_prompt($config, $systemPrompt, $userPrompt, $schema),
-            // Tell the RunPod worker which Ollama model to load. Without
-            // this, the worker defaults to whatever model is baked into
-            // its Docker image (often a tiny model like qwen2.5:1.5b).
+            // OpenAI chat-completions format — picked up by the worker's
+            // OllamaOpenAiEngine and forwarded with the model to
+            // POST localhost:11434/v1/chat/completions
             'model' => $runpodModel,
+            'messages' => [
+                ['role' => 'system', 'content' => $systemPrompt . "\n\n" . $schemaInstruction],
+                ['role' => 'user', 'content' => $userPrompt],
+            ],
+            'temperature' => 0.2,
+            'max_tokens' => 6144,
+            // Also include the flat prompt as a fallback for workers
+            // that only support the legacy OllamaEngine format.
+            'prompt' => supplycore_ai_runpod_prompt($config, $systemPrompt, $userPrompt, $schema),
         ],
     ];
+
+    error_log('[runpod-submit] model=' . $runpodModel . ' url=' . supplycore_ai_runpod_submit_url((string) ($config['runpod_url'] ?? '')));
+
     $response = http_post_json(
         supplycore_ai_runpod_submit_url((string) ($config['runpod_url'] ?? '')),
         $headers,
@@ -21724,10 +21748,17 @@ function supplycore_ai_decode_runpod_response(array $response): array
     }
 
     $candidates = [
+        // OpenAI chat completions format (from OllamaOpenAiEngine):
+        //   {"output": {"choices": [{"message": {"content": "..."}}]}}
+        $json['output']['choices'][0]['message']['content'] ?? null,
+        $json['output']['choices'][0]['text'] ?? null,
+        // Legacy Ollama /api/generate format (from OllamaEngine):
+        //   {"output": {"response": "..."}} or {"output": {"text": "..."}}
         $json['output']['response'] ?? null,
         $json['output']['text'] ?? null,
         $json['output'][0]['response'] ?? null,
         $json['output'][0]['text'] ?? null,
+        // Top-level fallbacks
         $json['response'] ?? null,
         $json['output'] ?? null,
     ];


### PR DESCRIPTION
## Problem

RunPod worker logs show it loading qwen-3b instead of gemma4:26b-a4b despite us sending `model` in the input payload (#771). Root cause: the worker's `OllamaOpenAiEngine` routes requests through `/v1/chat/completions` but our flat prompt format (`{"input": {"prompt": "...", "model": "..."}}`) doesn't map cleanly to the OpenAI completions API — the model field gets lost.

## Fix

### 1. OpenAI messages format

The input payload now uses the chat-completions structure that the worker's OpenAI engine natively understands:

```json
{"input": {
  "model": "gemma4:26b-a4b-it-q4_K_M",
  "messages": [
    {"role": "system", "content": "<system prompt + JSON schema instructions>"},
    {"role": "user", "content": "<user prompt with battle data>"}
  ],
  "temperature": 0.2,
  "max_tokens": 6144,
  "prompt": "<legacy flat prompt fallback>"
}}
```

The `messages` array gets forwarded directly to `POST localhost:11434/v1/chat/completions` **including the model name**. The flat `prompt` field is kept as a fallback for workers that only support the legacy OllamaEngine path.

### 2. Response decoder handles chat completions output

Added `output.choices[0].message.content` and `output.choices[0].text` as candidate paths in `supplycore_ai_decode_runpod_response()`. The OpenAI completions endpoint returns responses in `choices[].message.content`, not `output.response`.

### 3. Submit logging

New `[runpod-submit]` log line shows the resolved model and URL on every submission so you can confirm what's being sent:
```
[runpod-submit] model=gemma4:26b-a4b-it-q4_K_M url=https://api.runpod.ai/v2/.../run
```

## Important: worker-side action needed

Even with this fix, **the RunPod worker image must have gemma4:26b-a4b-it-q4_K_M available**. If the worker's `OLLAMA_MODEL_NAME` env var still points to `qwen:3b`, update it to `gemma4:26b-a4b-it-q4_K_M` and redeploy. The model name in our payload tells Ollama which model to use, but Ollama can only serve models that have been pulled.

## Test plan

- [ ] Check `journalctl -u supplycore-ai-worker` for `[runpod-submit] model=gemma4:26b-a4b-it-q4_K_M`
- [ ] Verify RunPod worker logs show `POST /v1/chat/completions` with the correct model
- [ ] Confirm briefing generates successfully with valid JSON schema output
- [ ] If still loading qwen: update RunPod worker env `OLLAMA_MODEL_NAME=gemma4:26b-a4b-it-q4_K_M` and redeploy

https://claude.ai/code/session_01PYdPoUa3UgyVArQLufSViC