### PR TITLE
Killmail overview: add 2024+ loss histogram and ESI coverage diagnostics

### DIFF
--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -11,6 +11,8 @@ $status = $data['status'] ?? [];
 $rows = $data['rows'] ?? [];
 $filters = $data['filters'] ?? [];
 $pagination = $data['pagination'] ?? [];
+$histogram = $data['histogram'] ?? [];
+$coverage = $data['coverage'] ?? [];
 $error = $data['error'] ?? null;
 $emptyMessage = (string) ($data['empty_message'] ?? 'No killmails available yet.');
 try {
@@ -80,6 +82,30 @@ if (function_exists('ob_flush')) { @ob_flush(); }
     <?php endforeach; ?>
 </section>
 <!-- ui-section:killmail-overview-summary:end -->
+
+<section class="mt-6 surface-secondary">
+    <div class="flex flex-wrap items-start justify-between gap-3">
+        <div>
+            <h2 class="text-base font-medium text-slate-50">Loss histogram</h2>
+            <p class="mt-1 text-sm text-muted">Monthly loss counts from <?= htmlspecialchars((string) ($coverage['start_date'] ?? '2024-01-01'), ENT_QUOTES) ?> onward.</p>
+        </div>
+    </div>
+    <?php if ($histogram === []): ?>
+        <p class="mt-4 text-sm text-muted">No loss histogram buckets available yet.</p>
+    <?php else: ?>
+        <div class="mt-4 grid gap-2">
+            <?php foreach ($histogram as $bucket): ?>
+                <div class="grid grid-cols-[88px_minmax(0,1fr)_56px] items-center gap-3 text-xs text-slate-300">
+                    <span class="text-muted"><?= htmlspecialchars((string) ($bucket['label'] ?? ''), ENT_QUOTES) ?></span>
+                    <div class="h-2 rounded-full bg-white/10">
+                        <div class="h-2 rounded-full bg-indigo-400/80" style="width: <?= max(0, min(100, (int) ($bucket['percent'] ?? 0))) ?>%"></div>
+                    </div>
+                    <span class="text-right text-slate-100"><?= number_format((int) ($bucket['count'] ?? 0)) ?></span>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+</section>
 
 <?php if (!empty($runtimeCard['show_latest_failure'])): ?>
     <section class="mt-6 rounded-2xl border px-4 py-4 text-sm <?= htmlspecialchars((string) ($health['tone'] ?? 'border-amber-500/40 bg-amber-500/10 text-amber-100'), ENT_QUOTES) ?>">
@@ -155,6 +181,10 @@ if (function_exists('ob_flush')) { @ob_flush(); }
                 <?php if ((string) ($status['worker_no_write_reason'] ?? '') !== ''): ?>
                     <p class="sm:col-span-2"><span class="text-slate-500">Zero-write reason</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['worker_no_write_reason'] ?? ''), ENT_QUOTES) ?></span></p>
                 <?php endif; ?>
+                <p><span class="text-slate-500">Participant characters</span><br><span class="mt-1 inline-block text-slate-100"><?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span><br><span class="text-xs text-muted">Distinct victim + attacker IDs on losses since <?= htmlspecialchars((string) ($coverage['start_date'] ?? '2024-01-01'), ENT_QUOTES) ?>.</span></p>
+                <p><span class="text-slate-500">ESI queue coverage</span><br><span class="mt-1 inline-block text-slate-100"><?= number_format((int) ($coverage['queued_in_esi_character_queue'] ?? 0)) ?> / <?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span><br><span class="text-xs text-muted">Participants present in <code>esi_character_queue</code>.</span></p>
+                <p><span class="text-slate-500">Current affiliation coverage</span><br><span class="mt-1 inline-block text-slate-100"><?= number_format((int) ($coverage['with_current_affiliation'] ?? 0)) ?> / <?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span><br><span class="text-xs text-muted">Participants with ESI current corp/alliance rows.</span></p>
+                <p><span class="text-slate-500">Alliance history coverage</span><br><span class="mt-1 inline-block text-slate-100"><?= number_format((int) ($coverage['with_alliance_history'] ?? 0)) ?> / <?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span><br><span class="text-xs text-muted">Participants with at least one historical alliance period.</span></p>
             </div>
         </details>
     </article>

--- a/src/db.php
+++ b/src/db.php
@@ -12449,7 +12449,7 @@ function db_killmail_filtered_recent(int $limit = 50): array
     );
 }
 
-function db_killmail_overview_summary(int $recentHours = 24): array
+function db_killmail_overview_summary(int $recentHours = 24, string $startDate = '2024-01-01 00:00:00'): array
 {
     $safeRecentHours = max(1, min(24 * 30, $recentHours));
     $trackedMatchesSql = db_killmail_tracked_matches_sql();
@@ -12462,19 +12462,25 @@ function db_killmail_overview_summary(int $recentHours = 24): array
             MAX(e.created_at) AS last_ingested_at,
             MAX(e.uploaded_at) AS latest_uploaded_at
          FROM {$latestSequencesSql} latest
-         INNER JOIN killmail_events e ON e.sequence_id = latest.sequence_id"
+         INNER JOIN killmail_events e ON e.sequence_id = latest.sequence_id
+         WHERE e.effective_killmail_at >= ?",
+        [$startDate]
     ) ?? [];
     $trackedCountRow = db_select_one(
         "SELECT COUNT(*) AS tracked_match_count
          FROM {$trackedMatchesSql} tracked
-         INNER JOIN {$latestSequencesSql} latest ON latest.sequence_id = tracked.sequence_id"
+         INNER JOIN {$latestSequencesSql} latest ON latest.sequence_id = tracked.sequence_id
+         INNER JOIN killmail_events e ON e.sequence_id = tracked.sequence_id
+         WHERE e.effective_killmail_at >= ?",
+        [$startDate]
     ) ?? [];
     $summary['tracked_match_count'] = (int) ($trackedCountRow['tracked_match_count'] ?? 0);
+    $summary['start_date'] = $startDate;
 
     return $summary;
 }
 
-function db_killmail_overview_filter_options(): array
+function db_killmail_overview_filter_options(string $startDate = '2024-01-01 00:00:00'): array
 {
     $latestSequencesSql = db_killmail_latest_sequences_sql();
     $alliances = db_select(
@@ -12487,8 +12493,10 @@ function db_killmail_overview_filter_options(): array
            ON emc.entity_type = 'alliance' AND emc.entity_id = e.victim_alliance_id
          WHERE e.victim_alliance_id IS NOT NULL
            AND e.victim_alliance_id > 0
+           AND e.effective_killmail_at >= ?
          ORDER BY entity_label ASC
-         LIMIT 200"
+         LIMIT 200",
+        [$startDate]
     );
 
     $corporations = db_select(
@@ -12501,13 +12509,127 @@ function db_killmail_overview_filter_options(): array
            ON emc.entity_type = 'corporation' AND emc.entity_id = e.victim_corporation_id
          WHERE e.victim_corporation_id IS NOT NULL
            AND e.victim_corporation_id > 0
+           AND e.effective_killmail_at >= ?
          ORDER BY entity_label ASC
-         LIMIT 200"
+         LIMIT 200",
+        [$startDate]
     );
 
     return [
         'alliances' => $alliances,
         'corporations' => $corporations,
+    ];
+}
+
+function db_killmail_overview_monthly_histogram(string $startDate = '2024-01-01'): array
+{
+    $latestSequencesSql = db_killmail_latest_sequences_sql();
+    return db_select(
+        "SELECT DATE_FORMAT(e.effective_killmail_at, '%Y-%m') AS bucket_month,
+                COUNT(*) AS loss_count
+         FROM {$latestSequencesSql} latest
+         INNER JOIN killmail_events e ON e.sequence_id = latest.sequence_id
+         WHERE e.mail_type = 'loss'
+           AND e.effective_killmail_at >= ?
+         GROUP BY DATE_FORMAT(e.effective_killmail_at, '%Y-%m')
+         ORDER BY bucket_month ASC",
+        [$startDate . ' 00:00:00']
+    );
+}
+
+function db_killmail_esi_coverage_snapshot(string $startDate = '2024-01-01'): array
+{
+    $startAt = $startDate . ' 00:00:00';
+    $participantCount = (int) db_fetch_single_value(
+        "SELECT COUNT(DISTINCT participant.character_id)
+         FROM (
+             SELECT ke.victim_character_id AS character_id
+             FROM killmail_events ke
+             WHERE ke.victim_character_id IS NOT NULL
+               AND ke.victim_character_id > 0
+               AND ke.effective_killmail_at >= ?
+             UNION
+             SELECT ka.character_id AS character_id
+             FROM killmail_attackers ka
+             INNER JOIN killmail_events ke ON ke.sequence_id = ka.sequence_id
+             WHERE ka.character_id IS NOT NULL
+               AND ka.character_id > 0
+               AND ke.effective_killmail_at >= ?
+         ) participant",
+        [$startAt, $startAt]
+    );
+
+    $queuedCount = (int) db_fetch_single_value(
+        "SELECT COUNT(*)
+         FROM esi_character_queue q
+         INNER JOIN (
+             SELECT ke.victim_character_id AS character_id
+             FROM killmail_events ke
+             WHERE ke.victim_character_id IS NOT NULL
+               AND ke.victim_character_id > 0
+               AND ke.effective_killmail_at >= ?
+             UNION
+             SELECT ka.character_id AS character_id
+             FROM killmail_attackers ka
+             INNER JOIN killmail_events ke ON ke.sequence_id = ka.sequence_id
+             WHERE ka.character_id IS NOT NULL
+               AND ka.character_id > 0
+               AND ke.effective_killmail_at >= ?
+         ) participant ON participant.character_id = q.character_id",
+        [$startAt, $startAt]
+    );
+
+    $affiliationCount = (int) db_fetch_single_value(
+        "SELECT COUNT(*)
+         FROM character_current_affiliation a
+         INNER JOIN (
+             SELECT ke.victim_character_id AS character_id
+             FROM killmail_events ke
+             WHERE ke.victim_character_id IS NOT NULL
+               AND ke.victim_character_id > 0
+               AND ke.effective_killmail_at >= ?
+             UNION
+             SELECT ka.character_id AS character_id
+             FROM killmail_attackers ka
+             INNER JOIN killmail_events ke ON ke.sequence_id = ka.sequence_id
+             WHERE ka.character_id IS NOT NULL
+               AND ka.character_id > 0
+               AND ke.effective_killmail_at >= ?
+         ) participant ON participant.character_id = a.character_id",
+        [$startAt, $startAt]
+    );
+
+    $allianceHistoryCount = (int) db_fetch_single_value(
+        "SELECT COUNT(DISTINCT h.character_id)
+         FROM character_alliance_history h
+         INNER JOIN (
+             SELECT ke.victim_character_id AS character_id
+             FROM killmail_events ke
+             WHERE ke.victim_character_id IS NOT NULL
+               AND ke.victim_character_id > 0
+               AND ke.effective_killmail_at >= ?
+             UNION
+             SELECT ka.character_id AS character_id
+             FROM killmail_attackers ka
+             INNER JOIN killmail_events ke ON ke.sequence_id = ka.sequence_id
+             WHERE ka.character_id IS NOT NULL
+               AND ka.character_id > 0
+               AND ke.effective_killmail_at >= ?
+         ) participant ON participant.character_id = h.character_id",
+        [$startAt, $startAt]
+    );
+
+    $missingAffiliation = max(0, $participantCount - $affiliationCount);
+    $missingAllianceHistory = max(0, $participantCount - $allianceHistoryCount);
+
+    return [
+        'start_date' => $startDate,
+        'participant_characters' => $participantCount,
+        'queued_in_esi_character_queue' => $queuedCount,
+        'with_current_affiliation' => $affiliationCount,
+        'with_alliance_history' => $allianceHistoryCount,
+        'missing_current_affiliation' => $missingAffiliation,
+        'missing_alliance_history' => $missingAllianceHistory,
     ];
 }
 
@@ -12656,6 +12778,7 @@ function db_killmail_overview_page(array $filters = []): array
     $trackedOnly = (bool) ($filters['tracked_only'] ?? false);
     $mailType = in_array((string) ($filters['mail_type'] ?? 'loss'), ['kill', 'loss', ''], true) ? (string) ($filters['mail_type'] ?? 'loss') : 'loss';
     $search = trim((string) ($filters['search'] ?? ''));
+    $startDate = trim((string) ($filters['start_date'] ?? '2024-01-01 00:00:00'));
     $trackedMatchesSql = db_killmail_tracked_matches_sql();
     $latestSequencesSql = db_killmail_latest_sequences_sql();
     $trackedJoinType = $trackedOnly ? 'INNER JOIN' : 'LEFT JOIN';
@@ -12708,6 +12831,8 @@ function db_killmail_overview_page(array $filters = []): array
         $conditions[] = 'e.mail_type = ?';
         $params[] = $mailType;
     }
+    $conditions[] = 'e.effective_killmail_at >= ?';
+    $params[] = $startDate;
 
     if ($search !== '') {
         $needle = '%' . $search . '%';

--- a/src/functions.php
+++ b/src/functions.php
@@ -11576,6 +11576,8 @@ function killmail_detail_data(): array
 function killmail_overview_data(): array
 {
     $recentHours = 24;
+    $overviewStartDate = '2024-01-01';
+    $overviewStartDateTime = $overviewStartDate . ' 00:00:00';
     $allowedPageSizes = [25, 50, 100];
     $pageSize = (int) ($_GET['page_size'] ?? 25);
     if (!in_array($pageSize, $allowedPageSizes, true)) {
@@ -11597,13 +11599,15 @@ function killmail_overview_data(): array
     // own 120-second cache entry and is busted together on the next killmail sync.
     $useCache = $filters['search'] === '';
 
-    $resolver = static function () use ($recentHours, $filters, $allowedPageSizes, $pageSize): array {
+    $resolver = static function () use ($recentHours, $filters, $allowedPageSizes, $pageSize, $overviewStartDate, $overviewStartDateTime): array {
         try {
-            $summaryRow = db_killmail_overview_summary($recentHours);
+            $summaryRow = db_killmail_overview_summary($recentHours, $overviewStartDateTime);
             $status = db_killmail_ingestion_status();
             $workerStatus = zkill_worker_runtime_status();
-            $options = db_killmail_overview_filter_options();
-            $listing = db_killmail_overview_page($filters);
+            $options = db_killmail_overview_filter_options($overviewStartDateTime);
+            $listing = db_killmail_overview_page($filters + ['start_date' => $overviewStartDateTime]);
+            $histogramRows = db_killmail_overview_monthly_histogram($overviewStartDate);
+            $esiCoverage = db_killmail_esi_coverage_snapshot($overviewStartDate);
             $storageDuplicateRows = db_killmail_duplicate_identities(50);
         } catch (Throwable $exception) {
             return [
@@ -11618,10 +11622,12 @@ function killmail_overview_data(): array
                     'result_duplicate_identity_count' => 0,
                 ],
                 'rows' => [],
+                'histogram' => [],
                 'filters' => $filters + [
                     'page_size_options' => $allowedPageSizes,
                     'alliance_options' => ['0' => 'All alliances'],
                     'corporation_options' => ['0' => 'All corporations'],
+                    'start_date' => $overviewStartDate,
                 ],
                 'pagination' => [
                     'page' => 1,
@@ -11631,6 +11637,15 @@ function killmail_overview_data(): array
                     'total_items' => 0,
                     'showing_from' => 0,
                     'showing_to' => 0,
+                ],
+                'coverage' => [
+                    'start_date' => $overviewStartDate,
+                    'participant_characters' => 0,
+                    'queued_in_esi_character_queue' => 0,
+                    'with_current_affiliation' => 0,
+                    'with_alliance_history' => 0,
+                    'missing_current_affiliation' => 0,
+                    'missing_alliance_history' => 0,
                 ],
                 'empty_message' => 'Killmail overview is unavailable because the database query failed.',
             ];
@@ -11909,22 +11924,40 @@ function killmail_overview_data(): array
             'result_duplicate_identities' => [],
         ];
         $statusView['health'] = killmail_ingestion_health_summary($statusView, $workerStatus);
+        $maxHistogramCount = 0;
+        foreach ($histogramRows as $histogramRow) {
+            $maxHistogramCount = max($maxHistogramCount, (int) ($histogramRow['loss_count'] ?? 0));
+        }
+        $histogram = array_map(static function (array $histogramRow) use ($maxHistogramCount): array {
+            $count = (int) ($histogramRow['loss_count'] ?? 0);
+            $monthKey = trim((string) ($histogramRow['bucket_month'] ?? ''));
+            $monthLabel = $monthKey !== '' ? gmdate('M Y', strtotime($monthKey . '-01')) : 'Unknown';
+            return [
+                'month' => $monthKey,
+                'label' => $monthLabel,
+                'count' => $count,
+                'percent' => $maxHistogramCount > 0 ? max(2, (int) round(($count / $maxHistogramCount) * 100)) : 0,
+            ];
+        }, $histogramRows);
 
         return [
             'error' => null,
             'summary' => [
-                ['label' => 'Total Ingested', 'value' => number_format($totalCount), 'context' => 'Killmails stored locally'],
+                ['label' => 'Total Ingested', 'value' => number_format($totalCount), 'context' => 'Killmails stored locally since ' . $overviewStartDate],
                 ['label' => 'Recent Ingestion', 'value' => number_format($recentCount), 'context' => 'Stored in the last ' . $recentHours . ' hours'],
-                ['label' => 'Tracked Entity Killmails', 'value' => number_format($trackedMatchCount), 'context' => 'Stored killmails where a tracked alliance or corporation appears on the victim side'],
+                ['label' => 'Tracked Entity Killmails', 'value' => number_format($trackedMatchCount), 'context' => 'Stored killmails since ' . $overviewStartDate . ' where a tracked alliance or corporation appears on the victim side'],
                 ['label' => 'Last Processed Sequence', 'value' => $maxSequenceId > 0 ? number_format($maxSequenceId) : '—', 'context' => $cursor !== '' ? ('Cursor ' . $cursor) : 'Cursor not recorded yet'],
                 ['label' => 'Sync Freshness', 'value' => killmail_relative_datetime($lastSuccessAt), 'context' => $lastSuccessAt !== null ? ('Last success ' . killmail_format_datetime($lastSuccessAt)) : 'No successful sync recorded'],
             ],
             'status' => $statusView,
             'rows' => $rows,
+            'histogram' => $histogram,
+            'coverage' => $esiCoverage,
             'filters' => $filters + [
                 'page_size_options' => $allowedPageSizes,
                 'alliance_options' => $allianceOptions,
                 'corporation_options' => $corporationOptions,
+                'start_date' => $overviewStartDate,
             ],
             'pagination' => [
                 'page' => (int) ($listing['page'] ?? 1),


### PR DESCRIPTION
### Motivation
- Provide confidence that killmail participants since 2024 are discovered and enriched via ESI and make the dataset visible on the Killmail Loss Overview. 
- Give operators a quick, scoped view (2024 onward) of monthly loss distribution and per-participant ESI/enrichment coverage to verify ingestion and enrichment pipelines.

### Description
- Scope killmail overview queries to a consistent start-date window (`2024-01-01`) by adding a `startDate` parameter to the summary, filter-options, and paginated listing queries in `db_killmail_overview_*` so the overview only reports from 2024 onward (`src/db.php`).
- Add `db_killmail_overview_monthly_histogram()` to compute monthly loss buckets and `db_killmail_esi_coverage_snapshot()` to measure participant coverage across `esi_character_queue`, `character_current_affiliation`, and `character_alliance_history` (`src/db.php`).
- Wire the new diagnostics into the overview data pipeline (`killmail_overview_data()`), compute histogram buckets and percent-scaled bar values, and surface an ESI coverage snapshot (`src/functions.php`).
- Render a new Loss histogram section and ESI coverage diagnostics on the Killmail Loss Overview UI (`public/killmail-intelligence/index.php`) with the default start-date label.
- Default start window is `2024-01-01` (configurable via the `start_date` filter passed to DB calls).

### Testing
- Ran PHP syntax checks: `php -l src/functions.php` — passed. 
- Ran PHP syntax checks: `php -l src/db.php` — passed. 
- Ran PHP syntax checks: `php -l public/killmail-intelligence/index.php` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d893c47458832fb87d76c881d64d25)