### PR TITLE
Fix CIP collation mismatch and missing table reference

### DIFF
--- a/database/migrations/20260420_character_intelligence_profiles.sql
+++ b/database/migrations/20260420_character_intelligence_profiles.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS intelligence_signal_definitions (
         COMMENT 'Parameters for normalization (e.g. {"cap":3.0} for zscore_capped)',
     created_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 2. Character Intelligence Signals
 --    The canonical signal store.  Every pipeline emits typed signals here
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS character_intelligence_signals (
     INDEX idx_cis_computed (computed_at),
     INDEX idx_cis_reinforced (last_reinforced_at),
     INDEX idx_cis_character (character_id, computed_at)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 3. Character Intelligence Profiles
 --    The fused, canonical profile per character.  Single source of truth.
@@ -124,7 +124,7 @@ CREATE TABLE IF NOT EXISTS character_intelligence_profiles (
     INDEX idx_cip_computed (computed_at),
     INDEX idx_cip_behavioral (behavioral_score DESC),
     INDEX idx_cip_graph (graph_score DESC)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 4. Character Intelligence Labels
 --    Analyst feedback capture.  Collected from day one, processed later.
@@ -143,7 +143,7 @@ CREATE TABLE IF NOT EXISTS character_intelligence_labels (
     created_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     INDEX idx_cil_character (character_id, created_at),
     INDEX idx_cil_label (label, created_at)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 5. CIP History (lightweight daily snapshots for trend analysis)
 CREATE TABLE IF NOT EXISTS character_intelligence_profile_history (
@@ -163,4 +163,4 @@ CREATE TABLE IF NOT EXISTS character_intelligence_profile_history (
     relational_score    DECIMAL(10,6)   NOT NULL DEFAULT 0.000000,
     PRIMARY KEY (character_id, snapshot_date),
     INDEX idx_ciph_date (snapshot_date, risk_score DESC)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/migrations/20260420_intelligence_analyst_surface.sql
+++ b/database/migrations/20260420_intelligence_analyst_surface.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS intelligence_event_notes (
     note            TEXT            NOT NULL,
     created_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     INDEX idx_ien_event (event_id, created_at DESC)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 2. Event Digests
 --    Periodic summaries produced by the Python event engine.
@@ -52,4 +52,4 @@ CREATE TABLE IF NOT EXISTS intelligence_event_digests (
     created_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     INDEX idx_ied_type_period (digest_type, period_end DESC),
     INDEX idx_ied_created (created_at DESC)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/migrations/20260420_intelligence_calibration.sql
+++ b/database/migrations/20260420_intelligence_calibration.sql
@@ -60,4 +60,4 @@ CREATE TABLE IF NOT EXISTS intelligence_calibration_snapshots (
     created_at              TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE INDEX idx_ics_date (snapshot_date),
     INDEX idx_ics_created (created_at DESC)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/migrations/20260420_intelligence_compound_analytics.sql
+++ b/database/migrations/20260420_intelligence_compound_analytics.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS compound_analytics_snapshots (
     created_at              TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE INDEX idx_cas_date_type (snapshot_date, compound_type),
     INDEX idx_cas_type (compound_type, snapshot_date DESC)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 2. Compound Analyst Outcomes
 --    When an analyst resolves or provides feedback on an event/character
@@ -68,4 +68,4 @@ CREATE TABLE IF NOT EXISTS compound_analyst_outcomes (
     INDEX idx_cao_char (character_id, created_at DESC),
     INDEX idx_cao_compound (compound_type, outcome, created_at DESC),
     INDEX idx_cao_outcome (outcome, compound_type)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/migrations/20260420_intelligence_compound_signals.sql
+++ b/database/migrations/20260420_intelligence_compound_signals.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS intelligence_compound_definitions (
     created_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     UNIQUE INDEX idx_icd_type (compound_type)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 2. Materialized Compound Signals (per-character)
 CREATE TABLE IF NOT EXISTS character_intelligence_compound_signals (
@@ -58,4 +58,4 @@ CREATE TABLE IF NOT EXISTS character_intelligence_compound_signals (
     UNIQUE INDEX idx_cics_char_type (character_id, compound_type),
     INDEX idx_cics_type_score (compound_type, score DESC),
     INDEX idx_cics_detected (first_detected_at DESC)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/migrations/20260420_intelligence_events.sql
+++ b/database/migrations/20260420_intelligence_events.sql
@@ -76,7 +76,7 @@ CREATE TABLE IF NOT EXISTS intelligence_events (
     INDEX idx_ie_active_impact (state, impact_score DESC),
     INDEX idx_ie_detected (first_detected_at DESC),
     INDEX idx_ie_updated (last_updated_at DESC)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 2. Event State Transition History
 --    Audit log of all state changes for accountability and debugging.
@@ -93,4 +93,4 @@ CREATE TABLE IF NOT EXISTS intelligence_event_history (
     created_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     INDEX idx_ieh_event (event_id, created_at),
     INDEX idx_ieh_created (created_at)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/migrations/20260421_fix_cip_collation.sql
+++ b/database/migrations/20260421_fix_cip_collation.sql
@@ -1,0 +1,22 @@
+-- ---------------------------------------------------------------------------
+-- Fix collation mismatch between CIP tables and existing schema
+--
+-- CIP tables were created with utf8mb4_unicode_ci but the rest of the
+-- database uses the server default (utf8mb4_general_ci).  This causes
+-- "Illegal mix of collations" errors on JOINs.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE intelligence_events CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE intelligence_event_history CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE intelligence_event_notes CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE intelligence_event_digests CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE intelligence_signal_definitions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE character_intelligence_signals CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE character_intelligence_profiles CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE character_intelligence_labels CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE character_intelligence_profile_history CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE intelligence_calibration_snapshots CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE intelligence_compound_definitions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE character_intelligence_compound_signals CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE compound_analytics_snapshots CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE compound_analyst_outcomes CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;

--- a/src/db.php
+++ b/src/db.php
@@ -18446,7 +18446,7 @@ function db_intelligence_events_queue(
                    emc.entity_name AS entity_name
             FROM intelligence_events ie
             LEFT JOIN entity_metadata_cache emc
-                ON emc.entity_type = ie.entity_type AND emc.entity_id = ie.entity_id
+                ON emc.entity_type = ie.entity_type COLLATE utf8mb4_general_ci AND emc.entity_id = ie.entity_id
             {$whereClause}
             ORDER BY {$sortBy} {$sortDir}
             LIMIT ? OFFSET ?";
@@ -18564,7 +18564,7 @@ function db_intelligence_event_detail(int $eventId): ?array
                 emc.entity_name AS entity_name
          FROM intelligence_events ie
          LEFT JOIN entity_metadata_cache emc
-             ON emc.entity_type = ie.entity_type AND emc.entity_id = ie.entity_id
+             ON emc.entity_type = ie.entity_type COLLATE utf8mb4_general_ci AND emc.entity_id = ie.entity_id
          WHERE ie.id = ?",
         [$eventId]
     );
@@ -19104,11 +19104,9 @@ function db_cip_operational_health(): array
 
     // Event engine last run
     $lastRun = db_select_one(
-        "SELECT finished_at, rows_processed, rows_written, meta_json
-         FROM scheduler_job_runs
-         WHERE job_key = 'cip_event_engine'
-         ORDER BY finished_at DESC
-         LIMIT 1"
+        "SELECT last_finished_at AS finished_at, latest_status, latest_event_type
+         FROM scheduler_job_current_status
+         WHERE job_key = 'cip_event_engine'"
     );
 
     // Suppression stats


### PR DESCRIPTION
## Summary

- **Collation fix**: CIP tables were created with `utf8mb4_unicode_ci` but the rest of the database uses `utf8mb4_general_ci`. JOINs between `intelligence_events.entity_type` and `entity_metadata_cache.entity_type` caused "Illegal mix of collations" errors on the event queue page.
  - Added `COLLATE utf8mb4_general_ci` to JOIN conditions in queries (runtime fix)
  - Updated all CIP migrations to use `DEFAULT CHARSET=utf8mb4` without explicit collation
  - Added `20260421_fix_cip_collation.sql` ALTER TABLE migration to convert existing tables
- **Missing table fix**: `db_cip_operational_health()` referenced `scheduler_job_runs` which doesn't exist — changed to `scheduler_job_current_status`

## Test plan

- [ ] Run `20260421_fix_cip_collation.sql` migration
- [ ] Verify `/intelligence-events/` loads without collation error
- [ ] Verify `/intelligence-events/admin.php` loads without missing table error

https://claude.ai/code/session_01HBACXAtr7wwQDhQrHGHmB4