### PR TITLE
Show real pilot counts in participant panel headers

### DIFF
--- a/public/theater-intelligence/partials/_participants.php
+++ b/public/theater-intelligence/partials/_participants.php
@@ -490,9 +490,18 @@ function _render_structure_row(array $sk, array $resolvedEntities, array $shipTy
                 <h3 class="text-sm font-semibold <?= $panel['colorClass'] ?>">
                     <?= htmlspecialchars($panel['label'], ENT_QUOTES) ?>
                     <span class="<?= $panel['badgeClass'] ?> text-[10px] rounded px-1.5 py-0.5 ml-1.5"><?= $panel['badgeLabel'] ?></span>
+                    <?php
+                        // Use the real pilot count from alliance summary, not the truncated participant list
+                        $realPilotCount = (int) ($sidePanels[$panel['side']]['pilots'] ?? 0);
+                        $shownCount = count($panel['rows']) + count($panel['structure_kills'] ?? []);
+                        $isTruncated = $shownCount < $realPilotCount;
+                    ?>
                     <span class="text-muted font-normal text-xs ml-1" data-panel-count>
-                        (<?= count($panel['rows']) + count($panel['structure_kills'] ?? []) ?>)
+                        (<?= number_format($realPilotCount) ?>)
                     </span>
+                    <?php if ($isTruncated): ?>
+                        <span class="text-[9px] text-amber-500/70 font-normal ml-0.5" title="Showing top <?= number_format($shownCount) ?> of <?= number_format($realPilotCount) ?> pilots">showing <?= number_format($shownCount) ?></span>
+                    <?php endif; ?>
                 </h3>
             </div>
             <div class="flex items-center gap-1 mb-2 flex-wrap">


### PR DESCRIPTION
## Summary
- Participant panel headers now show the real pilot count from `theater_alliance_summary` instead of the truncated displayed row count
- Adds a "showing N" indicator when the participant list is truncated (1,000 row limit)

## What was wrong
The Atioth theater has 8,711 unique pilots, but the participant panels showed `Friendly (248)`, `Hostile (726)`, `Third Party (26)` — totaling exactly 1,000 (the query limit). The panel headers were using `count($panel['rows'])` instead of the real pilot counts from the alliance summary.

## Fix
Uses `$sidePanels[$side]['pilots']` (derived from `theater_alliance_summary.participant_count`) for the header count, and shows a small amber "showing N" note when the displayed list is truncated.

## Test plan
- [ ] View a large theater (8k+ pilots) — verify panel headers show real totals
- [ ] Verify "showing N" appears when list is truncated
- [ ] View a small theater (<1000 pilots) — verify no "showing N" indicator

https://claude.ai/code/session_01Qg9kHao7jb4j3xSraMgWSv