### PR TITLE
Reopen GitHub issues when failures reoccur after resolution

### DIFF
--- a/python/orchestrator/jobs/log_to_issues_worker.py
+++ b/python/orchestrator/jobs/log_to_issues_worker.py
@@ -69,6 +69,14 @@ def _close_github_issue(token: str, repo: str, issue_number: int) -> None:
         resp.read()
 
 
+def _reopen_github_issue(token: str, repo: str, issue_number: int) -> None:
+    url = f"https://api.github.com/repos/{repo}/issues/{issue_number}"
+    payload = json.dumps({"state": "open"}).encode()
+    req = urllib.request.Request(url, data=payload, headers=_github_headers(token), method="PATCH")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        resp.read()
+
+
 def _comment_github_issue(token: str, repo: str, issue_number: int, body: str) -> None:
     url = f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments"
     payload = json.dumps({"body": body}).encode()
@@ -200,17 +208,26 @@ def run_log_to_issues(
     for fp, occurrences in grouped.items():
         job_name = str(occurrences[0]["job_name"])
         norm_error = str(occurrences[0]["_normalized"])
-        first_ts = min(r["started_at"] for r in occurrences)
-        last_ts = max(r["started_at"] for r in occurrences)
 
         existing = db.fetch_one(
-            "SELECT id, github_issue_number, occurrence_count, resolved_at "
+            "SELECT id, github_issue_number, occurrence_count, resolved_at, last_seen_at "
             "FROM log_issue_tracker WHERE fingerprint = %s",
             (fp,),
         )
 
         if existing:
-            # Always bump count and update last_seen.
+            # Only count occurrences newer than last scan to avoid double-counting.
+            prev_last_seen = existing.get("last_seen_at")
+            if prev_last_seen:
+                occurrences = [r for r in occurrences if r["started_at"] > prev_last_seen]
+            if not occurrences:
+                continue
+
+        first_ts = min(r["started_at"] for r in occurrences)
+        last_ts = max(r["started_at"] for r in occurrences)
+
+        if existing:
+            # Bump count and update last_seen with only new occurrences.
             db.execute(
                 "UPDATE log_issue_tracker "
                 "SET occurrence_count = occurrence_count + %s, "
@@ -234,8 +251,12 @@ def run_log_to_issues(
                                 int(existing["github_issue_number"]),
                                 f"This failure has reoccurred ({len(occurrences)} new occurrence(s) since last resolution). Reopening for triage.",
                             )
+                            _reopen_github_issue(
+                                github_token, github_repo,
+                                int(existing["github_issue_number"]),
+                            )
                         except Exception as exc:
-                            warnings.append(f"Failed to comment on #{existing['github_issue_number']}: {exc}")
+                            warnings.append(f"Failed to reopen #{existing['github_issue_number']}: {exc}")
                 issues_updated += 1
                 continue
 


### PR DESCRIPTION
## Summary
This change enhances the log-to-issues worker to automatically reopen GitHub issues when a previously resolved failure reoccurs, improving visibility and triage workflow for intermittent failures.

## Key Changes
- Added `_reopen_github_issue()` function to update GitHub issue state to "open" via the GitHub API
- Modified occurrence tracking to filter out duplicates by comparing against `last_seen_at` timestamp, preventing double-counting when the same failures are scanned multiple times
- Updated issue reopening logic to:
  - Only count new occurrences (those after the previous `last_seen_at`)
  - Skip processing if no new occurrences are found
  - Call the new reopen function when a resolved issue reoccurs
  - Update error messaging to reflect the reopen operation
- Added `last_seen_at` to the database query to track when issues were last observed

## Implementation Details
- The timestamp filtering ensures accurate occurrence counts by excluding occurrences that were already processed in previous scans
- The reopen operation is performed via PATCH request to the GitHub API, consistent with the existing `_close_github_issue()` pattern
- Error handling wraps both the comment and reopen operations, with updated warning messages for clarity

https://claude.ai/code/session_01Jz96Skw5Zru7njoFifSCbW