### PR TITLE
Fix engagement_rate overflow in opposition snapshots

### DIFF
--- a/database/migrations/20260408_widen_opposition_snapshot_engagement_rate.sql
+++ b/database/migrations/20260408_widen_opposition_snapshot_engagement_rate.sql
@@ -1,0 +1,4 @@
+-- Widen engagement_rate column to match source (alliance_dossiers.avg_engagement_rate DECIMAL(8,4)).
+-- DECIMAL(5,2) overflows when kills_per_week exceeds 999.99 for active alliances.
+ALTER TABLE opposition_daily_snapshots
+    MODIFY COLUMN engagement_rate DECIMAL(8,4) DEFAULT NULL;

--- a/python/orchestrator/jobs/compute_opposition_daily_snapshots.py
+++ b/python/orchestrator/jobs/compute_opposition_daily_snapshots.py
@@ -602,7 +602,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, Any]:
             "ship_classes": ship.get("ship_classes", []),
             "ship_types": ship.get("ship_types", []),
             "posture": dos.get("posture"),
-            "engagement_rate": dos.get("engagement_rate"),
+            "engagement_rate": min(dos["engagement_rate"], 9999.9999) if dos.get("engagement_rate") is not None else None,
             "allies": rel.get("allies", []),
             "enemies": rel.get("hostiles", []),
             "theaters": theaters.get(aid, []),


### PR DESCRIPTION
## Summary
Fixes a data overflow issue in the opposition daily snapshots where the `engagement_rate` column was too narrow to accommodate values from the source data, causing data loss for active alliances with high engagement rates.

## Changes
- **Database Migration**: Widened `engagement_rate` column in `opposition_daily_snapshots` table from `DECIMAL(5,2)` to `DECIMAL(8,4)` to match the source column type in `alliance_dossiers.avg_engagement_rate`
- **Data Processing**: Added a safeguard in the snapshot computation job to cap engagement rate values at 9999.9999 to prevent overflow even with the wider column, while preserving null values

## Details
The original `DECIMAL(5,2)` column could only store values up to 999.99, which caused overflow errors when computing snapshots for active alliances with higher engagement rates. The new `DECIMAL(8,4)` precision matches the source data type and provides adequate capacity. The capping logic ensures data integrity during the transition and protects against any edge cases in the source data.

https://claude.ai/code/session_013v519FrjS91ZXnSXvCzrrX