### PR TITLE
Add manual theater creation feature

### DIFF
--- a/public/theater-intelligence/create.php
+++ b/public/theater-intelligence/create.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Battle Intelligence — Create Manual Theater';
+
+$error = null;
+$success = null;
+$formSystem = trim((string) ($_POST['system_name'] ?? $_GET['system_name'] ?? ''));
+$formStart = trim((string) ($_POST['start_time'] ?? $_GET['start_time'] ?? ''));
+$formEnd = trim((string) ($_POST['end_time'] ?? $_GET['end_time'] ?? ''));
+$formLabel = trim((string) ($_POST['label'] ?? ''));
+$formConstellation = isset($_POST['include_constellation']) && $_POST['include_constellation'] === '1';
+$previewBattles = [];
+$isPreview = isset($_POST['preview']);
+$isCreate = isset($_POST['create']);
+
+// ── Resolve system ──────────────────────────────────────────────────────────
+$resolvedSystem = null;
+if ($formSystem !== '') {
+    $candidates = db_ref_system_search($formSystem, 5);
+    // Prefer exact match
+    foreach ($candidates as $c) {
+        if (strcasecmp((string) $c['system_name'], $formSystem) === 0) {
+            $resolvedSystem = $c;
+            break;
+        }
+    }
+    if ($resolvedSystem === null && $candidates !== []) {
+        $resolvedSystem = $candidates[0];
+    }
+}
+
+// ── Preview or Create ───────────────────────────────────────────────────────
+if (($isPreview || $isCreate) && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($resolvedSystem === null) {
+        $error = 'System not found. Please enter a valid system name.';
+    } elseif ($formStart === '' || $formEnd === '') {
+        $error = 'Start time and end time are required.';
+    } elseif (strtotime($formStart) === false || strtotime($formEnd) === false) {
+        $error = 'Invalid date/time format. Use YYYY-MM-DD HH:MM format.';
+    } elseif (strtotime($formEnd) <= strtotime($formStart)) {
+        $error = 'End time must be after start time.';
+    } else {
+        $startFormatted = date('Y-m-d H:i:s', strtotime($formStart));
+        $endFormatted = date('Y-m-d H:i:s', strtotime($formEnd));
+        $previewBattles = db_battles_in_range(
+            (int) $resolvedSystem['system_id'],
+            $startFormatted,
+            $endFormatted,
+            $formConstellation
+        );
+
+        if ($previewBattles === []) {
+            $error = 'No battles found in ' . htmlspecialchars((string) $resolvedSystem['system_name'], ENT_QUOTES)
+                   . ($formConstellation ? ' (constellation)' : '')
+                   . ' between ' . $startFormatted . ' and ' . $endFormatted . '.';
+        } elseif ($isCreate) {
+            $theaterId = db_create_manual_theater($previewBattles, $formLabel !== '' ? $formLabel : null);
+            if ($theaterId !== null) {
+                flash('success', 'Manual theater created with ' . count($previewBattles) . ' battles.');
+                header('Location: /theater-intelligence/view.php?theater_id=' . urlencode($theaterId));
+                exit;
+            }
+            $error = 'Failed to create theater. Please try again.';
+        }
+    }
+}
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+
+<section class="surface-primary">
+    <div class="flex items-center justify-between gap-4">
+        <div>
+            <p class="text-xs uppercase tracking-[0.16em] text-muted">Battle Intelligence</p>
+            <h1 class="mt-1 text-2xl font-semibold text-slate-50">Create Manual Theater</h1>
+            <p class="mt-2 text-sm text-muted">Manually group battles into a theater by specifying a system, time range, and optional label. Useful for extended fights that span multiple auto-clustering windows.</p>
+        </div>
+        <div class="flex gap-2">
+            <a href="/theater-intelligence" class="btn-secondary">Back to Theaters</a>
+        </div>
+    </div>
+</section>
+
+<?php if ($error !== null): ?>
+    <section class="surface-primary mt-4">
+        <div class="rounded border border-red-700/50 bg-red-900/20 px-4 py-3 text-sm text-red-300"><?= htmlspecialchars($error, ENT_QUOTES) ?></div>
+    </section>
+<?php endif; ?>
+
+<section class="surface-primary mt-4">
+    <form method="POST" class="space-y-4">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="text-xs text-muted block mb-1">System Name</label>
+                <input type="text" name="system_name" required
+                       value="<?= htmlspecialchars($formSystem, ENT_QUOTES) ?>"
+                       placeholder="e.g. X47L-Q"
+                       class="w-full rounded bg-slate-800 border border-border px-3 py-2 text-sm text-slate-100 placeholder-slate-500">
+                <?php if ($resolvedSystem !== null && ($isPreview || $isCreate)): ?>
+                    <p class="text-[11px] text-green-400 mt-1">
+                        Matched: <?= htmlspecialchars((string) $resolvedSystem['system_name'], ENT_QUOTES) ?>
+                        <span class="text-muted">(<?= htmlspecialchars((string) ($resolvedSystem['constellation_name'] ?? ''), ENT_QUOTES) ?>, <?= htmlspecialchars((string) ($resolvedSystem['region_name'] ?? ''), ENT_QUOTES) ?>)</span>
+                    </p>
+                <?php endif; ?>
+            </div>
+            <div>
+                <label class="text-xs text-muted block mb-1">Label <span class="text-slate-500">(optional)</span></label>
+                <input type="text" name="label"
+                       value="<?= htmlspecialchars($formLabel, ENT_QUOTES) ?>"
+                       placeholder="e.g. The Big One - 12h Siege"
+                       class="w-full rounded bg-slate-800 border border-border px-3 py-2 text-sm text-slate-100 placeholder-slate-500">
+            </div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="text-xs text-muted block mb-1">Start Time <span class="text-slate-500">(EVE time)</span></label>
+                <input type="datetime-local" name="start_time" required
+                       value="<?= htmlspecialchars($formStart, ENT_QUOTES) ?>"
+                       class="w-full rounded bg-slate-800 border border-border px-3 py-2 text-sm text-slate-100">
+            </div>
+            <div>
+                <label class="text-xs text-muted block mb-1">End Time <span class="text-slate-500">(EVE time)</span></label>
+                <input type="datetime-local" name="end_time" required
+                       value="<?= htmlspecialchars($formEnd, ENT_QUOTES) ?>"
+                       class="w-full rounded bg-slate-800 border border-border px-3 py-2 text-sm text-slate-100">
+            </div>
+        </div>
+        <div class="flex items-center gap-2">
+            <input type="checkbox" name="include_constellation" value="1" id="include_constellation"
+                   <?= $formConstellation ? 'checked' : '' ?>
+                   class="rounded bg-slate-800 border-border text-accent">
+            <label for="include_constellation" class="text-sm text-slate-300">Include entire constellation</label>
+            <span class="text-[11px] text-muted">(captures fights that spilled into adjacent systems)</span>
+        </div>
+        <div class="flex gap-2 pt-2">
+            <button type="submit" name="preview" value="1" class="btn-secondary">Preview Battles</button>
+            <?php if ($previewBattles !== []): ?>
+                <button type="submit" name="create" value="1" class="btn-primary">Create Theater (<?= count($previewBattles) ?> battles)</button>
+            <?php endif; ?>
+        </div>
+    </form>
+</section>
+
+<?php if ($previewBattles !== []): ?>
+<section class="surface-primary mt-4">
+    <h2 class="text-lg font-semibold text-slate-50 mb-3">Preview: <?= count($previewBattles) ?> Battles Found</h2>
+    <?php
+        $previewTotalParticipants = array_sum(array_column($previewBattles, 'participant_count'));
+        $previewStart = min(array_column($previewBattles, 'started_at'));
+        $previewEnd = max(array_column($previewBattles, 'ended_at'));
+        $previewDuration = max(1, (int) (strtotime($previewEnd) - strtotime($previewStart)));
+        $previewDurationLabel = $previewDuration >= 3600 ? number_format($previewDuration / 3600, 1) . 'h' : number_format($previewDuration / 60, 0) . 'm';
+        $previewSystems = array_unique(array_column($previewBattles, 'system_name'));
+    ?>
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+        <div class="rounded bg-slate-800/50 border border-border/50 px-3 py-2">
+            <p class="text-[10px] uppercase tracking-wider text-muted">Battles</p>
+            <p class="text-lg font-semibold text-slate-100"><?= count($previewBattles) ?></p>
+        </div>
+        <div class="rounded bg-slate-800/50 border border-border/50 px-3 py-2">
+            <p class="text-[10px] uppercase tracking-wider text-muted">Total Participants</p>
+            <p class="text-lg font-semibold text-slate-100"><?= number_format($previewTotalParticipants) ?></p>
+        </div>
+        <div class="rounded bg-slate-800/50 border border-border/50 px-3 py-2">
+            <p class="text-[10px] uppercase tracking-wider text-muted">Duration</p>
+            <p class="text-lg font-semibold text-slate-100"><?= $previewDurationLabel ?></p>
+        </div>
+        <div class="rounded bg-slate-800/50 border border-border/50 px-3 py-2">
+            <p class="text-[10px] uppercase tracking-wider text-muted">Systems</p>
+            <p class="text-lg font-semibold text-slate-100"><?= count($previewSystems) ?></p>
+            <p class="text-[10px] text-muted"><?= htmlspecialchars(implode(', ', $previewSystems), ENT_QUOTES) ?></p>
+        </div>
+    </div>
+
+    <div class="table-shell">
+        <table class="table-ui">
+            <thead>
+                <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                    <th class="px-3 py-2 text-left">System</th>
+                    <th class="px-3 py-2 text-left">Started</th>
+                    <th class="px-3 py-2 text-left">Ended</th>
+                    <th class="px-3 py-2 text-right">Participants</th>
+                    <th class="px-3 py-2 text-left">Size</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($previewBattles as $b): ?>
+                    <tr class="border-b border-border/50">
+                        <td class="px-3 py-2 text-sm text-slate-100"><?= htmlspecialchars((string) ($b['system_name'] ?? '-'), ENT_QUOTES) ?></td>
+                        <td class="px-3 py-2 text-sm text-slate-300"><?= htmlspecialchars((string) ($b['started_at'] ?? ''), ENT_QUOTES) ?></td>
+                        <td class="px-3 py-2 text-sm text-slate-300"><?= htmlspecialchars((string) ($b['ended_at'] ?? ''), ENT_QUOTES) ?></td>
+                        <td class="px-3 py-2 text-sm text-slate-100 text-right"><?= number_format((int) ($b['participant_count'] ?? 0)) ?></td>
+                        <td class="px-3 py-2 text-sm text-slate-400"><?= htmlspecialchars((string) ($b['battle_size_class'] ?? '-'), ENT_QUOTES) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</section>
+<?php endif; ?>
+
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/theater-intelligence/index.php
+++ b/public/theater-intelligence/index.php
@@ -50,6 +50,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
             <p class="mt-2 text-sm text-muted">Battles grouped into strategic theaters by system proximity, time window, and participant overlap. Each theater shows the primary matchup and outcome assessment.</p>
         </div>
         <div class="flex gap-2">
+            <a href="/theater-intelligence/create.php" class="btn-primary">Create Manual Theater</a>
             <a href="/battle-intelligence" class="btn-secondary">Suspicion Board</a>
             <a href="/battle-intelligence/battles.php" class="btn-secondary">Battle Anomalies</a>
         </div>

--- a/src/db.php
+++ b/src/db.php
@@ -15835,6 +15835,185 @@ function db_theater_map_regions(): array
 }
 
 // ---------------------------------------------------------------------------
+// Manual Theater Creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Search ref_systems by name (exact or LIKE).
+ */
+function db_ref_system_search(string $query, int $limit = 20): array
+{
+    return db_select(
+        'SELECT rs.system_id, rs.system_name, rs.constellation_id, rs.region_id,
+                rr.region_name, rc.constellation_name
+         FROM ref_systems rs
+         LEFT JOIN ref_regions rr ON rr.region_id = rs.region_id
+         LEFT JOIN ref_constellations rc ON rc.constellation_id = rs.constellation_id
+         WHERE rs.system_name LIKE ?
+         ORDER BY
+            CASE WHEN rs.system_name = ? THEN 0 ELSE 1 END,
+            rs.system_name ASC
+         LIMIT ?',
+        ['%' . $query . '%', $query, $limit]
+    );
+}
+
+/**
+ * Find battles in a system (or all systems in the same constellation) within a time range.
+ */
+function db_battles_in_range(int $systemId, string $startTime, string $endTime, bool $includeConstellation = false): array
+{
+    if ($includeConstellation) {
+        return db_select(
+            'SELECT br.battle_id, br.system_id, br.started_at, br.ended_at,
+                    br.participant_count, br.battle_size_class,
+                    rs.system_name, rs.region_id
+             FROM battle_rollups br
+             INNER JOIN ref_systems rs ON rs.system_id = br.system_id
+             WHERE rs.constellation_id = (SELECT constellation_id FROM ref_systems WHERE system_id = ? LIMIT 1)
+               AND br.started_at <= ?
+               AND br.ended_at   >= ?
+             ORDER BY br.started_at ASC',
+            [$systemId, $endTime, $startTime]
+        );
+    }
+
+    return db_select(
+        'SELECT br.battle_id, br.system_id, br.started_at, br.ended_at,
+                br.participant_count, br.battle_size_class,
+                rs.system_name, rs.region_id
+         FROM battle_rollups br
+         INNER JOIN ref_systems rs ON rs.system_id = br.system_id
+         WHERE br.system_id = ?
+           AND br.started_at <= ?
+           AND br.ended_at   >= ?
+         ORDER BY br.started_at ASC',
+        [$systemId, $endTime, $startTime]
+    );
+}
+
+/**
+ * Create a manual theater from a set of battles.
+ * Returns the theater_id on success, null on failure.
+ */
+function db_create_manual_theater(array $battles, ?string $label = null): ?string
+{
+    if ($battles === []) {
+        return null;
+    }
+
+    // Deterministic theater_id from sorted battle IDs (mirrors Python _compute_theater_id)
+    $battleIds = array_map(fn(array $b): string => (string) $b['battle_id'], $battles);
+    sort($battleIds);
+    $theaterId = hash('sha256', implode('|', $battleIds));
+
+    // Check if this exact theater already exists
+    $existing = db_select_one('SELECT theater_id FROM theaters WHERE theater_id = ?', [$theaterId]);
+    if ($existing !== null) {
+        return $theaterId; // already exists with same battles
+    }
+
+    // Compute aggregates
+    $startTimes = array_map(fn(array $b): string => (string) $b['started_at'], $battles);
+    $endTimes = array_map(fn(array $b): string => (string) $b['ended_at'], $battles);
+    sort($startTimes);
+    rsort($endTimes);
+    $startTime = $startTimes[0];
+    $endTime = $endTimes[0];
+    $durationSeconds = max(1, (int) (strtotime($endTime) - strtotime($startTime)));
+
+    // Systems
+    $systems = [];
+    foreach ($battles as $b) {
+        $sid = (int) $b['system_id'];
+        if (!isset($systems[$sid])) {
+            $systems[$sid] = [
+                'system_id' => $sid,
+                'system_name' => (string) ($b['system_name'] ?? ''),
+                'kill_count' => 0,
+                'participant_count' => 0,
+            ];
+        }
+        $systems[$sid]['kill_count'] += (int) ($b['participant_count'] ?? 0);
+        $systems[$sid]['participant_count'] += (int) ($b['participant_count'] ?? 0);
+    }
+
+    // Primary system = most participants
+    $primarySystem = null;
+    $primaryRegionId = null;
+    foreach ($systems as $s) {
+        if ($primarySystem === null || $s['participant_count'] > $primarySystem['participant_count']) {
+            $primarySystem = $s;
+        }
+    }
+    if ($primarySystem !== null) {
+        // Get region from the first battle matching primary system
+        foreach ($battles as $b) {
+            if ((int) $b['system_id'] === $primarySystem['system_id'] && !empty($b['region_id'])) {
+                $primaryRegionId = (int) $b['region_id'];
+                break;
+            }
+        }
+    }
+
+    // Count unique participants across all battles
+    $participantRows = db_select(
+        'SELECT COUNT(DISTINCT character_id) AS cnt
+         FROM battle_participants
+         WHERE battle_id IN (' . implode(',', array_fill(0, count($battleIds), '?')) . ')',
+        $battleIds
+    );
+    $participantCount = (int) ($participantRows[0]['cnt'] ?? 0);
+
+    $now = date('Y-m-d H:i:s');
+
+    // Insert theater
+    db_execute(
+        'INSERT INTO theaters (
+            theater_id, label, primary_system_id, region_id,
+            start_time, end_time, duration_seconds,
+            battle_count, system_count, total_kills, total_isk,
+            participant_count, anomaly_score,
+            clustering_method, computed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?, 0, ?, ?)',
+        [
+            $theaterId,
+            $label,
+            $primarySystem['system_id'] ?? null,
+            $primaryRegionId,
+            $startTime,
+            $endTime,
+            $durationSeconds,
+            count($battles),
+            count($systems),
+            $participantCount,
+            'manual',
+            $now,
+        ]
+    );
+
+    // Insert theater_battles
+    foreach ($battles as $b) {
+        db_execute(
+            'INSERT IGNORE INTO theater_battles (theater_id, battle_id, system_id, weight, phase)
+             VALUES (?, ?, ?, 1.0000, NULL)',
+            [$theaterId, (string) $b['battle_id'], (int) $b['system_id']]
+        );
+    }
+
+    // Insert theater_systems
+    foreach ($systems as $s) {
+        db_execute(
+            'INSERT IGNORE INTO theater_systems (theater_id, system_id, system_name, kill_count, isk_destroyed, participant_count, weight, phase)
+             VALUES (?, ?, ?, ?, 0, ?, 1.0000, NULL)',
+            [$theaterId, $s['system_id'], $s['system_name'], $s['kill_count'], $s['participant_count']]
+        );
+    }
+
+    return $theaterId;
+}
+
+// ---------------------------------------------------------------------------
 // Threat Corridors
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Adds a new manual theater creation interface that allows users to group battles into a theater by specifying a system, time range, and optional label. This is useful for extended fights that span multiple auto-clustering windows.

## Key Changes
- **New page**: `public/theater-intelligence/create.php` - Form-based interface for creating manual theaters with:
  - System name search with fuzzy matching and exact match preference
  - Start/end time inputs with validation
  - Optional constellation-wide battle inclusion
  - Preview of matched battles before creation
  - Summary statistics (battle count, participants, duration, systems involved)
  
- **Database functions** in `src/db.php`:
  - `db_ref_system_search()` - Search reference systems by name with exact match prioritization
  - `db_battles_in_range()` - Query battles within a time range for a specific system or entire constellation
  - `db_create_manual_theater()` - Create a manual theater from a set of battles, computing:
    - Deterministic theater ID from sorted battle IDs
    - Aggregated metrics (duration, participant count, systems involved)
    - Primary system determination (most participants)
    - Insertion into `theaters`, `theater_battles`, and `theater_systems` tables

- **UI enhancement**: Added "Create Manual Theater" button to `public/theater-intelligence/index.php`

## Implementation Details
- Theater ID is deterministically computed from sorted battle IDs (mirrors Python implementation)
- Duplicate theater detection prevents re-creation of identical groupings
- Form supports both preview and create workflows with validation at each step
- Constellation-wide search captures battles that spilled into adjacent systems
- Comprehensive error handling for invalid systems, time ranges, and empty result sets
- Responsive grid layout with battle preview table showing system, timestamps, participants, and battle size

https://claude.ai/code/session_01Qg9kHao7jb4j3xSraMgWSv