### PR TITLE
Add sovereignty monitoring feature

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -17340,8 +17340,9 @@ function db_sovereignty_campaigns_active(): array
          LEFT JOIN ref_constellations rc ON rc.constellation_id = sc.constellation_id
          LEFT JOIN entity_metadata_cache emc
               ON emc.entity_type = 'alliance' AND emc.entity_id = sc.defender_id
-         LEFT JOIN ref_item_types rit ON rit.type_id = sc.structure_id
-         LEFT JOIN ref_sov_structure_roles rsr ON rsr.structure_type_id = sc.structure_id
+         LEFT JOIN sovereignty_structures sst ON sst.structure_id = sc.structure_id
+         LEFT JOIN ref_item_types rit ON rit.type_id = sst.structure_type_id
+         LEFT JOIN ref_sov_structure_roles rsr ON rsr.structure_type_id = sst.structure_type_id
          LEFT JOIN corp_contacts cc
               ON cc.contact_type = 'alliance' AND cc.contact_id = sc.defender_id
          WHERE sc.is_active = 1
@@ -17462,7 +17463,7 @@ function db_sovereignty_map_list(int $limit = 50, int $offset = 0, ?string $sear
               ON cc.contact_type = 'alliance' AND cc.contact_id = sm.alliance_id
          WHERE {$whereClause}
            AND sm.owner_entity_id IS NOT NULL
-         ORDER BY rs.region_name, rs.system_name
+         ORDER BY rr.region_name, rs.system_name
          LIMIT ? OFFSET ?",
         $params
     );


### PR DESCRIPTION
## Summary

- Adds real-time sovereignty monitoring via three public ESI endpoints (campaigns, structures, map) with Equinox-ready generic structure model
- 8 new database tables including `ref_sov_structure_roles` for DB-driven structure type classification, `sovereignty_map/structures` with full history ledgers, campaigns with delayed outcome resolution, and operational alerts
- 3 ESI sync jobs at endpoint-matched cadences (campaigns 60s, structures 180s, map 1800s) plus an alert compute job (120s)
- Sovereignty dashboard at `/sovereignty/` with KPI metrics strip, active campaign score bars, filterable sov map with ADM/vuln status, and campaign outcome history
- System detail page with structures, ADM gauges, ownership timeline, and structure history
- Alliance dossier integration showing sov stats (systems held, avg ADM, contests, losses/gains)
- Navigation entry under Battle Intelligence

## Test plan

- [ ] Run migration `20260418_sovereignty_monitoring.sql` to create tables
- [ ] Verify `sovereignty_map_sync` populates `sovereignty_map` from ESI
- [ ] Verify `sovereignty_structures_sync` populates structures with correct `structure_role` values from `ref_sov_structure_roles`
- [ ] Verify `sovereignty_campaigns_sync` captures active campaigns
- [ ] Verify `compute_sovereignty_alerts` generates alerts when standings data exists
- [ ] Load `/sovereignty/` and confirm dashboard renders with metrics, campaigns, sov map, alerts
- [ ] Click a system to verify `/sovereignty/view.php` renders detail with timeline
- [ ] Check alliance dossier page shows sovereignty section for sov-holding alliances
- [ ] Verify "Sovereignty" appears in sidebar under Battle Intelligence

https://claude.ai/code/session_01GJXPdBFK7ZrMMsgDDnYmdZ