### PR TITLE
UI/UX audit: navigation, dashboard, settings performance

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -982,7 +982,9 @@ $staticDataState = null;
 $settingsPipelineHealth = array_values((array) ($syncDashboard['pipeline_health'] ?? []));
 $settingsSystemStatus = (array) ($syncDashboard['system_status'] ?? []);
 $rebuildStatus = ($section === 'automation-sync') ? supplycore_rebuild_status_read() : null;
-$runtimeDatasetCards = array_values((array) ($syncDashboard['runtime_dataset_cards'] ?? []));
+$runtimeDatasetCards = ($section === 'automation-sync')
+    ? array_values((array) ($syncDashboard['runtime_dataset_cards'] ?? []))
+    : (($section === 'workspace' && $dbStatus['ok']) ? supplycore_settings_runtime_dataset_cards() : []);
 $automationJobs = ($section === 'automation-sync') ? automation_runtime_jobs_overview() : [];
 $automationEnabledCount = count(array_filter($automationJobs, static fn (array $job): bool => !empty($job['enabled'])));
 if ($dbStatus['ok']) {
@@ -1019,15 +1021,17 @@ $trackedCorporations = [];
 $killmailStatus = null;
 $killmailWorkerStatus = [];
 $killmailStatusSummary = [];
-$itemScope = item_scope_view_model();
-$ollamaConfig = supplycore_ai_ollama_config();
-$ollamaStatus = supplycore_ai_status_summary();
+$itemScope = ($section === 'market-scope') ? item_scope_view_model() : [];
+$ollamaConfig = ($section === 'ai-alerts') ? supplycore_ai_ollama_config() : [];
+$ollamaStatus = ($section === 'ai-alerts') ? supplycore_ai_status_summary() : [];
 if ($dbStatus['ok']) {
     try {
-        $trackedAlliances = db_killmail_tracked_alliances_active();
-        $trackedCorporations = db_killmail_tracked_corporations_active();
-        $killmailStatus = db_killmail_ingestion_status();
-        $killmailWorkerStatus = zkill_worker_runtime_status();
+        if ($section === 'ai-alerts') {
+            $trackedAlliances = db_killmail_tracked_alliances_active();
+            $trackedCorporations = db_killmail_tracked_corporations_active();
+            $killmailStatus = db_killmail_ingestion_status();
+            $killmailWorkerStatus = zkill_worker_runtime_status();
+        }
     } catch (Throwable) {
         $trackedAlliances = [];
         $trackedCorporations = [];


### PR DESCRIPTION
## Summary

- **Navigation overhaul**: Reorganize sidebar into 4 grouped sections (Supply Operations, Intelligence, Counterintel, System) via new `nav_groups()` function, remove misleading badge counts
- **Dashboard rework**: Add situational awareness strip (sov/theater/killmail), reorder sections to lead with buy-all, cut verbose subtitles, add actionable empty-state guidance
- **Settings performance fix**: Defer `item_scope_view_model()` (26K type iterations, ~500ms), `sync_schedule_settings_view_model()`, `automation_runtime_jobs_overview()`, runtime config, AI config, and killmail data to only load on their active settings section — eliminates workspace tab timeouts
- **Page-level fixes**: Doctrine search/filter bar, collapsible deal-alert diagnostics, killmail signal noise reduction ("Routine loss" for default rows), sovereignty duplicate column header fix, pipeline job grouping with repeat badges
- **Cross-cutting**: Runtime diagnostics sections collapsible with advanced sections collapsed by default, sensitive config fields use `type="password"`, "Select all" checkbox per automation job group, dismiss-all button for deal alerts, `supplycore_datetime_html()` helper for consistent timestamps

## Test plan

- [ ] Load settings workspace tab — should render in <200ms (previously timed out)
- [ ] Navigate to each settings section (market-scope, ai-alerts, automation-sync, runtime-diagnostics) — verify data loads correctly on each
- [ ] Verify sidebar navigation shows grouped sections with headings
- [ ] Check dashboard situational awareness strip links to correct pages
- [ ] Test doctrine search filter on /doctrines/
- [ ] Verify killmail intelligence page shows "Routine loss" for default-signal rows
- [ ] Check sovereignty page has distinct "Attacker Score" / "Defender Score" column headers
- [ ] Verify pipeline page groups consecutive repeated jobs with Nx badge

https://claude.ai/code/session_015ecxDHmfi54MUzCsi5VDb7