### PR TITLE
Fix lane services crash-looping on startup

### DIFF
--- a/ops/systemd/supplycore-lane-compute.service
+++ b/ops/systemd/supplycore-lane-compute.service
@@ -17,8 +17,8 @@ RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
 MemoryMax=3G
-StandardOutput=append:/var/www/SupplyCore/storage/logs/lane-compute.log
-StandardError=append:/var/www/SupplyCore/storage/logs/lane-compute.log
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/ops/systemd/supplycore-lane-ingestion.service
+++ b/ops/systemd/supplycore-lane-ingestion.service
@@ -16,8 +16,8 @@ RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
 MemoryMax=1G
-StandardOutput=append:/var/www/SupplyCore/storage/logs/lane-ingestion.log
-StandardError=append:/var/www/SupplyCore/storage/logs/lane-ingestion.log
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/ops/systemd/supplycore-lane-maintenance.service
+++ b/ops/systemd/supplycore-lane-maintenance.service
@@ -17,8 +17,8 @@ RestartSec=10
 KillSignal=SIGTERM
 TimeoutStopSec=90
 MemoryMax=512M
-StandardOutput=append:/var/www/SupplyCore/storage/logs/lane-maintenance.log
-StandardError=append:/var/www/SupplyCore/storage/logs/lane-maintenance.log
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/ops/systemd/supplycore-lane-realtime.service
+++ b/ops/systemd/supplycore-lane-realtime.service
@@ -16,8 +16,8 @@ RestartSec=3
 KillSignal=SIGTERM
 TimeoutStopSec=90
 MemoryMax=2G
-StandardOutput=append:/var/www/SupplyCore/storage/logs/lane-realtime.log
-StandardError=append:/var/www/SupplyCore/storage/logs/lane-realtime.log
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/ops/systemd/supplycore-loop-runner.service
+++ b/ops/systemd/supplycore-loop-runner.service
@@ -16,8 +16,8 @@ RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
 MemoryMax=4G
-StandardOutput=append:/var/www/SupplyCore/storage/logs/worker.log
-StandardError=append:/var/www/SupplyCore/storage/logs/worker.log
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/python/orchestrator/logging_utils.py
+++ b/python/orchestrator/logging_utils.py
@@ -64,10 +64,15 @@ def configure_logging(
             should_attach_file_handler = True
 
         if should_attach_file_handler:
-            log_file.parent.mkdir(parents=True, exist_ok=True)
-            file_handler = logging.FileHandler(log_file, encoding="utf-8")
-            file_handler.setFormatter(JsonFormatter())
-            logger.addHandler(file_handler)
+            try:
+                log_file.parent.mkdir(parents=True, exist_ok=True)
+                file_handler = logging.FileHandler(log_file, encoding="utf-8")
+                file_handler.setFormatter(JsonFormatter())
+                logger.addHandler(file_handler)
+            except PermissionError:
+                # Fall back gracefully — stdout handler is already attached,
+                # so logs still reach journalctl / systemd output.
+                pass
 
     logger.propagate = False
     return LoggerAdapter(logger, {})

--- a/python/orchestrator/loop_runner.py
+++ b/python/orchestrator/loop_runner.py
@@ -476,8 +476,11 @@ def _run_loop(
 # ---------------------------------------------------------------------------
 
 def _write_state_file(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json_dumps_safe(payload, indent=2) + "\n", encoding="utf-8")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json_dumps_safe(payload, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        pass  # best-effort; don't crash the runner over a heartbeat file
 
 
 # ---------------------------------------------------------------------------
@@ -535,6 +538,11 @@ def main(argv: list[str] | None = None) -> int:
     worker_settings = dict(raw_config.get("workers") or {})
 
     log_file = Path(worker_settings.get("worker_log_file", app_root / "storage/logs/worker.log"))
+    # When running in lane mode, use a per-lane log file so multiple
+    # lane processes don't interleave writes in the same file.
+    lane = args.lane or ""
+    if lane:
+        log_file = log_file.with_name(f"lane-{lane}.log")
     logger = configure_logging(verbose=args.verbose, log_file=log_file)
     worker_id = f"loop-{socket.gethostname()}-{os.getpid()}"
 
@@ -560,12 +568,14 @@ def main(argv: list[str] | None = None) -> int:
             )
         return 1
 
-    lane = args.lane or ""
     if lane and lane not in _VALID_LANES:
         logger.error(f"unknown lane '{lane}', valid lanes: {sorted(_VALID_LANES)}")
         return 1
 
     state_file = Path(worker_settings.get("pool_state_file", app_root / "storage/run/loop-runner-heartbeat.json"))
+    # Per-lane state file so multiple lane processes don't overwrite each other.
+    if lane:
+        state_file = state_file.with_name(f"lane-{lane}-heartbeat.json")
 
     shutdown_event = threading.Event()
 


### PR DESCRIPTION
## Summary

All 4 lane services crash-loop with exit code 1 (restart counter 500+) because:

1. **PermissionError kills startup** — Python logger opens `storage/logs/worker.log` (owned by `root:root`, mode 644) as `www-data` → `PermissionError` → `bin/python_orchestrator.py` catches it → returns 1
2. **All 4 lanes shared the same log file** (`worker.log`) and heartbeat state file
3. **Errors invisible** — `StandardOutput=append:lane-*.log` swallowed output into root-owned files; `journalctl` showed only systemd restart messages

## Fixes

- **Per-lane Python log files**: `--lane realtime` writes to `lane-realtime.log` not `worker.log`
- **Per-lane heartbeat state files**: `lane-realtime-heartbeat.json` etc.
- **PermissionError resilience**: `FileHandler` creation caught gracefully — falls back to stdout
- **State file writes**: wrapped in `try/except OSError` — best-effort, won't crash
- **StandardOutput=journal** on all 5 service files — errors visible in `journalctl`

## After deploying

Fix existing file ownership:
```bash
sudo chown www-data:www-data storage/logs/lane-*.log storage/logs/worker.log
sudo chown www-data:www-data storage/run/*.json
sudo systemctl daemon-reload
sudo systemctl restart supplycore-lane-{realtime,ingestion,compute,maintenance}.service
```

## Test plan

- [ ] `journalctl -u supplycore-lane-realtime.service -n 20` shows Python log output (not blank)
- [ ] `ls -la storage/logs/lane-*.log` — per-lane files owned by www-data
- [ ] `ls -la storage/run/lane-*-heartbeat.json` — per-lane state files
- [ ] All 4 lane services stay running (no crash-loop)
- [ ] Log viewer shows jobs executing

https://claude.ai/code/session_01JJJPg2amuG6XyRztbPSL56