### PR TITLE
Fix runtime issues + add structured failure capture for CIP jobs

### DIFF
--- a/database/migrations/20260421_cip_incident_log.sql
+++ b/database/migrations/20260421_cip_incident_log.sql
@@ -1,0 +1,36 @@
+-- ---------------------------------------------------------------------------
+-- CIP Incident Log — structured failure capture for diagnostics
+--
+-- Every CIP job failure is recorded with full context so errors can be
+-- diagnosed without digging through log files.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS cip_incident_log (
+    id                  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    job_key             VARCHAR(120)    NOT NULL
+        COMMENT 'Which CIP job failed (e.g. seed_signal_definitions, cip_fusion)',
+    error_type          VARCHAR(200)    NOT NULL DEFAULT ''
+        COMMENT 'Exception class name (e.g. AttributeError, OperationalError)',
+    error_message       TEXT            NOT NULL
+        COMMENT 'Full error message',
+    traceback           LONGTEXT        DEFAULT NULL
+        COMMENT 'Full Python traceback',
+    -- Context at failure time
+    sql_query           TEXT            DEFAULT NULL
+        COMMENT 'The SQL query that was executing when the error occurred (if applicable)',
+    context_json        LONGTEXT        DEFAULT NULL
+        COMMENT 'Structured context: rows_processed, last_entity_id, calibration state, etc.',
+    -- Environment
+    hostname            VARCHAR(120)    DEFAULT NULL,
+    git_sha             VARCHAR(50)     DEFAULT NULL
+        COMMENT 'Git commit SHA at deploy time (if available)',
+    -- Resolution tracking
+    resolved            TINYINT(1)      NOT NULL DEFAULT 0,
+    resolved_by         VARCHAR(120)    DEFAULT NULL,
+    resolved_at         DATETIME        DEFAULT NULL,
+    -- Timestamps
+    created_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_cil_job (job_key, created_at DESC),
+    INDEX idx_cil_unresolved (resolved, created_at DESC),
+    INDEX idx_cil_error (error_type, created_at DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/public/intelligence-events/admin.php
+++ b/public/intelligence-events/admin.php
@@ -11,6 +11,14 @@ $title = 'CIP Admin & Operations';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = (string) ($_POST['action'] ?? '');
 
+    // Resolve incident
+    if ($action === 'resolve_incident') {
+        $incidentId = (int) ($_POST['incident_id'] ?? 0);
+        db_cip_incident_resolve($incidentId, 'analyst');
+        header('Location: /intelligence-events/admin.php?msg=incident_resolved');
+        exit;
+    }
+
     // Toggle compound enabled/disabled
     if ($action === 'toggle_compound') {
         $compoundType = (string) ($_POST['compound_type'] ?? '');
@@ -43,6 +51,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 // ── Load data ────────────────────────────────────────────────────────────
 
+$incidents = db_cip_incidents_recent(15);
+$unresolvedCount = db_cip_incidents_unresolved_count();
 $calibration = db_intelligence_calibration_latest();
 $calibrationHistory = db_calibration_history(7);
 $overrides = db_calibration_overrides_get();
@@ -58,6 +68,7 @@ $msg = match ($_GET['msg'] ?? '') {
     'overrides_saved'  => 'Calibration overrides saved. Takes effect on next calibration run.',
     'freeze_on'        => 'Calibration frozen. Thresholds will not change until unfrozen.',
     'freeze_off'       => 'Calibration unfrozen. Normal self-leveling resumed.',
+    'incident_resolved' => 'Incident marked as resolved.',
     default            => '',
 };
 
@@ -92,6 +103,60 @@ include __DIR__ . '/../../src/views/partials/header.php';
         <div class="mt-3 rounded bg-emerald-900/40 border border-emerald-700/50 px-4 py-2 text-sm text-emerald-300"><?= htmlspecialchars($msg, ENT_QUOTES) ?></div>
     <?php endif; ?>
 </section>
+
+<!-- Incidents -->
+<?php if ($unresolvedCount > 0 || $incidents !== []): ?>
+<section class="surface-primary mt-4">
+    <div class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-slate-100">CIP Incidents</h2>
+        <?php if ($unresolvedCount > 0): ?>
+            <span class="inline-flex items-center rounded-full bg-red-900/60 text-red-300 border border-red-800/50 px-2.5 py-1 text-xs font-semibold"><?= $unresolvedCount ?> unresolved</span>
+        <?php endif; ?>
+    </div>
+    <p class="mt-1 text-xs text-muted">Structured failure records from CIP jobs. Copy the error details to diagnose issues.</p>
+    <div class="mt-3 space-y-2">
+        <?php foreach ($incidents as $inc): ?>
+            <?php $isResolved = ((int) ($inc['resolved'] ?? 0)) === 1; ?>
+            <div class="surface-tertiary <?= $isResolved ? 'opacity-60' : '' ?>">
+                <div class="flex items-start justify-between gap-3">
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-2">
+                            <span class="text-sm font-medium <?= $isResolved ? 'text-slate-400' : 'text-red-400' ?>"><?= htmlspecialchars((string) ($inc['job_key'] ?? ''), ENT_QUOTES) ?></span>
+                            <span class="rounded bg-slate-700 px-1.5 py-0.5 text-[10px] text-slate-300"><?= htmlspecialchars((string) ($inc['error_type'] ?? ''), ENT_QUOTES) ?></span>
+                            <span class="text-[10px] text-muted"><?= htmlspecialchars((string) ($inc['created_at'] ?? ''), ENT_QUOTES) ?></span>
+                            <?php if (($inc['git_sha'] ?? '') !== ''): ?>
+                                <span class="text-[10px] text-muted">@ <?= htmlspecialchars((string) $inc['git_sha'], ENT_QUOTES) ?></span>
+                            <?php endif; ?>
+                        </div>
+                        <p class="mt-1 text-xs text-slate-200 break-all"><?= htmlspecialchars(mb_substr((string) ($inc['error_message'] ?? ''), 0, 300), ENT_QUOTES) ?></p>
+                        <?php if (($inc['traceback'] ?? '') !== ''): ?>
+                            <details class="mt-1">
+                                <summary class="text-[10px] text-accent cursor-pointer">Full traceback</summary>
+                                <pre class="mt-1 text-[10px] text-slate-400 overflow-x-auto max-h-40 whitespace-pre-wrap"><?= htmlspecialchars((string) $inc['traceback'], ENT_QUOTES) ?></pre>
+                            </details>
+                        <?php endif; ?>
+                        <?php if (($inc['sql_query'] ?? '') !== ''): ?>
+                            <details class="mt-1">
+                                <summary class="text-[10px] text-cyan-400 cursor-pointer">SQL context</summary>
+                                <pre class="mt-1 text-[10px] text-slate-400 overflow-x-auto max-h-20 whitespace-pre-wrap"><?= htmlspecialchars((string) $inc['sql_query'], ENT_QUOTES) ?></pre>
+                            </details>
+                        <?php endif; ?>
+                    </div>
+                    <?php if (!$isResolved): ?>
+                        <form method="post" class="shrink-0">
+                            <input type="hidden" name="action" value="resolve_incident">
+                            <input type="hidden" name="incident_id" value="<?= (int) $inc['id'] ?>">
+                            <button type="submit" class="rounded border border-emerald-700/50 bg-emerald-900/30 px-2 py-1 text-[10px] text-emerald-300 hover:bg-emerald-900/50">Resolve</button>
+                        </form>
+                    <?php else: ?>
+                        <span class="text-[10px] text-emerald-400">Resolved</span>
+                    <?php endif; ?>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</section>
+<?php endif; ?>
 
 <!-- Operational Health -->
 <section class="surface-primary mt-4">

--- a/python/orchestrator/jobs/cip_incident_capture.py
+++ b/python/orchestrator/jobs/cip_incident_capture.py
@@ -1,0 +1,121 @@
+"""CIP Incident Capture — structured failure recording for diagnostics.
+
+Wraps CIP job execution to capture full error context on failure:
+  - Exception type and message
+  - Full traceback
+  - SQL query if available (from OperationalError args)
+  - Structured context (rows processed, calibration state, etc.)
+  - Hostname and git SHA
+
+Usage in processor_registry.py:
+    Instead of: (run_cip_fusion, lambda db, cfg: (db,))
+    Use:        (wrap_cip_job("cip_fusion", run_cip_fusion), lambda db, cfg: (db,))
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import traceback
+from functools import wraps
+from typing import Any, Callable
+
+from ..json_utils import json_dumps_safe
+
+logger = logging.getLogger(__name__)
+
+# Try to read git SHA from common locations
+_GIT_SHA: str | None = None
+for _sha_path in ["/var/www/SupplyCore/.git-sha", "/var/www/SupplyCore/REVISION"]:
+    try:
+        with open(_sha_path) as f:
+            _GIT_SHA = f.read().strip()[:50]
+            break
+    except OSError:
+        pass
+if _GIT_SHA is None:
+    try:
+        import subprocess
+        _GIT_SHA = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd="/var/www/SupplyCore",
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        ).decode().strip()[:50]
+    except Exception:
+        pass
+
+
+def _extract_sql_from_error(exc: Exception) -> str | None:
+    """Try to extract the SQL query from a database error."""
+    # pymysql OperationalError often has the query in args
+    if hasattr(exc, 'args') and len(exc.args) >= 2:
+        msg = str(exc.args[1]) if len(exc.args) > 1 else str(exc.args[0])
+        if 'SQL' in msg or 'query' in msg.lower():
+            return msg
+    # Check for __cause__ chain
+    cause = exc.__cause__
+    if cause and hasattr(cause, 'args'):
+        return str(cause.args)
+    return None
+
+
+def record_incident(
+    db: Any,
+    job_key: str,
+    exc: Exception,
+    context: dict[str, Any] | None = None,
+) -> None:
+    """Record a CIP job failure to the incident log.
+
+    Best-effort: if the INSERT itself fails (e.g. DB down), we log and move on.
+    """
+    try:
+        tb = traceback.format_exception(type(exc), exc, exc.__traceback__)
+        tb_text = "".join(tb)
+        error_type = type(exc).__name__
+        error_message = str(exc)
+        sql_query = _extract_sql_from_error(exc)
+        context_json = json_dumps_safe(context) if context else None
+        hostname = socket.gethostname()
+
+        db.execute(
+            """INSERT INTO cip_incident_log
+                   (job_key, error_type, error_message, traceback,
+                    sql_query, context_json, hostname, git_sha)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s)""",
+            [
+                job_key, error_type, error_message, tb_text,
+                sql_query, context_json, hostname, _GIT_SHA,
+            ],
+        )
+        logger.info("CIP incident recorded for %s: %s", job_key, error_type)
+    except Exception as log_exc:
+        # If we can't write to the incident log, don't mask the original error
+        logger.warning(
+            "Failed to record CIP incident for %s: %s",
+            job_key, str(log_exc),
+        )
+
+
+def wrap_cip_job(job_key: str, fn: Callable) -> Callable:
+    """Decorator that wraps a CIP job to capture failures to the incident log.
+
+    The wrapped function still raises the original exception so the worker
+    pool handles it normally — this just adds structured capture.
+    """
+    @wraps(fn)
+    def wrapper(db: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(db, *args, **kwargs)
+        except Exception as exc:
+            # Capture the incident
+            record_incident(db, job_key, exc, context={
+                "args_count": len(args),
+                "kwargs_keys": list(kwargs.keys()),
+            })
+            # Re-raise so the worker pool handles it normally
+            raise
+
+    return wrapper

--- a/python/orchestrator/processor_registry.py
+++ b/python/orchestrator/processor_registry.py
@@ -89,6 +89,7 @@ from .jobs.cip_event_digest import run_cip_event_digest
 from .jobs.cip_compound_evaluator import run_cip_compound_evaluator
 from .jobs.cip_compound_analytics import run_cip_compound_analytics
 from .jobs.cip_calibration import run_cip_calibration
+from .jobs.cip_incident_capture import wrap_cip_job
 from .jobs.esi_sovereignty_sync import (
     run_sovereignty_campaigns_sync,
     run_sovereignty_structures_sync,
@@ -291,14 +292,15 @@ _PROCESSOR_DISPATCH: dict[str, tuple] = {
     # Corporation standings sync
     "corp_standings_sync": (run_corp_standings_sync, lambda db, cfg: (db, cfg)),
     # Character Intelligence Profiles (CIP) — fusion engine
-    "seed_signal_definitions": (run_seed_signal_definitions, lambda db, cfg: (db,)),
-    "cip_signal_emitter": (run_cip_signal_emitter, lambda db, cfg: (db,)),
-    "cip_fusion": (run_cip_fusion, lambda db, cfg: (db,)),
-    "cip_event_engine": (run_cip_event_engine, lambda db, cfg: (db,)),
-    "cip_event_digest": (run_cip_event_digest, lambda db, cfg: (db,)),
-    "cip_compound_evaluator": (run_cip_compound_evaluator, lambda db, cfg: (db,)),
-    "cip_compound_analytics": (run_cip_compound_analytics, lambda db, cfg: (db,)),
-    "cip_calibration": (run_cip_calibration, lambda db, cfg: (db,)),
+    # All CIP jobs wrapped with incident capture for structured failure diagnostics
+    "seed_signal_definitions": (wrap_cip_job("seed_signal_definitions", run_seed_signal_definitions), lambda db, cfg: (db,)),
+    "cip_signal_emitter": (wrap_cip_job("cip_signal_emitter", run_cip_signal_emitter), lambda db, cfg: (db,)),
+    "cip_fusion": (wrap_cip_job("cip_fusion", run_cip_fusion), lambda db, cfg: (db,)),
+    "cip_event_engine": (wrap_cip_job("cip_event_engine", run_cip_event_engine), lambda db, cfg: (db,)),
+    "cip_event_digest": (wrap_cip_job("cip_event_digest", run_cip_event_digest), lambda db, cfg: (db,)),
+    "cip_compound_evaluator": (wrap_cip_job("cip_compound_evaluator", run_cip_compound_evaluator), lambda db, cfg: (db,)),
+    "cip_compound_analytics": (wrap_cip_job("cip_compound_analytics", run_cip_compound_analytics), lambda db, cfg: (db,)),
+    "cip_calibration": (wrap_cip_job("cip_calibration", run_cip_calibration), lambda db, cfg: (db,)),
     # Sovereignty monitoring
     "sovereignty_campaigns_sync": (run_sovereignty_campaigns_sync, lambda db, cfg: (db, cfg)),
     "sovereignty_structures_sync": (run_sovereignty_structures_sync, lambda db, cfg: (db, cfg)),

--- a/src/db.php
+++ b/src/db.php
@@ -18977,6 +18977,48 @@ function db_compound_outcome_summary(): array
 }
 
 // ---------------------------------------------------------------------------
+// CIP Incident Log
+// ---------------------------------------------------------------------------
+
+/**
+ * Recent CIP incidents (unresolved first, then recent).
+ */
+function db_cip_incidents_recent(int $limit = 20): array
+{
+    return db_select(
+        "SELECT * FROM cip_incident_log
+         ORDER BY resolved ASC, created_at DESC
+         LIMIT ?",
+        [$limit]
+    );
+}
+
+/**
+ * Mark an incident as resolved.
+ */
+function db_cip_incident_resolve(int $incidentId, string $analyst): bool
+{
+    if ($incidentId <= 0) {
+        return false;
+    }
+    db()->prepare(
+        "UPDATE cip_incident_log
+         SET resolved = 1, resolved_by = ?, resolved_at = NOW()
+         WHERE id = ? AND resolved = 0"
+    )->execute([$analyst, $incidentId]);
+    return true;
+}
+
+/**
+ * Count of unresolved incidents.
+ */
+function db_cip_incidents_unresolved_count(): int
+{
+    $row = db_select_one("SELECT COUNT(*) AS cnt FROM cip_incident_log WHERE resolved = 0");
+    return (int) ($row['cnt'] ?? 0);
+}
+
+// ---------------------------------------------------------------------------
 // CIP Admin & Operational Health (Phase 5 hardening)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two parts: proactive runtime fixes from full audit, plus a structured failure capture layer so future errors are pre-packaged for diagnosis.

### Part 1: Runtime compatibility fixes (7 issues)

**Python fixes:**
- `cip_event_digest.py` — **full rewrite**. Was using raw `db.cursor()` (context manager, not raw cursor), calling `db.commit()` (doesn't exist), returning plain dict (needs JobResult), missing all standard imports
- `cip_compound_evaluator.py` — removed `db.commit()` (autocommit, method doesn't exist)
- `cip_compound_analytics.py` — removed `db.commit()`
- `cip_calibration.py` — removed `db.commit()`

**PHP fixes:**
- `db.php` — `ORDER BY cis.value` changed to `cis.signal_value` (column name mismatch)
- `view.php` — `$sig['value']` changed to `$sig['signal_value']`
- `db.php` — `effective_coverage` changed to `signal_coverage` in profile history query (column doesn't exist in history table)
- `view.php` — `$snap['effective_coverage']` changed to `$snap['signal_coverage']`

### Part 2: Structured failure capture

- **`cip_incident_log`** table: every CIP job failure recorded with full traceback, error type, SQL context, hostname, git SHA
- **`wrap_cip_job()`** decorator: wraps all 8 CIP jobs in processor_registry.py. On exception, records incident then re-raises normally
- **Admin incident viewer**: shows all CIP failures at top of `/intelligence-events/admin.php` with expandable tracebacks, SQL context, and one-click resolve

**New workflow:** instead of digging through log files, open the admin page → see failures with full context → copy to diagnose → mark resolved.

## Test plan

- [ ] Run `20260421_cip_incident_log.sql` migration
- [ ] Verify `seed_signal_definitions` runs cleanly
- [ ] Verify `cip_event_digest` runs cleanly (was completely broken)
- [ ] Verify `cip_compound_evaluator` runs cleanly
- [ ] Verify `/intelligence-events/view.php` loads without SQL errors
- [ ] Verify `/intelligence-events/admin.php` shows incidents section
- [ ] Intentionally break a job to verify incident capture works

https://claude.ai/code/session_01HBACXAtr7wwQDhQrHGHmB4