### PR TITLE
Handle missing relationship types in GDS projections

### DIFF
--- a/python/orchestrator/jobs/compute_map_intelligence.py
+++ b/python/orchestrator/jobs/compute_map_intelligence.py
@@ -61,11 +61,29 @@ def _gds_projection_exists(client: Neo4jClient) -> bool:
         return False
 
 
+def _relationship_types_present(client: Neo4jClient) -> list[str]:
+    """Return which of the expected relationship types actually exist in Neo4j."""
+    present = []
+    for rel_type in ("CONNECTS_TO", "JUMP_BRIDGE"):
+        try:
+            rows = client.query(
+                f"MATCH ()-[r:{rel_type}]->() RETURN r LIMIT 1"
+            )
+            if rows:
+                present.append(rel_type)
+        except Exception:
+            pass
+    return present
+
+
 def _ensure_gds_projection(client: Neo4jClient, *, force_recreate: bool = False) -> bool:
     """Create the GDS graph projection for universe topology.
 
     If the projection already exists and *force_recreate* is False, reuse it to
     avoid the overhead of dropping and reprojecting the full graph every run.
+
+    Only includes relationship types that actually exist in the database to
+    avoid GDS ``IllegalArgumentException`` when e.g. no jump bridges are configured.
     """
     try:
         if not force_recreate and _gds_projection_exists(client):
@@ -77,19 +95,19 @@ def _ensure_gds_projection(client: Neo4jClient, *, force_recreate: bool = False)
         except Exception:
             pass
 
+        rel_types = _relationship_types_present(client)
+        if not rel_types:
+            return False
+
+        rel_projection = ", ".join(
+            f"{rt}: {{orientation: 'UNDIRECTED'}}" for rt in rel_types
+        )
         client.query(
             f"""
             CALL gds.graph.project(
                 '{GDS_GRAPH_NAME}',
                 'System',
-                {{
-                    CONNECTS_TO: {{
-                        orientation: 'UNDIRECTED'
-                    }},
-                    JUMP_BRIDGE: {{
-                        orientation: 'UNDIRECTED'
-                    }}
-                }}
+                {{{rel_projection}}}
             )
             """,
             timeout_seconds=120,

--- a/python/orchestrator/jobs/graph_community_detection.py
+++ b/python/orchestrator/jobs/graph_community_detection.py
@@ -37,15 +37,33 @@ def _has_gds(client: Neo4jClient) -> bool:
 
 
 def _ensure_gds_projection(client: Neo4jClient) -> bool:
-    """Create the GDS in-memory graph projection for character community analysis."""
+    """Create the GDS in-memory graph projection for character community analysis.
+
+    Only includes relationship types that actually exist in the database to
+    avoid GDS ``IllegalArgumentException`` when some types are absent.
+    """
     try:
         try:
             client.query(f"CALL gds.graph.drop('{GDS_GRAPH_NAME}', false)")
         except Exception:
             pass
 
+        # Filter to relationship types that exist in the database
+        present_types = []
+        for rt in _COMMUNITY_REL_TYPES:
+            try:
+                rows = client.query(f"MATCH ()-[r:{rt}]->() RETURN r LIMIT 1")
+                if rows:
+                    present_types.append(rt)
+            except Exception:
+                pass
+
+        if not present_types:
+            logger.warning("GDS projection skipped: no community relationship types exist")
+            return False
+
         rel_projection = ", ".join(
-            f"{rt}: {{orientation: 'UNDIRECTED'}}" for rt in _COMMUNITY_REL_TYPES
+            f"{rt}: {{orientation: 'UNDIRECTED'}}" for rt in present_types
         )
         client.query(
             f"""

--- a/python/orchestrator/jobs/neo4j_ml_exploration.py
+++ b/python/orchestrator/jobs/neo4j_ml_exploration.py
@@ -131,8 +131,21 @@ def _create_projection(client: Neo4jClient, window: dict[str, Any]) -> bool:
         )
     else:
         # Lifetime: native projection, all relationships, undirected
-        rel_config_parts = []
+        # Only include relationship types that exist in the database
+        present_types = []
         for rt in CHARACTER_REL_TYPES:
+            try:
+                rows = client.query(f"MATCH ()-[r:{rt}]->() RETURN r LIMIT 1")
+                if rows:
+                    present_types.append(rt)
+            except Exception:
+                pass
+
+        if not present_types:
+            return False
+
+        rel_config_parts = []
+        for rt in present_types:
             rel_config_parts.append(
                 f"{rt}: {{orientation: 'UNDIRECTED', properties: 'weight'}}"
             )


### PR DESCRIPTION
## Summary
This PR adds defensive checks to GDS graph projection creation across three jobs to gracefully handle cases where expected relationship types don't exist in the database. This prevents `IllegalArgumentException` errors when creating projections with relationship types that are absent (e.g., when jump bridges are not configured).

## Key Changes
- **compute_map_intelligence.py**: Added `_relationship_types_present()` helper function to detect which relationship types (`CONNECTS_TO`, `JUMP_BRIDGE`) exist in the database. The GDS projection now dynamically includes only present relationship types, and returns `False` if none are found.

- **graph_community_detection.py**: Added inline checks to filter `_COMMUNITY_REL_TYPES` to only those that exist in the database before creating the projection. Returns `False` with a warning log if no community relationship types are present.

- **neo4j_ml_exploration.py**: Added similar filtering logic for `CHARACTER_REL_TYPES` in the lifetime projection path. Returns `False` early if no relationship types are found.

## Implementation Details
- Each file uses a consistent pattern: query for each relationship type with `MATCH ()-[r:{type}]->() RETURN r LIMIT 1` to check existence
- Exceptions during existence checks are silently caught to handle query errors gracefully
- Dynamic relationship projection strings are built only from present types
- All three implementations return `False` when no relationship types are found, allowing callers to handle the absence appropriately

https://claude.ai/code/session_01JW7okfcxxB7pzo7DcbykQQ