### PR TITLE
Update Neo4j graph projection for GDS 2.4+ compatibility

### DIFF
--- a/python/orchestrator/jobs/neo4j_ml_exploration.py
+++ b/python/orchestrator/jobs/neo4j_ml_exploration.py
@@ -145,16 +145,33 @@ def _create_projection(client: Neo4jClient, window: dict[str, Any]) -> tuple[boo
     # Always use Cypher projection — it handles missing relationship types
     # gracefully (returns zero rows) instead of failing hard like native
     # projection which validates all specified types exist upfront.
+    #
+    # GDS 2.4+ removed the ``gds.graph.project.cypher`` procedure and
+    # replaced it with a Cypher projection *function* that must be invoked
+    # inside a ``MATCH ... WITH gds.graph.project(...)`` pipeline (passing
+    # node/relationship *values*, not query strings).  Calling the old
+    # procedure form with query strings raises ``IllegalArgumentException:
+    # Invalid node projection, one or more labels not found`` because GDS
+    # falls back to the native factory and tries to parse the string as a
+    # node label.  A directional match combined with the
+    # ``undirectedRelationshipTypes`` option yields an undirected graph
+    # without double-counting edges from a symmetric Cypher pattern.
     client.query(
         f"""
-        CALL gds.graph.project(
+        MATCH (source:Character)-[r:{CHARACTER_REL_TYPES_STR}]->(target:Character)
+        {date_filter}
+        WITH gds.graph.project(
             '{name}',
-            'MATCH (c:Character) RETURN id(c) AS id',
-            'MATCH (a:Character)-[r:{CHARACTER_REL_TYPES_STR}]-(b:Character)
-             {date_filter}
-             RETURN id(a) AS source, id(b) AS target,
-                    COALESCE(r.weight, COALESCE(r.count, 1.0)) AS weight'
-        )
+            source,
+            target,
+            {{
+                relationshipProperties: {{
+                    weight: COALESCE(r.weight, COALESCE(r.count, 1.0))
+                }}
+            }},
+            {{ undirectedRelationshipTypes: ['*'] }}
+        ) AS g
+        RETURN g.graphName AS graphName
         """,
         timeout_seconds=180,
     )


### PR DESCRIPTION
## Summary
Updated the Neo4j graph projection logic to be compatible with GDS 2.4+, which replaced the `gds.graph.project.cypher` procedure with a Cypher projection function that must be invoked within a query pipeline.

## Key Changes
- Migrated from the deprecated `CALL gds.graph.project()` procedure with query string parameters to the new function-based approach
- Changed node/relationship specification from Cypher query strings to direct value passing within a `MATCH ... WITH gds.graph.project(...)` pipeline
- Moved relationship filtering (date filter) into the main `MATCH` clause for better efficiency
- Added `undirectedRelationshipTypes: ['*']` option to create an undirected graph without double-counting edges from symmetric patterns
- Converted relationship weight calculation from the query string to a `relationshipProperties` configuration object

## Implementation Details
- The new approach uses a directional match (`-[r]->`) combined with the `undirectedRelationshipTypes` option to avoid edge duplication
- Relationship properties (weight) are now specified in the configuration rather than in the Cypher query
- The projection is now returned as a graph object (`AS g`) with the graph name extracted in the final `RETURN` clause
- This change maintains the same graceful handling of missing relationship types while being compatible with GDS 2.4+

https://claude.ai/code/session_01XVN1q7BjrwQgMXHbShC4L8