### PR TITLE
Fix 7 runtime issues across CIP jobs and PHP pages

### DIFF
--- a/public/intelligence-events/view.php
+++ b/public/intelligence-events/view.php
@@ -328,7 +328,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     <tbody>
                     <?php foreach ($signals as $sig): ?>
                         <?php
-                        $sigVal = (float) ($sig['value'] ?? 0);
+                        $sigVal = (float) ($sig['signal_value'] ?? 0);
                         $sigConf = (float) ($sig['confidence'] ?? 0);
                         $sigWeight = (float) ($sig['weight_default'] ?? 0);
                         $contribution = $sigVal * $sigConf * $sigWeight;
@@ -451,7 +451,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             <td class="px-3 py-2 text-right text-sm"><?= number_format((float) ($snap['risk_percentile'] ?? 0) * 100, 2) ?>%</td>
                             <td class="px-3 py-2 text-right text-sm"><?= number_format((float) ($snap['confidence'] ?? 0), 3) ?></td>
                             <td class="px-3 py-2 text-right text-sm"><?= number_format((float) ($snap['freshness'] ?? 0), 3) ?></td>
-                            <td class="px-3 py-2 text-right text-sm"><?= number_format((float) ($snap['effective_coverage'] ?? 0), 3) ?></td>
+                            <td class="px-3 py-2 text-right text-sm"><?= number_format((float) ($snap['signal_coverage'] ?? 0), 3) ?></td>
                         </tr>
                     <?php endforeach; ?>
                     </tbody>

--- a/python/orchestrator/jobs/cip_calibration.py
+++ b/python/orchestrator/jobs/cip_calibration.py
@@ -268,8 +268,6 @@ def run_cip_calibration(db: SupplyCoreDb) -> JobResult:
         round(noise_ratio, 4), round(suppression_rate, 4),
         band_critical, band_high, band_moderate, band_low,
     ])
-    db.commit()
-
     elapsed = int((time.monotonic() - t0) * 1000)
     logger.info(
         "cip_calibration: pop=%d, events=%d created, noise=%.3f | "

--- a/python/orchestrator/jobs/cip_compound_analytics.py
+++ b/python/orchestrator/jobs/cip_compound_analytics.py
@@ -162,8 +162,6 @@ def run_cip_compound_analytics(db: SupplyCoreDb) -> JobResult:
         ])
         rows_written += 1
 
-    db.commit()
-
     elapsed = int((time.monotonic() - t0) * 1000)
     logger.info("cip_compound_analytics: wrote %d compound snapshots for %s", rows_written, today)
 

--- a/python/orchestrator/jobs/cip_compound_evaluator.py
+++ b/python/orchestrator/jobs/cip_compound_evaluator.py
@@ -307,8 +307,6 @@ def run_cip_compound_evaluator(db: SupplyCoreDb) -> JobResult:
                     """, [cid, defn.compound_type])
                     deactivated += 1
 
-    db.commit()
-
     elapsed = int((time.monotonic() - t0) * 1000)
     total = created + updated + deactivated
 

--- a/python/orchestrator/jobs/cip_event_digest.py
+++ b/python/orchestrator/jobs/cip_event_digest.py
@@ -13,35 +13,40 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timedelta
+import time
+from datetime import datetime, timedelta, UTC
+
+from ..db import SupplyCoreDb
+from ..job_result import JobResult
+from ..job_utils import finish_job_run, start_job_run
 
 logger = logging.getLogger(__name__)
 
 
-def run_cip_event_digest(db) -> dict:
+def run_cip_event_digest(db: SupplyCoreDb) -> JobResult:
     """Generate a daily event digest covering the last 24 hours."""
-    now = datetime.utcnow()
-    period_end = now
-    period_start = now - timedelta(hours=24)
+    job = start_job_run(db, "cip_event_digest")
+    t0 = time.monotonic()
+
+    now = datetime.now(UTC)
+    period_end = now.strftime("%Y-%m-%d %H:%M:%S")
+    period_start = (now - timedelta(hours=24)).strftime("%Y-%m-%d %H:%M:%S")
 
     logger.info("Generating event digest for %s — %s", period_start, period_end)
 
-    cur = db.cursor()
-
     # ── New events (created in this window) ─────────────────────────
-    cur.execute(
+    new_events = db.fetch_all(
         """SELECT id, event_type, event_family, severity, impact_score,
                   title, entity_type, entity_id
            FROM intelligence_events
            WHERE first_detected_at >= %s AND first_detected_at < %s
            ORDER BY impact_score DESC""",
-        (period_start, period_end),
+        [period_start, period_end],
     )
-    new_events = cur.fetchall()
     new_count = len(new_events)
 
     # ── Escalated events (escalation_count increased in this window) ─
-    cur.execute(
+    escalated_events = db.fetch_all(
         """SELECT id, event_type, event_family, severity, previous_severity,
                   impact_score, title, escalation_count, entity_type, entity_id
            FROM intelligence_events
@@ -49,54 +54,49 @@ def run_cip_event_digest(db) -> dict:
              AND escalation_count > 1
              AND state = 'active'
            ORDER BY impact_score DESC""",
-        (period_start, period_end),
+        [period_start, period_end],
     )
-    escalated_events = cur.fetchall()
     escalated_count = len(escalated_events)
 
     # ── Resolved events ──────────────────────────────────────────────
-    cur.execute(
+    resolved_events = db.fetch_all(
         """SELECT id, event_type, event_family, severity, impact_score,
                   title, entity_type, entity_id
            FROM intelligence_events
            WHERE resolved_at >= %s AND resolved_at < %s
            ORDER BY impact_score DESC""",
-        (period_start, period_end),
+        [period_start, period_end],
     )
-    resolved_events = cur.fetchall()
     resolved_count = len(resolved_events)
 
     # ── Expired events ───────────────────────────────────────────────
-    cur.execute(
+    expired_row = db.fetch_one(
         """SELECT COUNT(*) AS cnt
            FROM intelligence_event_history
            WHERE new_state = 'expired'
              AND created_at >= %s AND created_at < %s""",
-        (period_start, period_end),
+        [period_start, period_end],
     )
-    expired_row = cur.fetchone()
     expired_count = int(expired_row["cnt"]) if expired_row else 0
 
     # ── Still-active unchanged: active events NOT new, NOT escalated in window ─
-    cur.execute(
+    unchanged_row = db.fetch_one(
         """SELECT COUNT(*) AS cnt
            FROM intelligence_events
            WHERE state = 'active'
              AND first_detected_at < %s
              AND (last_updated_at < %s OR escalation_count <= 1)""",
-        (period_start, period_start),
+        [period_start, period_start],
     )
-    unchanged_row = cur.fetchone()
     unchanged_active_count = int(unchanged_row["cnt"]) if unchanged_row else 0
 
     # ── Active breakdown by family ────────────────────────────────────
-    cur.execute(
+    breakdown_rows = db.fetch_all(
         """SELECT event_family, severity, COUNT(*) AS cnt
            FROM intelligence_events
            WHERE state = 'active'
            GROUP BY event_family, severity"""
     )
-    breakdown_rows = cur.fetchall()
 
     threat_active = 0
     threat_critical = 0
@@ -129,7 +129,7 @@ def run_cip_event_digest(db) -> dict:
     top_resolved = [_event_summary(e) for e in resolved_events[:top_n]]
 
     # ── Insert digest ─────────────────────────────────────────────────
-    cur.execute(
+    db.execute(
         """INSERT INTO intelligence_event_digests
                (digest_type, period_start, period_end,
                 new_events, escalated_events, resolved_events, expired_events,
@@ -141,16 +141,17 @@ def run_cip_event_digest(db) -> dict:
                    %s, %s, %s,
                    %s, %s, %s,
                    'cip_event_digest')""",
-        (
+        [
             period_start, period_end,
             new_count, escalated_count, resolved_count, expired_count,
             threat_active, threat_critical, quality_active,
             json.dumps(top_new) if top_new else None,
             json.dumps(top_escalated) if top_escalated else None,
             json.dumps(top_resolved) if top_resolved else None,
-        ),
+        ],
     )
-    db.commit()
+
+    elapsed = int((time.monotonic() - t0) * 1000)
 
     logger.info(
         "Digest generated: %d new, %d escalated, %d resolved, %d expired | "
@@ -159,12 +160,24 @@ def run_cip_event_digest(db) -> dict:
         threat_active, threat_critical, quality_active,
     )
 
-    return {
-        "new": new_count,
-        "escalated": escalated_count,
-        "resolved": resolved_count,
-        "expired": expired_count,
-        "threat_active": threat_active,
-        "threat_critical": threat_critical,
-        "quality_active": quality_active,
-    }
+    finish_job_run(db, job, status="success",
+                   rows_processed=new_count + escalated_count + resolved_count,
+                   rows_written=1,
+                   meta={"new": new_count, "escalated": escalated_count,
+                         "resolved": resolved_count, "expired": expired_count})
+
+    return JobResult(
+        status="success",
+        summary=f"Digest: {new_count} new, {escalated_count} escalated, {resolved_count} resolved, {expired_count} expired",
+        started_at="", finished_at="",
+        duration_ms=elapsed,
+        rows_seen=new_count + escalated_count + resolved_count,
+        rows_processed=new_count + escalated_count + resolved_count,
+        rows_written=1,
+        rows_skipped=0, rows_failed=0, batches_completed=1,
+        checkpoint_before=None, checkpoint_after=None,
+        has_more=False, error_text=None, warnings=[],
+        meta={"new": new_count, "escalated": escalated_count,
+              "resolved": resolved_count, "expired": expired_count,
+              "unchanged_active": unchanged_active_count},
+    )

--- a/src/db.php
+++ b/src/db.php
@@ -18756,7 +18756,7 @@ function db_intelligence_event_evidence(int $eventId): array
          FROM character_intelligence_signals cis
          JOIN intelligence_signal_definitions isd ON isd.signal_type = cis.signal_type
          WHERE cis.character_id = ?
-         ORDER BY (cis.value * cis.confidence * isd.weight_default) DESC
+         ORDER BY (cis.signal_value * cis.confidence * isd.weight_default) DESC
          LIMIT 20",
         [$characterId]
     );
@@ -18764,7 +18764,7 @@ function db_intelligence_event_evidence(int $eventId): array
     // Profile history (last 7 snapshots for trend)
     $history = db_select(
         "SELECT snapshot_date, risk_score, risk_rank, risk_percentile,
-                confidence, freshness, effective_coverage
+                confidence, freshness, signal_coverage
          FROM character_intelligence_profile_history
          WHERE character_id = ?
          ORDER BY snapshot_date DESC


### PR DESCRIPTION
## Summary

Proactive audit of all CIP code against actual SupplyCoreDb API, database schema, and worker pool contracts. Fixes all issues found before they surface as production errors.

### Python fixes (4 jobs)
- **cip_event_digest.py** — full rewrite. Was using raw `db.cursor()` (context manager, not raw cursor), calling `db.commit()` (doesn't exist), returning plain dict (needs JobResult), missing all standard imports, using deprecated `datetime.utcnow()`
- **cip_compound_evaluator.py** — removed `db.commit()` call
- **cip_compound_analytics.py** — removed `db.commit()` call
- **cip_calibration.py** — removed `db.commit()` call

SupplyCoreDb uses `autocommit=True`. There is no `commit()` method. All 4 would crash with `AttributeError`.

### PHP fixes (2 files, 4 bugs)
- **db.php** `db_intelligence_event_evidence()` — `ORDER BY cis.value` changed to `cis.signal_value` (column name mismatch → SQL error)
- **view.php** — `$sig['value']` changed to `$sig['signal_value']` (reading wrong key from query result)
- **db.php** profile history query — `effective_coverage` changed to `signal_coverage` (column doesn't exist in `character_intelligence_profile_history` → SQL error)
- **view.php** profile trend — `$snap['effective_coverage']` changed to `$snap['signal_coverage']`

## Test plan

- [ ] `seed_signal_definitions` job runs cleanly (no more errors in log viewer)
- [ ] `cip_event_digest` job runs cleanly (was completely broken)
- [ ] `cip_compound_evaluator` job runs cleanly (db.commit removed)
- [ ] `cip_compound_analytics` job runs cleanly (db.commit removed)
- [ ] `cip_calibration` job runs cleanly (db.commit removed)
- [ ] `/intelligence-events/view.php` loads without SQL errors (signal_value + signal_coverage fixes)
- [ ] Event detail page shows contributing signals correctly

https://claude.ai/code/session_01HBACXAtr7wwQDhQrHGHmB4