### PR TITLE
Fix 504 Gateway Timeout on large theater view pages

### DIFF
--- a/public/theater-intelligence/view.php
+++ b/public/theater-intelligence/view.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 require_once __DIR__ . '/../../src/bootstrap.php';
 
+// Allow long-running computation for large theaters
+set_time_limit(300);
+
 $theaterId = trim((string) ($_GET['theater_id'] ?? ''));
 if ($theaterId === '') {
     header('Location: /theater-intelligence');
@@ -381,6 +384,26 @@ if ($viewSnapshot !== null && !$pendingLock) {
 
 } else {
     // ── Slow path: compute everything from scratch ──────────────────────
+
+    // Flush the page header + loading skeleton to the browser immediately.
+    // This keeps the nginx proxy alive (it sees bytes flowing) and gives
+    // the user visual feedback while the heavy queries run.
+    $title = htmlspecialchars((string) ($theater['primary_system_name'] ?? 'Theater'), ENT_QUOTES) . ' Theater';
+    include __DIR__ . '/../../src/views/partials/header.php';
+    echo '<div id="theater-loading-skeleton" class="surface-primary mt-4">';
+    echo '  <div class="flex flex-col items-center justify-center py-16 gap-4">';
+    echo '    <div class="relative">';
+    echo '      <div class="w-12 h-12 rounded-full border-2 border-amber-500/20"></div>';
+    echo '      <div class="absolute inset-0 w-12 h-12 rounded-full border-2 border-transparent border-t-amber-500 animate-spin"></div>';
+    echo '    </div>';
+    echo '    <p class="text-sm text-slate-400">Loading theater data for ' . number_format((int) ($theater['battle_count'] ?? 0)) . ' battles...</p>';
+    echo '  </div>';
+    echo '</div>';
+    // Flush to browser — this is what prevents the 504
+    if (ob_get_level()) ob_end_flush();
+    flush();
+
+    $_headerAlreadyFlushed = true;
 
     // Load raw data
     $battles = db_theater_battles($theaterId);
@@ -1025,7 +1048,12 @@ if (($sideAlliancesByPilots['opponent'] ?? []) !== [] && ($sideAlliancesByPilots
     ];
 }
 
-include __DIR__ . '/../../src/views/partials/header.php';
+if (empty($_headerAlreadyFlushed)) {
+    include __DIR__ . '/../../src/views/partials/header.php';
+} else {
+    // Hide the loading skeleton now that real content is ready
+    echo '<script>document.getElementById("theater-loading-skeleton")?.remove();</script>';
+}
 
 // ── Render partials ────────────────────────────────────────────────────
 include __DIR__ . '/partials/_header.php';


### PR DESCRIPTION
## Summary
- Fixes 504 Gateway Timeout when loading large theater view pages (100+ battles, 8k+ pilots)
- Flushes the HTML page header + loading spinner to the browser before running heavy queries
- Sets `set_time_limit(300)` to prevent PHP execution timeout

## Root cause
The theater view slow path (unlocked theaters without cached snapshots) runs ~10 heavy DB queries sequentially for battle data, alliance summaries, participants, fleet composition, etc. For a 137-battle theater with 8,711 pilots, this takes minutes. The openresty/nginx proxy has a `proxy_read_timeout` that kills the connection when no bytes are sent within its window.

## Fix
Before starting the heavy queries, flush:
1. The HTML `<head>` and page navigation (via the standard header partial)
2. A loading skeleton with a spinner and "Loading theater data for N battles..."

This sends bytes to the proxy immediately, keeping the connection alive. Once the data is computed, a small `<script>` tag removes the skeleton and the real content renders below.

The snapshot/fast path is unaffected — it doesn't need early flushing since it loads instantly.

## Test plan
- [ ] Load a large unlocked theater (100+ battles) — verify spinner appears, no 504
- [ ] Load a locked theater with snapshot — verify instant load, no skeleton flash
- [ ] Load a small theater — verify normal behavior

https://claude.ai/code/session_01Qg9kHao7jb4j3xSraMgWSv