### PR TITLE
Only use ai_jobs queue for RunPod; run other providers inline

### DIFF
--- a/public/opposition-intelligence/generate.php
+++ b/public/opposition-intelligence/generate.php
@@ -19,18 +19,17 @@ if ($date === '' || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
     $date = gmdate('Y-m-d');
 }
 
-// Opposition briefings now run through the ai_jobs queue drained by
-// bin/ai_briefing_worker.php (systemd: supplycore-ai-worker.service). The
-// provider is picked per-feature via settings (ai_provider_opposition_global)
-// — no more hard-coded runtime override here.
 $error = null;
 $jobId = null;
-$status = 'queued';
+$generated = 0;
 
 if (!supplycore_ai_ollama_enabled()) {
     $status = 'disabled';
     $error = 'AI briefings are disabled in settings.';
-} else {
+} elseif (supplycore_ai_needs_queue('opposition_global')) {
+    // RunPod: enqueue to ai_jobs for the systemd worker to drain.
+    // Cold starts can take minutes — the web request must not wait.
+    $status = 'queued';
     try {
         $jobId = supplycore_ai_jobs_enqueue(
             'opposition_global',
@@ -42,11 +41,27 @@ if (!supplycore_ai_ollama_enabled()) {
         $status = 'error';
         $error = $e->getMessage();
     }
+} else {
+    // Local Ollama / Claude / Groq: run inline on the web request.
+    // These providers respond in seconds, no queue needed.
+    @set_time_limit(0);
+    @ini_set('max_execution_time', '0');
+    ignore_user_abort(false);
+
+    try {
+        $generated = opposition_ai_generate_daily_briefings($date);
+        $status = 'ok';
+    } catch (Throwable $e) {
+        error_log('[opposition-intel-generate] ' . $e->getMessage());
+        $status = 'error';
+        $error = $e->getMessage();
+    }
 }
 
 $flash = [
     'status' => $status,
     'job_id' => $jobId,
+    'generated' => $generated,
     'error' => $error,
     'date' => $date,
 ];

--- a/public/opposition-intelligence/index.php
+++ b/public/opposition-intelligence/index.php
@@ -130,10 +130,17 @@ if ($flash !== null) {
 ?>
 <?php if ($flash): ?>
     <?php $flashStatus = (string) ($flash['status'] ?? ''); ?>
-    <?php if ($flashStatus === 'queued'): ?>
+    <?php if ($flashStatus === 'ok'): ?>
+        <section class="surface-primary mt-4 border border-emerald-500/30 bg-emerald-500/10">
+            <p class="text-sm text-emerald-200">
+                <strong>Intel generation complete.</strong>
+                Generated <?= (int) ($flash['generated'] ?? 0) ?> briefing(s) for <?= htmlspecialchars((string) ($flash['date'] ?? ''), ENT_QUOTES) ?>.
+            </p>
+        </section>
+    <?php elseif ($flashStatus === 'queued'): ?>
         <section class="surface-primary mt-4 border border-sky-500/30 bg-sky-500/10">
             <p class="text-sm text-sky-200">
-                <strong>Intel generation queued.</strong>
+                <strong>Intel generation queued (RunPod).</strong>
                 Job #<?= (int) ($flash['job_id'] ?? 0) ?> is running in the background for
                 <?= htmlspecialchars((string) ($flash['date'] ?? ''), ENT_QUOTES) ?>.
                 Refresh this page in a minute to see the result.
@@ -143,10 +150,10 @@ if ($flash !== null) {
         <section class="surface-primary mt-4 border border-amber-500/30 bg-amber-500/10">
             <p class="text-sm text-amber-200">
                 <strong>Intel generation disabled.</strong>
-                Enable AI briefings in Settings to queue a job.
+                Enable AI briefings in Settings to generate.
             </p>
         </section>
-    <?php else: ?>
+    <?php elseif ($flashStatus === 'error'): ?>
         <section class="surface-primary mt-4 border border-red-500/30 bg-red-500/10">
             <p class="text-sm text-red-200">
                 <strong>Intel generation failed.</strong>

--- a/src/functions.php
+++ b/src/functions.php
@@ -21858,6 +21858,18 @@ function supplycore_ai_resolve_feature_config(string $feature, ?string $explicit
     return $config;
 }
 
+/**
+ * Whether a provider needs the async ai_jobs queue. Only RunPod has
+ * multi-minute cold starts that would blow past web request timeouts.
+ * Local Ollama, Claude, and Groq respond in seconds and can run
+ * inline on the web request thread.
+ */
+function supplycore_ai_needs_queue(string $feature): bool
+{
+    $config = supplycore_ai_resolve_feature_config($feature);
+    return ((string) ($config['provider'] ?? 'local')) === 'runpod';
+}
+
 function supplycore_ai_jobs_feature_valid(string $feature): bool
 {
     static $valid = null;
@@ -22871,27 +22883,38 @@ function theater_lock_report(string $theaterId): ?array
         return ['error' => 'Battle report is already locked'];
     }
 
-    // Lock the theater immediately. AI summary generation is enqueued to
-    // the ai_jobs queue and drained by bin/ai_briefing_worker.php — the web
-    // request no longer waits on the model to respond.
+    // Lock the theater immediately regardless of AI outcome.
     db_execute('UPDATE theaters SET locked_at = NOW() WHERE theater_id = ?', [$theaterId]);
 
     if (!supplycore_ai_ollama_enabled()) {
         return ['ai_status' => 'disabled'];
     }
 
-    try {
-        $jobId = supplycore_ai_jobs_enqueue(
-            'theater_lock',
-            $theaterId,
-            ['theater_id' => $theaterId]
-        );
-    } catch (Throwable $e) {
-        error_log('[theater-lock] Failed to enqueue AI job: ' . $e->getMessage());
-        return ['ai_status' => 'error', 'error' => $e->getMessage()];
+    // Only RunPod needs the async ai_jobs queue (cold starts can take
+    // minutes). Local Ollama / Claude / Groq respond in seconds and
+    // run inline on the web request thread.
+    if (supplycore_ai_needs_queue('theater_lock')) {
+        try {
+            $jobId = supplycore_ai_jobs_enqueue(
+                'theater_lock',
+                $theaterId,
+                ['theater_id' => $theaterId]
+            );
+        } catch (Throwable $e) {
+            error_log('[theater-lock] Failed to enqueue AI job: ' . $e->getMessage());
+            return ['ai_status' => 'error', 'error' => $e->getMessage()];
+        }
+        return ['ai_status' => 'queued', 'ai_job_id' => $jobId];
     }
 
-    return ['ai_status' => 'queued', 'ai_job_id' => $jobId];
+    // Inline execution for non-RunPod providers.
+    try {
+        $result = theater_ai_summary_generate($theaterId, true);
+        return $result ?? ['ai_status' => 'done'];
+    } catch (Throwable $e) {
+        error_log('[theater-lock] Inline AI generation failed: ' . $e->getMessage());
+        return ['ai_status' => 'error', 'error' => $e->getMessage()];
+    }
 }
 
 /**


### PR DESCRIPTION
## Problem

The ai_jobs queue + systemd worker was built for RunPod's multi-minute cold starts. But the code routed **all** providers through the queue, which broke Local Ollama / Claude / Groq — those providers respond in seconds and don't need async processing. The result: non-RunPod briefings silently fell back to deterministic mode.

## Fix

| Provider | Path | Why |
|---|---|---|
| **RunPod** | ai_jobs queue → systemd worker | Cold starts take minutes; web request can't wait |
| **Local Ollama** | Inline on web request | Same machine, responds in seconds |
| **Claude** | Inline on web request | API responds in seconds |
| **Groq** | Inline on web request | API responds in seconds |

### New helper

```php
supplycore_ai_needs_queue(string $feature): bool
```
Returns `true` only when the resolved provider for a feature is `runpod`.

### theater_lock_report()
- RunPod → enqueue to ai_jobs, return `{ai_status: queued}`
- Others → call `theater_ai_summary_generate()` inline, return result directly

### opposition generate.php
- RunPod → enqueue, flash `queued`, redirect
- Others → run `opposition_ai_generate_daily_briefings()` inline with `set_time_limit(0)`, flash `ok` with count, redirect

### Flash UI
Restored the `ok` (inline complete) status with the green success banner alongside `queued` (RunPod async) with the blue banner.

## Test plan

- [ ] Set provider to **Local Ollama** → click "Generate Intel" → briefings generate inline, green "complete" flash
- [ ] Set provider to **Groq** → click "Generate Intel" → briefings generate inline
- [ ] Set provider to **RunPod** → click "Generate Intel" → blue "queued" flash, job appears in ai_jobs table
- [ ] Lock a theater with provider = Local Ollama → AI summary appears immediately
- [ ] Lock a theater with provider = RunPod → queued status, worker picks it up

https://claude.ai/code/session_01PYdPoUa3UgyVArQLufSViC