### PR TITLE
Fix JobResult not dict-compatible in processor registry

### DIFF
--- a/python/orchestrator/processor_registry.py
+++ b/python/orchestrator/processor_registry.py
@@ -328,6 +328,10 @@ def run_registered_processor(job_key: str, db: Any, raw_config: dict[str, Any], 
         raw_result = processor_fn(*arg_factory(db, raw_config), verbose=verbose)
     else:
         raw_result = processor_fn(*arg_factory(db, raw_config))
+    # Normalize: if the processor returned a JobResult object instead of a dict,
+    # convert it so from_raw() can process it.
+    if isinstance(raw_result, JobResult):
+        raw_result = raw_result.to_dict()
     return JobResult.from_raw(raw_result, job_key=job_key).to_dict()
 
 


### PR DESCRIPTION
## Summary

- CIP jobs return `JobResult` objects but `run_registered_processor()` passes the raw result to `JobResult.from_raw()` which calls `.get()` on it — causing `AttributeError: 'JobResult' object has no attribute 'get'`
- Fixed by checking if the raw result is a `JobResult` and converting to dict via `.to_dict()` before passing to `from_raw()`
- Handles both old-style dict-returning processors and new `JobResult`-returning CIP processors

## Test plan

- [ ] Verify `seed_signal_definitions` runs without AttributeError
- [ ] Verify other CIP jobs (signal_emitter, fusion, etc.) can complete successfully

https://claude.ai/code/session_01HBACXAtr7wwQDhQrHGHmB4