### PR TITLE
Sovereignty: friendly-first defaults and live refresh

### DIFF
--- a/public/sovereignty/index.php
+++ b/public/sovereignty/index.php
@@ -7,19 +7,21 @@ $title = 'Sovereignty — Battle Intelligence';
 $liveRefreshConfig = supplycore_live_refresh_page_config('sovereignty');
 
 $search = isset($_GET['q']) ? trim((string) $_GET['q']) : null;
-$filter = isset($_GET['filter']) ? trim((string) $_GET['filter']) : null;
-if ($filter !== null && !in_array($filter, ['friendly', 'hostile', 'neutral'], true)) {
-    $filter = null;
+$filter = isset($_GET['filter']) ? trim((string) $_GET['filter']) : 'friendly';
+if (!in_array($filter, ['friendly', 'hostile', 'neutral', 'all'], true)) {
+    $filter = 'friendly';
 }
+$mapFilter = $filter === 'all' ? null : $filter;
+$showAllCampaigns = isset($_GET['show_all_campaigns']);
 $page = max(1, (int) ($_GET['page'] ?? 1));
 $perPage = 50;
 $offset = ($page - 1) * $perPage;
 
 $metrics = db_sovereignty_dashboard_metrics();
 $alerts = db_sovereignty_alerts_active(10);
-$activeCampaigns = db_sovereignty_campaigns_active();
-$mapRows = db_sovereignty_map_list($perPage, $offset, $search, $filter);
-$totalCount = db_sovereignty_map_count($search, $filter);
+$activeCampaigns = db_sovereignty_campaigns_active($showAllCampaigns ? null : 'friendly');
+$mapRows = db_sovereignty_map_list($perPage, $offset, $search, $mapFilter);
+$totalCount = db_sovereignty_map_count($search, $mapFilter);
 $totalPages = max(1, (int) ceil($totalCount / $perPage));
 $recentHistory = db_sovereignty_campaigns_history(15, 0);
 
@@ -95,9 +97,21 @@ include __DIR__ . '/../../src/views/partials/header.php';
 <?php endif; ?>
 
 <!-- Active Campaigns -->
-<?php if ($activeCampaigns): ?>
+<?php if ($activeCampaigns || $showAllCampaigns): ?>
 <section class="surface-primary mt-4">
-    <p class="text-xs uppercase tracking-[0.16em] text-muted mb-3">Active Campaigns</p>
+    <div class="flex items-center justify-between mb-3">
+        <p class="text-xs uppercase tracking-[0.16em] text-muted">Active Campaigns<?php if (!$showAllCampaigns): ?> <span class="text-slate-500">(Friendly only)</span><?php endif; ?></p>
+        <?php
+            $campaignToggleParams = $_GET;
+            if ($showAllCampaigns) {
+                unset($campaignToggleParams['show_all_campaigns']);
+            } else {
+                $campaignToggleParams['show_all_campaigns'] = '1';
+            }
+            $campaignToggleHref = '/sovereignty/?' . http_build_query($campaignToggleParams);
+        ?>
+        <a href="<?= htmlspecialchars($campaignToggleHref) ?>" class="btn-secondary text-xs"><?= $showAllCampaigns ? 'Friendly Only' : 'Show All' ?></a>
+    </div>
     <div class="table-shell">
         <table class="table-ui">
             <thead>
@@ -155,11 +169,12 @@ include __DIR__ . '/../../src/views/partials/header.php';
         <p class="text-xs uppercase tracking-[0.16em] text-muted">Sovereignty Map</p>
         <div class="flex gap-1.5 items-center">
             <?php
-            $filters = [null => 'All', 'friendly' => 'Friendly', 'hostile' => 'Hostile', 'neutral' => 'Neutral'];
+            $filters = ['friendly' => 'Friendly', 'hostile' => 'Hostile', 'neutral' => 'Neutral', 'all' => 'All'];
             foreach ($filters as $fVal => $fLabel):
-                $isActive = ($filter ?? '') === ($fVal ?? '');
+                $isActive = $filter === $fVal;
                 $cls = $isActive ? 'btn-primary text-xs' : 'btn-secondary text-xs';
-                $href = '/sovereignty/?' . http_build_query(array_filter(['filter' => $fVal, 'q' => $search]));
+                $toggleParams = array_filter(['filter' => $fVal, 'q' => $search, 'show_all_campaigns' => $showAllCampaigns ? '1' : null]);
+                $href = '/sovereignty/?' . http_build_query($toggleParams);
             ?>
                 <a href="<?= htmlspecialchars($href) ?>" class="<?= $cls ?>"><?= $fLabel ?></a>
             <?php endforeach; ?>
@@ -175,7 +190,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
         </div>
         <button type="submit" class="btn-secondary h-fit text-sm">Search</button>
         <?php if ($search !== null): ?>
-            <a href="/sovereignty/<?= $filter ? '?filter=' . $filter : '' ?>" class="text-sm text-accent">Clear</a>
+            <a href="/sovereignty/?<?= http_build_query(array_filter(['filter' => $filter, 'show_all_campaigns' => $showAllCampaigns ? '1' : null])) ?>" class="text-sm text-accent">Clear</a>
         <?php endif; ?>
     </form>
 
@@ -240,10 +255,10 @@ include __DIR__ . '/../../src/views/partials/header.php';
             <span>Page <?= $page ?> of <?= $totalPages ?> (<?= number_format($totalCount) ?> systems)</span>
             <div class="flex gap-2">
                 <?php if ($page > 1): ?>
-                    <a href="?<?= http_build_query(array_filter(['page' => $page - 1, 'q' => $search, 'filter' => $filter])) ?>" class="btn-secondary text-xs">Previous</a>
+                    <a href="?<?= http_build_query(array_filter(['page' => $page - 1, 'q' => $search, 'filter' => $filter, 'show_all_campaigns' => $showAllCampaigns ? '1' : null])) ?>" class="btn-secondary text-xs">Previous</a>
                 <?php endif; ?>
                 <?php if ($page < $totalPages): ?>
-                    <a href="?<?= http_build_query(array_filter(['page' => $page + 1, 'q' => $search, 'filter' => $filter])) ?>" class="btn-secondary text-xs">Next</a>
+                    <a href="?<?= http_build_query(array_filter(['page' => $page + 1, 'q' => $search, 'filter' => $filter, 'show_all_campaigns' => $showAllCampaigns ? '1' : null])) ?>" class="btn-secondary text-xs">Next</a>
                 <?php endif; ?>
             </div>
         </div>

--- a/src/db.php
+++ b/src/db.php
@@ -17332,8 +17332,23 @@ function db_sovereignty_alerts_count(): int
     return (int) ($rows[0]['cnt'] ?? 0);
 }
 
-function db_sovereignty_campaigns_active(): array
+function db_sovereignty_campaigns_active(?string $standingFilter = null): array
 {
+    $where = 'sc.is_active = 1';
+    $params = [];
+
+    if ($standingFilter === 'friendly') {
+        $standings = db_corp_contacts_by_standing();
+        $ids = $standings['friendly_alliance_ids'];
+        if ($ids) {
+            $ph = implode(',', array_fill(0, count($ids), '?'));
+            $where .= " AND sc.defender_id IN ({$ph})";
+            $params = array_merge($params, $ids);
+        } else {
+            $where .= ' AND 0';
+        }
+    }
+
     return db_select(
         "SELECT sc.*,
                 rs.system_name,
@@ -17363,9 +17378,10 @@ function db_sovereignty_campaigns_active(): array
          LEFT JOIN ref_sov_structure_roles rsr ON rsr.structure_type_id = sst.structure_type_id
          LEFT JOIN corp_contacts cc
               ON cc.contact_type = 'alliance' AND cc.contact_id = sc.defender_id
-         WHERE sc.is_active = 1
+         WHERE {$where}
          ORDER BY CASE WHEN cc.standing > 0 THEN 0 WHEN cc.standing < 0 THEN 2 ELSE 1 END,
-                  sc.start_time ASC"
+                  sc.start_time ASC",
+        $params
     );
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -19950,6 +19950,18 @@ function supplycore_ui_refresh_section_version_definitions(): array
                 ];
             },
         ],
+        'sovereignty_version' => [
+            'domains' => ['sovereignty'],
+            'ui_sections' => ['sovereignty-alerts', 'sovereignty-campaigns', 'sovereignty-map'],
+            'resolver' => static function (): array {
+                return supplycore_ui_refresh_version_from_sync_state(
+                    'sovereignty_version',
+                    ['sovereignty.campaigns', 'sovereignty.structures', 'sovereignty.map', 'sovereignty.alerts'],
+                    ['sovereignty'],
+                    ['sovereignty-alerts', 'sovereignty-campaigns', 'sovereignty-map']
+                );
+            },
+        ],
     ];
 }
 
@@ -20005,6 +20017,26 @@ function supplycore_ui_refresh_job_domain_map(): array
             'domains' => ['dashboard', 'deal_alerts'],
             'ui_sections' => ['dashboard-queues', 'deal-alerts-summary', 'deal-alerts-status', 'deal-alerts-table'],
             'version_keys' => ['dashboard_summary_version', 'deal_alerts_version'],
+        ],
+        'sovereignty_campaigns_sync' => [
+            'domains' => ['sovereignty'],
+            'ui_sections' => ['sovereignty-alerts', 'sovereignty-campaigns'],
+            'version_keys' => ['sovereignty_version'],
+        ],
+        'sovereignty_structures_sync' => [
+            'domains' => ['sovereignty'],
+            'ui_sections' => ['sovereignty-map'],
+            'version_keys' => ['sovereignty_version'],
+        ],
+        'sovereignty_map_sync' => [
+            'domains' => ['sovereignty'],
+            'ui_sections' => ['sovereignty-map'],
+            'version_keys' => ['sovereignty_version'],
+        ],
+        'compute_sovereignty_alerts' => [
+            'domains' => ['sovereignty'],
+            'ui_sections' => ['sovereignty-alerts'],
+            'version_keys' => ['sovereignty_version'],
         ],
     ];
 }
@@ -20403,6 +20435,18 @@ function supplycore_live_refresh_page_registry(): array
                 'killmail-overview-summary' => ['version_keys' => ['killmail_overview_version']],
                 'killmail-overview-status' => ['version_keys' => ['killmail_overview_version']],
                 'killmail-overview-table' => ['version_keys' => ['killmail_overview_version']],
+            ],
+        ],
+        'sovereignty' => [
+            'path' => '/sovereignty/index.php',
+            'public_path' => '/sovereignty',
+            'script' => dirname(__DIR__) . '/public/sovereignty/index.php',
+            'domains' => ['sovereignty'],
+            'version_keys' => ['sovereignty_version'],
+            'sections' => [
+                'sovereignty-alerts' => ['version_keys' => ['sovereignty_version']],
+                'sovereignty-campaigns' => ['version_keys' => ['sovereignty_version']],
+                'sovereignty-map' => ['version_keys' => ['sovereignty_version']],
             ],
         ],
         'log_viewer' => [


### PR DESCRIPTION
## Summary

- Default sovereignty page to show **friendly systems first** in the sov map (was showing all ~8000 systems)
- Default active campaigns to **friendly-only** — hostile/neutral campaigns hidden by default with a **"Show All"** toggle button
- Filter tab order changed to Friendly > Hostile > Neutral > All (friendly is the default active tab)
- All query parameters (filter, search, show_all_campaigns) preserved across pagination and filter changes
- **Live refresh enabled** — sovereignty page now auto-updates via SSE when sovereignty sync jobs complete:
  - Registered in `supplycore_live_refresh_page_registry()` with sovereignty domain
  - Added `sovereignty_version` to section version definitions, resolved from `sovereignty.campaigns/structures/map/alerts` sync_state entries
  - Added all 4 sovereignty jobs to `supplycore_ui_refresh_job_domain_map()` so job completions trigger UI refresh events

## Test plan

- [ ] Navigate to `/sovereignty/` — verify sov map defaults to Friendly tab (not All)
- [ ] Verify campaigns table shows only friendly campaigns by default
- [ ] Click "Show All" on campaigns — verify hostile/neutral campaigns appear
- [ ] Click "Friendly Only" — verify it goes back to friendly-only
- [ ] Switch between filter tabs (Friendly/Hostile/Neutral/All) — verify pagination and search state preserved
- [ ] Verify Live Refresh toggle appears and can be enabled
- [ ] Enable live refresh, wait for a sovereignty sync to complete — verify page data updates automatically

https://claude.ai/code/session_01GJXPdBFK7ZrMMsgDDnYmdZ