### PR TITLE
UI/UX audit v2: readability, severity, diagnostics cleanup

### DIFF
--- a/public/activity-priority/index.php
+++ b/public/activity-priority/index.php
@@ -45,84 +45,96 @@ include __DIR__ . '/../../src/views/partials/header.php';
         </div>
 
         <div class="mt-5 space-y-4">
-            <?php foreach ($activeDoctrines as $row): ?>
+            <?php foreach ($activeDoctrines as $idx => $row): ?>
                 <?php $tone = activity_priority_level_tone((string) ($row['activity_level'] ?? 'low')); ?>
-                <article class="surface-tertiary">
-                    <div class="flex flex-wrap items-start justify-between gap-3">
-                        <div class="min-w-0 flex-1">
-                            <div class="flex flex-wrap items-center gap-2">
-                                <?php $doctrineGroupId = (int) ($row['entity_id'] ?? 0); ?>
-                                <?php if ($doctrineGroupId > 0): ?>
-                                    <a href="/doctrines/#doctrine-<?= $doctrineGroupId ?>" class="truncate text-lg font-semibold text-cyan-100 transition hover:text-cyan-50 hover:underline">
-                                        <?= htmlspecialchars((string) ($row['doctrine_name'] ?? ''), ENT_QUOTES) ?>
-                                    </a>
-                                <?php else: ?>
-                                    <h3 class="truncate text-lg font-semibold text-white"><?= htmlspecialchars((string) ($row['doctrine_name'] ?? ''), ENT_QUOTES) ?></h3>
-                                <?php endif; ?>
-                                <span class="badge <?= htmlspecialchars($tone, ENT_QUOTES) ?>"><?= htmlspecialchars(ucfirst((string) ($row['activity_level'] ?? 'low')), ENT_QUOTES) ?></span>
-                                <span class="badge border-white/10 bg-white/5 text-slate-200">#<?= (int) ($row['rank_position'] ?? 0) ?></span>
-                                <span class="badge border-white/10 bg-white/5 text-slate-300"><?= htmlspecialchars((string) ($row['movement_label'] ?? 'Holding'), ENT_QUOTES) ?></span>
-                            </div>
-                            <p class="mt-2 text-sm text-slate-300"><?= htmlspecialchars((string) ($row['explanation'] ?? ''), ENT_QUOTES) ?></p>
+                <?php
+                    $scoreDelta = (float) ($row['score_delta'] ?? 0.0);
+                    $rankDelta = (int) ($row['rank_delta'] ?? 0);
+                    $hasDelta = abs($scoreDelta) >= 0.05 || $rankDelta !== 0;
+                ?>
+                <details class="group surface-tertiary"<?= $idx < 5 ? ' open' : '' ?>>
+                    <summary class="flex cursor-pointer flex-wrap items-center justify-between gap-3 list-none [&::-webkit-details-marker]:hidden">
+                        <div class="min-w-0 flex-1 flex flex-wrap items-center gap-2">
+                            <?php $doctrineGroupId = (int) ($row['entity_id'] ?? 0); ?>
+                            <?php if ($doctrineGroupId > 0): ?>
+                                <a href="/doctrines/#doctrine-<?= $doctrineGroupId ?>" class="truncate text-lg font-semibold text-cyan-100 transition hover:text-cyan-50 hover:underline" onclick="event.stopPropagation()">
+                                    <?= htmlspecialchars((string) ($row['doctrine_name'] ?? ''), ENT_QUOTES) ?>
+                                </a>
+                            <?php else: ?>
+                                <h3 class="truncate text-lg font-semibold text-white"><?= htmlspecialchars((string) ($row['doctrine_name'] ?? ''), ENT_QUOTES) ?></h3>
+                            <?php endif; ?>
+                            <span class="badge <?= htmlspecialchars($tone, ENT_QUOTES) ?>"><?= htmlspecialchars(ucfirst((string) ($row['activity_level'] ?? 'low')), ENT_QUOTES) ?></span>
+                            <span class="badge border-white/10 bg-white/5 text-slate-200">#<?= (int) ($row['rank_position'] ?? 0) ?></span>
+                            <span class="text-sm text-slate-400"><?= htmlspecialchars((string) ($row['readiness_label'] ?? 'Market ready'), ENT_QUOTES) ?></span>
+                            <span class="badge border-white/10 bg-white/5 text-slate-300"><?= doctrine_format_quantity((int) ($row['readiness_gap_count'] ?? 0)) ?> fit gaps</span>
                         </div>
-                        <div class="text-right">
-                            <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Activity score</p>
-                            <p class="mt-2 text-2xl font-semibold text-white"><?= htmlspecialchars(number_format((float) ($row['activity_score'] ?? 0.0), 1), ENT_QUOTES) ?></p>
-                            <p class="mt-1 text-xs text-slate-500">Δ <?= htmlspecialchars(number_format((float) ($row['score_delta'] ?? 0.0), 1), ENT_QUOTES) ?> · rank <?= (int) ($row['rank_delta'] ?? 0) >= 0 ? '+' : '' ?><?= (int) ($row['rank_delta'] ?? 0) ?></p>
+                        <div class="flex items-center gap-4">
+                            <p class="text-2xl font-semibold text-white"><?= htmlspecialchars(number_format((float) ($row['activity_score'] ?? 0.0), 1), ENT_QUOTES) ?></p>
+                            <svg class="h-4 w-4 text-slate-500 transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                         </div>
-                    </div>
+                    </summary>
 
-                    <div class="mt-4 grid gap-3 md:grid-cols-4">
-                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Hull losses</p>
-                            <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['hull_losses_24h'] ?? 0)) ?> / <?= doctrine_format_quantity((int) ($row['hull_losses_3d'] ?? 0)) ?> / <?= doctrine_format_quantity((int) ($row['hull_losses_7d'] ?? 0)) ?></p>
-                            <p class="mt-1 text-xs text-slate-500">24h · 3d · 7d</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Module losses</p>
-                            <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['module_losses_24h'] ?? 0)) ?> / <?= doctrine_format_quantity((int) ($row['module_losses_3d'] ?? 0)) ?> / <?= doctrine_format_quantity((int) ($row['module_losses_7d'] ?? 0)) ?></p>
-                            <p class="mt-1 text-xs text-slate-500">Doctrine-linked modules in tracked losses</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Fit-equivalent pressure</p>
-                            <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars(number_format((float) ($row['fit_equivalent_losses_24h'] ?? 0.0), 1), ENT_QUOTES) ?> / <?= htmlspecialchars(number_format((float) ($row['fit_equivalent_losses_7d'] ?? 0.0), 1), ENT_QUOTES) ?></p>
-                            <p class="mt-1 text-xs text-slate-500">24h / 7d fit-equivalent module losses</p>
-                        </div>
-                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Readiness state</p>
-                            <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($row['readiness_label'] ?? 'Market ready'), ENT_QUOTES) ?></p>
-                            <p class="mt-1 text-xs text-slate-500"><?= htmlspecialchars((string) ($row['resupply_pressure'] ?? 'Stable'), ENT_QUOTES) ?> · <?= doctrine_format_quantity((int) ($row['readiness_gap_count'] ?? 0)) ?> fit gaps</p>
-                        </div>
-                    </div>
+                    <div class="mt-4 border-t border-white/8 pt-4">
+                        <p class="text-sm text-slate-300"><?= htmlspecialchars((string) ($row['explanation'] ?? ''), ENT_QUOTES) ?></p>
+                        <?php if ($hasDelta): ?>
+                            <p class="mt-1 text-xs text-slate-500">Δ <?= htmlspecialchars(number_format($scoreDelta, 1), ENT_QUOTES) ?> · rank <?= $rankDelta >= 0 ? '+' : '' ?><?= $rankDelta ?></p>
+                        <?php endif; ?>
 
-                    <div class="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(280px,0.9fr)]">
-                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Explainable score components</p>
-                            <div class="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-                                <?php foreach ((array) ($row['score_components'] ?? []) as $label => $value): ?>
-                                    <div class="rounded-xl border border-white/8 bg-black/20 px-3 py-2">
-                                        <p class="text-[11px] uppercase tracking-[0.12em] text-slate-500"><?= htmlspecialchars(str_replace('_', ' ', (string) $label), ENT_QUOTES) ?></p>
-                                        <p class="mt-1 text-sm font-semibold text-slate-100"><?= htmlspecialchars(number_format((float) $value, 1), ENT_QUOTES) ?></p>
-                                    </div>
-                                <?php endforeach; ?>
+                        <div class="mt-4 grid gap-3 md:grid-cols-4">
+                            <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                                <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Hull losses</p>
+                                <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['hull_losses_24h'] ?? 0)) ?> / <?= doctrine_format_quantity((int) ($row['hull_losses_3d'] ?? 0)) ?> / <?= doctrine_format_quantity((int) ($row['hull_losses_7d'] ?? 0)) ?></p>
+                                <p class="mt-1 text-xs text-slate-500">24h · 3d · 7d</p>
+                            </div>
+                            <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                                <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Module losses</p>
+                                <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['module_losses_24h'] ?? 0)) ?> / <?= doctrine_format_quantity((int) ($row['module_losses_3d'] ?? 0)) ?> / <?= doctrine_format_quantity((int) ($row['module_losses_7d'] ?? 0)) ?></p>
+                                <p class="mt-1 text-xs text-slate-500">Doctrine-linked modules in tracked losses</p>
+                            </div>
+                            <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                                <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Fit-equivalent pressure</p>
+                                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars(number_format((float) ($row['fit_equivalent_losses_24h'] ?? 0.0), 1), ENT_QUOTES) ?> / <?= htmlspecialchars(number_format((float) ($row['fit_equivalent_losses_7d'] ?? 0.0), 1), ENT_QUOTES) ?></p>
+                                <p class="mt-1 text-xs text-slate-500">24h / 7d fit-equivalent module losses</p>
+                            </div>
+                            <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                                <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Readiness state</p>
+                                <p class="mt-2 text-lg font-semibold text-slate-50"><?= htmlspecialchars((string) ($row['readiness_label'] ?? 'Market ready'), ENT_QUOTES) ?></p>
+                                <p class="mt-1 text-xs text-slate-500"><?= htmlspecialchars((string) ($row['resupply_pressure'] ?? 'Stable'), ENT_QUOTES) ?> · <?= doctrine_format_quantity((int) ($row['readiness_gap_count'] ?? 0)) ?> fit gaps</p>
                             </div>
                         </div>
-                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Most active fits in this group</p>
-                            <div class="mt-3 space-y-2">
-                                <?php foreach ((array) ($row['top_fits'] ?? []) as $fit): ?>
-                                    <div class="intelligence-row">
-                                        <div class="min-w-0 flex-1">
-                                            <p class="truncate text-sm font-semibold text-slate-100"><?= htmlspecialchars((string) ($fit['fit_name'] ?? ''), ENT_QUOTES) ?></p>
-                                            <p class="mt-1 text-xs text-slate-500"><?= htmlspecialchars(ucfirst((string) ($fit['activity_level'] ?? 'low')), ENT_QUOTES) ?></p>
-                                        </div>
-                                        <p class="text-sm font-semibold text-cyan-100"><?= htmlspecialchars(number_format((float) ($fit['activity_score'] ?? 0.0), 1), ENT_QUOTES) ?></p>
+
+                        <details class="mt-4">
+                            <summary class="cursor-pointer text-xs text-slate-500 hover:text-slate-300">Explainable score components &amp; active fits</summary>
+                            <div class="mt-3 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(280px,0.9fr)]">
+                                <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                                    <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Explainable score components</p>
+                                    <div class="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                                        <?php foreach ((array) ($row['score_components'] ?? []) as $label => $value): ?>
+                                            <div class="rounded-xl border border-white/8 bg-black/20 px-3 py-2">
+                                                <p class="text-[11px] uppercase tracking-[0.12em] text-slate-500"><?= htmlspecialchars(str_replace('_', ' ', (string) $label), ENT_QUOTES) ?></p>
+                                                <p class="mt-1 text-sm font-semibold text-slate-100"><?= htmlspecialchars(number_format((float) $value, 1), ENT_QUOTES) ?></p>
+                                            </div>
+                                        <?php endforeach; ?>
                                     </div>
-                                <?php endforeach; ?>
+                                </div>
+                                <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                                    <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Most active fits in this group</p>
+                                    <div class="mt-3 space-y-2">
+                                        <?php foreach ((array) ($row['top_fits'] ?? []) as $fit): ?>
+                                            <div class="intelligence-row">
+                                                <div class="min-w-0 flex-1">
+                                                    <p class="truncate text-sm font-semibold text-slate-100"><?= htmlspecialchars((string) ($fit['fit_name'] ?? ''), ENT_QUOTES) ?></p>
+                                                    <p class="mt-1 text-xs text-slate-500"><?= htmlspecialchars(ucfirst((string) ($fit['activity_level'] ?? 'low')), ENT_QUOTES) ?></p>
+                                                </div>
+                                                <p class="text-sm font-semibold text-cyan-100"><?= htmlspecialchars(number_format((float) ($fit['activity_score'] ?? 0.0), 1), ENT_QUOTES) ?></p>
+                                            </div>
+                                        <?php endforeach; ?>
+                                    </div>
+                                </div>
                             </div>
-                        </div>
+                        </details>
                     </div>
-                </article>
+                </details>
             <?php endforeach; ?>
             <?php if ($activeDoctrines === []): ?>
                 <div class="surface-tertiary text-sm text-slate-400">No doctrine activity snapshot has been materialized yet. Wait for the next background recompute.</div>
@@ -214,81 +226,92 @@ include __DIR__ . '/../../src/views/partials/header.php';
     </div>
 
     <div class="mt-5 space-y-4">
-        <?php foreach ($priorityItems as $row): ?>
+        <?php foreach ($priorityItems as $pIdx => $row): ?>
             <?php $tone = activity_priority_level_tone((string) ($row['priority_band'] ?? 'watch')); ?>
-            <article class="surface-tertiary">
-                <div class="flex flex-wrap items-start justify-between gap-3">
-                    <div class="min-w-0 flex-1">
-                        <div class="flex flex-wrap items-center gap-2">
-                            <h3 class="truncate text-lg font-semibold text-white"><?= htmlspecialchars((string) ($row['item_name'] ?? ''), ENT_QUOTES) ?></h3>
-                            <span class="badge <?= htmlspecialchars($tone, ENT_QUOTES) ?>"><?= htmlspecialchars(ucfirst((string) ($row['priority_band'] ?? 'watch')), ENT_QUOTES) ?></span>
-                            <?php if (!empty($row['is_doctrine_linked'])): ?>
-                                <span class="badge border-cyan-400/20 bg-cyan-500/10 text-cyan-100">Doctrine-linked</span>
-                            <?php endif; ?>
-                            <span class="badge border-white/10 bg-white/5 text-slate-300">#<?= (int) ($row['rank_position'] ?? 0) ?></span>
+            <?php
+                $pScoreDelta = (float) ($row['score_delta'] ?? 0.0);
+                $pRankDelta = (int) ($row['rank_delta'] ?? 0);
+                $pHasDelta = abs($pScoreDelta) >= 0.05 || $pRankDelta !== 0;
+            ?>
+            <details class="group surface-tertiary"<?= $pIdx < 10 ? ' open' : '' ?>>
+                <summary class="flex cursor-pointer flex-wrap items-center justify-between gap-3 list-none [&::-webkit-details-marker]:hidden">
+                    <div class="min-w-0 flex-1 flex flex-wrap items-center gap-2">
+                        <h3 class="truncate text-lg font-semibold text-white"><?= htmlspecialchars((string) ($row['item_name'] ?? ''), ENT_QUOTES) ?></h3>
+                        <span class="badge <?= htmlspecialchars($tone, ENT_QUOTES) ?>"><?= htmlspecialchars(ucfirst((string) ($row['priority_band'] ?? 'watch')), ENT_QUOTES) ?></span>
+                        <?php if (!empty($row['is_doctrine_linked'])): ?>
+                            <span class="badge border-cyan-400/20 bg-cyan-500/10 text-cyan-100">Doctrine-linked</span>
+                        <?php endif; ?>
+                        <span class="badge border-white/10 bg-white/5 text-slate-300">#<?= (int) ($row['rank_position'] ?? 0) ?></span>
+                    </div>
+                    <div class="flex items-center gap-4">
+                        <p class="text-2xl font-semibold text-white"><?= htmlspecialchars(number_format((float) ($row['priority_score'] ?? 0.0), 1), ENT_QUOTES) ?></p>
+                        <svg class="h-4 w-4 text-slate-500 transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    </div>
+                </summary>
+
+                <div class="mt-4 border-t border-white/8 pt-4">
+                    <p class="text-sm text-slate-300"><?= htmlspecialchars((string) ($row['explanation'] ?? ''), ENT_QUOTES) ?></p>
+                    <?php if ($pHasDelta): ?>
+                        <p class="mt-1 text-xs text-slate-500">Δ <?= htmlspecialchars(number_format($pScoreDelta, 1), ENT_QUOTES) ?> · rank <?= $pRankDelta >= 0 ? '+' : '' ?><?= $pRankDelta ?></p>
+                    <?php endif; ?>
+
+                    <div class="mt-4 grid gap-3 md:grid-cols-5">
+                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Linked doctrines</p>
+                            <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['linked_doctrine_count'] ?? 0)) ?></p>
+                            <p class="mt-1 text-xs text-slate-500"><?= doctrine_format_quantity((int) ($row['linked_active_doctrine_count'] ?? 0)) ?> active now</p>
                         </div>
-                        <p class="mt-2 text-sm text-slate-300"><?= htmlspecialchars((string) ($row['explanation'] ?? ''), ENT_QUOTES) ?></p>
+                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Recent losses</p>
+                            <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['recent_loss_qty_24h'] ?? 0)) ?> / <?= doctrine_format_quantity((int) ($row['recent_loss_qty_7d'] ?? 0)) ?></p>
+                            <p class="mt-1 text-xs text-slate-500">24h / 7d tracked victim-side quantity</p>
+                        </div>
+                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Local stock</p>
+                            <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['local_sell_volume'] ?? 0)) ?></p>
+                            <p class="mt-1 text-xs text-slate-500"><?= doctrine_format_quantity((int) ($row['local_sell_orders'] ?? 0)) ?> sell orders</p>
+                        </div>
+                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Readiness impact</p>
+                            <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['readiness_gap_fit_count'] ?? 0)) ?></p>
+                            <p class="mt-1 text-xs text-slate-500">fits with open target gaps</p>
+                        </div>
+                        <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                            <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Bottleneck status</p>
+                            <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['bottleneck_fit_count'] ?? 0)) ?></p>
+                            <p class="mt-1 text-xs text-slate-500"><?= htmlspecialchars(ucfirst((string) ($row['depletion_state'] ?? 'stable')), ENT_QUOTES) ?> depletion</p>
+                        </div>
                     </div>
-                    <div class="text-right">
-                        <p class="text-xs uppercase tracking-[0.16em] text-slate-500">Priority score</p>
-                        <p class="mt-2 text-2xl font-semibold text-white"><?= htmlspecialchars(number_format((float) ($row['priority_score'] ?? 0.0), 1), ENT_QUOTES) ?></p>
-                        <p class="mt-1 text-xs text-slate-500">Δ <?= htmlspecialchars(number_format((float) ($row['score_delta'] ?? 0.0), 1), ENT_QUOTES) ?> · rank <?= (int) ($row['rank_delta'] ?? 0) >= 0 ? '+' : '' ?><?= (int) ($row['rank_delta'] ?? 0) ?></p>
-                    </div>
-                </div>
 
-                <div class="mt-4 grid gap-3 md:grid-cols-5">
-                    <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                        <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Linked doctrines</p>
-                        <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['linked_doctrine_count'] ?? 0)) ?></p>
-                        <p class="mt-1 text-xs text-slate-500"><?= doctrine_format_quantity((int) ($row['linked_active_doctrine_count'] ?? 0)) ?> active now</p>
-                    </div>
-                    <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                        <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Recent losses</p>
-                        <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['recent_loss_qty_24h'] ?? 0)) ?> / <?= doctrine_format_quantity((int) ($row['recent_loss_qty_7d'] ?? 0)) ?></p>
-                        <p class="mt-1 text-xs text-slate-500">24h / 7d tracked victim-side quantity</p>
-                    </div>
-                    <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                        <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Local stock</p>
-                        <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['local_sell_volume'] ?? 0)) ?></p>
-                        <p class="mt-1 text-xs text-slate-500"><?= doctrine_format_quantity((int) ($row['local_sell_orders'] ?? 0)) ?> sell orders</p>
-                    </div>
-                    <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                        <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Readiness impact</p>
-                        <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['readiness_gap_fit_count'] ?? 0)) ?></p>
-                        <p class="mt-1 text-xs text-slate-500">fits with open target gaps</p>
-                    </div>
-                    <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                        <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Bottleneck status</p>
-                        <p class="mt-2 text-lg font-semibold text-slate-50"><?= doctrine_format_quantity((int) ($row['bottleneck_fit_count'] ?? 0)) ?></p>
-                        <p class="mt-1 text-xs text-slate-500"><?= htmlspecialchars(ucfirst((string) ($row['depletion_state'] ?? 'stable')), ENT_QUOTES) ?> depletion</p>
-                    </div>
-                </div>
-
-                <div class="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.9fr)]">
-                    <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                        <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Explainable score components</p>
-                        <div class="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-                            <?php foreach ((array) ($row['score_components'] ?? []) as $label => $value): ?>
-                                <div class="rounded-xl border border-white/8 bg-black/20 px-3 py-2">
-                                    <p class="text-[11px] uppercase tracking-[0.12em] text-slate-500"><?= htmlspecialchars(str_replace('_', ' ', (string) $label), ENT_QUOTES) ?></p>
-                                    <p class="mt-1 text-sm font-semibold text-slate-100"><?= htmlspecialchars(number_format((float) $value, 1), ENT_QUOTES) ?></p>
+                    <details class="mt-4">
+                        <summary class="cursor-pointer text-xs text-slate-500 hover:text-slate-300">Explainable score components &amp; linked doctrines</summary>
+                        <div class="mt-3 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.9fr)]">
+                            <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                                <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Explainable score components</p>
+                                <div class="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                                    <?php foreach ((array) ($row['score_components'] ?? []) as $label => $value): ?>
+                                        <div class="rounded-xl border border-white/8 bg-black/20 px-3 py-2">
+                                            <p class="text-[11px] uppercase tracking-[0.12em] text-slate-500"><?= htmlspecialchars(str_replace('_', ' ', (string) $label), ENT_QUOTES) ?></p>
+                                            <p class="mt-1 text-sm font-semibold text-slate-100"><?= htmlspecialchars(number_format((float) $value, 1), ENT_QUOTES) ?></p>
+                                        </div>
+                                    <?php endforeach; ?>
                                 </div>
-                            <?php endforeach; ?>
+                            </div>
+                            <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
+                                <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Linked doctrine groups</p>
+                                <div class="mt-3 flex flex-wrap gap-2">
+                                    <?php foreach ((array) ($row['linked_doctrine_names'] ?? []) as $name): ?>
+                                        <span class="badge border-white/10 bg-white/5 text-slate-200"><?= htmlspecialchars((string) $name, ENT_QUOTES) ?></span>
+                                    <?php endforeach; ?>
+                                    <?php if ((array) ($row['linked_doctrine_names'] ?? []) === []): ?>
+                                        <span class="text-sm text-slate-500">No doctrine link recorded.</span>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                    <div class="rounded-2xl border border-white/8 bg-slate-950/50 px-3 py-3">
-                        <p class="text-xs uppercase tracking-[0.14em] text-slate-500">Linked doctrine groups</p>
-                        <div class="mt-3 flex flex-wrap gap-2">
-                            <?php foreach ((array) ($row['linked_doctrine_names'] ?? []) as $name): ?>
-                                <span class="badge border-white/10 bg-white/5 text-slate-200"><?= htmlspecialchars((string) $name, ENT_QUOTES) ?></span>
-                            <?php endforeach; ?>
-                            <?php if ((array) ($row['linked_doctrine_names'] ?? []) === []): ?>
-                                <span class="text-sm text-slate-500">No doctrine link recorded.</span>
-                            <?php endif; ?>
-                        </div>
-                    </div>
+                    </details>
                 </div>
-            </article>
+            </details>
         <?php endforeach; ?>
         <?php if ($priorityItems === []): ?>
             <div class="surface-tertiary text-sm text-slate-400">No item-priority snapshot has been materialized yet.</div>

--- a/public/deal-alerts/index.php
+++ b/public/deal-alerts/index.php
@@ -128,25 +128,28 @@ include __DIR__ . '/../../src/views/partials/header.php';
         <a href="/settings?section=deal-alerts" class="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-100 hover:bg-white/10">Tune thresholds</a>
     </div>
 
-    <div class="mt-5 grid gap-3 rounded-[1.35rem] border border-white/8 bg-black/20 p-4 text-sm text-slate-300 lg:grid-cols-2">
-        <div>
-            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Materialization diagnostics</p>
-            <ul class="mt-3 space-y-2">
-                <li>History rows loaded: <span class="font-semibold text-white"><?= number_format((int) ($materialization['history_row_count'] ?? 0)) ?></span></li>
-                <li>Sources scanned: <span class="font-semibold text-white"><?= number_format((int) ($materialization['sources_scanned'] ?? 0)) ?></span></li>
-                <li>Inactive rows marked: <span class="font-semibold text-white"><?= number_format((int) ($materialization['inactive_row_count'] ?? 0)) ?></span></li>
-                <li>Latest success: <span class="font-semibold text-white"><?= htmlspecialchars(supplycore_format_datetime(isset($materialization['last_success_at']) ? (string) $materialization['last_success_at'] : null), ENT_QUOTES) ?></span></li>
-            </ul>
+    <details class="mt-5">
+        <summary class="cursor-pointer rounded-[1.35rem] border border-white/8 bg-black/20 px-4 py-3 text-sm font-medium text-slate-300 hover:bg-black/30">Materialization diagnostics</summary>
+        <div class="mt-2 grid gap-3 rounded-[1.35rem] border border-white/8 bg-black/20 p-4 text-sm text-slate-300 lg:grid-cols-2">
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Materialization detail</p>
+                <ul class="mt-3 space-y-2">
+                    <li>History rows loaded: <span class="font-semibold text-white"><?= number_format((int) ($materialization['history_row_count'] ?? 0)) ?></span></li>
+                    <li>Sources scanned: <span class="font-semibold text-white"><?= number_format((int) ($materialization['sources_scanned'] ?? 0)) ?></span></li>
+                    <li>Inactive rows marked: <span class="font-semibold text-white"><?= number_format((int) ($materialization['inactive_row_count'] ?? 0)) ?></span></li>
+                    <li>Latest success: <span class="font-semibold text-white"><?= htmlspecialchars(supplycore_format_datetime(isset($materialization['last_success_at']) ? (string) $materialization['last_success_at'] : null), ENT_QUOTES) ?></span></li>
+                </ul>
+            </div>
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Zero-output / failure detail</p>
+                <p class="mt-3 text-sm text-slate-300"><?= htmlspecialchars((string) ($materialization['last_reason_zero_output'] ?? $materialization['last_failure_reason'] ?? 'No zero-output or failure reason recorded.'), ENT_QUOTES) ?></p>
+                <p class="mt-3 text-xs text-slate-500">
+                    Freshness source: <?= htmlspecialchars((string) ($sourceVerification['freshness_timestamp_source'] ?? 'Unavailable'), ENT_QUOTES) ?>
+                    · Rows source: <?= htmlspecialchars((string) ($sourceVerification['table_row_source'] ?? 'Unavailable'), ENT_QUOTES) ?>
+                </p>
+            </div>
         </div>
-        <div>
-            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Zero-output / failure detail</p>
-            <p class="mt-3 text-sm text-slate-300"><?= htmlspecialchars((string) ($materialization['last_reason_zero_output'] ?? $materialization['last_failure_reason'] ?? 'No zero-output or failure reason recorded.'), ENT_QUOTES) ?></p>
-            <p class="mt-3 text-xs text-slate-500">
-                Freshness source: <?= htmlspecialchars((string) ($sourceVerification['freshness_timestamp_source'] ?? 'Unavailable'), ENT_QUOTES) ?>
-                · Rows source: <?= htmlspecialchars((string) ($sourceVerification['table_row_source'] ?? 'Unavailable'), ENT_QUOTES) ?>
-            </p>
-        </div>
-    </div>
+    </details>
 
     <form method="get" class="mt-5 grid gap-3 rounded-[1.35rem] border border-white/8 bg-black/20 p-4 lg:grid-cols-[minmax(0,1.2fr)_repeat(4,minmax(0,0.5fr))]">
         <label class="block space-y-2">

--- a/public/market-status/missing-items.php
+++ b/public/market-status/missing-items.php
@@ -11,7 +11,6 @@ $tableColumns = [
     'module' => 'Module',
     'reference_price' => market_hub_reference_name() . ' Price',
     'daily_volume' => 'Daily Volume',
-    'price_delta' => 'Price Delta',
     'score' => 'Score',
     'priority' => 'Priority',
 ];

--- a/public/opposition-intelligence/index.php
+++ b/public/opposition-intelligence/index.php
@@ -255,7 +255,7 @@ if ($flash !== null) {
             </div>
         <?php endif; ?>
     <?php else: ?>
-        <p class="text-sm text-muted">No briefing available for this date. Run the opposition daily snapshot job and AI briefing generator to produce a SITREP.</p>
+        <p class="text-sm text-muted">No briefing available for this date. Click <strong>Generate Intel</strong> above to create one, or wait for the next scheduled run.</p>
     <?php endif; ?>
 </section>
 
@@ -276,7 +276,6 @@ if ($flash !== null) {
                         <th class="px-3 py-2 text-right">ISK Lost</th>
                         <th class="px-3 py-2 text-right">Pilots</th>
                         <th class="px-3 py-2 text-left">Top Systems</th>
-                        <th class="px-3 py-2 text-left">Intel</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -328,16 +327,6 @@ if ($flash !== null) {
                             <td class="px-3 py-2 text-sm text-right font-mono"><?= htmlspecialchars($formatIsk((float) $s['isk_lost'])) ?></td>
                             <td class="px-3 py-2 text-sm text-right font-mono"><?= (int) $s['active_pilots'] ?></td>
                             <td class="px-3 py-2 text-xs text-muted"><?= htmlspecialchars(implode(', ', $topSystems)) ?></td>
-                            <td class="px-3 py-2 text-xs">
-                                <?php if ($allianceBriefing): ?>
-                                    <?php $ta = $allianceBriefing['threat_assessment'] ?? 'moderate'; ?>
-                                    <span class="inline-block rounded border px-1.5 py-0.5 text-[10px] uppercase <?= $threatColors[$ta] ?? $threatColors['moderate'] ?>">
-                                        <?= htmlspecialchars(strtoupper($ta)) ?>
-                                    </span>
-                                <?php else: ?>
-                                    <span class="text-muted">-</span>
-                                <?php endif; ?>
-                            </td>
                         </tr>
                     <?php endforeach; ?>
                 </tbody>

--- a/python/orchestrator/jobs/compute_alliance_dossiers.py
+++ b/python/orchestrator/jobs/compute_alliance_dossiers.py
@@ -402,12 +402,16 @@ def _load_behavior_metrics_bulk(db: SupplyCoreDb, alliance_ids: list[int]) -> di
 
         if kills_per_week >= 50 and avg_gang_size >= 10:
             posture = "aggressive"
-        elif kills_per_week >= 10 and avg_gang_size < 8:
+        elif kills_per_week >= 20 and avg_gang_size >= 8:
+            posture = "committed"
+        elif kills_per_week >= 10:
+            posture = "balanced"
+        elif kills_per_week >= 3:
             posture = "opportunistic"
         elif total_kills < 10:
             posture = "infrequent"
         else:
-            posture = "balanced"
+            posture = "opportunistic"
 
         result[aid] = {
             "kills_per_week": kills_per_week, "avg_gang_size": avg_gang_size,

--- a/src/db.php
+++ b/src/db.php
@@ -17745,12 +17745,19 @@ function db_opposition_daily_briefing(string $date, string $type = 'global', ?in
 function db_opposition_daily_briefings_recent(int $days = 14): array
 {
     $pdo = db();
+    // Return only the latest briefing per date (dedup multiple runs per day)
     $stmt = $pdo->prepare(
-        "SELECT * FROM opposition_daily_briefings
-         WHERE briefing_type = 'global' AND briefing_date >= DATE_SUB(CURDATE(), INTERVAL :days DAY)
-         ORDER BY briefing_date DESC"
+        "SELECT b.*
+         FROM opposition_daily_briefings b
+         INNER JOIN (
+             SELECT briefing_date, MAX(id) AS max_id
+             FROM opposition_daily_briefings
+             WHERE briefing_type = 'global' AND briefing_date >= DATE_SUB(CURDATE(), INTERVAL :days1 DAY)
+             GROUP BY briefing_date
+         ) latest ON b.id = latest.max_id
+         ORDER BY b.briefing_date DESC"
     );
-    $stmt->execute(['days' => $days]);
+    $stmt->execute(['days1' => $days]);
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -8225,10 +8225,13 @@ function market_score_data_freshness(string $allianceObservedAt, string $referen
 
 function market_signal_severity(int $score): string
 {
-    if ($score >= 75) {
+    if ($score >= 85) {
+        return 'Critical';
+    }
+    if ($score >= 65) {
         return 'High';
     }
-    if ($score >= 45) {
+    if ($score >= 40) {
         return 'Medium';
     }
 
@@ -11921,14 +11924,17 @@ function missing_items_data(): array
         ],
         'freshness' => $outcomes['_freshness'] ?? supplycore_snapshot_freshness(market_comparison_snapshot_key()),
         'rows' => array_map(static function (array $row): array {
+            // Blend opportunity_score with volume_score for better differentiation among missing items
+            $opp = (int) ($row['opportunity_score'] ?? 0);
+            $vol = (int) ($row['volume_score'] ?? 0);
+            $blended = (int) round($opp * 0.5 + $vol * 0.5);
             return [
                 'module' => $row['type_name'] !== '' ? $row['type_name'] : ('Type #' . $row['type_id']),
                 'reference_price' => market_format_isk($row['reference_best_sell_price']),
                 'daily_volume' => (string) ($row['reference_total_sell_volume'] ?? 0),
-                'price_delta' => sprintf('%+.1f%%', (float) ($row['deviation_percent'] ?? 0.0)),
-                'score' => (string) ((int) ($row['opportunity_score'] ?? 0)),
-                'priority' => (string) ($row['opportunity_tier'] ?? 'Low'),
-                'row_tone' => (int) ($row['opportunity_score'] ?? 0) >= 75 ? 'opp_high' : ((int) ($row['opportunity_score'] ?? 0) >= 45 ? 'opp_medium' : 'opp_low'),
+                'score' => (string) $blended,
+                'priority' => market_signal_severity($blended),
+                'row_tone' => $blended >= 75 ? 'opp_high' : ($blended >= 45 ? 'opp_medium' : 'opp_low'),
             ];
         }, array_slice($missingRows, 0, 30)),
         ];
@@ -12327,7 +12333,7 @@ function module_history_data(array $request = []): array
 
     $snapshotContext = $skipReason !== null
         ? $skipReason
-        : 'Raw rows fetched: ' . $seriesFetched . ' · Alliance ID: ' . (int) $source['alliance_structure_id'] . ' · Hub ID: ' . (int) $source['hub_source_id'];
+        : $selected['description'];
 
     return [
         'filters' => $filters,
@@ -23952,13 +23958,13 @@ function activity_priority_snapshot_has_computed_metrics(array $snapshot): bool
 
 function activity_priority_level_from_score(float $score): string
 {
-    if ($score >= 78.0) {
+    if ($score >= 200.0) {
         return 'highly active';
     }
-    if ($score >= 56.0) {
+    if ($score >= 80.0) {
         return 'active';
     }
-    if ($score >= 32.0) {
+    if ($score >= 30.0) {
         return 'moderate';
     }
 
@@ -23967,13 +23973,13 @@ function activity_priority_level_from_score(float $score): string
 
 function activity_priority_item_band(float $score): string
 {
-    if ($score >= 82.0) {
+    if ($score >= 200.0) {
         return 'critical';
     }
-    if ($score >= 66.0) {
+    if ($score >= 80.0) {
         return 'high';
     }
-    if ($score >= 44.0) {
+    if ($score >= 30.0) {
         return 'elevated';
     }
 

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -34,10 +34,12 @@ $pageFreshnessLine = $pageFreshness !== []
                     <p class="eyebrow text-cyan/80"><?= htmlspecialchars(brand_console_label(), ENT_QUOTES) ?></p>
                     <div class="mt-3 flex flex-wrap items-center gap-3">
                         <h1 class="text-3xl font-semibold tracking-tight text-white sm:text-[2.1rem]"><?= htmlspecialchars($title ?? 'Dashboard', ENT_QUOTES) ?></h1>
-                        <span class="status-chip <?= htmlspecialchars($pageHeaderBadgeTone, ENT_QUOTES) ?>">
-                            <span class="h-2 w-2 rounded-full bg-cyan shadow-[0_0_12px_rgba(34,211,238,0.65)]"></span>
-                            <?= htmlspecialchars($pageHeaderBadge, ENT_QUOTES) ?>
-                        </span>
+                        <?php if ($pageHeaderBadge !== ''): ?>
+                            <span class="status-chip <?= htmlspecialchars($pageHeaderBadgeTone, ENT_QUOTES) ?>">
+                                <span class="h-2 w-2 rounded-full bg-cyan shadow-[0_0_12px_rgba(34,211,238,0.65)]"></span>
+                                <?= htmlspecialchars($pageHeaderBadge, ENT_QUOTES) ?>
+                            </span>
+                        <?php endif; ?>
                     </div>
                     <?php if ($pageHeaderSummary !== ''): ?>
                         <p class="mt-3 max-w-2xl text-sm leading-6 text-slate-300/88"><?= htmlspecialchars($pageHeaderSummary, ENT_QUOTES) ?></p>

--- a/src/views/partials/module-page.php
+++ b/src/views/partials/module-page.php
@@ -207,7 +207,12 @@ $buildPageUrl = static function (int $targetPage) use ($queryParams): string {
                                 <?php elseif ($key === 'severity' || $key === 'priority'): ?>
                                     <?php
                                     $sev = strtolower($value);
-                                    $sevTone = $sev === 'high' ? 'text-rose-300 bg-rose-500/10 border-rose-500/40' : ($sev === 'medium' ? 'text-amber-300 bg-amber-500/10 border-amber-500/40' : 'text-slate-300 bg-slate-500/10 border-slate-500/40');
+                                    $sevTone = match (true) {
+                                        $sev === 'critical' => 'text-rose-200 bg-rose-500/20 border-rose-400/50',
+                                        $sev === 'high' => 'text-rose-300 bg-rose-500/10 border-rose-500/40',
+                                        $sev === 'medium' => 'text-amber-300 bg-amber-500/10 border-amber-500/40',
+                                        default => 'text-slate-300 bg-slate-500/10 border-slate-500/40',
+                                    };
                                     ?>
                                     <span class="rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] <?= $sevTone ?>"><?= htmlspecialchars($value, ENT_QUOTES) ?></span>
                                 <?php elseif ($key === 'updated_at'): ?>


### PR DESCRIPTION
## Summary

- **Fix engagement_rate overflow** — widen `opposition_daily_snapshots.engagement_rate` from `DECIMAL(5,2)` to `DECIMAL(8,4)` to match source column, with Python-side clamp as safety net. Fixes `DataError: Out of range value for column 'engagement_rate'`
- **Activity Priority readability overhaul** — collapse cards by default (top 5 open), nest score components behind secondary toggle, hide zero-delta lines, widen severity graduation thresholds (200/80/30 vs old 78/56/32)
- **Score/severity flattening fix** — add "Critical" tier to `market_signal_severity`, blend `opportunity_score + volume_score` for missing items to differentiate rankings
- **Alliance Dossier posture rebalance** — add "committed" tier, redistribute thresholds to reduce "opportunistic" dominance
- **Opposition Intel cleanup** — dedup briefing history (one row per date via `MAX(id)` subquery), remove empty "Intel" column, improve empty-state guidance
- **Deal Alerts** — wrap materialization diagnostics in collapsible `<details>`
- **Missing Items** — remove meaningless "+0.0% Price Delta" column
- **Module History** — replace debug "Raw rows fetched: N" with module description
- **Header** — hide empty page header badge when `$pageHeaderBadge` is blank

## Test plan

- [ ] Verify `/activity-priority` cards collapse/expand correctly, top 5 open by default
- [ ] Confirm severity labels show graduated tiers (Critical/High/Medium/Low) not flat "Critical" everywhere
- [ ] Check `/opposition-intelligence` briefing history shows one row per date
- [ ] Verify `/market-status/missing-items` no longer shows Price Delta column
- [ ] Confirm `/deal-alerts` materialization diagnostics are collapsed by default
- [ ] Run `compute_opposition_daily_snapshots` after applying migration to verify engagement_rate no longer overflows
- [ ] Run `compute_alliance_dossiers` to verify posture distribution improves

https://claude.ai/code/session_013v519FrjS91ZXnSXvCzrrX