### PR TITLE
UI/UX audit: navigation, dashboard, settings performance

### DIFF
--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -41,7 +41,13 @@ $sectionChildren = [
     ],
 ];
 $requestedSection = (string) ($_GET['section'] ?? 'workspace');
+if (str_contains($requestedSection, '?')) {
+    $requestedSection = strstr($requestedSection, '?', true);
+}
 $requestedSubsection = trim((string) ($_GET['subsection'] ?? ''));
+if (str_contains($requestedSubsection, '?')) {
+    $requestedSubsection = strstr($requestedSubsection, '?', true);
+}
 $knownChildren = $sectionChildren[$section] ?? [];
 $activeSubsection = array_key_first($knownChildren) ?? 'general';
 if (array_key_exists($requestedSubsection, $knownChildren)) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -678,6 +678,10 @@ function migrate_local_config_to_app_settings(string $localConfigPath): array
 function active_section(): string
 {
     $section = (string) ($_GET['section'] ?? 'workspace');
+    // Strip stray ?suffix when users append ?debug=perf with ? instead of &
+    if (str_contains($section, '?')) {
+        $section = strstr($section, '?', true);
+    }
     $aliases = setting_section_aliases();
     if (array_key_exists($section, $aliases)) {
         $section = (string) $aliases[$section];


### PR DESCRIPTION
## Summary

- **Navigation overhaul**: Sidebar grouped into 4 sections (Supply Operations, Intelligence, Counterintel, System) via `nav_groups()`, removed misleading badge counts
- **Dashboard rework**: Situational awareness strip (sov/theater/killmail), reordered sections, actionable empty-state guidance
- **Settings performance**: Defer `item_scope_view_model()` (26K type iterations, ~500ms), AI config, killmail data, sync dashboard, and runtime config to only load on their active section — eliminates workspace tab timeouts
- **Page-level fixes**: Doctrine search/filter, collapsible deal-alert diagnostics, killmail signal noise reduction ("Routine loss"), sov duplicate column fix, pipeline job grouping with repeat badges
- **Cross-cutting**: Collapsible runtime diagnostics (advanced collapsed by default), `type="password"` for secrets, "Select all" per automation job group, dismiss-all for deal alerts
- **`?debug=perf` robustness**: Now works even when appended with `?` instead of `&` (e.g. `?section=ai-alerts?debug=perf`), and section/subsection routing no longer breaks from the malformed URL

## Test plan

- [ ] Settings workspace tab loads fast (~165ms, no timeout)
- [ ] Navigate to each settings section — data loads correctly per section
- [ ] `?section=ai-alerts?debug=perf` shows perf panel AND loads AI & Alerts (not workspace)
- [ ] Sidebar shows grouped navigation with section headings
- [ ] Dashboard situational awareness strip links to correct pages
- [ ] Doctrine search filter works on /doctrines/
- [ ] Killmail intelligence shows "Routine loss" for default-signal rows
- [ ] Sovereignty has distinct "Attacker Score" / "Defender Score" columns

https://claude.ai/code/session_015ecxDHmfi54MUzCsi5VDb7