### PR TITLE
Make ?debug=perf work even with malformed URLs (double ? instead of &)

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -133,7 +133,11 @@ supplycore_request_perf_init();
 
 function supplycore_perf_debug_enabled(): bool
 {
-    return isset($_GET['debug']) && $_GET['debug'] === 'perf';
+    if (isset($_GET['debug']) && $_GET['debug'] === 'perf') {
+        return true;
+    }
+    // Also match when ?debug=perf is appended with a second ? instead of &
+    return str_contains((string) ($_SERVER['REQUEST_URI'] ?? ''), 'debug=perf');
 }
 
 function supplycore_perf_debug_footer(): string


### PR DESCRIPTION
Checks REQUEST_URI as fallback so ?section=foo?debug=perf still triggers the perf panel.

https://claude.ai/code/session_015ecxDHmfi54MUzCsi5VDb7