### PR TITLE
fix: HotAlliance untag query rejects nested MATCH in COUNT{}

### DIFF
--- a/python/orchestrator/jobs/compute_bloom_entry_points.py
+++ b/python/orchestrator/jobs/compute_bloom_entry_points.py
@@ -232,14 +232,16 @@ def _refresh_hot_alliances(
     max_tags: int,
 ) -> dict[str, int]:
     """Tag alliances with recent engagement volume."""
+    # COUNT { } subqueries on this Neo4j version only accept a single
+    # pattern + WHERE, not nested MATCH clauses.  Use an OPTIONAL MATCH
+    # aggregation instead — this also matches the tag path semantics,
+    # which counts DISTINCT recent battles rather than path rows.
     untagged = client.query(
         """
         MATCH (a:HotAlliance)
-        WITH a, COUNT {
-            (p:Character)-[:MEMBER_OF_ALLIANCE]->(a)
-            MATCH (p)-[:PARTICIPATED_IN]->(b:Battle)
-            WHERE b.started_at >= toString(datetime() - duration({days: $window}))
-        } AS recent_count
+        OPTIONAL MATCH (a)<-[:MEMBER_OF_ALLIANCE]-(:Character)-[:PARTICIPATED_IN]->(b:Battle)
+        WHERE b.started_at >= toString(datetime() - duration({days: $window}))
+        WITH a, count(DISTINCT b) AS recent_count
         WHERE recent_count < $min_engagements
         WITH a LIMIT $cap
         REMOVE a:HotAlliance


### PR DESCRIPTION
## Summary

Follow-up fix to #912. The `_refresh_hot_alliances` untag query in `compute_bloom_entry_points` was using a `COUNT { }` subquery with a nested `MATCH` clause, which the installed Neo4j rejects at parse time:

```
Invalid input 'MATCH': expected a graph pattern, ',', 'WHERE' or '}'
"            MATCH (p)-[:PARTICIPATED_IN]->(b:Battle)"
             ^
```

On this Neo4j version, `COUNT { }` only supports a single pattern followed by an optional `WHERE` — the full sub-query form (`COUNT { MATCH ... MATCH ... }`) is a 5.6+ feature.

## Fix

Rewrote the untag path as an `OPTIONAL MATCH` aggregation:

```cypher
MATCH (a:HotAlliance)
OPTIONAL MATCH (a)<-[:MEMBER_OF_ALLIANCE]-(:Character)-[:PARTICIPATED_IN]->(b:Battle)
WHERE b.started_at >= toString(datetime() - duration({days: $window}))
WITH a, count(DISTINCT b) AS recent_count
WHERE recent_count < $min_engagements
WITH a LIMIT $cap
REMOVE a:HotAlliance
...
```

Bonus: the untag path now counts `DISTINCT b` (distinct recent battles), which matches the tag path's semantics exactly — the previous `COUNT { }` form counted raw path rows, which over-counted by alliance member fan-out.

## Other helpers verified clean

- `_refresh_hot_battles` / `_refresh_high_risk_pilots` — no `COUNT { }`, plain `WHERE`
- `_refresh_strategic_systems` — uses the supported single-pattern + `WHERE` form of `COUNT { }`

## Test plan

- [ ] `python -m orchestrator run-job --app-root /var/www/SupplyCore --job-key compute_bloom_entry_points` returns `status: success`
- [ ] Verify all four entry-point tiers receive tags:
  ```cypher
  MATCH (n:HotBattle)       RETURN 'HotBattle'       AS tag, count(n) AS c
  UNION ALL
  MATCH (n:HighRiskPilot)   RETURN 'HighRiskPilot'   AS tag, count(n) AS c
  UNION ALL
  MATCH (n:StrategicSystem) RETURN 'StrategicSystem' AS tag, count(n) AS c
  UNION ALL
  MATCH (n:HotAlliance)     RETURN 'HotAlliance'     AS tag, count(n) AS c;
  ```

https://claude.ai/code/session_01X9KALy4YQAZ38BMvHMFcTC