### PR TITLE
Fix JobRun.finished_at AttributeError in all CIP jobs

### DIFF
--- a/python/orchestrator/jobs/cip_calibration.py
+++ b/python/orchestrator/jobs/cip_calibration.py
@@ -53,7 +53,7 @@ def run_cip_calibration(db: SupplyCoreDb) -> JobResult:
         elapsed = int((time.monotonic() - t0) * 1000)
         return JobResult(
             status="success", summary="Calibration frozen by admin override",
-            started_at=job.started_at, finished_at=job.finished_at,
+            started_at="", finished_at="",
             duration_ms=elapsed, rows_seen=0, rows_processed=0, rows_written=0,
             rows_skipped=0, rows_failed=0, batches_completed=0,
             checkpoint_before=None, checkpoint_after=None,
@@ -291,7 +291,7 @@ def run_cip_calibration(db: SupplyCoreDb) -> JobResult:
     return JobResult(
         status="success",
         summary=f"Calibration: surge={calibrated_surge:.4f}, rank_jump={calibrated_rank_jump}, freshness={calibrated_freshness:.2f}, noise={noise_ratio:.3f}",
-        started_at=job.started_at, finished_at=job.finished_at,
+        started_at="", finished_at="",
         duration_ms=elapsed, rows_seen=total_profiled,
         rows_processed=total_profiled, rows_written=1,
         rows_skipped=0, rows_failed=0, batches_completed=1,

--- a/python/orchestrator/jobs/cip_compound_analytics.py
+++ b/python/orchestrator/jobs/cip_compound_analytics.py
@@ -173,7 +173,7 @@ def run_cip_compound_analytics(db: SupplyCoreDb) -> JobResult:
     return JobResult(
         status="success",
         summary=f"Compound analytics: {rows_written} snapshots for {today}",
-        started_at=job.started_at, finished_at=job.finished_at,
+        started_at="", finished_at="",
         duration_ms=elapsed, rows_seen=len(ENABLED_COMPOUNDS),
         rows_processed=len(ENABLED_COMPOUNDS), rows_written=rows_written,
         rows_skipped=0, rows_failed=0, batches_completed=1,

--- a/python/orchestrator/jobs/cip_compound_evaluator.py
+++ b/python/orchestrator/jobs/cip_compound_evaluator.py
@@ -149,7 +149,7 @@ def run_cip_compound_evaluator(db: SupplyCoreDb) -> JobResult:
         finish_job_run(db, job, status="success", rows_processed=0, rows_written=0)
         return JobResult(
             status="success", summary="No recent profiles to evaluate",
-            started_at=job.started_at, finished_at=job.finished_at,
+            started_at="", finished_at="",
             duration_ms=0, rows_seen=0, rows_processed=0, rows_written=0,
             rows_skipped=0, rows_failed=0, batches_completed=0,
             checkpoint_before=None, checkpoint_after=None,
@@ -326,7 +326,7 @@ def run_cip_compound_evaluator(db: SupplyCoreDb) -> JobResult:
     return JobResult(
         status="success",
         summary=f"Compounds: {created} created, {updated} updated, {deactivated} deactivated",
-        started_at=job.started_at, finished_at=job.finished_at,
+        started_at="", finished_at="",
         duration_ms=elapsed, rows_seen=len(char_ids),
         rows_processed=len(char_ids), rows_written=total,
         rows_skipped=0, rows_failed=0, batches_completed=1,

--- a/python/orchestrator/jobs/cip_event_engine.py
+++ b/python/orchestrator/jobs/cip_event_engine.py
@@ -932,7 +932,7 @@ def run_cip_event_engine(db: SupplyCoreDb) -> JobResult:
     return JobResult(
         status="success",
         summary=f"Events: {created} created, {updated} updated, {resolved} resolved, {expired} expired",
-        started_at=job.started_at, finished_at=job.finished_at,
+        started_at="", finished_at="",
         duration_ms=elapsed, rows_seen=len(candidates),
         rows_processed=len(candidates), rows_written=total_actions,
         rows_skipped=0, rows_failed=0, batches_completed=1,

--- a/python/orchestrator/jobs/cip_fusion.py
+++ b/python/orchestrator/jobs/cip_fusion.py
@@ -468,7 +468,7 @@ def run_cip_fusion(db: SupplyCoreDb) -> JobResult:
         finish_job_run(db, job, status="success", rows_processed=0, rows_written=0)
         return JobResult(
             status="success", summary="No signals to fuse",
-            started_at=job.started_at, finished_at=job.finished_at,
+            started_at="", finished_at="",
             duration_ms=0, rows_seen=0, rows_processed=0, rows_written=0,
             rows_skipped=0, rows_failed=0, batches_completed=0,
             checkpoint_before=None, checkpoint_after=None,
@@ -516,7 +516,7 @@ def run_cip_fusion(db: SupplyCoreDb) -> JobResult:
     return JobResult(
         status="success",
         summary=f"Fused {total_written} profiles from {len(all_signals)} signals across {len(by_character)} characters",
-        started_at=job.started_at, finished_at=job.finished_at,
+        started_at="", finished_at="",
         duration_ms=elapsed, rows_seen=len(all_signals),
         rows_processed=len(all_signals), rows_written=total_written,
         rows_skipped=0, rows_failed=0,

--- a/python/orchestrator/jobs/cip_signal_definitions.py
+++ b/python/orchestrator/jobs/cip_signal_definitions.py
@@ -372,7 +372,7 @@ def run_seed_signal_definitions(db: SupplyCoreDb) -> JobResult:
         return JobResult(
             status="success",
             summary=f"Seeded {rows_written} signal definitions",
-            started_at=job.started_at, finished_at=job.finished_at,
+            started_at="", finished_at="",
             duration_ms=0, rows_seen=len(SIGNAL_DEFINITIONS),
             rows_processed=len(SIGNAL_DEFINITIONS), rows_written=rows_written,
             rows_skipped=0, rows_failed=0, batches_completed=1,

--- a/python/orchestrator/jobs/cip_signal_emitter.py
+++ b/python/orchestrator/jobs/cip_signal_emitter.py
@@ -475,7 +475,7 @@ def run_cip_signal_emitter(db: SupplyCoreDb) -> JobResult:
     return JobResult(
         status="success",
         summary=f"Emitted {total_written} signals from {len(adapters)} adapters",
-        started_at=job.started_at, finished_at=job.finished_at,
+        started_at="", finished_at="",
         duration_ms=elapsed, rows_seen=total_written,
         rows_processed=total_written, rows_written=total_written,
         rows_skipped=0, rows_failed=0, batches_completed=len(adapters),


### PR DESCRIPTION
## Summary

- All 7 CIP jobs (`seed_signal_definitions`, `cip_signal_emitter`, `cip_fusion`, `cip_event_engine`, `cip_compound_evaluator`, `cip_compound_analytics`, `cip_calibration`) were failing with `AttributeError: 'JobRun' object has no attribute 'finished_at'`
- `JobRun` dataclass only has `(job_name, run_id, started_at)` — `finished_at` doesn't exist
- Fixed by passing empty strings for `started_at`/`finished_at` in `JobResult` constructors — `JobResult` auto-fills with current UTC timestamp when empty
- 10 occurrences fixed across 7 files

## Test plan

- [ ] Verify `seed_signal_definitions` job runs successfully (was failing every ~2 minutes)
- [ ] Verify other CIP jobs can start without AttributeError

https://claude.ai/code/session_01HBACXAtr7wwQDhQrHGHmB4