### PR TITLE
Add sovereignty monitoring system with real-time campaign and structure tracking

### DIFF
--- a/database/migrations/20260418_sovereignty_monitoring.sql
+++ b/database/migrations/20260418_sovereignty_monitoring.sql
@@ -1,0 +1,185 @@
+-- Sovereignty Monitoring — 8 tables + 4 sync schedule entries
+-- Equinox-ready: generic structure model, DB-driven role classification,
+-- ownership entity hierarchy, full history ledgers.
+
+-- ── Structure role mapping (DB-driven, no redeploy on CCP changes) ──────────
+
+CREATE TABLE IF NOT EXISTS ref_sov_structure_roles (
+    structure_type_id   INT UNSIGNED PRIMARY KEY,
+    structure_role      VARCHAR(32) NOT NULL,
+    is_sov_structure    TINYINT(1) NOT NULL DEFAULT 0,
+    notes               VARCHAR(255) DEFAULT NULL,
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO ref_sov_structure_roles (structure_type_id, structure_role, is_sov_structure, notes) VALUES
+    (32458, 'legacy_ihub', 1, 'Infrastructure Hub'),
+    (32226, 'legacy_tcu',  1, 'Territorial Claim Unit')
+ON DUPLICATE KEY UPDATE updated_at = CURRENT_TIMESTAMP;
+
+-- ── Current sovereignty map snapshot ────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS sovereignty_map (
+    system_id           BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+    alliance_id         BIGINT UNSIGNED DEFAULT NULL,
+    corporation_id      BIGINT UNSIGNED DEFAULT NULL,
+    faction_id          BIGINT UNSIGNED DEFAULT NULL,
+    owner_entity_id     BIGINT UNSIGNED DEFAULT NULL,
+    owner_entity_type   ENUM('alliance','corporation','faction') DEFAULT NULL,
+    fetched_at          DATETIME NOT NULL,
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_alliance (alliance_id),
+    KEY idx_faction (faction_id),
+    KEY idx_owner (owner_entity_id, owner_entity_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ── Ownership change ledger (append-only) ───────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS sovereignty_map_history (
+    id                          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    system_id                   BIGINT UNSIGNED NOT NULL,
+    previous_alliance_id        BIGINT UNSIGNED DEFAULT NULL,
+    new_alliance_id             BIGINT UNSIGNED DEFAULT NULL,
+    previous_corporation_id     BIGINT UNSIGNED DEFAULT NULL,
+    new_corporation_id          BIGINT UNSIGNED DEFAULT NULL,
+    previous_faction_id         BIGINT UNSIGNED DEFAULT NULL,
+    new_faction_id              BIGINT UNSIGNED DEFAULT NULL,
+    previous_owner_entity_id    BIGINT UNSIGNED DEFAULT NULL,
+    previous_owner_entity_type  ENUM('alliance','corporation','faction') DEFAULT NULL,
+    new_owner_entity_id         BIGINT UNSIGNED DEFAULT NULL,
+    new_owner_entity_type       ENUM('alliance','corporation','faction') DEFAULT NULL,
+    changed_at                  DATETIME NOT NULL,
+    created_at                  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_system (system_id, changed_at),
+    KEY idx_new_alliance (new_alliance_id),
+    KEY idx_previous_alliance (previous_alliance_id),
+    KEY idx_new_owner (new_owner_entity_id, new_owner_entity_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ── Current sovereignty structures (generic model) ─────────────────────────
+
+CREATE TABLE IF NOT EXISTS sovereignty_structures (
+    structure_id                    BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+    alliance_id                     BIGINT UNSIGNED NOT NULL,
+    solar_system_id                 BIGINT UNSIGNED NOT NULL,
+    structure_type_id               INT UNSIGNED NOT NULL,
+    structure_role                  VARCHAR(32) NOT NULL DEFAULT 'unknown',
+    vulnerability_occupancy_level   DECIMAL(4,1) DEFAULT NULL,
+    vulnerable_start_time           DATETIME DEFAULT NULL,
+    vulnerable_end_time             DATETIME DEFAULT NULL,
+    fetched_at                      DATETIME NOT NULL,
+    created_at                      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_alliance (alliance_id),
+    KEY idx_system (solar_system_id),
+    KEY idx_type (structure_type_id),
+    KEY idx_role (structure_role)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ── Structure history (ADM drift, vuln shifts, appearance/disappearance) ────
+
+CREATE TABLE IF NOT EXISTS sovereignty_structures_history (
+    id                      BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    structure_id            BIGINT UNSIGNED NOT NULL,
+    alliance_id             BIGINT UNSIGNED NOT NULL,
+    solar_system_id         BIGINT UNSIGNED NOT NULL,
+    structure_type_id       INT UNSIGNED NOT NULL,
+    structure_role          VARCHAR(32) NOT NULL,
+    event_type              ENUM('appeared','disappeared','adm_changed','owner_changed','vuln_changed') NOT NULL,
+    previous_adm            DECIMAL(4,1) DEFAULT NULL,
+    new_adm                 DECIMAL(4,1) DEFAULT NULL,
+    previous_alliance_id    BIGINT UNSIGNED DEFAULT NULL,
+    new_alliance_id         BIGINT UNSIGNED DEFAULT NULL,
+    details_json            JSON DEFAULT NULL,
+    recorded_at             DATETIME NOT NULL,
+    created_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_structure (structure_id, recorded_at),
+    KEY idx_system (solar_system_id, recorded_at),
+    KEY idx_alliance (alliance_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ── Active entosis campaigns (live state) ───────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS sovereignty_campaigns (
+    campaign_id         INT UNSIGNED NOT NULL PRIMARY KEY,
+    event_type          VARCHAR(32) NOT NULL,
+    solar_system_id     BIGINT UNSIGNED NOT NULL,
+    constellation_id    BIGINT UNSIGNED NOT NULL,
+    structure_id        BIGINT UNSIGNED NOT NULL,
+    defender_id         BIGINT UNSIGNED NOT NULL,
+    attackers_score     DECIMAL(4,2) NOT NULL DEFAULT 0.00,
+    defender_score      DECIMAL(4,2) NOT NULL DEFAULT 0.00,
+    start_time          DATETIME NOT NULL,
+    first_seen_at       DATETIME NOT NULL,
+    last_seen_at        DATETIME NOT NULL,
+    is_active           TINYINT(1) NOT NULL DEFAULT 1,
+    KEY idx_active (is_active, solar_system_id),
+    KEY idx_defender (defender_id),
+    KEY idx_system (solar_system_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ── Completed campaign outcomes (append-only, delayed resolution) ───────────
+
+CREATE TABLE IF NOT EXISTS sovereignty_campaigns_history (
+    id                      BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    campaign_id             INT UNSIGNED NOT NULL,
+    event_type              VARCHAR(32) NOT NULL,
+    solar_system_id         BIGINT UNSIGNED NOT NULL,
+    constellation_id        BIGINT UNSIGNED NOT NULL,
+    structure_id            BIGINT UNSIGNED NOT NULL,
+    defender_id             BIGINT UNSIGNED NOT NULL,
+    final_attackers_score   DECIMAL(4,2) NOT NULL,
+    final_defender_score    DECIMAL(4,2) NOT NULL,
+    outcome                 ENUM('defended','captured','unknown') NOT NULL DEFAULT 'unknown',
+    start_time              DATETIME NOT NULL,
+    ended_at                DATETIME NOT NULL,
+    created_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_campaign (campaign_id),
+    KEY idx_system (solar_system_id, ended_at),
+    KEY idx_defender (defender_id),
+    KEY idx_outcome (outcome)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ── Operational alerts (status-driven lifecycle) ────────────────────────────
+
+CREATE TABLE IF NOT EXISTS sovereignty_alerts (
+    id                  BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    alert_type          ENUM('campaign_friendly','campaign_hostile','sov_lost','sov_gained','low_adm','vuln_window') NOT NULL,
+    solar_system_id     BIGINT UNSIGNED DEFAULT NULL,
+    alliance_id         BIGINT UNSIGNED DEFAULT NULL,
+    structure_id        BIGINT UNSIGNED DEFAULT NULL,
+    campaign_id         INT UNSIGNED DEFAULT NULL,
+    severity            ENUM('critical','warning','info') NOT NULL,
+    title               VARCHAR(255) NOT NULL,
+    details_json        JSON DEFAULT NULL,
+    status              ENUM('active','stale','resolved') NOT NULL DEFAULT 'active',
+    detected_at         DATETIME NOT NULL,
+    last_seen_at        DATETIME NOT NULL,
+    resolved_at         DATETIME DEFAULT NULL,
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_status_severity (status, severity, detected_at),
+    KEY idx_system (solar_system_id),
+    KEY idx_campaign (campaign_id),
+    KEY idx_alliance (alliance_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ── Register sync jobs ──────────────────────────────────────────────────────
+
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode)
+VALUES ('sovereignty_campaigns_sync', 1, 60, 'python')
+ON DUPLICATE KEY UPDATE enabled = enabled;
+
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode)
+VALUES ('sovereignty_structures_sync', 1, 180, 'python')
+ON DUPLICATE KEY UPDATE enabled = enabled;
+
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode)
+VALUES ('sovereignty_map_sync', 1, 1800, 'python')
+ON DUPLICATE KEY UPDATE enabled = enabled;
+
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode)
+VALUES ('compute_sovereignty_alerts', 1, 120, 'python')
+ON DUPLICATE KEY UPDATE enabled = enabled;

--- a/public/alliance-dossiers/view.php
+++ b/public/alliance-dossiers/view.php
@@ -511,4 +511,38 @@ if ($allianceBriefings !== []):
 </section>
 <?php endif; ?>
 
+<!-- Sovereignty -->
+<?php $sovStats = db_sovereignty_stats_for_alliance($allianceId); ?>
+<?php if ($sovStats['systems_held'] > 0 || $sovStats['active_campaigns'] > 0): ?>
+<section class="surface-primary mt-4">
+    <p class="text-xs uppercase tracking-[0.16em] text-muted mb-3">Sovereignty</p>
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        <div>
+            <p class="text-xs text-muted">Systems Held</p>
+            <p class="text-lg font-semibold text-slate-100"><?= number_format($sovStats['systems_held']) ?></p>
+        </div>
+        <div>
+            <p class="text-xs text-muted">Structures</p>
+            <p class="text-lg font-semibold text-slate-100"><?= number_format($sovStats['structures_count']) ?></p>
+        </div>
+        <div>
+            <p class="text-xs text-muted">Avg ADM</p>
+            <p class="text-lg font-semibold <?= ($sovStats['avg_adm'] ?? 0) < 3.0 ? 'text-amber-400' : 'text-green-400' ?>"><?= $sovStats['avg_adm'] !== null ? number_format($sovStats['avg_adm'], 1) : '—' ?></p>
+        </div>
+        <div>
+            <p class="text-xs text-muted">Under Contest</p>
+            <p class="text-lg font-semibold <?= $sovStats['active_campaigns'] > 0 ? 'text-red-400' : 'text-slate-400' ?>"><?= number_format($sovStats['active_campaigns']) ?></p>
+        </div>
+        <div>
+            <p class="text-xs text-muted">Losses (30d)</p>
+            <p class="text-lg font-semibold text-red-400"><?= number_format($sovStats['losses_30d']) ?></p>
+        </div>
+        <div>
+            <p class="text-xs text-muted">Gains (30d)</p>
+            <p class="text-lg font-semibold text-green-400"><?= number_format($sovStats['gains_30d']) ?></p>
+        </div>
+    </div>
+</section>
+<?php endif; ?>
+
 <?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/sovereignty/index.php
+++ b/public/sovereignty/index.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Sovereignty — Battle Intelligence';
+$liveRefreshConfig = supplycore_live_refresh_page_config('sovereignty');
+
+$search = isset($_GET['q']) ? trim((string) $_GET['q']) : null;
+$filter = isset($_GET['filter']) ? trim((string) $_GET['filter']) : null;
+if ($filter !== null && !in_array($filter, ['friendly', 'hostile', 'neutral'], true)) {
+    $filter = null;
+}
+$page = max(1, (int) ($_GET['page'] ?? 1));
+$perPage = 50;
+$offset = ($page - 1) * $perPage;
+
+$metrics = db_sovereignty_dashboard_metrics();
+$alerts = db_sovereignty_alerts_active(10);
+$activeCampaigns = db_sovereignty_campaigns_active();
+$mapRows = db_sovereignty_map_list($perPage, $offset, $search, $filter);
+$totalCount = db_sovereignty_map_count($search, $filter);
+$totalPages = max(1, (int) ceil($totalCount / $perPage));
+$recentHistory = db_sovereignty_campaigns_history(15, 0);
+
+// Handle alert resolve action.
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['resolve_alert_id'])) {
+    db_sovereignty_alert_resolve((int) $_POST['resolve_alert_id']);
+    header('Location: /sovereignty/');
+    exit;
+}
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+
+<section class="surface-primary">
+    <div class="flex items-center justify-between gap-4">
+        <div>
+            <p class="text-xs uppercase tracking-[0.16em] text-muted">Battle Intelligence</p>
+            <h1 class="mt-1 text-2xl font-semibold text-slate-50">Sovereignty Monitor</h1>
+            <p class="mt-2 text-sm text-muted">Real-time sovereignty status, entosis campaigns, structure ADM levels, and ownership changes across New Eden.</p>
+        </div>
+    </div>
+</section>
+
+<!-- KPI Metrics Strip -->
+<section class="mt-4 grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-3">
+    <?php
+    $kpis = [
+        ['label' => 'Friendly Systems', 'value' => number_format($metrics['friendly_systems_held']), 'color' => 'text-cyan-400'],
+        ['label' => 'Hostile Systems', 'value' => number_format($metrics['hostile_systems_held']), 'color' => 'text-red-400'],
+        ['label' => 'Under Contest', 'value' => number_format($metrics['friendly_under_contest']), 'color' => $metrics['friendly_under_contest'] > 0 ? 'text-red-400' : 'text-slate-400'],
+        ['label' => 'Avg Friendly ADM', 'value' => $metrics['avg_friendly_adm'] !== null ? number_format($metrics['avg_friendly_adm'], 1) : '—', 'color' => 'text-amber-400'],
+        ['label' => 'Vulnerable Now', 'value' => number_format($metrics['friendly_vulnerable_now']), 'color' => $metrics['friendly_vulnerable_now'] > 0 ? 'text-amber-400' : 'text-slate-400'],
+        ['label' => 'Low ADM', 'value' => number_format($metrics['friendly_low_adm_count']), 'color' => $metrics['friendly_low_adm_count'] > 0 ? 'text-amber-400' : 'text-slate-400'],
+        ['label' => 'Changes 7d / 30d', 'value' => $metrics['ownership_changes_7d'] . ' / ' . $metrics['ownership_changes_30d'], 'color' => 'text-slate-300'],
+    ];
+    foreach ($kpis as $kpi): ?>
+        <div class="surface-primary rounded px-3 py-2.5">
+            <p class="text-xs uppercase tracking-[0.14em] text-muted"><?= $kpi['label'] ?></p>
+            <p class="mt-1 text-lg font-semibold <?= $kpi['color'] ?>"><?= $kpi['value'] ?></p>
+        </div>
+    <?php endforeach; ?>
+</section>
+
+<!-- Active Alerts -->
+<?php if ($alerts): ?>
+<section class="mt-4 space-y-2">
+    <p class="text-xs uppercase tracking-[0.16em] text-muted mb-2">Active Alerts</p>
+    <?php foreach ($alerts as $a):
+        $severityColors = [
+            'critical' => 'border-red-500/60 bg-red-950/30',
+            'warning'  => 'border-amber-500/60 bg-amber-950/30',
+            'info'     => 'border-cyan-500/60 bg-cyan-950/30',
+        ];
+        $borderClass = $severityColors[$a['severity']] ?? 'border-border';
+        $timeSince = time() - strtotime($a['detected_at']);
+        $timeLabel = $timeSince < 3600 ? round($timeSince / 60) . 'm ago' : round($timeSince / 3600, 1) . 'h ago';
+    ?>
+        <div class="surface-primary border-l-4 <?= $borderClass ?> rounded flex items-center justify-between px-4 py-2.5">
+            <div>
+                <span class="text-sm font-medium text-slate-100"><?= htmlspecialchars($a['title']) ?></span>
+                <?php if ($a['system_name']): ?>
+                    <a href="/sovereignty/view.php?system_id=<?= (int) $a['solar_system_id'] ?>" class="ml-2 text-xs text-accent hover:underline"><?= htmlspecialchars($a['system_name']) ?></a>
+                <?php endif; ?>
+                <span class="ml-2 text-xs text-muted"><?= $timeLabel ?></span>
+            </div>
+            <form method="POST" class="inline">
+                <input type="hidden" name="resolve_alert_id" value="<?= (int) $a['id'] ?>">
+                <button type="submit" class="text-xs text-muted hover:text-slate-300">Resolve</button>
+            </form>
+        </div>
+    <?php endforeach; ?>
+</section>
+<?php endif; ?>
+
+<!-- Active Campaigns -->
+<?php if ($activeCampaigns): ?>
+<section class="surface-primary mt-4">
+    <p class="text-xs uppercase tracking-[0.16em] text-muted mb-3">Active Campaigns</p>
+    <div class="table-shell">
+        <table class="table-ui">
+            <thead>
+                <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                    <th class="px-3 py-2 text-left">System</th>
+                    <th class="px-3 py-2 text-left">Region</th>
+                    <th class="px-3 py-2 text-left">Type</th>
+                    <th class="px-3 py-2 text-left">Defender</th>
+                    <th class="px-3 py-2 text-center">Attacker</th>
+                    <th class="px-3 py-2 text-center">Defender</th>
+                    <th class="px-3 py-2 text-left">Started</th>
+                    <th class="px-3 py-2 text-center">Standing</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($activeCampaigns as $c):
+                    $standing = (float) ($c['defender_standing'] ?? 0);
+                    $standingClass = $standing > 0 ? 'text-cyan-400' : ($standing < 0 ? 'text-red-400' : 'text-slate-400');
+                    $standingLabel = $standing > 0 ? 'Friendly' : ($standing < 0 ? 'Hostile' : 'Neutral');
+                    $atkPct = max(0, min(100, round((float) $c['attackers_score'] * 100)));
+                    $defPct = max(0, min(100, round((float) $c['defender_score'] * 100)));
+                ?>
+                    <tr class="border-b border-border/40">
+                        <td class="px-3 py-2">
+                            <a href="/sovereignty/view.php?system_id=<?= (int) $c['solar_system_id'] ?>" class="text-accent hover:underline"><?= htmlspecialchars($c['system_name'] ?? 'Unknown') ?></a>
+                        </td>
+                        <td class="px-3 py-2 text-muted text-sm"><?= htmlspecialchars($c['region_name'] ?? '') ?></td>
+                        <td class="px-3 py-2 text-sm" title="<?= htmlspecialchars($c['event_type']) ?>"><?= htmlspecialchars($c['campaign_type_normalized'] ?? $c['event_type']) ?></td>
+                        <td class="px-3 py-2 text-sm"><?= htmlspecialchars($c['defender_name'] ?? 'Alliance #' . $c['defender_id']) ?></td>
+                        <td class="px-3 py-2 text-center">
+                            <div class="w-16 h-2 bg-slate-700 rounded-full inline-block align-middle">
+                                <div class="h-2 bg-red-500 rounded-full" style="width: <?= $atkPct ?>%"></div>
+                            </div>
+                            <span class="text-xs text-muted ml-1"><?= $atkPct ?>%</span>
+                        </td>
+                        <td class="px-3 py-2 text-center">
+                            <div class="w-16 h-2 bg-slate-700 rounded-full inline-block align-middle">
+                                <div class="h-2 bg-cyan-500 rounded-full" style="width: <?= $defPct ?>%"></div>
+                            </div>
+                            <span class="text-xs text-muted ml-1"><?= $defPct ?>%</span>
+                        </td>
+                        <td class="px-3 py-2 text-sm text-muted"><?= htmlspecialchars(substr($c['start_time'], 0, 16)) ?></td>
+                        <td class="px-3 py-2 text-center"><span class="text-xs font-medium <?= $standingClass ?>"><?= $standingLabel ?></span></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</section>
+<?php endif; ?>
+
+<!-- Sovereignty Map -->
+<section class="surface-primary mt-4">
+    <div class="flex items-center justify-between gap-4 mb-3">
+        <p class="text-xs uppercase tracking-[0.16em] text-muted">Sovereignty Map</p>
+        <div class="flex gap-1.5 items-center">
+            <?php
+            $filters = [null => 'All', 'friendly' => 'Friendly', 'hostile' => 'Hostile', 'neutral' => 'Neutral'];
+            foreach ($filters as $fVal => $fLabel):
+                $isActive = ($filter ?? '') === ($fVal ?? '');
+                $cls = $isActive ? 'btn-primary text-xs' : 'btn-secondary text-xs';
+                $href = '/sovereignty/?' . http_build_query(array_filter(['filter' => $fVal, 'q' => $search]));
+            ?>
+                <a href="<?= htmlspecialchars($href) ?>" class="<?= $cls ?>"><?= $fLabel ?></a>
+            <?php endforeach; ?>
+        </div>
+    </div>
+
+    <form method="GET" class="flex gap-3 items-end flex-wrap mb-3">
+        <?php if ($filter): ?><input type="hidden" name="filter" value="<?= htmlspecialchars($filter) ?>"><?php endif; ?>
+        <div>
+            <input type="text" name="q" value="<?= htmlspecialchars((string) ($search ?? ''), ENT_QUOTES) ?>"
+                   class="w-64 rounded bg-slate-800 border border-border px-2 py-1.5 text-sm text-slate-100"
+                   placeholder="Search system, region, alliance...">
+        </div>
+        <button type="submit" class="btn-secondary h-fit text-sm">Search</button>
+        <?php if ($search !== null): ?>
+            <a href="/sovereignty/<?= $filter ? '?filter=' . $filter : '' ?>" class="text-sm text-accent">Clear</a>
+        <?php endif; ?>
+    </form>
+
+    <div class="table-shell">
+        <table class="table-ui">
+            <thead>
+                <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                    <th class="px-3 py-2 text-left">System</th>
+                    <th class="px-3 py-2 text-left">Constellation</th>
+                    <th class="px-3 py-2 text-left">Region</th>
+                    <th class="px-3 py-2 text-left">Holding Alliance</th>
+                    <th class="px-3 py-2 text-left">Structure</th>
+                    <th class="px-3 py-2 text-right">ADM</th>
+                    <th class="px-3 py-2 text-left">Vuln Window</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if ($mapRows === []): ?>
+                    <tr><td colspan="7" class="px-3 py-6 text-center text-muted">No sovereignty data yet. Run the sovereignty sync jobs to populate.</td></tr>
+                <?php endif; ?>
+                <?php foreach ($mapRows as $m):
+                    $ownerStanding = (float) ($m['owner_standing'] ?? 0);
+                    $standingClass = $ownerStanding > 0 ? 'text-cyan-400' : ($ownerStanding < 0 ? 'text-red-400' : 'text-slate-300');
+                    $admStatusColors = [
+                        'critical' => 'text-red-400',
+                        'weak'     => 'text-amber-400',
+                        'stable'   => 'text-green-400',
+                        'strong'   => 'text-cyan-400',
+                    ];
+                    $admColor = $admStatusColors[$m['adm_status'] ?? ''] ?? 'text-slate-400';
+                    $isVulnNow = (int) ($m['is_vulnerable_now'] ?? 0);
+                ?>
+                    <tr class="border-b border-border/40">
+                        <td class="px-3 py-2">
+                            <a href="/sovereignty/view.php?system_id=<?= (int) $m['system_id'] ?>" class="text-accent hover:underline"><?= htmlspecialchars($m['system_name'] ?? 'Unknown') ?></a>
+                        </td>
+                        <td class="px-3 py-2 text-sm text-muted"><?= htmlspecialchars($m['constellation_name'] ?? '') ?></td>
+                        <td class="px-3 py-2 text-sm text-muted"><?= htmlspecialchars($m['region_name'] ?? '') ?></td>
+                        <td class="px-3 py-2 text-sm <?= $standingClass ?>"><?= htmlspecialchars($m['owner_name'] ?? 'Unknown') ?></td>
+                        <td class="px-3 py-2 text-sm text-muted"><?= htmlspecialchars(ucfirst(str_replace('_', ' ', $m['structure_role'] ?? '—'))) ?></td>
+                        <td class="px-3 py-2 text-right text-sm <?= $admColor ?>"><?= $m['adm'] !== null ? number_format((float) $m['adm'], 1) : '—' ?></td>
+                        <td class="px-3 py-2 text-sm">
+                            <?php if ($m['vulnerable_start_time']): ?>
+                                <?php if ($isVulnNow): ?>
+                                    <span class="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-red-900/60 text-red-300">VULNERABLE</span>
+                                <?php else: ?>
+                                    <span class="text-muted"><?= substr($m['vulnerable_start_time'], 11, 5) ?> — <?= substr($m['vulnerable_end_time'], 11, 5) ?></span>
+                                <?php endif; ?>
+                            <?php else: ?>
+                                <span class="text-muted">—</span>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+
+    <!-- Pagination -->
+    <?php if ($totalPages > 1): ?>
+        <div class="mt-3 flex items-center justify-between text-sm text-muted">
+            <span>Page <?= $page ?> of <?= $totalPages ?> (<?= number_format($totalCount) ?> systems)</span>
+            <div class="flex gap-2">
+                <?php if ($page > 1): ?>
+                    <a href="?<?= http_build_query(array_filter(['page' => $page - 1, 'q' => $search, 'filter' => $filter])) ?>" class="btn-secondary text-xs">Previous</a>
+                <?php endif; ?>
+                <?php if ($page < $totalPages): ?>
+                    <a href="?<?= http_build_query(array_filter(['page' => $page + 1, 'q' => $search, 'filter' => $filter])) ?>" class="btn-secondary text-xs">Next</a>
+                <?php endif; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+</section>
+
+<!-- Recent Campaign History -->
+<?php if ($recentHistory): ?>
+<section class="surface-primary mt-4">
+    <p class="text-xs uppercase tracking-[0.16em] text-muted mb-3">Recent Campaign Outcomes</p>
+    <div class="table-shell">
+        <table class="table-ui">
+            <thead>
+                <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                    <th class="px-3 py-2 text-left">System</th>
+                    <th class="px-3 py-2 text-left">Region</th>
+                    <th class="px-3 py-2 text-left">Type</th>
+                    <th class="px-3 py-2 text-left">Defender</th>
+                    <th class="px-3 py-2 text-center">Outcome</th>
+                    <th class="px-3 py-2 text-left">Ended</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($recentHistory as $h):
+                    $outcomeColors = [
+                        'defended' => 'bg-green-900/60 text-green-300',
+                        'captured' => 'bg-red-900/60 text-red-300',
+                        'unknown'  => 'bg-slate-700/60 text-slate-400',
+                    ];
+                    $outcomeClass = $outcomeColors[$h['outcome']] ?? 'bg-slate-700/60 text-slate-400';
+                ?>
+                    <tr class="border-b border-border/40">
+                        <td class="px-3 py-2">
+                            <a href="/sovereignty/view.php?system_id=<?= (int) $h['solar_system_id'] ?>" class="text-accent hover:underline"><?= htmlspecialchars($h['system_name'] ?? 'Unknown') ?></a>
+                        </td>
+                        <td class="px-3 py-2 text-sm text-muted"><?= htmlspecialchars($h['region_name'] ?? '') ?></td>
+                        <td class="px-3 py-2 text-sm"><?= htmlspecialchars($h['campaign_type_normalized'] ?? $h['event_type']) ?></td>
+                        <td class="px-3 py-2 text-sm"><?= htmlspecialchars($h['defender_name'] ?? 'Alliance #' . $h['defender_id']) ?></td>
+                        <td class="px-3 py-2 text-center"><span class="inline-block px-1.5 py-0.5 rounded text-xs font-medium <?= $outcomeClass ?>"><?= ucfirst($h['outcome']) ?></span></td>
+                        <td class="px-3 py-2 text-sm text-muted"><?= htmlspecialchars(substr($h['ended_at'], 0, 16)) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</section>
+<?php endif; ?>
+
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/sovereignty/view.php
+++ b/public/sovereignty/view.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$systemId = (int) ($_GET['system_id'] ?? 0);
+if ($systemId <= 0) {
+    header('Location: /sovereignty/');
+    exit;
+}
+
+$detail = db_sovereignty_system_detail($systemId);
+$owner = $detail['owner'];
+$structures = $detail['structures'];
+$campaigns = $detail['campaigns'];
+$mapHistory = $detail['map_history'];
+$structureHistory = $detail['structure_history'];
+
+$systemName = $owner['system_name'] ?? 'Unknown System';
+$title = "{$systemName} — Sovereignty Detail";
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+
+<section class="surface-primary">
+    <div class="flex items-center gap-3">
+        <a href="/sovereignty/" class="text-accent hover:underline text-sm">&larr; Sovereignty</a>
+    </div>
+    <div class="mt-3">
+        <p class="text-xs uppercase tracking-[0.16em] text-muted">System Sovereignty</p>
+        <h1 class="mt-1 text-2xl font-semibold text-slate-50"><?= htmlspecialchars($systemName) ?></h1>
+        <?php if ($owner): ?>
+            <?php
+                $sec = (float) ($owner['system_security'] ?? 0);
+                $secColor = $sec >= 0.5 ? 'text-green-400' : ($sec > 0.0 ? 'text-amber-400' : 'text-red-400');
+                $ownerStanding = (float) ($owner['owner_standing'] ?? 0);
+                $standingClass = $ownerStanding > 0 ? 'text-cyan-400' : ($ownerStanding < 0 ? 'text-red-400' : 'text-slate-300');
+                $standingLabel = $ownerStanding > 0 ? 'Friendly' : ($ownerStanding < 0 ? 'Hostile' : 'Neutral');
+            ?>
+            <div class="mt-2 flex items-center gap-4 text-sm">
+                <span class="text-muted"><?= htmlspecialchars($owner['constellation_name'] ?? '') ?></span>
+                <span class="text-muted"><?= htmlspecialchars($owner['region_name'] ?? '') ?></span>
+                <span class="<?= $secColor ?>"><?= number_format($sec, 1) ?></span>
+                <span class="text-muted">Owner:</span>
+                <span class="<?= $standingClass ?> font-medium"><?= htmlspecialchars($owner['owner_name'] ?? 'Unknown') ?></span>
+                <span class="inline-block px-1.5 py-0.5 rounded text-xs <?= $ownerStanding > 0 ? 'bg-cyan-900/50 text-cyan-300' : ($ownerStanding < 0 ? 'bg-red-900/50 text-red-300' : 'bg-slate-700/50 text-slate-400') ?>"><?= $standingLabel ?></span>
+            </div>
+        <?php else: ?>
+            <p class="mt-2 text-sm text-muted">No sovereignty data available for this system.</p>
+        <?php endif; ?>
+    </div>
+</section>
+
+<!-- Sovereignty Structures -->
+<section class="surface-primary mt-4">
+    <p class="text-xs uppercase tracking-[0.16em] text-muted mb-3">Sovereignty Structures</p>
+    <?php if ($structures): ?>
+        <div class="table-shell">
+            <table class="table-ui">
+                <thead>
+                    <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                        <th class="px-3 py-2 text-left">Type</th>
+                        <th class="px-3 py-2 text-left">Role</th>
+                        <th class="px-3 py-2 text-left">Owner</th>
+                        <th class="px-3 py-2 text-right">ADM</th>
+                        <th class="px-3 py-2 text-left">Vuln Window</th>
+                        <th class="px-3 py-2 text-center">Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($structures as $s):
+                        $admStatusColors = [
+                            'critical' => 'text-red-400',
+                            'weak'     => 'text-amber-400',
+                            'stable'   => 'text-green-400',
+                            'strong'   => 'text-cyan-400',
+                        ];
+                        $admColor = $admStatusColors[$s['adm_status'] ?? ''] ?? 'text-slate-400';
+                        $isSovHub = in_array($s['structure_role'], ['sov_hub'], true);
+                        $roleLabel = ucfirst(str_replace('_', ' ', $s['structure_role'] ?? 'unknown'));
+                        $isVulnNow = (int) ($s['is_vulnerable_now'] ?? 0);
+                        $vulnIn = (int) ($s['vulnerable_in_minutes'] ?? 0);
+                    ?>
+                        <tr class="border-b border-border/40 <?= $isSovHub ? 'bg-cyan-950/10' : '' ?>">
+                            <td class="px-3 py-2 text-sm"><?= htmlspecialchars($s['structure_type_name'] ?? 'Type #' . $s['structure_type_id']) ?></td>
+                            <td class="px-3 py-2 text-sm <?= $isSovHub ? 'text-cyan-400 font-medium' : 'text-muted' ?>"><?= $roleLabel ?></td>
+                            <td class="px-3 py-2 text-sm"><?= htmlspecialchars($s['alliance_name'] ?? 'Unknown') ?></td>
+                            <td class="px-3 py-2 text-right">
+                                <?php if ($s['vulnerability_occupancy_level'] !== null): ?>
+                                    <span class="<?= $admColor ?> font-medium"><?= number_format((float) $s['vulnerability_occupancy_level'], 1) ?></span>
+                                    <span class="text-xs text-muted ml-1"><?= ucfirst($s['adm_status'] ?? '') ?></span>
+                                <?php else: ?>
+                                    <span class="text-muted">—</span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="px-3 py-2 text-sm">
+                                <?php if ($s['vulnerable_start_time']): ?>
+                                    <span class="text-muted"><?= substr($s['vulnerable_start_time'], 11, 5) ?> — <?= substr($s['vulnerable_end_time'], 11, 5) ?></span>
+                                    <?php if ($vulnIn > 0 && !$isVulnNow): ?>
+                                        <span class="text-xs text-amber-400 ml-1">in <?= $vulnIn ?>m</span>
+                                    <?php endif; ?>
+                                <?php else: ?>
+                                    <span class="text-muted">—</span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="px-3 py-2 text-center">
+                                <?php if ($isVulnNow): ?>
+                                    <span class="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-red-900/60 text-red-300">VULNERABLE</span>
+                                <?php else: ?>
+                                    <span class="text-xs text-green-400">Protected</span>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php else: ?>
+        <p class="text-sm text-muted">No sovereignty structures in this system.</p>
+    <?php endif; ?>
+</section>
+
+<!-- Active Campaigns -->
+<?php if ($campaigns): ?>
+<section class="surface-primary mt-4">
+    <p class="text-xs uppercase tracking-[0.16em] text-muted mb-3">Active Campaigns</p>
+    <?php foreach ($campaigns as $c):
+        $atkPct = max(0, min(100, round((float) $c['attackers_score'] * 100)));
+        $defPct = max(0, min(100, round((float) $c['defender_score'] * 100)));
+    ?>
+        <div class="mb-3 p-3 rounded border border-border/50 bg-slate-800/30">
+            <div class="flex items-center justify-between text-sm mb-2">
+                <span class="font-medium text-slate-100"><?= htmlspecialchars($c['event_type']) ?></span>
+                <span class="text-muted">Defender: <?= htmlspecialchars($c['defender_name'] ?? 'Alliance #' . $c['defender_id']) ?></span>
+            </div>
+            <div class="flex gap-4 items-center">
+                <div class="flex-1">
+                    <p class="text-xs text-red-400 mb-1">Attackers <?= $atkPct ?>%</p>
+                    <div class="w-full h-3 bg-slate-700 rounded-full"><div class="h-3 bg-red-500 rounded-full" style="width: <?= $atkPct ?>%"></div></div>
+                </div>
+                <div class="flex-1">
+                    <p class="text-xs text-cyan-400 mb-1">Defenders <?= $defPct ?>%</p>
+                    <div class="w-full h-3 bg-slate-700 rounded-full"><div class="h-3 bg-cyan-500 rounded-full" style="width: <?= $defPct ?>%"></div></div>
+                </div>
+            </div>
+        </div>
+    <?php endforeach; ?>
+</section>
+<?php endif; ?>
+
+<!-- Ownership Timeline -->
+<section class="surface-primary mt-4">
+    <p class="text-xs uppercase tracking-[0.16em] text-muted mb-3">Ownership Timeline</p>
+    <?php if ($mapHistory): ?>
+        <div class="space-y-2">
+            <?php foreach ($mapHistory as $h): ?>
+                <div class="flex items-center gap-3 text-sm border-l-2 border-border/50 pl-3 py-1">
+                    <span class="text-muted min-w-[120px]"><?= htmlspecialchars(substr($h['changed_at'], 0, 16)) ?></span>
+                    <span class="text-red-400"><?= htmlspecialchars($h['previous_owner_name'] ?? ($h['previous_owner_entity_id'] ? 'Entity #' . $h['previous_owner_entity_id'] : 'None')) ?></span>
+                    <span class="text-muted">&rarr;</span>
+                    <span class="text-cyan-400"><?= htmlspecialchars($h['new_owner_name'] ?? ($h['new_owner_entity_id'] ? 'Entity #' . $h['new_owner_entity_id'] : 'None')) ?></span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php else: ?>
+        <p class="text-sm text-muted">No ownership changes recorded yet.</p>
+    <?php endif; ?>
+</section>
+
+<!-- Structure History -->
+<section class="surface-primary mt-4">
+    <p class="text-xs uppercase tracking-[0.16em] text-muted mb-3">Structure History</p>
+    <?php if ($structureHistory): ?>
+        <div class="table-shell">
+            <table class="table-ui">
+                <thead>
+                    <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                        <th class="px-3 py-2 text-left">Time</th>
+                        <th class="px-3 py-2 text-left">Type</th>
+                        <th class="px-3 py-2 text-left">Event</th>
+                        <th class="px-3 py-2 text-left">Details</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($structureHistory as $sh):
+                        $eventColors = [
+                            'appeared'      => 'text-green-400',
+                            'disappeared'   => 'text-red-400',
+                            'adm_changed'   => 'text-amber-400',
+                            'owner_changed' => 'text-purple-400',
+                            'vuln_changed'  => 'text-slate-400',
+                        ];
+                        $eventColor = $eventColors[$sh['event_type']] ?? 'text-slate-400';
+
+                        $detailText = '';
+                        if ($sh['event_type'] === 'adm_changed') {
+                            $detailText = ($sh['previous_adm'] ?? '?') . ' → ' . ($sh['new_adm'] ?? '?');
+                        } elseif ($sh['event_type'] === 'owner_changed') {
+                            $detailText = 'Alliance changed';
+                        } elseif ($sh['event_type'] === 'appeared') {
+                            $detailText = 'Structure deployed';
+                        } elseif ($sh['event_type'] === 'disappeared') {
+                            $detailText = 'Structure removed';
+                        } else {
+                            $detailText = 'Vulnerability window shifted';
+                        }
+                    ?>
+                        <tr class="border-b border-border/40">
+                            <td class="px-3 py-2 text-sm text-muted"><?= htmlspecialchars(substr($sh['recorded_at'], 0, 16)) ?></td>
+                            <td class="px-3 py-2 text-sm"><?= htmlspecialchars($sh['structure_type_name'] ?? ucfirst(str_replace('_', ' ', $sh['structure_role']))) ?></td>
+                            <td class="px-3 py-2 text-sm <?= $eventColor ?>"><?= ucfirst(str_replace('_', ' ', $sh['event_type'])) ?></td>
+                            <td class="px-3 py-2 text-sm text-muted"><?= htmlspecialchars($detailText) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php else: ?>
+        <p class="text-sm text-muted">No structure history recorded yet.</p>
+    <?php endif; ?>
+</section>
+
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/python/orchestrator/jobs/compute_sovereignty_alerts.py
+++ b/python/orchestrator/jobs/compute_sovereignty_alerts.py
@@ -1,0 +1,380 @@
+"""Sovereignty Alert Computation.
+
+Cross-references sovereignty data with diplomatic standings to generate
+operational alerts:
+
+- Friendly sov under attack (critical)
+- Hostile sov under attack (info)
+- Sov ownership lost/gained (critical/info)
+- Low ADM warnings (warning)
+- Upcoming vulnerability windows (warning)
+
+Alert lifecycle: active → stale → resolved.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from ..db import SupplyCoreDb
+from .sync_runtime import run_sync_phase_job
+
+log = logging.getLogger(__name__)
+
+JOB_KEY = "compute_sovereignty_alerts"
+
+# Configurable thresholds.
+_LOW_ADM_THRESHOLD = 3.0
+_VULN_WINDOW_HOURS = 2
+_STALE_MINUTES = 5  # 2× the 120s job interval
+
+
+def _load_standing_ids(db: SupplyCoreDb) -> dict[str, set[int]]:
+    """Load friendly/hostile alliance IDs from corp_contacts.
+
+    Mirrors the logic from theater_analysis._load_side_configuration_ids
+    but imported as a standalone to avoid coupling to the theater module.
+    """
+    friendly: set[int] = set()
+    hostile: set[int] = set()
+
+    try:
+        rows = db.fetch_all(
+            """SELECT contact_id, contact_type, standing
+               FROM corp_contacts
+               WHERE contact_type = 'alliance' AND standing != 0"""
+        )
+        for row in rows:
+            contact_id = int(row.get("contact_id") or 0)
+            standing = float(row.get("standing") or 0)
+            if contact_id <= 0:
+                continue
+            if standing > 0:
+                friendly.add(contact_id)
+            elif standing < 0:
+                hostile.add(contact_id)
+    except Exception as exc:
+        log.warning("Failed to load standings: %s", exc)
+
+    return {"friendly": friendly, "hostile": hostile}
+
+
+def _upsert_alert(
+    db: SupplyCoreDb,
+    *,
+    alert_type: str,
+    severity: str,
+    title: str,
+    solar_system_id: int | None = None,
+    alliance_id: int | None = None,
+    structure_id: int | None = None,
+    campaign_id: int | None = None,
+    details: dict | None = None,
+    now_sql: str,
+) -> None:
+    """Upsert an alert: update last_seen_at if active, else create new."""
+    details_json = json.dumps(details) if details else None
+
+    # Try to find an existing active alert of the same type for the same target.
+    where_parts = ["alert_type = %s", "status IN ('active','stale')"]
+    where_params: list = [alert_type]
+
+    if campaign_id is not None:
+        where_parts.append("campaign_id = %s")
+        where_params.append(campaign_id)
+    elif structure_id is not None:
+        where_parts.append("structure_id = %s")
+        where_params.append(structure_id)
+    elif solar_system_id is not None:
+        where_parts.append("solar_system_id = %s")
+        where_params.append(solar_system_id)
+
+    existing = db.fetch_one(
+        f"SELECT id FROM sovereignty_alerts WHERE {' AND '.join(where_parts)} LIMIT 1",
+        where_params,
+    )
+
+    if existing:
+        db.execute(
+            "UPDATE sovereignty_alerts SET last_seen_at = %s, status = 'active', "
+            "severity = %s, title = %s, details_json = %s WHERE id = %s",
+            [now_sql, severity, title, details_json, existing["id"]],
+        )
+    else:
+        db.execute(
+            """INSERT INTO sovereignty_alerts
+               (alert_type, solar_system_id, alliance_id, structure_id, campaign_id,
+                severity, title, details_json, status, detected_at, last_seen_at)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'active', %s, %s)""",
+            [alert_type, solar_system_id, alliance_id, structure_id, campaign_id,
+             severity, title, details_json, now_sql, now_sql],
+        )
+
+
+def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    now_sql = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    standings = _load_standing_ids(db)
+    friendly = standings["friendly"]
+    hostile = standings["hostile"]
+    warnings: list[str] = []
+    alerts_created = 0
+
+    if not friendly and not hostile:
+        warnings.append(
+            "No standings data available — run corp_standings_sync first. "
+            "Sovereignty alerts require diplomatic standings to classify friendly/hostile."
+        )
+        return {
+            "rows_processed": 0,
+            "rows_written": 0,
+            "warnings": warnings,
+            "summary": "Skipped — no standings configured.",
+        }
+
+    # ── 1. Campaign alerts ───────────────────────────────────────────────
+    active_campaigns = db.fetch_all(
+        "SELECT campaign_id, event_type, solar_system_id, defender_id, "
+        "attackers_score, defender_score FROM sovereignty_campaigns WHERE is_active = 1"
+    )
+
+    for c in active_campaigns:
+        defender_id = int(c["defender_id"])
+        campaign_id = int(c["campaign_id"])
+        system_id = int(c["solar_system_id"])
+
+        # Resolve system name for title.
+        sys_row = db.fetch_one(
+            "SELECT system_name FROM ref_systems WHERE system_id = %s", (system_id,)
+        )
+        sys_name = str(sys_row["system_name"]) if sys_row else f"System {system_id}"
+
+        if defender_id in friendly:
+            _upsert_alert(
+                db,
+                alert_type="campaign_friendly",
+                severity="critical",
+                title=f"Friendly sov under attack in {sys_name}",
+                solar_system_id=system_id,
+                alliance_id=defender_id,
+                campaign_id=campaign_id,
+                details={
+                    "event_type": c["event_type"],
+                    "attackers_score": float(c["attackers_score"]),
+                    "defender_score": float(c["defender_score"]),
+                },
+                now_sql=now_sql,
+            )
+            alerts_created += 1
+        elif defender_id in hostile:
+            _upsert_alert(
+                db,
+                alert_type="campaign_hostile",
+                severity="info",
+                title=f"Hostile sov under attack in {sys_name}",
+                solar_system_id=system_id,
+                alliance_id=defender_id,
+                campaign_id=campaign_id,
+                details={
+                    "event_type": c["event_type"],
+                    "attackers_score": float(c["attackers_score"]),
+                    "defender_score": float(c["defender_score"]),
+                },
+                now_sql=now_sql,
+            )
+            alerts_created += 1
+
+    # Resolve campaign alerts where campaign is no longer active.
+    db.execute(
+        """UPDATE sovereignty_alerts
+           SET status = 'resolved', resolved_at = %s
+           WHERE alert_type IN ('campaign_friendly', 'campaign_hostile')
+             AND status = 'active'
+             AND campaign_id IS NOT NULL
+             AND campaign_id NOT IN (
+                 SELECT campaign_id FROM sovereignty_campaigns WHERE is_active = 1
+             )""",
+        [now_sql],
+    )
+
+    # ── 2. Ownership change alerts ───────────────────────────────────────
+    recent_changes = db.fetch_all(
+        """SELECT system_id, previous_alliance_id, new_alliance_id,
+                  previous_owner_entity_id, new_owner_entity_id
+           FROM sovereignty_map_history
+           WHERE changed_at > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 2 HOUR)"""
+    )
+
+    for ch in recent_changes:
+        system_id = int(ch["system_id"])
+        prev_ally = int(ch.get("previous_alliance_id") or ch.get("previous_owner_entity_id") or 0)
+        new_ally = int(ch.get("new_alliance_id") or ch.get("new_owner_entity_id") or 0)
+
+        sys_row = db.fetch_one(
+            "SELECT system_name FROM ref_systems WHERE system_id = %s", (system_id,)
+        )
+        sys_name = str(sys_row["system_name"]) if sys_row else f"System {system_id}"
+
+        if prev_ally in friendly and new_ally not in friendly:
+            _upsert_alert(
+                db,
+                alert_type="sov_lost",
+                severity="critical",
+                title=f"Sovereignty lost in {sys_name}",
+                solar_system_id=system_id,
+                alliance_id=prev_ally,
+                details={"previous_owner": prev_ally, "new_owner": new_ally},
+                now_sql=now_sql,
+            )
+            alerts_created += 1
+
+        if new_ally in friendly and prev_ally not in friendly:
+            _upsert_alert(
+                db,
+                alert_type="sov_gained",
+                severity="info",
+                title=f"Sovereignty gained in {sys_name}",
+                solar_system_id=system_id,
+                alliance_id=new_ally,
+                details={"previous_owner": prev_ally, "new_owner": new_ally},
+                now_sql=now_sql,
+            )
+            alerts_created += 1
+
+    # ── 3. Low ADM warnings ──────────────────────────────────────────────
+    if friendly:
+        placeholders = ",".join(["%s"] * len(friendly))
+        low_adm_structures = db.fetch_all(
+            f"""SELECT structure_id, alliance_id, solar_system_id,
+                       vulnerability_occupancy_level
+                FROM sovereignty_structures
+                WHERE alliance_id IN ({placeholders})
+                  AND vulnerability_occupancy_level IS NOT NULL
+                  AND vulnerability_occupancy_level < %s""",
+            [*friendly, _LOW_ADM_THRESHOLD],
+        )
+
+        for s in low_adm_structures:
+            system_id = int(s["solar_system_id"])
+            sys_row = db.fetch_one(
+                "SELECT system_name FROM ref_systems WHERE system_id = %s", (system_id,)
+            )
+            sys_name = str(sys_row["system_name"]) if sys_row else f"System {system_id}"
+            adm = float(s["vulnerability_occupancy_level"])
+
+            _upsert_alert(
+                db,
+                alert_type="low_adm",
+                severity="warning",
+                title=f"Low ADM ({adm:.1f}) in {sys_name}",
+                solar_system_id=system_id,
+                alliance_id=int(s["alliance_id"]),
+                structure_id=int(s["structure_id"]),
+                details={"adm": adm, "threshold": _LOW_ADM_THRESHOLD},
+                now_sql=now_sql,
+            )
+            alerts_created += 1
+
+        # Resolve low ADM alerts where ADM has recovered.
+        db.execute(
+            f"""UPDATE sovereignty_alerts sa
+                SET sa.status = 'resolved', sa.resolved_at = %s
+                WHERE sa.alert_type = 'low_adm'
+                  AND sa.status = 'active'
+                  AND sa.structure_id IS NOT NULL
+                  AND sa.structure_id NOT IN (
+                      SELECT ss.structure_id FROM sovereignty_structures ss
+                      WHERE ss.alliance_id IN ({placeholders})
+                        AND ss.vulnerability_occupancy_level IS NOT NULL
+                        AND ss.vulnerability_occupancy_level < %s
+                  )""",
+            [now_sql, *friendly, _LOW_ADM_THRESHOLD],
+        )
+
+    # ── 4. Vulnerability window warnings ─────────────────────────────────
+    if friendly:
+        placeholders = ",".join(["%s"] * len(friendly))
+        vuln_soon = db.fetch_all(
+            f"""SELECT structure_id, alliance_id, solar_system_id,
+                       vulnerable_start_time, vulnerable_end_time
+                FROM sovereignty_structures
+                WHERE alliance_id IN ({placeholders})
+                  AND vulnerable_start_time IS NOT NULL
+                  AND vulnerable_start_time <= DATE_ADD(UTC_TIMESTAMP(), INTERVAL %s HOUR)
+                  AND vulnerable_end_time >= UTC_TIMESTAMP()""",
+            [*friendly, _VULN_WINDOW_HOURS],
+        )
+
+        for s in vuln_soon:
+            system_id = int(s["solar_system_id"])
+            sys_row = db.fetch_one(
+                "SELECT system_name FROM ref_systems WHERE system_id = %s", (system_id,)
+            )
+            sys_name = str(sys_row["system_name"]) if sys_row else f"System {system_id}"
+
+            _upsert_alert(
+                db,
+                alert_type="vuln_window",
+                severity="warning",
+                title=f"Vulnerability window active/upcoming in {sys_name}",
+                solar_system_id=system_id,
+                alliance_id=int(s["alliance_id"]),
+                structure_id=int(s["structure_id"]),
+                details={
+                    "vulnerable_start": str(s["vulnerable_start_time"])[:19],
+                    "vulnerable_end": str(s["vulnerable_end_time"])[:19],
+                },
+                now_sql=now_sql,
+            )
+            alerts_created += 1
+
+        # Resolve vuln window alerts where window has passed.
+        db.execute(
+            """UPDATE sovereignty_alerts
+               SET status = 'resolved', resolved_at = %s
+               WHERE alert_type = 'vuln_window'
+                 AND status = 'active'
+                 AND structure_id IS NOT NULL
+                 AND structure_id NOT IN (
+                     SELECT ss.structure_id FROM sovereignty_structures ss
+                     WHERE ss.vulnerable_end_time >= UTC_TIMESTAMP()
+                 )""",
+            [now_sql],
+        )
+
+    # ── 5. Mark stale alerts ─────────────────────────────────────────────
+    db.execute(
+        """UPDATE sovereignty_alerts
+           SET status = 'stale'
+           WHERE status = 'active'
+             AND last_seen_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %s MINUTE)""",
+        [_STALE_MINUTES],
+    )
+
+    db.execute(
+        """INSERT INTO sync_state (dataset_key, sync_mode, status, last_success_at, last_row_count)
+           VALUES ('sovereignty.alerts', 'full', 'success', UTC_TIMESTAMP(), %s)
+           ON DUPLICATE KEY UPDATE status='success', last_success_at=UTC_TIMESTAMP(),
+               last_row_count=VALUES(last_row_count), updated_at=UTC_TIMESTAMP()""",
+        [alerts_created],
+    )
+
+    return {
+        "rows_processed": len(active_campaigns) + len(recent_changes),
+        "rows_written": alerts_created,
+        "warnings": warnings,
+        "summary": f"Generated {alerts_created} sovereignty alerts.",
+        "meta": {"alerts_created": alerts_created, "friendly_count": len(friendly), "hostile_count": len(hostile)},
+    }
+
+
+def run_compute_sovereignty_alerts(db: SupplyCoreDb) -> dict[str, object]:
+    return run_sync_phase_job(
+        db,
+        job_key=JOB_KEY,
+        phase="A",
+        objective="sovereignty alerts",
+        processor=_processor,
+    )

--- a/python/orchestrator/jobs/esi_sovereignty_sync.py
+++ b/python/orchestrator/jobs/esi_sovereignty_sync.py
@@ -1,0 +1,751 @@
+"""ESI Sovereignty Sync — three jobs at different cadences.
+
+Public ESI endpoints (no auth required):
+- ``GET /sovereignty/campaigns/``  — active entosis fights (~5s cache)
+- ``GET /sovereignty/structures/`` — sov structures + ADM + vuln windows (~120s cache)
+- ``GET /sovereignty/map/``        — system ownership (~3600s cache)
+
+Jobs:
+- ``sovereignty_campaigns_sync``   — 60s interval
+- ``sovereignty_structures_sync``  — 180s interval
+- ``sovereignty_map_sync``         — 1800s interval
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from ..db import SupplyCoreDb
+from .sync_runtime import run_sync_phase_job
+
+log = logging.getLogger(__name__)
+
+_ESI_GROUP = "esi-sovereignty"
+
+# ── Module-level cache for structure role lookups (per-process lifetime) ──────
+
+_role_cache: dict[int, str] = {}
+
+
+# ── Shared helpers ───────────────────────────────────────────────────────────
+
+def _ensure_tables(db: SupplyCoreDb) -> None:
+    """Ensure all sovereignty tables exist (idempotent)."""
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS ref_sov_structure_roles (
+            structure_type_id   INT UNSIGNED PRIMARY KEY,
+            structure_role      VARCHAR(32) NOT NULL,
+            is_sov_structure    TINYINT(1) NOT NULL DEFAULT 0,
+            notes               VARCHAR(255) DEFAULT NULL,
+            created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """)
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS sovereignty_map (
+            system_id           BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+            alliance_id         BIGINT UNSIGNED DEFAULT NULL,
+            corporation_id      BIGINT UNSIGNED DEFAULT NULL,
+            faction_id          BIGINT UNSIGNED DEFAULT NULL,
+            owner_entity_id     BIGINT UNSIGNED DEFAULT NULL,
+            owner_entity_type   ENUM('alliance','corporation','faction') DEFAULT NULL,
+            fetched_at          DATETIME NOT NULL,
+            created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            KEY idx_alliance (alliance_id),
+            KEY idx_faction (faction_id),
+            KEY idx_owner (owner_entity_id, owner_entity_type)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """)
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS sovereignty_map_history (
+            id                          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            system_id                   BIGINT UNSIGNED NOT NULL,
+            previous_alliance_id        BIGINT UNSIGNED DEFAULT NULL,
+            new_alliance_id             BIGINT UNSIGNED DEFAULT NULL,
+            previous_corporation_id     BIGINT UNSIGNED DEFAULT NULL,
+            new_corporation_id          BIGINT UNSIGNED DEFAULT NULL,
+            previous_faction_id         BIGINT UNSIGNED DEFAULT NULL,
+            new_faction_id              BIGINT UNSIGNED DEFAULT NULL,
+            previous_owner_entity_id    BIGINT UNSIGNED DEFAULT NULL,
+            previous_owner_entity_type  ENUM('alliance','corporation','faction') DEFAULT NULL,
+            new_owner_entity_id         BIGINT UNSIGNED DEFAULT NULL,
+            new_owner_entity_type       ENUM('alliance','corporation','faction') DEFAULT NULL,
+            changed_at                  DATETIME NOT NULL,
+            created_at                  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            KEY idx_system (system_id, changed_at),
+            KEY idx_new_alliance (new_alliance_id),
+            KEY idx_previous_alliance (previous_alliance_id),
+            KEY idx_new_owner (new_owner_entity_id, new_owner_entity_type)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """)
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS sovereignty_structures (
+            structure_id                    BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+            alliance_id                     BIGINT UNSIGNED NOT NULL,
+            solar_system_id                 BIGINT UNSIGNED NOT NULL,
+            structure_type_id               INT UNSIGNED NOT NULL,
+            structure_role                  VARCHAR(32) NOT NULL DEFAULT 'unknown',
+            vulnerability_occupancy_level   DECIMAL(4,1) DEFAULT NULL,
+            vulnerable_start_time           DATETIME DEFAULT NULL,
+            vulnerable_end_time             DATETIME DEFAULT NULL,
+            fetched_at                      DATETIME NOT NULL,
+            created_at                      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at                      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            KEY idx_alliance (alliance_id),
+            KEY idx_system (solar_system_id),
+            KEY idx_type (structure_type_id),
+            KEY idx_role (structure_role)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """)
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS sovereignty_structures_history (
+            id                      BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            structure_id            BIGINT UNSIGNED NOT NULL,
+            alliance_id             BIGINT UNSIGNED NOT NULL,
+            solar_system_id         BIGINT UNSIGNED NOT NULL,
+            structure_type_id       INT UNSIGNED NOT NULL,
+            structure_role          VARCHAR(32) NOT NULL,
+            event_type              ENUM('appeared','disappeared','adm_changed','owner_changed','vuln_changed') NOT NULL,
+            previous_adm            DECIMAL(4,1) DEFAULT NULL,
+            new_adm                 DECIMAL(4,1) DEFAULT NULL,
+            previous_alliance_id    BIGINT UNSIGNED DEFAULT NULL,
+            new_alliance_id         BIGINT UNSIGNED DEFAULT NULL,
+            details_json            JSON DEFAULT NULL,
+            recorded_at             DATETIME NOT NULL,
+            created_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            KEY idx_structure (structure_id, recorded_at),
+            KEY idx_system (solar_system_id, recorded_at),
+            KEY idx_alliance (alliance_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """)
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS sovereignty_campaigns (
+            campaign_id         INT UNSIGNED NOT NULL PRIMARY KEY,
+            event_type          VARCHAR(32) NOT NULL,
+            solar_system_id     BIGINT UNSIGNED NOT NULL,
+            constellation_id    BIGINT UNSIGNED NOT NULL,
+            structure_id        BIGINT UNSIGNED NOT NULL,
+            defender_id         BIGINT UNSIGNED NOT NULL,
+            attackers_score     DECIMAL(4,2) NOT NULL DEFAULT 0.00,
+            defender_score      DECIMAL(4,2) NOT NULL DEFAULT 0.00,
+            start_time          DATETIME NOT NULL,
+            first_seen_at       DATETIME NOT NULL,
+            last_seen_at        DATETIME NOT NULL,
+            is_active           TINYINT(1) NOT NULL DEFAULT 1,
+            KEY idx_active (is_active, solar_system_id),
+            KEY idx_defender (defender_id),
+            KEY idx_system (solar_system_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """)
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS sovereignty_campaigns_history (
+            id                      BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            campaign_id             INT UNSIGNED NOT NULL,
+            event_type              VARCHAR(32) NOT NULL,
+            solar_system_id         BIGINT UNSIGNED NOT NULL,
+            constellation_id        BIGINT UNSIGNED NOT NULL,
+            structure_id            BIGINT UNSIGNED NOT NULL,
+            defender_id             BIGINT UNSIGNED NOT NULL,
+            final_attackers_score   DECIMAL(4,2) NOT NULL,
+            final_defender_score    DECIMAL(4,2) NOT NULL,
+            outcome                 ENUM('defended','captured','unknown') NOT NULL DEFAULT 'unknown',
+            start_time              DATETIME NOT NULL,
+            ended_at                DATETIME NOT NULL,
+            created_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE KEY uq_campaign (campaign_id),
+            KEY idx_system (solar_system_id, ended_at),
+            KEY idx_defender (defender_id),
+            KEY idx_outcome (outcome)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """)
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS sovereignty_alerts (
+            id                  BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            alert_type          ENUM('campaign_friendly','campaign_hostile','sov_lost','sov_gained','low_adm','vuln_window') NOT NULL,
+            solar_system_id     BIGINT UNSIGNED DEFAULT NULL,
+            alliance_id         BIGINT UNSIGNED DEFAULT NULL,
+            structure_id        BIGINT UNSIGNED DEFAULT NULL,
+            campaign_id         INT UNSIGNED DEFAULT NULL,
+            severity            ENUM('critical','warning','info') NOT NULL,
+            title               VARCHAR(255) NOT NULL,
+            details_json        JSON DEFAULT NULL,
+            status              ENUM('active','stale','resolved') NOT NULL DEFAULT 'active',
+            detected_at         DATETIME NOT NULL,
+            last_seen_at        DATETIME NOT NULL,
+            resolved_at         DATETIME DEFAULT NULL,
+            created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            KEY idx_status_severity (status, severity, detected_at),
+            KEY idx_system (solar_system_id),
+            KEY idx_campaign (campaign_id),
+            KEY idx_alliance (alliance_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """)
+    # Seed default structure role mappings.
+    db.execute("""
+        INSERT IGNORE INTO ref_sov_structure_roles (structure_type_id, structure_role, is_sov_structure, notes) VALUES
+            (32458, 'legacy_ihub', 1, 'Infrastructure Hub'),
+            (32226, 'legacy_tcu',  1, 'Territorial Claim Unit')
+    """)
+
+
+def _lookup_structure_role(db: SupplyCoreDb, structure_type_id: int) -> str:
+    """DB-driven structure role lookup with per-process caching."""
+    if structure_type_id in _role_cache:
+        return _role_cache[structure_type_id]
+
+    row = db.fetch_one(
+        "SELECT structure_role FROM ref_sov_structure_roles WHERE structure_type_id = %s",
+        (structure_type_id,),
+    )
+    if row:
+        role = str(row["structure_role"])
+    else:
+        role = "other"
+        db.execute(
+            """INSERT IGNORE INTO ref_sov_structure_roles
+               (structure_type_id, structure_role, is_sov_structure, notes)
+               VALUES (%s, 'other', 0, NULL)""",
+            (structure_type_id,),
+        )
+
+    _role_cache[structure_type_id] = role
+    return role
+
+
+def _resolve_owner_entity(
+    alliance_id: int | None,
+    corporation_id: int | None,
+    faction_id: int | None,
+) -> tuple[int | None, str | None]:
+    """Ownership priority: alliance > corporation > faction."""
+    if alliance_id and alliance_id > 0:
+        return alliance_id, "alliance"
+    if corporation_id and corporation_id > 0:
+        return corporation_id, "corporation"
+    if faction_id and faction_id > 0:
+        return faction_id, "faction"
+    return None, None
+
+
+def _queue_sov_entity_names(db: SupplyCoreDb, entity_ids: set[int]) -> None:
+    """Queue alliance/corp/faction IDs for background name resolution."""
+    if not entity_ids:
+        return
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    for eid in sorted(entity_ids):
+        db.execute(
+            """INSERT INTO entity_metadata_cache
+               (entity_type, entity_id, source_system, resolution_status, last_requested_at)
+               VALUES ('alliance', %s, 'queue', 'pending', %s)
+               ON DUPLICATE KEY UPDATE last_requested_at = VALUES(last_requested_at)""",
+            [eid, now],
+        )
+    log.info("Queued %d sovereignty entity IDs for name resolution.", len(entity_ids))
+
+
+def _build_gateway(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None):
+    """Build ESI gateway from config (reused across all three jobs)."""
+    from ..esi_gateway import build_gateway
+
+    redis_cfg = dict((raw_config or {}).get("redis") or {})
+    if redis_cfg.get("enabled"):
+        return build_gateway(db=db, redis_config=redis_cfg)
+    return None
+
+
+def _esi_get(gateway, path: str):
+    """Fetch a public ESI endpoint. Returns body or None."""
+    if gateway is None:
+        from ..esi_client import EsiClient
+        client = EsiClient()
+        resp = client.get(path)
+        if resp.status_code == 200:
+            return resp.body
+        log.warning("ESI %s returned %d (no gateway)", path, resp.status_code)
+        return None
+
+    resp = gateway.get(
+        path,
+        access_token=None,
+        group=_ESI_GROUP,
+        route_template=path,
+        identity="sovereignty",
+    )
+    if resp.status_code == 304:
+        return resp.body  # cached
+    if resp.status_code == 200:
+        return resp.body
+    log.warning("ESI %s returned %d", path, resp.status_code)
+    return None
+
+
+# ── Job A: Campaigns Sync (60s) ─────────────────────────────────────────────
+
+def _campaigns_processor(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None) -> dict[str, object]:
+    gateway = _build_gateway(db, raw_config)
+    _ensure_tables(db)
+
+    warnings: list[str] = []
+    now_sql = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    rows_processed = 0
+    rows_written = 0
+
+    body = _esi_get(gateway, "/latest/sovereignty/campaigns/")
+    if body is None:
+        return {
+            "rows_processed": 0,
+            "rows_written": 0,
+            "warnings": ["ESI /sovereignty/campaigns/ returned no data."],
+            "summary": "Skipped — no campaign data from ESI.",
+        }
+
+    if not isinstance(body, list):
+        warnings.append(f"Unexpected response type: {type(body).__name__}")
+        return {"rows_processed": 0, "rows_written": 0, "warnings": warnings, "summary": "Skipped — bad response."}
+
+    rows_processed = len(body)
+    active_campaign_ids: set[int] = set()
+    entity_ids: set[int] = set()
+
+    for entry in body:
+        campaign_id = int(entry.get("campaign_id") or 0)
+        if campaign_id <= 0:
+            continue
+
+        active_campaign_ids.add(campaign_id)
+        defender_id = int(entry.get("defender_id") or 0)
+        if defender_id > 0:
+            entity_ids.add(defender_id)
+
+        event_type = str(entry.get("event_type") or "unknown")[:32]
+        solar_system_id = int(entry.get("solar_system_id") or 0)
+        constellation_id = int(entry.get("constellation_id") or 0)
+        structure_id = int(entry.get("structure_id") or 0)
+        attackers_score = float(entry.get("attackers_score") or 0)
+        defender_score = float(entry.get("defender_score") or 0)
+        start_time = str(entry.get("start_time") or now_sql).replace("T", " ").replace("Z", "")[:19]
+
+        db.execute(
+            """INSERT INTO sovereignty_campaigns
+               (campaign_id, event_type, solar_system_id, constellation_id, structure_id,
+                defender_id, attackers_score, defender_score, start_time, first_seen_at, last_seen_at, is_active)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 1)
+               ON DUPLICATE KEY UPDATE
+                   attackers_score = VALUES(attackers_score),
+                   defender_score = VALUES(defender_score),
+                   last_seen_at = VALUES(last_seen_at),
+                   is_active = 1""",
+            [campaign_id, event_type, solar_system_id, constellation_id, structure_id,
+             defender_id, attackers_score, defender_score, start_time, now_sql, now_sql],
+        )
+        rows_written += 1
+
+    # Mark campaigns no longer in API response as inactive and archive them.
+    previously_active = db.fetch_all(
+        "SELECT campaign_id, event_type, solar_system_id, constellation_id, structure_id, "
+        "defender_id, attackers_score, defender_score, start_time, first_seen_at "
+        "FROM sovereignty_campaigns WHERE is_active = 1"
+    )
+    newly_ended = 0
+    for row in previously_active:
+        cid = int(row["campaign_id"])
+        if cid in active_campaign_ids:
+            continue
+        # Campaign disappeared from API — mark inactive.
+        db.execute("UPDATE sovereignty_campaigns SET is_active = 0 WHERE campaign_id = %s", (cid,))
+        # Archive to history with outcome=unknown (delayed resolution).
+        db.execute(
+            """INSERT INTO sovereignty_campaigns_history
+               (campaign_id, event_type, solar_system_id, constellation_id, structure_id,
+                defender_id, final_attackers_score, final_defender_score, outcome, start_time, ended_at)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'unknown', %s, %s)
+               ON DUPLICATE KEY UPDATE
+                   final_attackers_score = VALUES(final_attackers_score),
+                   final_defender_score = VALUES(final_defender_score),
+                   ended_at = VALUES(ended_at)""",
+            [cid, row["event_type"], row["solar_system_id"], row["constellation_id"],
+             row["structure_id"], row["defender_id"], float(row["attackers_score"]),
+             float(row["defender_score"]), str(row["start_time"])[:19], now_sql],
+        )
+        newly_ended += 1
+
+    # Delayed outcome resolution for campaigns ended >60 minutes ago.
+    _resolve_campaign_outcomes(db, now_sql)
+
+    _queue_sov_entity_names(db, entity_ids)
+
+    db.execute(
+        """INSERT INTO sync_state (dataset_key, sync_mode, status, last_success_at, last_row_count)
+           VALUES ('sovereignty.campaigns', 'full', 'success', UTC_TIMESTAMP(), %s)
+           ON DUPLICATE KEY UPDATE status='success', last_success_at=UTC_TIMESTAMP(),
+               last_row_count=VALUES(last_row_count), updated_at=UTC_TIMESTAMP()""",
+        [rows_written],
+    )
+
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": warnings,
+        "summary": f"Campaigns: {len(active_campaign_ids)} active, {newly_ended} ended.",
+        "meta": {"active_campaigns": len(active_campaign_ids), "newly_ended": newly_ended},
+    }
+
+
+def _resolve_campaign_outcomes(db: SupplyCoreDb, now_sql: str) -> None:
+    """Resolve unknown campaign outcomes using post-state evidence.
+
+    Only resolves campaigns ended >60 minutes ago to allow map data
+    to converge (2 map sync cycles at 30-minute intervals).
+    """
+    unknown_rows = db.fetch_all(
+        """SELECT id, campaign_id, solar_system_id, structure_id, defender_id,
+                  start_time, ended_at
+           FROM sovereignty_campaigns_history
+           WHERE outcome = 'unknown'
+             AND ended_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL 60 MINUTE)"""
+    )
+    for row in unknown_rows:
+        system_id = int(row["solar_system_id"])
+        structure_id = int(row["structure_id"])
+        defender_id = int(row["defender_id"])
+        start_time = row["start_time"]
+
+        outcome = "defended"  # default if no change detected
+
+        # 1. Structure evidence (highest confidence).
+        struct_row = db.fetch_one(
+            "SELECT alliance_id FROM sovereignty_structures WHERE structure_id = %s",
+            (structure_id,),
+        )
+        if struct_row is None:
+            # Structure disappeared → captured.
+            outcome = "captured"
+        elif int(struct_row.get("alliance_id") or 0) != defender_id:
+            # Structure owner changed → captured.
+            outcome = "captured"
+        else:
+            # 2. Map evidence.
+            map_row = db.fetch_one(
+                "SELECT alliance_id FROM sovereignty_map WHERE system_id = %s",
+                (system_id,),
+            )
+            if map_row and int(map_row.get("alliance_id") or 0) != defender_id:
+                outcome = "captured"
+
+        db.execute(
+            "UPDATE sovereignty_campaigns_history SET outcome = %s WHERE id = %s",
+            [outcome, row["id"]],
+        )
+        if outcome != "defended":
+            log.info("Campaign %d outcome resolved: %s", int(row["campaign_id"]), outcome)
+
+
+# ── Job B: Structures Sync (180s) ───────────────────────────────────────────
+
+def _structures_processor(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None) -> dict[str, object]:
+    gateway = _build_gateway(db, raw_config)
+    _ensure_tables(db)
+
+    warnings: list[str] = []
+    now_sql = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    rows_processed = 0
+    rows_written = 0
+
+    body = _esi_get(gateway, "/latest/sovereignty/structures/")
+    if body is None:
+        return {
+            "rows_processed": 0,
+            "rows_written": 0,
+            "warnings": ["ESI /sovereignty/structures/ returned no data."],
+            "summary": "Skipped — no structures data from ESI.",
+        }
+
+    if not isinstance(body, list):
+        warnings.append(f"Unexpected response type: {type(body).__name__}")
+        return {"rows_processed": 0, "rows_written": 0, "warnings": warnings, "summary": "Skipped — bad response."}
+
+    rows_processed = len(body)
+
+    # Load current snapshot for change detection.
+    existing_rows = db.fetch_all(
+        "SELECT structure_id, alliance_id, solar_system_id, structure_type_id, structure_role, "
+        "vulnerability_occupancy_level, vulnerable_start_time, vulnerable_end_time "
+        "FROM sovereignty_structures"
+    )
+    existing: dict[int, dict] = {int(r["structure_id"]): r for r in existing_rows}
+    seen_structure_ids: set[int] = set()
+    entity_ids: set[int] = set()
+    history_events = 0
+
+    for entry in body:
+        structure_id = int(entry.get("structure_id") or 0)
+        if structure_id <= 0:
+            continue
+
+        seen_structure_ids.add(structure_id)
+        alliance_id = int(entry.get("alliance_id") or 0)
+        solar_system_id = int(entry.get("solar_system_id") or 0)
+        structure_type_id = int(entry.get("structure_type_id") or 0)
+        adm = entry.get("vulnerability_occupancy_level")
+        adm_val = float(adm) if adm is not None else None
+        vuln_start = entry.get("vulnerable_start_time")
+        vuln_end = entry.get("vulnerable_end_time")
+        vuln_start_sql = str(vuln_start).replace("T", " ").replace("Z", "")[:19] if vuln_start else None
+        vuln_end_sql = str(vuln_end).replace("T", " ").replace("Z", "")[:19] if vuln_end else None
+
+        if alliance_id > 0:
+            entity_ids.add(alliance_id)
+
+        role = _lookup_structure_role(db, structure_type_id)
+
+        # Detect changes vs existing snapshot.
+        prev = existing.get(structure_id)
+        if prev is None:
+            # New structure appeared.
+            db.execute(
+                """INSERT INTO sovereignty_structures_history
+                   (structure_id, alliance_id, solar_system_id, structure_type_id, structure_role,
+                    event_type, new_adm, recorded_at)
+                   VALUES (%s, %s, %s, %s, %s, 'appeared', %s, %s)""",
+                [structure_id, alliance_id, solar_system_id, structure_type_id, role, adm_val, now_sql],
+            )
+            history_events += 1
+        else:
+            prev_alliance = int(prev.get("alliance_id") or 0)
+            prev_adm = float(prev["vulnerability_occupancy_level"]) if prev.get("vulnerability_occupancy_level") is not None else None
+            prev_vuln_start = str(prev.get("vulnerable_start_time") or "")[:19] if prev.get("vulnerable_start_time") else None
+            prev_vuln_end = str(prev.get("vulnerable_end_time") or "")[:19] if prev.get("vulnerable_end_time") else None
+
+            if prev_alliance != alliance_id:
+                db.execute(
+                    """INSERT INTO sovereignty_structures_history
+                       (structure_id, alliance_id, solar_system_id, structure_type_id, structure_role,
+                        event_type, previous_alliance_id, new_alliance_id, recorded_at)
+                       VALUES (%s, %s, %s, %s, %s, 'owner_changed', %s, %s, %s)""",
+                    [structure_id, alliance_id, solar_system_id, structure_type_id, role,
+                     prev_alliance, alliance_id, now_sql],
+                )
+                history_events += 1
+
+            if prev_adm is not None and adm_val is not None and abs(prev_adm - adm_val) >= 0.1:
+                db.execute(
+                    """INSERT INTO sovereignty_structures_history
+                       (structure_id, alliance_id, solar_system_id, structure_type_id, structure_role,
+                        event_type, previous_adm, new_adm, recorded_at)
+                       VALUES (%s, %s, %s, %s, %s, 'adm_changed', %s, %s, %s)""",
+                    [structure_id, alliance_id, solar_system_id, structure_type_id, role,
+                     prev_adm, adm_val, now_sql],
+                )
+                history_events += 1
+
+            if prev_vuln_start != vuln_start_sql or prev_vuln_end != vuln_end_sql:
+                db.execute(
+                    """INSERT INTO sovereignty_structures_history
+                       (structure_id, alliance_id, solar_system_id, structure_type_id, structure_role,
+                        event_type, details_json, recorded_at)
+                       VALUES (%s, %s, %s, %s, %s, 'vuln_changed', %s, %s)""",
+                    [structure_id, alliance_id, solar_system_id, structure_type_id, role,
+                     json.dumps({"prev_start": prev_vuln_start, "prev_end": prev_vuln_end,
+                                 "new_start": vuln_start_sql, "new_end": vuln_end_sql}),
+                     now_sql],
+                )
+                history_events += 1
+
+        # Upsert structure.
+        db.execute(
+            """INSERT INTO sovereignty_structures
+               (structure_id, alliance_id, solar_system_id, structure_type_id, structure_role,
+                vulnerability_occupancy_level, vulnerable_start_time, vulnerable_end_time, fetched_at)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+               ON DUPLICATE KEY UPDATE
+                   alliance_id = VALUES(alliance_id),
+                   solar_system_id = VALUES(solar_system_id),
+                   structure_type_id = VALUES(structure_type_id),
+                   structure_role = VALUES(structure_role),
+                   vulnerability_occupancy_level = VALUES(vulnerability_occupancy_level),
+                   vulnerable_start_time = VALUES(vulnerable_start_time),
+                   vulnerable_end_time = VALUES(vulnerable_end_time),
+                   fetched_at = VALUES(fetched_at)""",
+            [structure_id, alliance_id, solar_system_id, structure_type_id, role,
+             adm_val, vuln_start_sql, vuln_end_sql, now_sql],
+        )
+        rows_written += 1
+
+    # Detect disappeared structures.
+    for sid, prev in existing.items():
+        if sid not in seen_structure_ids:
+            db.execute(
+                """INSERT INTO sovereignty_structures_history
+                   (structure_id, alliance_id, solar_system_id, structure_type_id, structure_role,
+                    event_type, previous_adm, recorded_at)
+                   VALUES (%s, %s, %s, %s, %s, 'disappeared', %s, %s)""",
+                [sid, int(prev.get("alliance_id") or 0), int(prev.get("solar_system_id") or 0),
+                 int(prev.get("structure_type_id") or 0), str(prev.get("structure_role") or "unknown"),
+                 float(prev["vulnerability_occupancy_level"]) if prev.get("vulnerability_occupancy_level") is not None else None,
+                 now_sql],
+            )
+            db.execute("DELETE FROM sovereignty_structures WHERE structure_id = %s", (sid,))
+            history_events += 1
+
+    _queue_sov_entity_names(db, entity_ids)
+
+    db.execute(
+        """INSERT INTO sync_state (dataset_key, sync_mode, status, last_success_at, last_row_count)
+           VALUES ('sovereignty.structures', 'full', 'success', UTC_TIMESTAMP(), %s)
+           ON DUPLICATE KEY UPDATE status='success', last_success_at=UTC_TIMESTAMP(),
+               last_row_count=VALUES(last_row_count), updated_at=UTC_TIMESTAMP()""",
+        [rows_written],
+    )
+
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": warnings,
+        "summary": f"Structures: {rows_written} upserted, {history_events} history events.",
+        "meta": {"structures_count": rows_written, "history_events": history_events},
+    }
+
+
+# ── Job C: Map Sync (1800s) ─────────────────────────────────────────────────
+
+def _map_processor(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None) -> dict[str, object]:
+    gateway = _build_gateway(db, raw_config)
+    _ensure_tables(db)
+
+    warnings: list[str] = []
+    now_sql = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    rows_processed = 0
+    rows_written = 0
+
+    body = _esi_get(gateway, "/latest/sovereignty/map/")
+    if body is None:
+        return {
+            "rows_processed": 0,
+            "rows_written": 0,
+            "warnings": ["ESI /sovereignty/map/ returned no data."],
+            "summary": "Skipped — no map data from ESI.",
+        }
+
+    if not isinstance(body, list):
+        warnings.append(f"Unexpected response type: {type(body).__name__}")
+        return {"rows_processed": 0, "rows_written": 0, "warnings": warnings, "summary": "Skipped — bad response."}
+
+    rows_processed = len(body)
+
+    # Load current snapshot for change detection.
+    existing_rows = db.fetch_all(
+        "SELECT system_id, alliance_id, corporation_id, faction_id, "
+        "owner_entity_id, owner_entity_type FROM sovereignty_map"
+    )
+    existing: dict[int, dict] = {int(r["system_id"]): r for r in existing_rows}
+    entity_ids: set[int] = set()
+    ownership_changes = 0
+
+    for entry in body:
+        system_id = int(entry.get("system_id") or 0)
+        if system_id <= 0:
+            continue
+
+        alliance_id = int(entry.get("alliance_id") or 0) or None
+        corporation_id = int(entry.get("corporation_id") or 0) or None
+        faction_id = int(entry.get("faction_id") or 0) or None
+        owner_id, owner_type = _resolve_owner_entity(alliance_id, corporation_id, faction_id)
+
+        if alliance_id:
+            entity_ids.add(alliance_id)
+
+        # Check for ownership change.
+        prev = existing.get(system_id)
+        if prev is not None:
+            prev_owner_id = int(prev.get("owner_entity_id") or 0) or None
+            prev_owner_type = prev.get("owner_entity_type")
+            if prev_owner_id != owner_id or prev_owner_type != owner_type:
+                db.execute(
+                    """INSERT INTO sovereignty_map_history
+                       (system_id, previous_alliance_id, new_alliance_id,
+                        previous_corporation_id, new_corporation_id,
+                        previous_faction_id, new_faction_id,
+                        previous_owner_entity_id, previous_owner_entity_type,
+                        new_owner_entity_id, new_owner_entity_type, changed_at)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                    [system_id,
+                     int(prev.get("alliance_id") or 0) or None, alliance_id,
+                     int(prev.get("corporation_id") or 0) or None, corporation_id,
+                     int(prev.get("faction_id") or 0) or None, faction_id,
+                     prev_owner_id, prev_owner_type,
+                     owner_id, owner_type, now_sql],
+                )
+                ownership_changes += 1
+
+        # Upsert map entry.
+        db.execute(
+            """INSERT INTO sovereignty_map
+               (system_id, alliance_id, corporation_id, faction_id,
+                owner_entity_id, owner_entity_type, fetched_at)
+               VALUES (%s, %s, %s, %s, %s, %s, %s)
+               ON DUPLICATE KEY UPDATE
+                   alliance_id = VALUES(alliance_id),
+                   corporation_id = VALUES(corporation_id),
+                   faction_id = VALUES(faction_id),
+                   owner_entity_id = VALUES(owner_entity_id),
+                   owner_entity_type = VALUES(owner_entity_type),
+                   fetched_at = VALUES(fetched_at)""",
+            [system_id, alliance_id, corporation_id, faction_id,
+             owner_id, owner_type, now_sql],
+        )
+        rows_written += 1
+
+    _queue_sov_entity_names(db, entity_ids)
+
+    db.execute(
+        """INSERT INTO sync_state (dataset_key, sync_mode, status, last_success_at, last_row_count)
+           VALUES ('sovereignty.map', 'full', 'success', UTC_TIMESTAMP(), %s)
+           ON DUPLICATE KEY UPDATE status='success', last_success_at=UTC_TIMESTAMP(),
+               last_row_count=VALUES(last_row_count), updated_at=UTC_TIMESTAMP()""",
+        [rows_written],
+    )
+
+    return {
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
+        "warnings": warnings,
+        "summary": f"Map: {rows_written} systems upserted, {ownership_changes} ownership changes.",
+        "meta": {"systems_count": rows_written, "ownership_changes": ownership_changes},
+    }
+
+
+# ── Entry points ─────────────────────────────────────────────────────────────
+
+def run_sovereignty_campaigns_sync(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None) -> dict[str, object]:
+    return run_sync_phase_job(
+        db,
+        job_key="sovereignty_campaigns_sync",
+        phase="A",
+        objective="sovereignty campaigns",
+        processor=lambda d: _campaigns_processor(d, raw_config),
+    )
+
+
+def run_sovereignty_structures_sync(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None) -> dict[str, object]:
+    return run_sync_phase_job(
+        db,
+        job_key="sovereignty_structures_sync",
+        phase="A",
+        objective="sovereignty structures",
+        processor=lambda d: _structures_processor(d, raw_config),
+    )
+
+
+def run_sovereignty_map_sync(db: SupplyCoreDb, raw_config: dict[str, Any] | None = None) -> dict[str, object]:
+    return run_sync_phase_job(
+        db,
+        job_key="sovereignty_map_sync",
+        phase="A",
+        objective="sovereignty map",
+        processor=lambda d: _map_processor(d, raw_config),
+    )

--- a/python/orchestrator/processor_registry.py
+++ b/python/orchestrator/processor_registry.py
@@ -80,6 +80,12 @@ from .jobs.killmail_zkb_repair import run_killmail_zkb_repair
 from .jobs.corp_standings_sync import run_corp_standings_sync
 from .jobs.behavioral_scoring import run_compute_behavioral_scoring
 from .jobs.compute_opposition_daily_snapshots import run_compute_opposition_daily_snapshots
+from .jobs.esi_sovereignty_sync import (
+    run_sovereignty_campaigns_sync,
+    run_sovereignty_structures_sync,
+    run_sovereignty_map_sync,
+)
+from .jobs.compute_sovereignty_alerts import run_compute_sovereignty_alerts
 
 
 def _php_bridge(cfg: dict[str, Any]) -> PhpBridge:
@@ -141,6 +147,7 @@ PYTHON_COMPUTE_PROCESSOR_JOB_KEYS: set[str] = {
     "killmail_zkb_repair",
     "compute_behavioral_scoring",
     "compute_opposition_daily_snapshots",
+    "compute_sovereignty_alerts",
 }
 
 PYTHON_SYNC_PROCESSOR_JOB_KEYS: set[str] = {
@@ -167,6 +174,9 @@ PYTHON_SYNC_PROCESSOR_JOB_KEYS: set[str] = {
     "tracked_alliance_member_sync",
     "cache_expiry_cleanup_sync",
     "corp_standings_sync",
+    "sovereignty_campaigns_sync",
+    "sovereignty_structures_sync",
+    "sovereignty_map_sync",
 }
 PYTHON_PROCESSOR_JOB_KEYS: set[str] = PYTHON_COMPUTE_PROCESSOR_JOB_KEYS | PYTHON_SYNC_PROCESSOR_JOB_KEYS
 
@@ -260,6 +270,11 @@ _PROCESSOR_DISPATCH: dict[str, tuple] = {
     "jump_bridge_sync": (run_jump_bridge_sync, lambda db, cfg: (db, neo4j_runtime(cfg))),
     # Corporation standings sync
     "corp_standings_sync": (run_corp_standings_sync, lambda db, cfg: (db, cfg)),
+    # Sovereignty monitoring
+    "sovereignty_campaigns_sync": (run_sovereignty_campaigns_sync, lambda db, cfg: (db, cfg)),
+    "sovereignty_structures_sync": (run_sovereignty_structures_sync, lambda db, cfg: (db, cfg)),
+    "sovereignty_map_sync": (run_sovereignty_map_sync, lambda db, cfg: (db, cfg)),
+    "compute_sovereignty_alerts": (run_compute_sovereignty_alerts, lambda db, cfg: (db,)),
     # Maintenance
     "cache_expiry_cleanup_sync": (run_cache_expiry_cleanup_sync, lambda db, cfg: (db,)),
     # Killmail repair

--- a/src/db.php
+++ b/src/db.php
@@ -17281,3 +17281,515 @@ function db_opposition_latest_snapshot_date(): ?string
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     return $row['d'] ?? null;
 }
+
+// ── Sovereignty Monitoring ──────────────────────────────────────────────────
+
+function db_sovereignty_alerts_active(int $limit = 50): array
+{
+    return db_select(
+        "SELECT sa.*,
+                rs.system_name,
+                rs.security AS system_security,
+                rr.region_name,
+                emc.entity_name AS alliance_name
+         FROM sovereignty_alerts sa
+         LEFT JOIN ref_systems rs ON rs.system_id = sa.solar_system_id
+         LEFT JOIN ref_regions rr ON rr.region_id = rs.region_id
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = sa.alliance_id
+         WHERE sa.status = 'active'
+         ORDER BY FIELD(sa.severity, 'critical', 'warning', 'info'),
+                  sa.detected_at DESC
+         LIMIT ?",
+        [max(1, min(200, $limit))]
+    );
+}
+
+function db_sovereignty_alerts_count(): int
+{
+    $rows = db_select(
+        "SELECT COUNT(*) AS cnt FROM sovereignty_alerts
+         WHERE status = 'active' AND severity IN ('critical', 'warning')"
+    );
+    return (int) ($rows[0]['cnt'] ?? 0);
+}
+
+function db_sovereignty_campaigns_active(): array
+{
+    return db_select(
+        "SELECT sc.*,
+                rs.system_name,
+                rs.security AS system_security,
+                rr.region_name,
+                rc.constellation_name,
+                emc.entity_name AS defender_name,
+                rit.type_name AS structure_type_name,
+                rsr.structure_role,
+                rsr.is_sov_structure,
+                cc.standing AS defender_standing,
+                CASE
+                    WHEN sc.event_type LIKE '%defense%' THEN 'Sovereignty Defense'
+                    WHEN rsr.structure_role IN ('sov_hub','legacy_ihub','legacy_tcu') THEN 'Sovereignty Capture'
+                    WHEN sc.event_type LIKE '%freeport%' THEN 'Freeport'
+                    WHEN sc.event_type LIKE '%station%' THEN 'Station Contest'
+                    ELSE 'Unknown'
+                END AS campaign_type_normalized
+         FROM sovereignty_campaigns sc
+         LEFT JOIN ref_systems rs ON rs.system_id = sc.solar_system_id
+         LEFT JOIN ref_regions rr ON rr.region_id = rs.region_id
+         LEFT JOIN ref_constellations rc ON rc.constellation_id = sc.constellation_id
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = sc.defender_id
+         LEFT JOIN ref_item_types rit ON rit.type_id = sc.structure_id
+         LEFT JOIN ref_sov_structure_roles rsr ON rsr.structure_type_id = sc.structure_id
+         LEFT JOIN corp_contacts cc
+              ON cc.contact_type = 'alliance' AND cc.contact_id = sc.defender_id
+         WHERE sc.is_active = 1
+         ORDER BY CASE WHEN cc.standing > 0 THEN 0 WHEN cc.standing < 0 THEN 2 ELSE 1 END,
+                  sc.start_time ASC"
+    );
+}
+
+function db_sovereignty_campaigns_history(int $limit = 50, int $offset = 0): array
+{
+    return db_select(
+        "SELECT sch.*,
+                rs.system_name,
+                rs.security AS system_security,
+                rr.region_name,
+                emc.entity_name AS defender_name,
+                cc.standing AS defender_standing,
+                CASE
+                    WHEN sch.event_type LIKE '%defense%' THEN 'Sovereignty Defense'
+                    WHEN sch.event_type LIKE '%freeport%' THEN 'Freeport'
+                    WHEN sch.event_type LIKE '%station%' THEN 'Station Contest'
+                    ELSE 'Sovereignty Contest'
+                END AS campaign_type_normalized
+         FROM sovereignty_campaigns_history sch
+         LEFT JOIN ref_systems rs ON rs.system_id = sch.solar_system_id
+         LEFT JOIN ref_regions rr ON rr.region_id = rs.region_id
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = sch.defender_id
+         LEFT JOIN corp_contacts cc
+              ON cc.contact_type = 'alliance' AND cc.contact_id = sch.defender_id
+         ORDER BY sch.ended_at DESC
+         LIMIT ? OFFSET ?",
+        [max(1, min(200, $limit)), max(0, $offset)]
+    );
+}
+
+function db_sovereignty_map_list(int $limit = 50, int $offset = 0, ?string $search = null, ?string $filter = null): array
+{
+    $where = ['1=1'];
+    $params = [];
+
+    if ($search !== null && trim($search) !== '') {
+        $term = '%' . trim($search) . '%';
+        $where[] = '(rs.system_name LIKE ? OR rr.region_name LIKE ? OR emc.entity_name LIKE ?)';
+        $params[] = $term;
+        $params[] = $term;
+        $params[] = $term;
+    }
+
+    if ($filter === 'friendly') {
+        $standings = db_corp_contacts_by_standing();
+        $ids = $standings['friendly_alliance_ids'];
+        if ($ids) {
+            $placeholders = implode(',', array_fill(0, count($ids), '?'));
+            $where[] = "sm.alliance_id IN ({$placeholders})";
+            $params = array_merge($params, $ids);
+        } else {
+            $where[] = '0';
+        }
+    } elseif ($filter === 'hostile') {
+        $standings = db_corp_contacts_by_standing();
+        $ids = $standings['hostile_alliance_ids'];
+        if ($ids) {
+            $placeholders = implode(',', array_fill(0, count($ids), '?'));
+            $where[] = "sm.alliance_id IN ({$placeholders})";
+            $params = array_merge($params, $ids);
+        } else {
+            $where[] = '0';
+        }
+    } elseif ($filter === 'neutral') {
+        $standings = db_corp_contacts_by_standing();
+        $allKnown = array_merge($standings['friendly_alliance_ids'], $standings['hostile_alliance_ids']);
+        if ($allKnown) {
+            $placeholders = implode(',', array_fill(0, count($allKnown), '?'));
+            $where[] = "(sm.alliance_id IS NULL OR sm.alliance_id NOT IN ({$placeholders}))";
+            $params = array_merge($params, $allKnown);
+        }
+    }
+
+    $whereClause = implode(' AND ', $where);
+    $params[] = max(1, min(200, $limit));
+    $params[] = max(0, $offset);
+
+    return db_select(
+        "SELECT sm.*,
+                rs.system_name,
+                rs.security AS system_security,
+                rs.constellation_id,
+                rr.region_name,
+                rc.constellation_name,
+                emc.entity_name AS owner_name,
+                ss.structure_role,
+                ss.vulnerability_occupancy_level AS adm,
+                ss.vulnerable_start_time,
+                ss.vulnerable_end_time,
+                CASE
+                    WHEN ss.vulnerability_occupancy_level IS NULL THEN NULL
+                    WHEN ss.vulnerability_occupancy_level < 2.0 THEN 'critical'
+                    WHEN ss.vulnerability_occupancy_level < 3.0 THEN 'weak'
+                    WHEN ss.vulnerability_occupancy_level < 4.5 THEN 'stable'
+                    ELSE 'strong'
+                END AS adm_status,
+                CASE
+                    WHEN ss.vulnerable_start_time <= UTC_TIMESTAMP()
+                         AND ss.vulnerable_end_time >= UTC_TIMESTAMP() THEN 1
+                    ELSE 0
+                END AS is_vulnerable_now,
+                cc.standing AS owner_standing
+         FROM sovereignty_map sm
+         LEFT JOIN ref_systems rs ON rs.system_id = sm.system_id
+         LEFT JOIN ref_regions rr ON rr.region_id = rs.region_id
+         LEFT JOIN ref_constellations rc ON rc.constellation_id = rs.constellation_id
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = sm.owner_entity_id
+         LEFT JOIN sovereignty_structures ss ON ss.solar_system_id = sm.system_id
+              AND ss.structure_role IN ('sov_hub','legacy_ihub')
+         LEFT JOIN corp_contacts cc
+              ON cc.contact_type = 'alliance' AND cc.contact_id = sm.alliance_id
+         WHERE {$whereClause}
+           AND sm.owner_entity_id IS NOT NULL
+         ORDER BY rs.region_name, rs.system_name
+         LIMIT ? OFFSET ?",
+        $params
+    );
+}
+
+function db_sovereignty_map_count(?string $search = null, ?string $filter = null): int
+{
+    $where = ['sm.owner_entity_id IS NOT NULL'];
+    $params = [];
+
+    if ($search !== null && trim($search) !== '') {
+        $term = '%' . trim($search) . '%';
+        $where[] = '(rs.system_name LIKE ? OR rr.region_name LIKE ? OR emc.entity_name LIKE ?)';
+        $params[] = $term;
+        $params[] = $term;
+        $params[] = $term;
+    }
+
+    if ($filter === 'friendly') {
+        $standings = db_corp_contacts_by_standing();
+        $ids = $standings['friendly_alliance_ids'];
+        if ($ids) {
+            $placeholders = implode(',', array_fill(0, count($ids), '?'));
+            $where[] = "sm.alliance_id IN ({$placeholders})";
+            $params = array_merge($params, $ids);
+        } else {
+            $where[] = '0';
+        }
+    } elseif ($filter === 'hostile') {
+        $standings = db_corp_contacts_by_standing();
+        $ids = $standings['hostile_alliance_ids'];
+        if ($ids) {
+            $placeholders = implode(',', array_fill(0, count($ids), '?'));
+            $where[] = "sm.alliance_id IN ({$placeholders})";
+            $params = array_merge($params, $ids);
+        } else {
+            $where[] = '0';
+        }
+    } elseif ($filter === 'neutral') {
+        $standings = db_corp_contacts_by_standing();
+        $allKnown = array_merge($standings['friendly_alliance_ids'], $standings['hostile_alliance_ids']);
+        if ($allKnown) {
+            $placeholders = implode(',', array_fill(0, count($allKnown), '?'));
+            $where[] = "(sm.alliance_id IS NULL OR sm.alliance_id NOT IN ({$placeholders}))";
+            $params = array_merge($params, $allKnown);
+        }
+    }
+
+    $whereClause = implode(' AND ', $where);
+    $rows = db_select(
+        "SELECT COUNT(*) AS cnt
+         FROM sovereignty_map sm
+         LEFT JOIN ref_systems rs ON rs.system_id = sm.system_id
+         LEFT JOIN ref_regions rr ON rr.region_id = rs.region_id
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = sm.owner_entity_id
+         WHERE {$whereClause}",
+        $params
+    );
+    return (int) ($rows[0]['cnt'] ?? 0);
+}
+
+function db_sovereignty_structures_list(int $limit = 50, int $offset = 0, ?string $filter = null): array
+{
+    $where = ['1=1'];
+    $params = [];
+
+    if ($filter === 'friendly' || $filter === 'hostile') {
+        $standings = db_corp_contacts_by_standing();
+        $ids = $filter === 'friendly' ? $standings['friendly_alliance_ids'] : $standings['hostile_alliance_ids'];
+        if ($ids) {
+            $placeholders = implode(',', array_fill(0, count($ids), '?'));
+            $where[] = "ss.alliance_id IN ({$placeholders})";
+            $params = array_merge($params, $ids);
+        } else {
+            $where[] = '0';
+        }
+    }
+
+    $whereClause = implode(' AND ', $where);
+    $params[] = max(1, min(200, $limit));
+    $params[] = max(0, $offset);
+
+    return db_select(
+        "SELECT ss.*,
+                rs.system_name,
+                rs.security AS system_security,
+                rr.region_name,
+                emc.entity_name AS alliance_name,
+                rit.type_name AS structure_type_name,
+                cc.standing AS alliance_standing,
+                CASE
+                    WHEN ss.vulnerability_occupancy_level IS NULL THEN NULL
+                    WHEN ss.vulnerability_occupancy_level < 2.0 THEN 'critical'
+                    WHEN ss.vulnerability_occupancy_level < 3.0 THEN 'weak'
+                    WHEN ss.vulnerability_occupancy_level < 4.5 THEN 'stable'
+                    ELSE 'strong'
+                END AS adm_status,
+                CASE
+                    WHEN ss.vulnerable_start_time <= UTC_TIMESTAMP()
+                         AND ss.vulnerable_end_time >= UTC_TIMESTAMP() THEN 1
+                    ELSE 0
+                END AS is_vulnerable_now,
+                TIMESTAMPDIFF(MINUTE, UTC_TIMESTAMP(), ss.vulnerable_start_time) AS vulnerable_in_minutes,
+                TIMESTAMPDIFF(MINUTE, ss.vulnerable_start_time, ss.vulnerable_end_time) AS vulnerable_duration_minutes
+         FROM sovereignty_structures ss
+         LEFT JOIN ref_systems rs ON rs.system_id = ss.solar_system_id
+         LEFT JOIN ref_regions rr ON rr.region_id = rs.region_id
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = ss.alliance_id
+         LEFT JOIN ref_item_types rit ON rit.type_id = ss.structure_type_id
+         LEFT JOIN corp_contacts cc
+              ON cc.contact_type = 'alliance' AND cc.contact_id = ss.alliance_id
+         WHERE {$whereClause}
+         ORDER BY rr.region_name, rs.system_name
+         LIMIT ? OFFSET ?",
+        $params
+    );
+}
+
+function db_sovereignty_system_detail(int $systemId): array
+{
+    $result = ['owner' => null, 'structures' => [], 'campaigns' => [], 'map_history' => [], 'structure_history' => []];
+
+    $ownerRows = db_select(
+        "SELECT sm.*,
+                rs.system_name, rs.security AS system_security,
+                rs.constellation_id, rr.region_name, rc.constellation_name,
+                emc.entity_name AS owner_name,
+                cc.standing AS owner_standing
+         FROM sovereignty_map sm
+         LEFT JOIN ref_systems rs ON rs.system_id = sm.system_id
+         LEFT JOIN ref_regions rr ON rr.region_id = rs.region_id
+         LEFT JOIN ref_constellations rc ON rc.constellation_id = rs.constellation_id
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = sm.owner_entity_id
+         LEFT JOIN corp_contacts cc
+              ON cc.contact_type = 'alliance' AND cc.contact_id = sm.alliance_id
+         WHERE sm.system_id = ?
+         LIMIT 1",
+        [$systemId]
+    );
+    $result['owner'] = $ownerRows[0] ?? null;
+
+    $result['structures'] = db_select(
+        "SELECT ss.*,
+                emc.entity_name AS alliance_name,
+                rit.type_name AS structure_type_name,
+                CASE
+                    WHEN ss.vulnerability_occupancy_level IS NULL THEN NULL
+                    WHEN ss.vulnerability_occupancy_level < 2.0 THEN 'critical'
+                    WHEN ss.vulnerability_occupancy_level < 3.0 THEN 'weak'
+                    WHEN ss.vulnerability_occupancy_level < 4.5 THEN 'stable'
+                    ELSE 'strong'
+                END AS adm_status,
+                CASE
+                    WHEN ss.vulnerable_start_time <= UTC_TIMESTAMP()
+                         AND ss.vulnerable_end_time >= UTC_TIMESTAMP() THEN 1
+                    ELSE 0
+                END AS is_vulnerable_now,
+                TIMESTAMPDIFF(MINUTE, UTC_TIMESTAMP(), ss.vulnerable_start_time) AS vulnerable_in_minutes,
+                TIMESTAMPDIFF(MINUTE, ss.vulnerable_start_time, ss.vulnerable_end_time) AS vulnerable_duration_minutes
+         FROM sovereignty_structures ss
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = ss.alliance_id
+         LEFT JOIN ref_item_types rit ON rit.type_id = ss.structure_type_id
+         WHERE ss.solar_system_id = ?
+         ORDER BY FIELD(ss.structure_role, 'sov_hub', 'legacy_ihub', 'legacy_tcu', 'other', 'unknown')",
+        [$systemId]
+    );
+
+    $result['campaigns'] = db_select(
+        "SELECT sc.*,
+                emc.entity_name AS defender_name,
+                cc.standing AS defender_standing
+         FROM sovereignty_campaigns sc
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = sc.defender_id
+         LEFT JOIN corp_contacts cc
+              ON cc.contact_type = 'alliance' AND cc.contact_id = sc.defender_id
+         WHERE sc.solar_system_id = ?
+           AND sc.is_active = 1",
+        [$systemId]
+    );
+
+    $result['map_history'] = db_select(
+        "SELECT smh.*,
+                emc_prev.entity_name AS previous_owner_name,
+                emc_new.entity_name AS new_owner_name
+         FROM sovereignty_map_history smh
+         LEFT JOIN entity_metadata_cache emc_prev
+              ON emc_prev.entity_type = 'alliance' AND emc_prev.entity_id = smh.previous_owner_entity_id
+         LEFT JOIN entity_metadata_cache emc_new
+              ON emc_new.entity_type = 'alliance' AND emc_new.entity_id = smh.new_owner_entity_id
+         WHERE smh.system_id = ?
+         ORDER BY smh.changed_at DESC
+         LIMIT 100",
+        [$systemId]
+    );
+
+    $result['structure_history'] = db_select(
+        "SELECT ssh.*,
+                rit.type_name AS structure_type_name,
+                emc.entity_name AS alliance_name
+         FROM sovereignty_structures_history ssh
+         LEFT JOIN ref_item_types rit ON rit.type_id = ssh.structure_type_id
+         LEFT JOIN entity_metadata_cache emc
+              ON emc.entity_type = 'alliance' AND emc.entity_id = ssh.alliance_id
+         WHERE ssh.solar_system_id = ?
+         ORDER BY ssh.recorded_at DESC
+         LIMIT 100",
+        [$systemId]
+    );
+
+    return $result;
+}
+
+function db_sovereignty_stats_for_alliance(int $allianceId): array
+{
+    $rows = db_select(
+        "SELECT
+            (SELECT COUNT(*) FROM sovereignty_map WHERE alliance_id = ?) AS systems_held,
+            (SELECT COUNT(*) FROM sovereignty_structures WHERE alliance_id = ?) AS structures_count,
+            (SELECT AVG(vulnerability_occupancy_level) FROM sovereignty_structures
+             WHERE alliance_id = ? AND vulnerability_occupancy_level IS NOT NULL) AS avg_adm,
+            (SELECT COUNT(*) FROM sovereignty_campaigns
+             WHERE defender_id = ? AND is_active = 1) AS active_campaigns,
+            (SELECT COUNT(*) FROM sovereignty_map_history
+             WHERE previous_alliance_id = ?
+               AND changed_at > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 30 DAY)) AS losses_30d,
+            (SELECT COUNT(*) FROM sovereignty_map_history
+             WHERE new_alliance_id = ?
+               AND changed_at > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 30 DAY)) AS gains_30d",
+        [$allianceId, $allianceId, $allianceId, $allianceId, $allianceId, $allianceId]
+    );
+    $r = $rows[0] ?? [];
+    return [
+        'systems_held' => (int) ($r['systems_held'] ?? 0),
+        'structures_count' => (int) ($r['structures_count'] ?? 0),
+        'avg_adm' => $r['avg_adm'] !== null ? round((float) $r['avg_adm'], 1) : null,
+        'active_campaigns' => (int) ($r['active_campaigns'] ?? 0),
+        'losses_30d' => (int) ($r['losses_30d'] ?? 0),
+        'gains_30d' => (int) ($r['gains_30d'] ?? 0),
+    ];
+}
+
+function db_sovereignty_dashboard_metrics(): array
+{
+    $standings = db_corp_contacts_by_standing();
+    $friendlyIds = $standings['friendly_alliance_ids'];
+    $hostileIds = $standings['hostile_alliance_ids'];
+
+    $metrics = [
+        'friendly_systems_held' => 0,
+        'hostile_systems_held' => 0,
+        'friendly_under_contest' => 0,
+        'avg_friendly_adm' => null,
+        'friendly_vulnerable_now' => 0,
+        'friendly_low_adm_count' => 0,
+        'active_hostile_campaigns' => 0,
+        'ownership_changes_7d' => 0,
+        'ownership_changes_30d' => 0,
+    ];
+
+    if ($friendlyIds) {
+        $ph = implode(',', array_fill(0, count($friendlyIds), '?'));
+        $r = db_select("SELECT COUNT(*) AS cnt FROM sovereignty_map WHERE alliance_id IN ({$ph})", $friendlyIds);
+        $metrics['friendly_systems_held'] = (int) ($r[0]['cnt'] ?? 0);
+
+        $r = db_select(
+            "SELECT AVG(vulnerability_occupancy_level) AS avg_adm FROM sovereignty_structures
+             WHERE alliance_id IN ({$ph}) AND vulnerability_occupancy_level IS NOT NULL",
+            $friendlyIds
+        );
+        $metrics['avg_friendly_adm'] = $r[0]['avg_adm'] !== null ? round((float) $r[0]['avg_adm'], 1) : null;
+
+        $r = db_select(
+            "SELECT COUNT(*) AS cnt FROM sovereignty_structures
+             WHERE alliance_id IN ({$ph})
+               AND vulnerable_start_time <= UTC_TIMESTAMP()
+               AND vulnerable_end_time >= UTC_TIMESTAMP()",
+            $friendlyIds
+        );
+        $metrics['friendly_vulnerable_now'] = (int) ($r[0]['cnt'] ?? 0);
+
+        $r = db_select(
+            "SELECT COUNT(*) AS cnt FROM sovereignty_structures
+             WHERE alliance_id IN ({$ph})
+               AND vulnerability_occupancy_level IS NOT NULL
+               AND vulnerability_occupancy_level < 3.0",
+            $friendlyIds
+        );
+        $metrics['friendly_low_adm_count'] = (int) ($r[0]['cnt'] ?? 0);
+
+        $r = db_select(
+            "SELECT COUNT(*) AS cnt FROM sovereignty_campaigns
+             WHERE defender_id IN ({$ph}) AND is_active = 1",
+            $friendlyIds
+        );
+        $metrics['friendly_under_contest'] = (int) ($r[0]['cnt'] ?? 0);
+    }
+
+    if ($hostileIds) {
+        $ph = implode(',', array_fill(0, count($hostileIds), '?'));
+        $r = db_select("SELECT COUNT(*) AS cnt FROM sovereignty_map WHERE alliance_id IN ({$ph})", $hostileIds);
+        $metrics['hostile_systems_held'] = (int) ($r[0]['cnt'] ?? 0);
+
+        $r = db_select(
+            "SELECT COUNT(*) AS cnt FROM sovereignty_campaigns
+             WHERE defender_id IN ({$ph}) AND is_active = 1",
+            $hostileIds
+        );
+        $metrics['active_hostile_campaigns'] = (int) ($r[0]['cnt'] ?? 0);
+    }
+
+    $r = db_select("SELECT COUNT(*) AS cnt FROM sovereignty_map_history WHERE changed_at > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 7 DAY)");
+    $metrics['ownership_changes_7d'] = (int) ($r[0]['cnt'] ?? 0);
+
+    $r = db_select("SELECT COUNT(*) AS cnt FROM sovereignty_map_history WHERE changed_at > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 30 DAY)");
+    $metrics['ownership_changes_30d'] = (int) ($r[0]['cnt'] ?? 0);
+
+    return $metrics;
+}
+
+function db_sovereignty_alert_resolve(int $alertId): void
+{
+    $pdo = db();
+    $stmt = $pdo->prepare("UPDATE sovereignty_alerts SET status = 'resolved', resolved_at = UTC_TIMESTAMP() WHERE id = ?");
+    $stmt->execute([$alertId]);
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -380,6 +380,7 @@ function nav_items(): array
                 ['label' => 'Theater Overview', 'path' => '/theater-intelligence'],
                 ['label' => 'Theater Map', 'path' => '/theater-map'],
                 ['label' => 'Threat Corridors', 'path' => '/threat-corridors'],
+                ['label' => 'Sovereignty', 'path' => '/sovereignty'],
                 ['label' => 'Alliance Dossiers', 'path' => '/alliance-dossiers'],
                 ['label' => 'Opposition Intel', 'path' => '/opposition-intelligence'],
                 ['label' => 'Pilot Lookup', 'path' => '/battle-intelligence/pilot-lookup.php'],


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive sovereignty monitoring system for tracking EVE Online nullsec sovereignty data, including active entosis campaigns, structure ADM levels, ownership changes, and operational alerts. The system syncs data from public ESI endpoints at three different cadences and provides a web interface for battle intelligence.

## Key Changes

### Backend Infrastructure
- **New Python sync jobs** (`esi_sovereignty_sync.py`):
  - `sovereignty_campaigns_sync` (60s interval) — tracks active entosis fights
  - `sovereignty_structures_sync` (180s interval) — monitors structure ADM and vulnerability windows
  - `sovereignty_map_sync` (1800s interval) — tracks system ownership changes
  - All jobs use public ESI endpoints with optional Redis caching

- **Alert computation engine** (`compute_sovereignty_alerts.py`):
  - Generates operational alerts by cross-referencing sovereignty data with diplomatic standings
  - Alert types: friendly/hostile campaigns, ownership changes, low ADM warnings, vulnerability windows
  - Alert lifecycle management: active → stale → resolved

### Database Schema
- **8 new tables** with full history ledgers:
  - `sovereignty_map` — current system ownership snapshot
  - `sovereignty_map_history` — ownership change audit trail
  - `sovereignty_structures` — current structure state with ADM/vulnerability data
  - `sovereignty_structures_history` — structure event history
  - `sovereignty_campaigns` — active entosis campaigns
  - `sovereignty_campaigns_history` — completed campaign outcomes
  - `sovereignty_alerts` — operational alerts with severity levels
  - `ref_sov_structure_roles` — DB-driven structure type classification (Equinox-ready)

- All tables include proper indexing, timestamps, and JSON detail columns for extensibility

### Web Interface
- **Sovereignty dashboard** (`/sovereignty/`):
  - KPI metrics: friendly/hostile systems held, systems under contest, average ADM, vulnerability status
  - Active alerts panel with severity-based styling and quick-resolve actions
  - Active campaigns table with score tracking and standing indicators
  - Searchable/filterable sovereignty map with friendly/hostile/neutral filters
  - Recent campaign history

- **System detail view** (`/sovereignty/view.php`):
  - Per-system ownership and structure status
  - ADM levels with color-coded health indicators
  - Vulnerability window timers
  - Ownership and structure change history
  - Related active campaigns

### PHP Database Functions
- `db_sovereignty_alerts_active()` — fetch active alerts with system/region/alliance context
- `db_sovereignty_campaigns_active()` — list active campaigns with normalized types
- `db_sovereignty_campaigns_history()` — paginated completed campaign history
- `db_sovereignty_map_list()` — searchable/filterable sovereignty map with ADM status
- `db_sovereignty_structures_list()` — structure inventory with ADM and vulnerability data
- `db_sovereignty_dashboard_metrics()` — KPI aggregations for friendly/hostile/contested systems
- `db_sovereignty_system_detail()` — comprehensive per-system detail view
- `db_sovereignty_stats_for_alliance()` — alliance-specific sovereignty statistics

### Integration Points
- Registered three new sync jobs in `processor_registry.py`
- Added "Sovereignty Monitor" link to main navigation
- Added sovereignty widget to alliance dossier pages
- Queues entity IDs for background name resolution via existing `entity_metadata_cache`

## Implementation Details

- **Module-level role cache** in sync job for efficient structure type lookups across process lifetime
- **Ownership entity hierarchy**: alliance > corporation > faction priority for determining primary owner
- **Configurable alert thresholds**: low ADM (3.0), vulnerability window lookahead (2h), stale timeout (5m)
- **Standing-aware alerts**: friendly campaigns trigger critical severity, hostile campaigns trigger info
- **Idempotent table creation** in sync jobs with seed data for legacy structure types
- **JSON detail columns** for extensible alert/campaign metadata without schema changes
- **Dual ESI client support**: falls back to direct `EsiClient` if Redis gateway unavailable

https://claude.ai/code/session_01GJXPdBFK7ZrMMsgDDnYmdZ