### PR TITLE
Add fallback display for intelligence events without specific entity type

### DIFF
--- a/public/intelligence-events/view.php
+++ b/public/intelligence-events/view.php
@@ -203,6 +203,10 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     ?></span>
                 <?php endif; ?>
             </div>
+        <?php else: ?>
+            <div class="flex items-baseline gap-3">
+                <a href="/battle-intelligence/character.php?character_id=<?= urlencode((string) ((int) ($event['entity_id'] ?? 0))) ?>" class="text-2xl text-accent font-semibold hover:underline"><?= htmlspecialchars((string) ($event['entity_type'] ?? 'entity'), ENT_QUOTES) ?> #<?= (int) ($event['entity_id'] ?? 0) ?></a>
+            </div>
         <?php endif; ?>
 
         <!-- Event title and type -->


### PR DESCRIPTION
## Summary
Added an else clause to handle intelligence events that don't match specific entity types, providing a fallback display mechanism for generic entities.

## Key Changes
- Added conditional fallback rendering for events without a recognized entity type
- Displays a linked generic entity identifier (entity type and ID) when specific entity type conditions aren't met
- Uses consistent styling with the existing entity display patterns (flex layout, accent color, semibold text)
- Includes proper URL encoding and HTML escaping for security

## Implementation Details
- The fallback link directs to `/battle-intelligence/character.php` with the entity ID as a query parameter
- Entity type and ID are safely rendered using `htmlspecialchars()` and `urlencode()` respectively
- Maintains visual consistency with the existing conditional branches through matching CSS classes and layout structure

https://claude.ai/code/session_01UkpC3HRG3miFTTZkCnR5KY