### PR TITLE
Add missing db_fetch_single_value helper

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -696,6 +696,16 @@ function db_select_one(string $sql, array $params = []): ?array
     return $result === false ? null : $result;
 }
 
+function db_fetch_single_value(string $sql, array $params = []): mixed
+{
+    $row = db_select_one($sql, $params);
+    if (!is_array($row) || $row === []) {
+        return null;
+    }
+
+    return reset($row);
+}
+
 function db_execute(string $sql, array $params = []): bool
 {
     db_query_cache_clear();


### PR DESCRIPTION
### Motivation
- The killmail overview code called `db_fetch_single_value()` and caused a fatal when the helper was undefined, so the helper was reintroduced to restore scalar query usage.

### Description
- Added `db_fetch_single_value(string $sql, array $params = []): mixed` to `src/db.php` as a thin wrapper that delegates to `db_select_one()`.
- The helper returns `null` when no row is returned and otherwise returns the first column value via `reset()` so existing count/select usages work as scalars.

### Testing
- Ran `php -l src/db.php` to validate syntax and it returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d895d3b13c832f8760319d5bbaabf4)