### PR TITLE
Fix crashlooping compute services: add missing args to main.py parser

### DIFF
--- a/python/orchestrator/main.py
+++ b/python/orchestrator/main.py
@@ -70,6 +70,8 @@ def parse_args() -> argparse.Namespace:
     loop_runner.add_argument("--fast-only", action="store_true", help="Only run fast loop")
     loop_runner.add_argument("--background-only", action="store_true", help="Only run background loop")
     loop_runner.add_argument("--lane", default=None, help="Only run jobs in this lane (realtime/ingestion/compute/maintenance)")
+    loop_runner.add_argument("--memory-max-gb", type=float, default=None, help="Memory abort threshold in GiB")
+    loop_runner.add_argument("--no-tier-barriers", action="store_true", help="Use dependency-aware dispatch instead of tier barriers")
     loop_runner.add_argument("--verbose", action="store_true")
 
     zkill = subparsers.add_parser("zkill-worker", help="Run the dedicated zKill continuous worker")
@@ -265,6 +267,8 @@ def main() -> int:
             *( ["--fast-only"] if args.fast_only else [] ),
             *( ["--background-only"] if args.background_only else [] ),
             *( ["--lane", args.lane] if args.lane else [] ),
+            *( ["--memory-max-gb", str(args.memory_max_gb)] if args.memory_max_gb is not None else [] ),
+            *( ["--no-tier-barriers"] if args.no_tier_barriers else [] ),
             *( ["--verbose"] if args.verbose else [] ),
         ])
     if command == "zkill-worker":


### PR DESCRIPTION
## Summary

- `main.py` has a duplicate argparse for the `loop-runner` subcommand that gates which flags reach `loop_runner.py`
- `--memory-max-gb` and `--no-tier-barriers` were added to `loop_runner.py`'s parser but not `main.py`'s
- Both compute services were crashlooping with `unrecognized arguments` (restart counter hit 117)

## Test plan

- [ ] `systemctl restart supplycore-lane-compute supplycore-lane-compute-bg` — both should stay running
- [ ] `journalctl -u supplycore-lane-compute-bg --since "1 min ago"` — should show job execution, not argparse errors

https://claude.ai/code/session_0164vcHk1hCZk3cF1fQdLpcq