### PR TITLE
Async theater lock with EVE lore loading screen

### DIFF
--- a/public/theater-intelligence/lock-status.php
+++ b/public/theater-intelligence/lock-status.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Poll endpoint: returns the lock status of a theater.
+ * Used by the loading screen to know when processing is done.
+ */
+
+declare(strict_types=1);
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+header('Cache-Control: no-store');
+
+$theaterId = trim((string) ($_GET['theater_id'] ?? ''));
+if ($theaterId === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing theater_id']);
+    exit;
+}
+
+$theater = db_select_one(
+    'SELECT theater_id, locked_at, snapshot_data IS NOT NULL AS has_snapshot FROM theaters WHERE theater_id = ?',
+    [$theaterId]
+);
+
+if ($theater === null) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Theater not found']);
+    exit;
+}
+
+$lockedAt = $theater['locked_at'] ?? null;
+$hasSnapshot = (bool) ($theater['has_snapshot'] ?? false);
+
+if ($lockedAt === null) {
+    // Not locked yet (or lock was rolled back due to error)
+    echo json_encode(['status' => 'unlocked']);
+} elseif ($lockedAt === '1970-01-01 00:00:01') {
+    // Sentinel: lock in progress
+    echo json_encode(['status' => 'processing']);
+} elseif ($hasSnapshot) {
+    // Fully done: locked + snapshot saved
+    echo json_encode(['status' => 'complete']);
+} else {
+    // Locked but snapshot not yet saved (AI generation still running)
+    echo json_encode(['status' => 'processing']);
+}

--- a/public/theater-intelligence/lock.php
+++ b/public/theater-intelligence/lock.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Async lock endpoint: starts finalize + AI generation in the background.
+ * Returns immediately with JSON so the browser doesn't timeout.
+ *
+ * Uses the connection-close pattern: sends a response to the client,
+ * then continues processing in the background.
+ */
+
+declare(strict_types=1);
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+header('Cache-Control: no-store');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'POST required']);
+    exit;
+}
+
+$theaterId = trim((string) ($_POST['theater_id'] ?? ''));
+if ($theaterId === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing theater_id']);
+    exit;
+}
+
+$theater = db_theater_detail($theaterId);
+if ($theater === null) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Theater not found']);
+    exit;
+}
+
+if (theater_is_locked($theater)) {
+    echo json_encode(['status' => 'already_locked', 'theater_id' => $theaterId]);
+    exit;
+}
+
+// Mark as "locking" immediately so the UI can show progress.
+// We use a convention: set locked_at to a future sentinel value, then
+// overwrite with the real timestamp when done. The status endpoint
+// checks for this.
+db_execute(
+    "UPDATE theaters SET locked_at = '1970-01-01 00:00:01' WHERE theater_id = ? AND locked_at IS NULL",
+    [$theaterId]
+);
+
+// Send response immediately, then continue processing
+ignore_user_abort(true);
+set_time_limit(600); // 10 minutes max
+
+$response = json_encode(['status' => 'processing', 'theater_id' => $theaterId]);
+header('Content-Length: ' . strlen($response));
+header('Connection: close');
+echo $response;
+
+if (function_exists('fastcgi_finish_request')) {
+    fastcgi_finish_request();
+} else {
+    ob_end_flush();
+    flush();
+}
+
+// ── Background processing starts here ────────────────────────────────
+
+try {
+    // 1. Finalize: truncate + rebuild all derived tables from killmails
+    db_theater_finalize_manual($theaterId);
+
+    // 2. Reload theater data for snapshot
+    $battles = db_theater_battles($theaterId);
+    $systems = db_theater_systems($theaterId);
+    $timeline = db_theater_timeline($theaterId);
+    $allianceSummary = db_theater_alliance_summary($theaterId);
+    $fleetComposition = db_theater_fleet_composition($theaterId);
+    $participantsAll = db_theater_participants($theaterId, null, false, 1000);
+    $graphParticipants = db_theater_graph_participants($theaterId);
+    $structureKills = db_theater_structure_kills($theaterId);
+    $suspicion = db_theater_suspicion_summary($theaterId);
+    $graphSummary = db_theater_graph_summary($theaterId);
+    $turningPoints = db_theater_turning_points($theaterId);
+
+    // 3. Resolve entities
+    $entityRequests = ['alliance' => [], 'corporation' => [], 'character' => []];
+    foreach ($allianceSummary as $row) {
+        if (($id = (int) ($row['alliance_id'] ?? 0)) > 0) $entityRequests['alliance'][$id] = $id;
+        if (($id = (int) ($row['corporation_id'] ?? 0)) > 0) $entityRequests['corporation'][$id] = $id;
+    }
+    foreach ($participantsAll as $row) {
+        if (($id = (int) ($row['character_id'] ?? 0)) > 0) $entityRequests['character'][$id] = $id;
+        if (($id = (int) ($row['alliance_id'] ?? 0)) > 0) $entityRequests['alliance'][$id] = $id;
+        if (($id = (int) ($row['corporation_id'] ?? 0)) > 0) $entityRequests['corporation'][$id] = $id;
+    }
+    foreach ($entityRequests as $type => $ids) {
+        $entityRequests[$type] = array_values($ids);
+    }
+    $resolvedEntities = killmail_entity_resolve_batch($entityRequests, false);
+
+    // 4. Build side classification
+    $trackedAllianceIds = array_values(array_unique(array_map('intval', array_column(db_killmail_tracked_alliances_active(), 'alliance_id'))));
+    $opponentAllianceIds = array_values(array_unique(array_map('intval', array_column(db_killmail_opponent_alliances_active(), 'alliance_id'))));
+    $trackedCorporationIds = array_values(array_unique(array_map('intval', array_column(db_killmail_tracked_corporations_active(), 'corporation_id'))));
+    $opponentCorporationIds = array_values(array_unique(array_map('intval', array_column(db_killmail_opponent_corporations_active(), 'corporation_id'))));
+
+    $classifyAlliance = static function (int $allianceId, int $corporationId = 0) use (
+        $trackedAllianceIds, $opponentAllianceIds, $trackedCorporationIds, $opponentCorporationIds
+    ): string {
+        if ($allianceId > 0 && in_array($allianceId, $trackedAllianceIds, true)) return 'friendly';
+        if ($corporationId > 0 && in_array($corporationId, $trackedCorporationIds, true)) return 'friendly';
+        if ($allianceId > 0 && in_array($allianceId, $opponentAllianceIds, true)) return 'opponent';
+        if ($corporationId > 0 && in_array($corporationId, $opponentCorporationIds, true)) return 'opponent';
+        return 'third_party';
+    };
+
+    // 5. Compute derived view state
+    $theater = db_theater_detail($theaterId);
+    $derived = theater_compute_derived_view(
+        $theater, $battles, $timeline, $allianceSummary,
+        $participantsAll, $resolvedEntities, $structureKills, $classifyAlliance
+    );
+
+    // 6. Lock + AI generation
+    $aiSummary = theater_lock_report($theaterId);
+
+    // 7. Resolve ship type names
+    $allShipTypeIds = [];
+    foreach ($participantsAll as $p) {
+        $shipJson = $p['ship_type_ids'] ?? null;
+        if (is_string($shipJson)) {
+            $ids = json_decode($shipJson, true);
+            if (is_array($ids)) foreach ($ids as $stid) $allShipTypeIds[(int) $stid] = true;
+        }
+        $flyingShip = (int) ($p['flying_ship_type_id'] ?? 0);
+        if ($flyingShip > 0) $allShipTypeIds[$flyingShip] = true;
+    }
+    $shipTypeNames = !empty($allShipTypeIds) ? db_market_orders_current_compact_type_names(array_keys($allShipTypeIds)) : [];
+
+    // 8. Save snapshot
+    $theater = db_theater_detail($theaterId);
+    theater_view_snapshot_save($theaterId, [
+        'battles' => $battles,
+        'systems' => $systems,
+        'timeline' => $timeline,
+        'alliance_summary' => $allianceSummary,
+        'fleet_composition' => $fleetComposition,
+        'suspicion' => $suspicion,
+        'graph_summary' => $graphSummary,
+        'turning_points' => $turningPoints,
+        'participants' => $participantsAll,
+        'graph_participants' => $graphParticipants,
+        'structure_kills' => $structureKills,
+        'resolved_entities' => $resolvedEntities,
+        'ship_type_names' => $shipTypeNames,
+        'tracked_alliance_ids' => $trackedAllianceIds,
+        'opponent_alliance_ids' => $opponentAllianceIds,
+        'tracked_corporation_ids' => $trackedCorporationIds,
+        'opponent_corporation_ids' => $opponentCorporationIds,
+        'side_labels' => $derived['side_labels'],
+        'side_alliances_by_pilots' => $derived['side_alliances_by_pilots'],
+        'opponent_model' => $derived['opponent_model'],
+        'side_panels' => $derived['side_panels'],
+        'data_quality_notes' => $derived['data_quality_notes'],
+        'duration_label' => $derived['duration_label'],
+        'total_isk_destroyed' => $derived['total_isk_destroyed'],
+        'theater_start_actual' => $derived['theater_start_actual'],
+        'theater_end_actual' => $derived['theater_end_actual'],
+        'display_kill_total' => $derived['display_kill_total'],
+        'reported_kill_total' => $derived['reported_kill_total'],
+        'observed_kill_total' => $derived['observed_kill_total'],
+    ]);
+} catch (\Throwable $e) {
+    // If anything fails, unlock so the user can retry
+    db_execute(
+        "UPDATE theaters SET locked_at = NULL, snapshot_data = NULL WHERE theater_id = ?",
+        [$theaterId]
+    );
+    // Log the error for debugging
+    error_log("Theater lock failed for {$theaterId}: " . $e->getMessage());
+}

--- a/public/theater-intelligence/partials/_ai_briefing.php
+++ b/public/theater-intelligence/partials/_ai_briefing.php
@@ -86,13 +86,193 @@
             <h2 class="text-lg font-semibold text-slate-50">AI Briefing</h2>
             <p class="text-sm text-muted mt-1">Lock this battle report to generate a one-time AI briefing. Once locked, the report cannot be regenerated.</p>
         </div>
-        <form method="POST" class="inline" onsubmit="return confirm('Lock this battle report and generate the AI briefing? This action cannot be undone.');">
-            <input type="hidden" name="lock_report" value="1">
-            <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-amber-500 transition-colors" onclick="this.disabled=true;this.innerHTML='<svg class=\'animate-spin h-4 w-4\' viewBox=\'0 0 24 24\'><circle class=\'opacity-25\' cx=\'12\' cy=\'12\' r=\'10\' stroke=\'currentColor\' stroke-width=\'4\' fill=\'none\'></circle><path class=\'opacity-75\' fill=\'currentColor\' d=\'M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z\'></path></svg> Locking &amp; Generating…';this.form.submit();">
-                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
-                Lock &amp; Generate AI Report
-            </button>
-        </form>
+        <button type="button" id="lock-theater-btn"
+                class="inline-flex items-center gap-2 rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-amber-500 transition-colors"
+                onclick="theaterLockStart('<?= htmlspecialchars($theaterId, ENT_QUOTES) ?>')">
+            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
+            Lock &amp; Generate AI Report
+        </button>
     </div>
 </section>
+
+<!-- Lock processing overlay -->
+<div id="lock-overlay" class="fixed inset-0 z-50 hidden">
+    <div class="absolute inset-0 bg-black/90 backdrop-blur-sm"></div>
+    <div class="relative flex flex-col items-center justify-center h-full px-6">
+        <!-- Spinner -->
+        <div class="relative mb-8">
+            <div class="w-20 h-20 rounded-full border-2 border-amber-500/20"></div>
+            <div class="absolute inset-0 w-20 h-20 rounded-full border-2 border-transparent border-t-amber-500 animate-spin"></div>
+            <div class="absolute inset-2 w-16 h-16 rounded-full border-2 border-transparent border-b-blue-500/70 animate-spin" style="animation-duration: 1.5s; animation-direction: reverse;"></div>
+            <svg class="absolute inset-0 m-auto h-8 w-8 text-amber-500/80" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+        </div>
+
+        <h2 class="text-xl font-semibold text-slate-100 mb-2">Generating Battle Report</h2>
+        <p class="text-sm text-slate-400 mb-1" id="lock-status-text">Materializing theater data...</p>
+        <p class="text-xs text-slate-600 mb-10" id="lock-elapsed">0s</p>
+
+        <!-- Lore quote -->
+        <div class="max-w-lg text-center">
+            <p class="text-sm text-slate-300/80 italic leading-relaxed" id="lock-lore-text"></p>
+            <p class="text-[10px] text-slate-500 mt-2" id="lock-lore-source"></p>
+        </div>
+    </div>
+</div>
+
+<script>
+(() => {
+    const LORE = [
+        { text: "In the beginning there was the Void, and the Void was without form, and darkness was upon it.", source: "The Book of Emptiness, Amarr Scriptures" },
+        { text: "Among all the stargates that litter the New Eden cluster, there are a few that serve as chokepoints, controlling access to entire regions of space.", source: "Interstellar Navigation Primer" },
+        { text: "The capsuleer does not fear death. The capsuleer fears irrelevance.", source: "Caldari Naval Academy" },
+        { text: "War is not about destroying your enemy. War is about destroying your enemy's will to fight.", source: "Attributed to Jamyl Sarum I" },
+        { text: "Every gate camp, every bubble, every lost ship — these are the threads that weave the tapestry of null-sec sovereignty.", source: "Alliance Tournament Commentary" },
+        { text: "The Minmatar do not seek freedom because they lack chains. They seek freedom because they remember them.", source: "A History of the Minmatar People" },
+        { text: "There is no such thing as an unfair fight. There is only the prepared and the unprepared.", source: "Guristas Tactical Manual" },
+        { text: "To fly a Titan is to carry the weight of an empire on your capacitor.", source: "Capital Warfare Doctrine, CONCORD Archives" },
+        { text: "You haven't truly lived in null-sec until you've watched a Keepstar die.", source: "Common capsuleer saying" },
+        { text: "The overview doesn't lie. But it does sometimes lag.", source: "Fleet Commander proverb" },
+        { text: "Space is cold and empty, but local chat is colder and emptier.", source: "Wormhole Survival Guide" },
+        { text: "The greatest fleet commander is the one whose pilots log in.", source: "Old coalition wisdom" },
+        { text: "Trust, but verify. Then verify again. Then check d-scan.", source: "Pandemic Horde Newbro Manual" },
+        { text: "A single cyno can change the course of history.", source: "B-R5RB After Action Report" },
+        { text: "In nullsec, your allies are the friends you haven't reset yet.", source: "Diplomatic Relations 101" },
+        { text: "Every structure timer is someone's alarm clock.", source: "Sovereignty warfare handbook" },
+        { text: "The Jove gazed upon the empires below and saw only children playing with fire.", source: "The Jovian Decline, Chapter VII" },
+        { text: "Warp drive active.", source: "Aura" },
+        { text: "The capacitor is empty.", source: "Every pilot's last words" },
+        { text: "Somewhere in New Eden, right now, a Venture pilot is mining in a war zone, completely unbothered.", source: "r/Eve" },
+        { text: "FC, can I bring my Drake?", source: "The eternal question" },
+        { text: "Gate is red. Gate is always red.", source: "Scout wisdom" },
+        { text: "Your clone is your most valuable asset. Everything else is ammunition.", source: "Society of Conscious Thought" },
+    ];
+
+    let pollInterval = null;
+    let elapsedInterval = null;
+    let startTime = 0;
+    let loreIndex = 0;
+
+    function shuffleArray(arr) {
+        for (let i = arr.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [arr[i], arr[j]] = [arr[j], arr[i]];
+        }
+        return arr;
+    }
+
+    const shuffledLore = shuffleArray([...LORE]);
+
+    function showLore() {
+        const lore = shuffledLore[loreIndex % shuffledLore.length];
+        const textEl = document.getElementById('lock-lore-text');
+        const sourceEl = document.getElementById('lock-lore-source');
+        textEl.style.opacity = '0';
+        sourceEl.style.opacity = '0';
+        setTimeout(() => {
+            textEl.textContent = '"' + lore.text + '"';
+            sourceEl.textContent = '— ' + lore.source;
+            textEl.style.opacity = '1';
+            sourceEl.style.opacity = '1';
+        }, 400);
+        loreIndex++;
+    }
+
+    function updateElapsed() {
+        const sec = Math.floor((Date.now() - startTime) / 1000);
+        const el = document.getElementById('lock-elapsed');
+        if (el) el.textContent = sec + 's';
+    }
+
+    function setStatus(text) {
+        const el = document.getElementById('lock-status-text');
+        if (el) el.textContent = text;
+    }
+
+    window.theaterLockStart = function(theaterId) {
+        if (!confirm('Lock this battle report and generate the AI briefing? This action cannot be undone.')) {
+            return;
+        }
+
+        // Show overlay
+        const overlay = document.getElementById('lock-overlay');
+        overlay.classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+
+        // Add transitions for lore
+        const textEl = document.getElementById('lock-lore-text');
+        const sourceEl = document.getElementById('lock-lore-source');
+        textEl.style.transition = 'opacity 0.4s ease';
+        sourceEl.style.transition = 'opacity 0.4s ease';
+
+        startTime = Date.now();
+        elapsedInterval = setInterval(updateElapsed, 1000);
+        showLore();
+        setInterval(showLore, 8000);
+
+        // Disable the button
+        const btn = document.getElementById('lock-theater-btn');
+        if (btn) btn.disabled = true;
+
+        // Fire the async lock request
+        const formData = new FormData();
+        formData.append('theater_id', theaterId);
+
+        fetch('/theater-intelligence/lock.php', {
+            method: 'POST',
+            body: formData,
+        }).catch(() => {
+            // Connection might close — that's OK, we poll
+        });
+
+        // Start polling
+        setStatus('Materializing theater data...');
+        const statusMessages = [
+            { after: 5, text: 'Rebuilding alliance summaries...' },
+            { after: 15, text: 'Computing participant statistics...' },
+            { after: 30, text: 'Generating AI briefing...' },
+            { after: 60, text: 'Still generating — large battle report...' },
+            { after: 120, text: 'Almost there — finalizing report...' },
+            { after: 180, text: 'This is a big one — hang tight...' },
+        ];
+
+        pollInterval = setInterval(() => {
+            const elapsed = (Date.now() - startTime) / 1000;
+
+            // Update status message based on elapsed time
+            for (let i = statusMessages.length - 1; i >= 0; i--) {
+                if (elapsed >= statusMessages[i].after) {
+                    setStatus(statusMessages[i].text);
+                    break;
+                }
+            }
+
+            fetch('/theater-intelligence/lock-status.php?theater_id=' + encodeURIComponent(theaterId))
+                .then(r => r.json())
+                .then(data => {
+                    if (data.status === 'complete') {
+                        clearInterval(pollInterval);
+                        clearInterval(elapsedInterval);
+                        setStatus('Report complete! Redirecting...');
+                        setTimeout(() => {
+                            window.location.href = '/theater-intelligence/view.php?theater_id=' + encodeURIComponent(theaterId);
+                        }, 1000);
+                    } else if (data.status === 'unlocked') {
+                        // Lock was rolled back — error occurred
+                        clearInterval(pollInterval);
+                        clearInterval(elapsedInterval);
+                        overlay.classList.add('hidden');
+                        document.body.style.overflow = '';
+                        if (btn) btn.disabled = false;
+                        alert('Lock failed — please check the server logs and try again.');
+                    }
+                })
+                .catch(() => {
+                    // Network error — keep polling
+                });
+        }, 2000);
+    };
+})();
+</script>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- Lock + finalize + AI generation for large theaters now runs asynchronously instead of blocking the page request (which caused 504 Gateway Timeouts on 137-battle theaters)
- Full-screen loading overlay with double-ring spinner, elapsed timer, and rotating EVE lore quotes
- New `lock.php` endpoint uses `fastcgi_finish_request()` / connection-close pattern to respond immediately then continue processing
- New `lock-status.php` polling endpoint for the frontend to track completion
- On failure, `locked_at` is rolled back so the user can retry

## How it works
1. User clicks "Lock & Generate AI Report"
2. JS shows the loading overlay and POSTs to `/theater-intelligence/lock.php`
3. `lock.php` sets a sentinel `locked_at` value, responds with JSON, then continues in the background:
   - Runs `db_theater_finalize_manual()` (truncate + rebuild)
   - Resolves entities, computes derived view state
   - Calls `theater_lock_report()` (sets real locked_at + AI generation)
   - Saves the view snapshot
4. Frontend polls `/theater-intelligence/lock-status.php` every 2 seconds
5. When `locked_at` is set and `snapshot_data` exists, status returns "complete"
6. Frontend redirects to the theater view

## The important part
23 EVE lore quotes rotate every 8 seconds while you wait, including Amarr scriptures, fleet commander wisdom, r/Eve classics, and Aura voice lines.

## Test plan
- [ ] Lock a large theater (100+ battles) — verify no 504, loading screen appears
- [ ] Verify lore quotes rotate and elapsed timer counts up
- [ ] Verify redirect to theater view on completion with full snapshot data
- [ ] Kill the PHP process mid-lock — verify locked_at rolls back and user can retry
- [ ] Lock a small theater — verify it still works (fast completion)

https://claude.ai/code/session_01Qg9kHao7jb4j3xSraMgWSv