### PR TITLE
Register CIP pipeline jobs in sync_schedules

### DIFF
--- a/database/migrations/20260421_register_cip_schedules.sql
+++ b/database/migrations/20260421_register_cip_schedules.sql
@@ -1,0 +1,41 @@
+-- ---------------------------------------------------------------------------
+-- Register CIP pipeline jobs in sync_schedules
+--
+-- Without these entries, the worker pool never picks up the jobs.
+-- Intervals match cooldown_seconds from worker_registry.py.
+-- ---------------------------------------------------------------------------
+
+-- Tier 1: Signal emitter — harvests from upstream pipeline outputs
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode, timeout_seconds)
+VALUES ('cip_signal_emitter', 1, 30, 'python', 900)
+ON DUPLICATE KEY UPDATE enabled = 1, interval_seconds = 30, timeout_seconds = 900;
+
+-- Tier 2: Fusion engine — produces fused CIP profiles
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode, timeout_seconds)
+VALUES ('cip_fusion', 1, 30, 'python', 900)
+ON DUPLICATE KEY UPDATE enabled = 1, interval_seconds = 30, timeout_seconds = 900;
+
+-- Phase 4: Compound evaluator — materializes compound signal detections
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode, timeout_seconds)
+VALUES ('cip_compound_evaluator', 1, 30, 'python', 600)
+ON DUPLICATE KEY UPDATE enabled = 1, interval_seconds = 30, timeout_seconds = 600;
+
+-- Phase 5: Calibration — self-leveling thresholds from population stats
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode, timeout_seconds)
+VALUES ('cip_calibration', 1, 3600, 'python', 300)
+ON DUPLICATE KEY UPDATE enabled = 1, interval_seconds = 3600, timeout_seconds = 300;
+
+-- Tier 3: Event engine — delta detection + lifecycle management
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode, timeout_seconds)
+VALUES ('cip_event_engine', 1, 30, 'python', 300)
+ON DUPLICATE KEY UPDATE enabled = 1, interval_seconds = 30, timeout_seconds = 300;
+
+-- Tier 4: Event digest — periodic analyst summaries
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode, timeout_seconds)
+VALUES ('cip_event_digest', 1, 3600, 'python', 180)
+ON DUPLICATE KEY UPDATE enabled = 1, interval_seconds = 3600, timeout_seconds = 180;
+
+-- Phase 4.5: Compound analytics — daily validation metrics
+INSERT INTO sync_schedules (job_key, enabled, interval_seconds, execution_mode, timeout_seconds)
+VALUES ('cip_compound_analytics', 1, 3600, 'python', 300)
+ON DUPLICATE KEY UPDATE enabled = 1, interval_seconds = 3600, timeout_seconds = 300;


### PR DESCRIPTION
## Summary

- The CIP pipeline jobs exist in code (worker_registry, processor_registry) but were never registered in `sync_schedules` — meaning the worker pool never picks them up
- `seed_signal_definitions` was the only CIP job running because it happened to be auto-discovered, but the remaining 7 jobs in the pipeline had no schedule entries
- This migration registers all 7 remaining jobs with correct intervals and timeouts matching worker_registry.py

### Jobs registered

| Job | Interval | Timeout | Purpose |
|---|---|---|---|
| `cip_signal_emitter` | 30s | 900s | Harvest signals from upstream pipelines |
| `cip_fusion` | 30s | 900s | Fuse signals into CIP profiles |
| `cip_compound_evaluator` | 30s | 600s | Evaluate compound signal definitions |
| `cip_calibration` | 1hr | 300s | Self-leveling threshold calibration |
| `cip_event_engine` | 30s | 300s | Delta detection + event lifecycle |
| `cip_event_digest` | 1hr | 180s | Analyst summary digests |
| `cip_compound_analytics` | 1hr | 300s | Compound validation metrics |

Uses `ON DUPLICATE KEY UPDATE` so it's safe to re-run.

## Test plan

- [ ] Run `20260421_register_cip_schedules.sql` migration
- [ ] Verify all 7 jobs appear in the log viewer job list
- [ ] Wait one cycle (~30s) and verify `cip_signal_emitter` runs and emits signals
- [ ] Verify `cip_fusion` runs after emitter and produces profiles
- [ ] Check admin page — profiled chars should go from 0 to actual count

https://claude.ai/code/session_01HBACXAtr7wwQDhQrHGHmB4