### PR TITLE
Add retry logic for transient DB errors and stale sync run cleanup

### DIFF
--- a/database/migrations/20260423_widen_turnover_ratio_column.sql
+++ b/database/migrations/20260423_widen_turnover_ratio_column.sql
@@ -1,0 +1,5 @@
+-- Widen turnover_ratio_90d from DECIMAL(8,4) to DECIMAL(12,4).
+-- The old ceiling of 9999.9999 is too low when a corporation has many
+-- historical unique members but very few current members (e.g. 100 000 / 1).
+ALTER TABLE shell_corp_indicators
+    MODIFY COLUMN turnover_ratio_90d DECIMAL(12,4) NOT NULL DEFAULT 0.0000;

--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -22,6 +22,13 @@ _ERR_CANT_CONNECT = 2003
 
 _RETRYABLE_ERRORS = {_ERR_DEADLOCK, _ERR_LOCK_WAIT_TIMEOUT, _ERR_SERVER_GONE, _ERR_LOST_CONNECTION, _ERR_CANT_CONNECT}
 
+# Connection-level errors worth retrying on simple (non-transactional) operations.
+# Excludes deadlock/lock-wait since those imply a transaction conflict that a
+# simple auto-commit re-execution can safely retry.
+_CONNLOSS_ERRORS = {_ERR_SERVER_GONE, _ERR_LOST_CONNECTION, _ERR_CANT_CONNECT, _ERR_DEADLOCK, _ERR_LOCK_WAIT_TIMEOUT}
+_SIMPLE_MAX_RETRIES = 2
+_SIMPLE_BASE_DELAY = 0.3
+
 
 def _priority_rank(priority: str) -> int:
     normalized = priority.strip().lower()
@@ -66,43 +73,85 @@ class SupplyCoreDb:
         finally:
             connection.close()
 
+    def _is_retryable(self, exc: pymysql.err.OperationalError) -> bool:
+        return (exc.args[0] if exc.args else 0) in _CONNLOSS_ERRORS
+
     def fetch_one(self, sql: str, params: Sequence[Any] | None = None) -> dict[str, Any] | None:
-        with self.cursor() as (_, cursor):
-            if params is None:
-                cursor.execute(sql)
-            else:
-                cursor.execute(sql, params)
-            row = cursor.fetchone()
-            return dict(row) if row else None
+        for attempt in range(_SIMPLE_MAX_RETRIES + 1):
+            try:
+                with self.cursor() as (_, cursor):
+                    cursor.execute(sql, params)
+                    row = cursor.fetchone()
+                    return dict(row) if row else None
+            except pymysql.err.OperationalError as exc:
+                if attempt < _SIMPLE_MAX_RETRIES and self._is_retryable(exc):
+                    logger.warning("Retryable MariaDB error %d in fetch_one (attempt %d/%d): %s",
+                                   exc.args[0] if exc.args else 0, attempt + 1, _SIMPLE_MAX_RETRIES + 1, exc)
+                    time.sleep(_SIMPLE_BASE_DELAY * (2 ** attempt))
+                    continue
+                raise
+        return None  # unreachable, satisfies type checker
 
     def fetch_all(self, sql: str, params: Sequence[Any] | None = None) -> list[dict[str, Any]]:
-        with self.cursor() as (_, cursor):
-            if params is None:
-                cursor.execute(sql)
-            else:
-                cursor.execute(sql, params)
-            return [dict(row) for row in cursor.fetchall()]
+        for attempt in range(_SIMPLE_MAX_RETRIES + 1):
+            try:
+                with self.cursor() as (_, cursor):
+                    cursor.execute(sql, params)
+                    return [dict(row) for row in cursor.fetchall()]
+            except pymysql.err.OperationalError as exc:
+                if attempt < _SIMPLE_MAX_RETRIES and self._is_retryable(exc):
+                    logger.warning("Retryable MariaDB error %d in fetch_all (attempt %d/%d): %s",
+                                   exc.args[0] if exc.args else 0, attempt + 1, _SIMPLE_MAX_RETRIES + 1, exc)
+                    time.sleep(_SIMPLE_BASE_DELAY * (2 ** attempt))
+                    continue
+                raise
+        return []  # unreachable
 
     def execute(self, sql: str, params: Sequence[Any] | None = None) -> int:
-        with self.cursor() as (_, cursor):
-            if params is None:
-                return int(cursor.execute(sql))
-            return int(cursor.execute(sql, params))
+        for attempt in range(_SIMPLE_MAX_RETRIES + 1):
+            try:
+                with self.cursor() as (_, cursor):
+                    return int(cursor.execute(sql, params) if params is not None else cursor.execute(sql))
+            except pymysql.err.OperationalError as exc:
+                if attempt < _SIMPLE_MAX_RETRIES and self._is_retryable(exc):
+                    logger.warning("Retryable MariaDB error %d in execute (attempt %d/%d): %s",
+                                   exc.args[0] if exc.args else 0, attempt + 1, _SIMPLE_MAX_RETRIES + 1, exc)
+                    time.sleep(_SIMPLE_BASE_DELAY * (2 ** attempt))
+                    continue
+                raise
+        return 0  # unreachable
 
     def execute_many(self, sql: str, params_seq: Sequence[Sequence[Any]]) -> int:
-        with self.cursor() as (connection, cursor):
-            cursor.executemany(sql, params_seq)
-            connection.commit()
-            return int(cursor.rowcount)
+        for attempt in range(_SIMPLE_MAX_RETRIES + 1):
+            try:
+                with self.cursor() as (connection, cursor):
+                    cursor.executemany(sql, params_seq)
+                    connection.commit()
+                    return int(cursor.rowcount)
+            except pymysql.err.OperationalError as exc:
+                if attempt < _SIMPLE_MAX_RETRIES and self._is_retryable(exc):
+                    logger.warning("Retryable MariaDB error %d in execute_many (attempt %d/%d): %s",
+                                   exc.args[0] if exc.args else 0, attempt + 1, _SIMPLE_MAX_RETRIES + 1, exc)
+                    time.sleep(_SIMPLE_BASE_DELAY * (2 ** attempt))
+                    continue
+                raise
+        return 0  # unreachable
 
     def insert(self, sql: str, params: Sequence[Any] | None = None) -> int:
-        with self.cursor() as (connection, cursor):
-            if params is None:
-                cursor.execute(sql)
-            else:
-                cursor.execute(sql, params)
-            connection.commit()
-            return int(cursor.lastrowid or 0)
+        for attempt in range(_SIMPLE_MAX_RETRIES + 1):
+            try:
+                with self.cursor() as (connection, cursor):
+                    cursor.execute(sql, params)
+                    connection.commit()
+                    return int(cursor.lastrowid or 0)
+            except pymysql.err.OperationalError as exc:
+                if attempt < _SIMPLE_MAX_RETRIES and self._is_retryable(exc):
+                    logger.warning("Retryable MariaDB error %d in insert (attempt %d/%d): %s",
+                                   exc.args[0] if exc.args else 0, attempt + 1, _SIMPLE_MAX_RETRIES + 1, exc)
+                    time.sleep(_SIMPLE_BASE_DELAY * (2 ** attempt))
+                    continue
+                raise
+        return 0  # unreachable
 
     def iterate_batches(self, sql: str, params: Sequence[Any] | None = None, *, batch_size: int = 1000) -> Generator[list[dict[str, Any]], None, None]:
         with self.cursor(stream=True) as (_, cursor):

--- a/python/orchestrator/jobs/current_state_refresh_sync.py
+++ b/python/orchestrator/jobs/current_state_refresh_sync.py
@@ -1,11 +1,35 @@
 from __future__ import annotations
 
+import logging
+
 from ..db import SupplyCoreDb
 from ..json_utils import json_dumps_safe
 from .sync_runtime import run_sync_phase_job
 
+logger = logging.getLogger(__name__)
+
+_STALE_RUN_GRACE_SECONDS = 900  # 15 minutes — generous for streaming jobs
+
+
+def _reap_stale_sync_runs(db: SupplyCoreDb) -> int:
+    """Mark orphaned 'running' sync_runs as failed so they stop appearing as stuck."""
+    return db.execute(
+        """UPDATE sync_runs
+           SET run_status = 'failed',
+               finished_at = UTC_TIMESTAMP(),
+               error_message = 'Reaped: run exceeded timeout while still marked as running (worker likely crashed).',
+               updated_at = CURRENT_TIMESTAMP
+           WHERE run_status = 'running'
+             AND started_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %s SECOND)""",
+        (_STALE_RUN_GRACE_SECONDS,),
+    )
+
 
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
+    reaped = _reap_stale_sync_runs(db)
+    if reaped > 0:
+        logger.info("Reaped %d stale sync_runs row(s).", reaped)
+
     rows_processed = db.fetch_scalar("SELECT COUNT(*) FROM sync_schedules")
     rows_written = db.execute(
         """INSERT INTO scheduler_job_current_status (
@@ -38,19 +62,22 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
                 current_pressure_state = VALUES(current_pressure_state),
                 last_event_at = VALUES(last_event_at)"""
     )
-    payload = {"rows_processed": rows_processed, "rows_written": rows_written}
+    payload = {"rows_processed": rows_processed, "rows_written": rows_written, "reaped_stale_runs": reaped}
     db.upsert_intelligence_snapshot(
         snapshot_key="scheduler_current_state",
         payload_json=json_dumps_safe(payload),
         metadata_json=json_dumps_safe({"source": "sync_schedules"}),
         expires_seconds=600,
     )
+    summary = f"Refreshed scheduler current-state rows for {rows_written} jobs."
+    if reaped > 0:
+        summary += f" Reaped {reaped} stale sync_runs."
     return {
         "rows_processed": rows_processed,
         "rows_written": rows_written,
         "warnings": [],
-        "summary": f"Refreshed scheduler current-state rows for {rows_written} jobs.",
-        "meta": {"snapshot_key": "scheduler_current_state"},
+        "summary": summary,
+        "meta": {"snapshot_key": "scheduler_current_state", "reaped_stale_runs": reaped},
     }
 
 

--- a/python/orchestrator/jobs/shell_corp_detection.py
+++ b/python/orchestrator/jobs/shell_corp_detection.py
@@ -214,6 +214,7 @@ def run_shell_corp_detection(
 
             # Turnover ratio: unique members seen / current members
             turnover = unique_members / max(member_count, 1) if unique_members > 0 else 0.0
+            turnover = min(turnover, 99999999.9999)  # clamp to DECIMAL(12,4) ceiling
 
             shell_s, flags = _shell_score(
                 age_days=age_days,

--- a/python/orchestrator/neo4j.py
+++ b/python/orchestrator/neo4j.py
@@ -91,6 +91,13 @@ class Neo4jClient:
             try:
                 with ipv4_opener.open(request, timeout=effective_timeout) as response:
                     body = json.loads(response.read().decode("utf-8"))
+            except json.JSONDecodeError as error:
+                if attempt < _TRANSIENT_RETRY_LIMIT:
+                    time.sleep(_TRANSIENT_BASE_SLEEP * (2 ** attempt))
+                    continue
+                raise Neo4jError(
+                    f"Neo4j response was not valid JSON (truncated/corrupt at char {error.pos})"
+                ) from error
             except urllib.error.HTTPError as error:
                 details = error.read().decode("utf-8", errors="replace")
                 raise Neo4jError(f"Neo4j query failed ({error.code}): {details}") from error


### PR DESCRIPTION
## Summary
This PR adds resilience improvements to database operations and introduces cleanup for orphaned sync runs that may indicate worker crashes.

## Key Changes

### Database Retry Logic (`python/orchestrator/db.py`)
- Added retry mechanism for transient connection-level errors (`_CONNLOSS_ERRORS`) on simple (non-transactional) database operations
- Implemented exponential backoff with configurable max retries (2) and base delay (0.3s)
- Added `_is_retryable()` method to identify retriable `OperationalError` exceptions
- Applied retry logic to: `fetch_one()`, `fetch_all()`, `execute()`, `execute_many()`, and `insert()` methods
- Each retry attempt logs a warning with error code, attempt number, and exception details
- Retryable errors include: server gone, lost connection, can't connect, deadlock, and lock wait timeout

### Stale Sync Run Cleanup (`python/orchestrator/jobs/current_state_refresh_sync.py`)
- Added `_reap_stale_sync_runs()` function to mark orphaned 'running' sync_runs as failed
- Configured grace period of 900 seconds (15 minutes) for streaming jobs before marking as stale
- Runs as part of the scheduler current-state refresh job
- Updates failed runs with appropriate error message indicating worker crash
- Includes logging and updates job summary/metadata with reap count

### Neo4j JSON Error Handling (`python/orchestrator/neo4j.py`)
- Added explicit handling for `json.JSONDecodeError` when parsing Neo4j responses
- Implements retry logic for transient JSON decode failures
- Raises descriptive `Neo4jError` with character position information on final failure

### Database Schema (`database/migrations/20260423_widen_turnover_ratio_column.sql`)
- Widened `turnover_ratio_90d` column from `DECIMAL(8,4)` to `DECIMAL(12,4)` in `shell_corp_indicators` table
- Accommodates higher turnover ratios for corporations with many historical members but few current members

### Shell Corp Detection (`python/orchestrator/jobs/shell_corp_detection.py`)
- Added cap on turnover ratio calculation to prevent overflow in the widened column

## Implementation Details
- Retry logic uses exponential backoff: delay = base_delay × 2^attempt
- Unreachable return statements included to satisfy type checker requirements
- All retry attempts are logged for observability
- Stale run detection uses UTC timestamps for consistency

https://claude.ai/code/session_012yNhUBFo1Pk7PrA7wgj35Q