### PR TITLE
feat(bloom): Cypher cheat-sheet + PHP dashboard panel for Community E…

### DIFF
--- a/database/migrations/20260425_bloom_entry_points_materialized.sql
+++ b/database/migrations/20260425_bloom_entry_points_materialized.sql
@@ -1,0 +1,33 @@
+-- Bloom Operational Intelligence — dashboard materialization table
+-- ─────────────────────────────────────────────────────────────────────
+-- The compute_bloom_entry_points job maintains additive labels on the
+-- Neo4j graph (:HotBattle, :HighRiskPilot, :StrategicSystem,
+-- :HotAlliance).  Neo4j Community Edition has no Bloom UI, so operators
+-- need to see the tiers in the PHP dashboard instead.
+--
+-- This table is the read-side projection: the same job that tags the
+-- Neo4j labels also writes a ranked top-N row per tier here.  The PHP
+-- dashboard queries this table directly — one cheap SQL read per
+-- render, decoupled from Neo4j HTTP latency.
+--
+-- Schema notes:
+--   PRIMARY KEY (tier, rank_in_tier) gives O(1) "top N in tier" reads.
+--   entity_ref_type / entity_ref_id identifies the underlying graph
+--   node so the dashboard can link into the canonical PHP view.
+--   detail_json carries tier-specific extras (started_at,
+--   participant_count, suspicion_score, region_name, …) without
+--   needing a column per field.
+
+CREATE TABLE IF NOT EXISTS bloom_entry_points_materialized (
+    tier              VARCHAR(32)     NOT NULL,
+    rank_in_tier      SMALLINT UNSIGNED NOT NULL,
+    entity_ref_type   VARCHAR(32)     NOT NULL,
+    entity_ref_id     BIGINT UNSIGNED NOT NULL,
+    entity_name       VARCHAR(255)    NULL,
+    score             DOUBLE          NULL,
+    detail_json       JSON            NULL,
+    refreshed_at      DATETIME        NOT NULL,
+    PRIMARY KEY (tier, rank_in_tier),
+    KEY idx_bloom_entity (entity_ref_type, entity_ref_id),
+    KEY idx_bloom_refreshed (refreshed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/docs/BLOOM_CYPHER_CHEATSHEET.md
+++ b/docs/BLOOM_CYPHER_CHEATSHEET.md
@@ -1,0 +1,390 @@
+# Bloom Intelligence — Cypher Cheat-Sheet for Neo4j Browser
+
+> **Who this is for**: operators running **Neo4j Community Edition** who
+> cannot use the Bloom UI (Bloom is Enterprise-only). Every phrase from
+> `setup/neo4j_bloom_perspective.json` is reproduced here as a pasteable
+> Cypher snippet for the free **Neo4j Browser**.
+>
+> This gives you ~90% of the Bloom analyst workflow — you lose the
+> click-to-expand visual interaction, but all the curated queries still
+> work unchanged. The companion runbook is
+> `docs/BLOOM_OPERATIONAL_INTELLIGENCE.md`.
+
+---
+
+## 0. Setup
+
+### Open Neo4j Browser
+
+Neo4j Browser is the free web UI that ships with every Neo4j install
+(Community and Enterprise). It's almost certainly already running:
+
+    http://<your-neo4j-host>:7474/browser/
+
+Log in with the same credentials the orchestrator uses (the
+`neo4j.username` / `neo4j.password` values from `app_settings`, or from
+the `NEO4J_USERNAME` / `NEO4J_PASSWORD` env vars).
+
+### Setting query parameters
+
+Most of the phrases below use `$name` / `$system` / `$alliance`
+placeholders. In Neo4j Browser you set those with the `:params` command
+**once per session**, then every subsequent `MATCH` picks them up
+automatically:
+
+```
+:params {name: "Pilot Name Fragment"}
+```
+
+To set multiple at once:
+
+```
+:params {from: "Jita", to: "Amarr"}
+```
+
+To clear: `:params {}`.
+
+### Make sure the entry-point labels exist
+
+The "Show …" phrases in section 1 depend on the four additive labels
+maintained by the `compute_bloom_entry_points` job. Run this once to
+confirm they are populated:
+
+```cypher
+MATCH (n:HotBattle)       RETURN 'HotBattle'       AS tag, count(n) AS c
+UNION ALL
+MATCH (n:HighRiskPilot)   RETURN 'HighRiskPilot'   AS tag, count(n) AS c
+UNION ALL
+MATCH (n:StrategicSystem) RETURN 'StrategicSystem' AS tag, count(n) AS c
+UNION ALL
+MATCH (n:HotAlliance)     RETURN 'HotAlliance'     AS tag, count(n) AS c;
+```
+
+If any tier is zero, run the job manually:
+
+```bash
+python -m orchestrator run-job \
+  --app-root /var/www/SupplyCore \
+  --job-key compute_bloom_entry_points
+```
+
+---
+
+## 1. Discovery phrases
+
+Fast look-ups for the first click of any investigation.
+
+### Find pilot
+
+```
+:params {name: "pilot fragment"}
+```
+
+```cypher
+MATCH (p:Character)
+WHERE toLower(p.name) CONTAINS toLower($name)
+RETURN p
+ORDER BY COALESCE(p.suspicion_score, 0) DESC
+LIMIT 50;
+```
+
+### Find alliance
+
+```
+:params {name: "alliance fragment"}
+```
+
+```cypher
+MATCH (a:Alliance)
+WHERE toLower(a.name) CONTAINS toLower($name)
+RETURN a
+LIMIT 50;
+```
+
+### Show hot engagements
+
+No parameters — opens the `:HotBattle` tier ordered by heat score.
+
+```cypher
+MATCH (b:HotBattle)
+WITH b ORDER BY b.bloom_hot_score DESC LIMIT 50
+OPTIONAL MATCH (b)-[:IN_SYSTEM|LOCATED_IN]->(s:System)
+RETURN b, s;
+```
+
+### Show high-risk pilots
+
+No parameters — opens the `:HighRiskPilot` tier ordered by recent
+suspicion score.
+
+```cypher
+MATCH (p:HighRiskPilot)
+WITH p
+ORDER BY COALESCE(p.suspicion_score_recent, p.suspicion_score, 0) DESC
+LIMIT 50
+OPTIONAL MATCH (p)-[:MEMBER_OF_ALLIANCE]->(a:Alliance)
+RETURN p, a;
+```
+
+### Show strategic systems
+
+No parameters — opens the `:StrategicSystem` tier ordered by recent
+battle density.
+
+```cypher
+MATCH (s:StrategicSystem)
+WITH s ORDER BY s.bloom_recent_battle_count DESC LIMIT 50
+RETURN s;
+```
+
+---
+
+## 2. Locational phrases
+
+Where is the fighting happening right now?
+
+> **APOC required.** These three phrases use `apoc.date.format` for a
+> clean "last N days" window. If APOC is not installed, replace the
+> `apoc.date.format(...)` call with a literal ISO timestamp like
+> `'2026-04-03T00:00:00Z'` and re-run.
+
+### Show battles in a system (last 30 days)
+
+```
+:params {system: "Jita"}
+```
+
+```cypher
+MATCH (s:System)
+WHERE toLower(s.name) CONTAINS toLower($system)
+WITH s
+MATCH (b:Battle)-[:IN_SYSTEM|LOCATED_IN]->(s)
+WHERE b.started_at >= apoc.date.format(
+    datetime() - duration('P30D'),
+    'ms',
+    'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+)
+RETURN b, s
+ORDER BY b.started_at DESC
+LIMIT 100;
+```
+
+### Show battles in a region (last 14 days)
+
+```
+:params {region: "Delve"}
+```
+
+```cypher
+MATCH (r:Region)
+WHERE toLower(r.name) CONTAINS toLower($region)
+WITH r
+MATCH (b:Battle)-[:IN_SYSTEM|LOCATED_IN]->(:System)
+      -[:IN_CONSTELLATION]->(:Constellation)
+      -[:IN_REGION]->(r)
+WHERE b.started_at >= apoc.date.format(
+    datetime() - duration('P14D'),
+    'ms',
+    'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+)
+RETURN b, r
+ORDER BY b.started_at DESC
+LIMIT 100;
+```
+
+### Find alliances active in a system (last 30 days)
+
+```
+:params {system: "Jita"}
+```
+
+```cypher
+MATCH (s:System)
+WHERE toLower(s.name) CONTAINS toLower($system)
+WITH s
+MATCH (b:Battle)-[:IN_SYSTEM|LOCATED_IN]->(s)
+WHERE b.started_at >= apoc.date.format(
+    datetime() - duration('P30D'),
+    'ms',
+    'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+)
+MATCH (p:Character)-[:PARTICIPATED_IN]->(b)
+MATCH (p)-[:MEMBER_OF_ALLIANCE]->(a:Alliance)
+RETURN DISTINCT a, count(DISTINCT b) AS battles
+ORDER BY battles DESC
+LIMIT 50;
+```
+
+---
+
+## 3. Investigation phrases
+
+Pivot from a suspect / alliance / doctrine and follow the evidence.
+
+### Pilots who flew with a target (top 25 co-occurrence peers)
+
+```
+:params {name: "target pilot name"}
+```
+
+```cypher
+MATCH (p:Character)
+WHERE toLower(p.name) CONTAINS toLower($name)
+WITH p LIMIT 1
+MATCH (p)-[r:CO_OCCURS_WITH]-(other:Character)
+WHERE COALESCE(r.recent_weight, r.weight, 0) > 0
+RETURN p, r, other
+ORDER BY COALESCE(r.recent_weight, r.weight, 0) DESC
+LIMIT 25;
+```
+
+### Find pilots who flew with members of a hostile alliance
+
+```
+:params {alliance: "hostile alliance name"}
+```
+
+```cypher
+MATCH (a:Alliance)
+WHERE toLower(a.name) CONTAINS toLower($alliance)
+WITH a LIMIT 1
+MATCH (p:Character)-[:CO_OCCURS_WITH]-(hostile:Character)
+      -[:MEMBER_OF_ALLIANCE]->(a)
+WITH p, count(DISTINCT hostile) AS overlap
+ORDER BY overlap DESC
+LIMIT 50
+RETURN p, overlap;
+```
+
+### Doctrine usage — fits and items
+
+```
+:params {name: "doctrine name"}
+```
+
+```cypher
+MATCH (d:Doctrine)
+WHERE toLower(d.name) CONTAINS toLower($name)
+WITH d LIMIT 1
+MATCH (d)-[:USES]->(f:Fit)
+OPTIONAL MATCH (f)-[:CONTAINS]->(i:Item)
+RETURN d, f, i
+LIMIT 250;
+```
+
+### Alliance relationships (ally / hostile graph)
+
+```
+:params {name: "alliance name"}
+```
+
+```cypher
+MATCH (a:Alliance)
+WHERE toLower(a.name) CONTAINS toLower($name)
+WITH a LIMIT 1
+OPTIONAL MATCH (a)-[r1:ALLIED_WITH]-(ally:Alliance)
+OPTIONAL MATCH (a)-[r2:HOSTILE_TO]-(enemy:Alliance)
+RETURN a, r1, ally, r2, enemy
+LIMIT 100;
+```
+
+### Threat corridor — shortest gate path (≤ 10 jumps)
+
+```
+:params {from: "Jita", to: "Amarr"}
+```
+
+```cypher
+MATCH (a:System), (b:System)
+WHERE toLower(a.name) = toLower($from)
+  AND toLower(b.name) = toLower($to)
+MATCH path = shortestPath((a)-[:CONNECTS_TO*..10]-(b))
+RETURN path
+LIMIT 1;
+```
+
+### Explain suspicion — the visual evidence trace
+
+Pulls co-occurrence peers, anomaly associations, and side-crossings for
+a target. This is the human validation loop that closes the feedback
+between the scoring pipeline and analyst trust.
+
+```
+:params {name: "suspect pilot name"}
+```
+
+```cypher
+MATCH (p:Character)
+WHERE toLower(p.name) CONTAINS toLower($name)
+WITH p LIMIT 1
+OPTIONAL MATCH (p)-[r1:CO_OCCURS_WITH]-(peer:Character)
+WITH p, r1, peer
+ORDER BY COALESCE(r1.recent_weight, 0) DESC LIMIT 15
+OPTIONAL MATCH (p)-[r2:ASSOCIATED_WITH_ANOMALY]->(b:Battle)
+OPTIONAL MATCH (p)-[r3:CROSSED_SIDES]-(other:Character)
+RETURN p, r1, peer, r2, b, r3, other;
+```
+
+---
+
+## 4. Validation & freshness
+
+### Tag freshness — when was each tier last refreshed?
+
+```cypher
+MATCH (n)
+WHERE n.bloom_tagged_at IS NOT NULL
+RETURN labels(n) AS labels, n.bloom_tagged_at AS tagged_at
+ORDER BY tagged_at DESC
+LIMIT 25;
+```
+
+### Top 10 of each tier (quick sanity check)
+
+```cypher
+MATCH (b:HotBattle)
+RETURN 'HotBattle' AS tier, b.battle_id AS id, b.bloom_hot_score AS score
+ORDER BY score DESC LIMIT 10;
+```
+
+```cypher
+MATCH (p:HighRiskPilot)
+RETURN 'HighRiskPilot' AS tier, p.name AS name,
+       COALESCE(p.suspicion_score_recent, p.suspicion_score, 0) AS score
+ORDER BY score DESC LIMIT 10;
+```
+
+```cypher
+MATCH (s:StrategicSystem)
+RETURN 'StrategicSystem' AS tier, s.name AS name,
+       s.bloom_recent_battle_count AS battles
+ORDER BY battles DESC LIMIT 10;
+```
+
+```cypher
+MATCH (a:HotAlliance)
+RETURN 'HotAlliance' AS tier, a.name AS name,
+       a.bloom_recent_engagement_count AS engagements
+ORDER BY engagements DESC LIMIT 10;
+```
+
+---
+
+## 5. Operator notes
+
+- **Favourite the Browser tab**. Neo4j Browser lets you save any query
+  as a favourite (the star icon in the editor). Paste each phrase once,
+  star it, and your sidebar becomes the equivalent of the Bloom search
+  phrase list.
+- **Dense edges (`CO_OCCURS_WITH`, `SAME_FLEET`) are unbounded by
+  design.** Never write `MATCH (p)-[:CO_OCCURS_WITH*1..3]-(x)` — always
+  filter by `recent_weight` / `weight` and `LIMIT`.
+- **The PHP dashboard also surfaces the four tiers.** See the
+  *Intelligence Anchors* panel on the main dashboard, populated from
+  `bloom_entry_points_materialized` (maintained by the same job that
+  maintains the Neo4j labels). That gives you the top-10 view without
+  leaving the operator cockpit.
+- **Related docs:** `docs/BLOOM_OPERATIONAL_INTELLIGENCE.md` (full
+  runbook), `setup/neo4j_bloom_perspective.json` (the perspective JSON
+  these phrases are extracted from), `setup/neo4j_bloom_entry_points.cypher`
+  (the indexes backing the four tiers).

--- a/public/index.php
+++ b/public/index.php
@@ -62,6 +62,35 @@ try {
 } catch (Throwable) {
     $sitAwareness['sov_alerts'] = 0;
 }
+
+// --- Bloom Operational Intelligence: four-tier graph entry points ---
+// Read from `bloom_entry_points_materialized`, which is refreshed by the
+// compute_bloom_entry_points job (same run that maintains the Neo4j
+// :HotBattle / :HighRiskPilot / :StrategicSystem / :HotAlliance labels).
+// Neo4j Community Edition has no Bloom UI, so this panel is the operator-
+// facing projection of the four tiers. Guarded so a missing table (before
+// the migration runs) doesn't break the dashboard.
+$bloomTiers = [
+    'HotBattle'       => [],
+    'HighRiskPilot'   => [],
+    'StrategicSystem' => [],
+    'HotAlliance'     => [],
+];
+$bloomRefreshedAt = null;
+try {
+    if (function_exists('db_bloom_entry_points_by_tier')) {
+        foreach (array_keys($bloomTiers) as $tierKey) {
+            $rows = db_bloom_entry_points_by_tier($tierKey, 10);
+            $bloomTiers[$tierKey] = $rows;
+            if ($bloomRefreshedAt === null && !empty($rows)) {
+                $bloomRefreshedAt = (string) ($rows[0]['refreshed_at'] ?? '');
+            }
+        }
+    }
+} catch (Throwable) {
+    // Swallow: table may not exist yet on installs that haven't run the
+    // 20260425_bloom_entry_points_materialized migration.
+}
 ?>
 <?php
 $kpiThemes = [
@@ -288,6 +317,197 @@ try {
 </section>
 <!-- ui-section:dashboard-kpis:end -->
 <?php $sectionKpis = ob_get_clean(); ?>
+
+<?php ob_start(); // capture Bloom Operational Intelligence section ?>
+<?php
+$bloomHasAny = false;
+foreach ($bloomTiers as $__tierRows) {
+    if (!empty($__tierRows)) { $bloomHasAny = true; break; }
+}
+unset($__tierRows);
+$bloomTierMeta = [
+    'HotBattle' => [
+        'eyebrow' => 'Hot engagements',
+        'title'   => 'Hot Battles',
+        'subtitle' => 'Active fights ranked by heat score.',
+        'badgeClass' => 'border-rose-400/20 bg-rose-500/10 text-rose-200',
+        'badgeLabel' => 'Top 10 battles',
+        'valueClass' => 'text-rose-200',
+        'emptyLabel' => 'No battles tagged as hot right now.',
+    ],
+    'HighRiskPilot' => [
+        'eyebrow' => 'Threat actors',
+        'title'   => 'High-Risk Pilots',
+        'subtitle' => 'Suspicion-weighted watchlist.',
+        'badgeClass' => 'border-amber-400/20 bg-amber-500/10 text-amber-100',
+        'badgeLabel' => 'Top 10 pilots',
+        'valueClass' => 'text-amber-200',
+        'emptyLabel' => 'No pilots currently flagged as high risk.',
+    ],
+    'StrategicSystem' => [
+        'eyebrow' => 'Contested space',
+        'title'   => 'Strategic Systems',
+        'subtitle' => 'Systems with dense recent battle activity.',
+        'badgeClass' => 'border-cyan-400/20 bg-cyan-500/10 text-cyan-100',
+        'badgeLabel' => 'Top 10 systems',
+        'valueClass' => 'text-cyan-200',
+        'emptyLabel' => 'No systems currently flagged as strategic.',
+    ],
+    'HotAlliance' => [
+        'eyebrow' => 'Active blocs',
+        'title'   => 'Hot Alliances',
+        'subtitle' => 'Alliances engaged in the most recent fighting.',
+        'badgeClass' => 'border-fuchsia-400/20 bg-fuchsia-500/10 text-fuchsia-200',
+        'badgeLabel' => 'Top 10 alliances',
+        'valueClass' => 'text-fuchsia-200',
+        'emptyLabel' => 'No alliances currently flagged as hot.',
+    ],
+];
+?>
+<!-- ui-section:dashboard-bloom-entry-points:start -->
+<section class="mt-8" data-ui-section="dashboard-bloom-entry-points">
+    <article class="surface-primary">
+        <div class="section-header border-b border-white/8 pb-4">
+            <div>
+                <p class="eyebrow">Intelligence anchors</p>
+                <h2 class="mt-2 section-title">Bloom Entry Points</h2>
+                <p class="mt-2 section-copy">The four graph tiers maintained by <code class="font-mono text-xs text-slate-300">compute_bloom_entry_points</code>. Start any investigation here and pivot into the Neo4j Browser or the canonical PHP views.</p>
+            </div>
+            <div class="flex items-center gap-3">
+                <?php if ($bloomRefreshedAt !== null && $bloomRefreshedAt !== ''): ?>
+                    <span class="badge border-slate-500/20 bg-slate-500/10 text-slate-300">Refreshed <?= htmlspecialchars($bloomRefreshedAt, ENT_QUOTES) ?> UTC</span>
+                <?php endif; ?>
+                <a href="/docs/BLOOM_CYPHER_CHEATSHEET.md" class="btn-secondary text-xs">Cypher cheat-sheet</a>
+            </div>
+        </div>
+
+        <?php if (!$bloomHasAny): ?>
+            <div class="mt-5 rounded-[1.2rem] border border-white/6 bg-white/[0.02] px-4 py-4 text-sm text-slate-400">
+                No Bloom entry points have been materialized yet. Run the job with:
+                <code class="ml-1 rounded bg-slate-900/60 px-2 py-0.5 font-mono text-xs text-slate-200">python -m orchestrator run-job --app-root /var/www/SupplyCore --job-key compute_bloom_entry_points</code>
+            </div>
+        <?php else: ?>
+            <div class="mt-5 grid gap-5 lg:grid-cols-2 xl:grid-cols-4">
+                <?php foreach ($bloomTierMeta as $tierKey => $meta): ?>
+                    <?php $tierRows = (array) ($bloomTiers[$tierKey] ?? []); ?>
+                    <div class="surface-tertiary">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <p class="eyebrow"><?= htmlspecialchars($meta['eyebrow'], ENT_QUOTES) ?></p>
+                                <h3 class="mt-1 text-lg font-semibold text-white"><?= htmlspecialchars($meta['title'], ENT_QUOTES) ?></h3>
+                                <p class="mt-1 text-sm text-slate-400"><?= htmlspecialchars($meta['subtitle'], ENT_QUOTES) ?></p>
+                            </div>
+                            <span class="badge <?= htmlspecialchars($meta['badgeClass'], ENT_QUOTES) ?>"><?= htmlspecialchars($meta['badgeLabel'], ENT_QUOTES) ?></span>
+                        </div>
+                        <div class="mt-4 space-y-2.5">
+                            <?php if ($tierRows === []): ?>
+                                <div class="rounded-[1.2rem] border border-white/6 bg-white/[0.02] px-4 py-3 text-sm text-slate-400"><?= htmlspecialchars($meta['emptyLabel'], ENT_QUOTES) ?></div>
+                            <?php else: ?>
+                                <?php foreach (array_slice($tierRows, 0, 5) as $row): ?>
+                                    <?php
+                                    $refType = (string) ($row['entity_ref_type'] ?? '');
+                                    $refId   = (int) ($row['entity_ref_id'] ?? 0);
+                                    $name    = (string) ($row['entity_name'] ?? '');
+                                    $score   = $row['score'] ?? null;
+                                    $detail  = (array) ($row['detail'] ?? []);
+
+                                    $href = '#';
+                                    $secondary = '';
+                                    switch ($refType) {
+                                        case 'battle_id':
+                                            $href = '/theater-intelligence#battle-' . $refId;
+                                            $parts = [];
+                                            if (!empty($detail['started_at'])) {
+                                                $parts[] = (string) $detail['started_at'];
+                                            }
+                                            if (isset($detail['participant_count'])) {
+                                                $parts[] = (int) $detail['participant_count'] . ' pilots';
+                                            }
+                                            if (!empty($detail['system_name'])) {
+                                                $parts[] = (string) $detail['system_name'];
+                                            }
+                                            $secondary = implode(' · ', $parts);
+                                            if ($name === '') {
+                                                $name = 'Battle #' . $refId;
+                                            }
+                                            break;
+                                        case 'character_id':
+                                            $href = '/character.php?id=' . $refId;
+                                            $parts = [];
+                                            if (!empty($detail['alliance_name'])) {
+                                                $parts[] = (string) $detail['alliance_name'];
+                                            }
+                                            if (isset($detail['recent_battle_count'])) {
+                                                $parts[] = (int) $detail['recent_battle_count'] . ' recent battles';
+                                            }
+                                            $secondary = implode(' · ', $parts);
+                                            if ($name === '') {
+                                                $name = 'Character #' . $refId;
+                                            }
+                                            break;
+                                        case 'system_id':
+                                            $href = '/system.php?id=' . $refId;
+                                            $parts = [];
+                                            if (!empty($detail['region_name'])) {
+                                                $parts[] = (string) $detail['region_name'];
+                                            }
+                                            if (isset($detail['recent_battle_count'])) {
+                                                $parts[] = (int) $detail['recent_battle_count'] . ' recent battles';
+                                            }
+                                            $secondary = implode(' · ', $parts);
+                                            if ($name === '') {
+                                                $name = 'System #' . $refId;
+                                            }
+                                            break;
+                                        case 'alliance_id':
+                                            $href = '/alliance.php?id=' . $refId;
+                                            $parts = [];
+                                            if (isset($detail['recent_engagement_count'])) {
+                                                $parts[] = (int) $detail['recent_engagement_count'] . ' engagements';
+                                            }
+                                            if (isset($detail['recent_pilot_count'])) {
+                                                $parts[] = (int) $detail['recent_pilot_count'] . ' pilots';
+                                            }
+                                            $secondary = implode(' · ', $parts);
+                                            if ($name === '') {
+                                                $name = 'Alliance #' . $refId;
+                                            }
+                                            break;
+                                    }
+
+                                    $scoreLabel = '';
+                                    if (is_numeric($score)) {
+                                        $scoreLabel = number_format((float) $score, ((float) $score) >= 100 ? 0 : 1);
+                                    }
+                                    ?>
+                                    <a href="<?= htmlspecialchars($href, ENT_QUOTES) ?>" class="intelligence-row group">
+                                        <div class="min-w-0 flex-1">
+                                            <p class="truncate text-sm font-semibold text-slate-100"><?= htmlspecialchars($name, ENT_QUOTES) ?></p>
+                                            <?php if ($secondary !== ''): ?>
+                                                <p class="mt-1 truncate text-xs text-slate-500"><?= htmlspecialchars($secondary, ENT_QUOTES) ?></p>
+                                            <?php endif; ?>
+                                        </div>
+                                        <?php if ($scoreLabel !== ''): ?>
+                                            <div class="text-right">
+                                                <p class="text-sm font-semibold <?= htmlspecialchars($meta['valueClass'], ENT_QUOTES) ?>"><?= htmlspecialchars($scoreLabel, ENT_QUOTES) ?></p>
+                                                <p class="text-xs text-slate-500">score</p>
+                                            </div>
+                                        <?php endif; ?>
+                                    </a>
+                                <?php endforeach; ?>
+                                <?php if (count($tierRows) > 5): ?>
+                                    <p class="text-xs text-slate-500">+ <?= (int) (count($tierRows) - 5) ?> more in the materialized top-10.</p>
+                                <?php endif; ?>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </article>
+</section>
+<!-- ui-section:dashboard-bloom-entry-points:end -->
+<?php $sectionBloom = ob_get_clean(); ?>
 
 <?php ob_start(); // capture Buy All section ?>
 <!-- ui-section:dashboard-buyall:start -->
@@ -836,10 +1056,12 @@ if ($hasSitData): ?>
 <?php endif; ?>
 
 <?php
-// Reordered dashboard: Buy-all first (primary action), then doctrine, KPIs, rest
+// Reordered dashboard: Buy-all first (primary action), then doctrine, KPIs,
+// Bloom graph entry points, then the rest.
 echo $sectionBuyAll;
 echo $sectionDoctrine;
 echo $sectionKpis;
+echo $sectionBloom;
 
 // Opposition Intelligence Card (guarded against missing tables)
 $oppBriefing = null;

--- a/python/orchestrator/jobs/compute_bloom_entry_points.py
+++ b/python/orchestrator/jobs/compute_bloom_entry_points.py
@@ -34,10 +34,12 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import datetime, timezone
 from typing import Any
 
 from ..db import SupplyCoreDb
 from ..job_result import JobResult
+from ..json_utils import json_dumps_safe
 from ..neo4j import Neo4jClient, Neo4jConfig, Neo4jError
 
 logger = logging.getLogger(__name__)
@@ -58,6 +60,11 @@ DEFAULT_HOT_ALLIANCE_MIN_ENGAGEMENTS = 15
 
 # Hard cap per label to protect Bloom from run-away result sets.
 DEFAULT_MAX_TAGS_PER_LABEL = 500
+
+# How many rows per tier to surface in the PHP dashboard.
+# (The Neo4j labels themselves still honour max_tags_per_label — this
+# only bounds the dashboard read-side projection in MariaDB.)
+DASHBOARD_TOP_N = 10
 
 # Per-query timeout — these are all small aggregations so 60s is ample.
 _QUERY_TIMEOUT_SECONDS = 60
@@ -278,21 +285,220 @@ def _refresh_hot_alliances(
     return {"added": added, "removed": removed}
 
 
+# ── Dashboard read-side projection ───────────────────────────────────────
+#
+# Neo4j Community Edition has no Bloom UI, so operators need the four
+# tiers surfaced in the PHP dashboard instead.  After the labels have
+# been refreshed in Neo4j, we re-query the top DASHBOARD_TOP_N of each
+# tier and write them to the `bloom_entry_points_materialized` MariaDB
+# table so `public/index.php` can render them with a single SQL read.
+
+
+def _query_top_hot_battles(client: Neo4jClient, *, top_n: int) -> list[dict[str, Any]]:
+    rows = client.query(
+        """
+        MATCH (b:HotBattle)
+        OPTIONAL MATCH (b)-[:IN_SYSTEM|LOCATED_IN]->(s:System)
+        WITH b, s
+        ORDER BY COALESCE(b.bloom_hot_score, b.participant_count, 0) DESC
+        LIMIT $top_n
+        RETURN b.battle_id          AS battle_id,
+               toString(b.started_at) AS started_at,
+               b.participant_count  AS participant_count,
+               b.bloom_hot_score    AS bloom_hot_score,
+               s.system_id          AS system_id,
+               s.name               AS system_name
+        """,
+        parameters={"top_n": top_n},
+        timeout_seconds=_QUERY_TIMEOUT_SECONDS,
+    )
+    output: list[dict[str, Any]] = []
+    for row in rows:
+        battle_id = row.get("battle_id")
+        if battle_id is None:
+            continue
+        system_name = row.get("system_name") or ""
+        started_at = row.get("started_at") or ""
+        if system_name and started_at:
+            display_name = f"{system_name} @ {started_at}"
+        elif system_name:
+            display_name = system_name
+        else:
+            display_name = f"Battle {battle_id}"
+        output.append({
+            "entity_ref_type": "battle_id",
+            "entity_ref_id": int(battle_id),
+            "entity_name": display_name,
+            "score": float(row.get("bloom_hot_score") or row.get("participant_count") or 0),
+            "detail": {
+                "started_at": started_at,
+                "participant_count": row.get("participant_count"),
+                "system_id": row.get("system_id"),
+                "system_name": system_name or None,
+            },
+        })
+    return output
+
+
+def _query_top_high_risk_pilots(client: Neo4jClient, *, top_n: int) -> list[dict[str, Any]]:
+    rows = client.query(
+        """
+        MATCH (p:HighRiskPilot)
+        OPTIONAL MATCH (p)-[:MEMBER_OF_ALLIANCE]->(a:Alliance)
+        WITH p, a,
+             COALESCE(p.suspicion_score_recent, p.suspicion_score, 0) AS score
+        ORDER BY score DESC
+        LIMIT $top_n
+        RETURN p.character_id           AS character_id,
+               p.name                   AS character_name,
+               score                    AS score,
+               p.suspicion_score        AS suspicion_score,
+               p.suspicion_score_recent AS suspicion_score_recent,
+               a.alliance_id            AS alliance_id,
+               a.name                   AS alliance_name
+        """,
+        parameters={"top_n": top_n},
+        timeout_seconds=_QUERY_TIMEOUT_SECONDS,
+    )
+    output: list[dict[str, Any]] = []
+    for row in rows:
+        character_id = row.get("character_id")
+        if character_id is None:
+            continue
+        output.append({
+            "entity_ref_type": "character_id",
+            "entity_ref_id": int(character_id),
+            "entity_name": row.get("character_name") or f"Pilot {character_id}",
+            "score": float(row.get("score") or 0),
+            "detail": {
+                "suspicion_score": row.get("suspicion_score"),
+                "suspicion_score_recent": row.get("suspicion_score_recent"),
+                "alliance_id": row.get("alliance_id"),
+                "alliance_name": row.get("alliance_name"),
+            },
+        })
+    return output
+
+
+def _query_top_strategic_systems(client: Neo4jClient, *, top_n: int) -> list[dict[str, Any]]:
+    rows = client.query(
+        """
+        MATCH (s:StrategicSystem)
+        OPTIONAL MATCH (s)-[:IN_CONSTELLATION]->(:Constellation)-[:IN_REGION]->(r:Region)
+        WITH s, r
+        ORDER BY COALESCE(s.bloom_recent_battle_count, 0) DESC
+        LIMIT $top_n
+        RETURN s.system_id                  AS system_id,
+               s.name                       AS system_name,
+               s.security                   AS security,
+               s.bloom_recent_battle_count  AS recent_battle_count,
+               r.region_id                  AS region_id,
+               r.name                       AS region_name
+        """,
+        parameters={"top_n": top_n},
+        timeout_seconds=_QUERY_TIMEOUT_SECONDS,
+    )
+    output: list[dict[str, Any]] = []
+    for row in rows:
+        system_id = row.get("system_id")
+        if system_id is None:
+            continue
+        output.append({
+            "entity_ref_type": "system_id",
+            "entity_ref_id": int(system_id),
+            "entity_name": row.get("system_name") or f"System {system_id}",
+            "score": float(row.get("recent_battle_count") or 0),
+            "detail": {
+                "security": row.get("security"),
+                "recent_battle_count": row.get("recent_battle_count"),
+                "region_id": row.get("region_id"),
+                "region_name": row.get("region_name"),
+            },
+        })
+    return output
+
+
+def _query_top_hot_alliances(client: Neo4jClient, *, top_n: int) -> list[dict[str, Any]]:
+    rows = client.query(
+        """
+        MATCH (a:HotAlliance)
+        WITH a
+        ORDER BY COALESCE(a.bloom_recent_engagement_count, 0) DESC
+        LIMIT $top_n
+        RETURN a.alliance_id                   AS alliance_id,
+               a.name                          AS alliance_name,
+               a.bloom_recent_engagement_count AS recent_engagement_count
+        """,
+        parameters={"top_n": top_n},
+        timeout_seconds=_QUERY_TIMEOUT_SECONDS,
+    )
+    output: list[dict[str, Any]] = []
+    for row in rows:
+        alliance_id = row.get("alliance_id")
+        if alliance_id is None:
+            continue
+        output.append({
+            "entity_ref_type": "alliance_id",
+            "entity_ref_id": int(alliance_id),
+            "entity_name": row.get("alliance_name") or f"Alliance {alliance_id}",
+            "score": float(row.get("recent_engagement_count") or 0),
+            "detail": {
+                "recent_engagement_count": row.get("recent_engagement_count"),
+            },
+        })
+    return output
+
+
+def _materialize_tier(
+    db: SupplyCoreDb,
+    *,
+    tier: str,
+    rows: list[dict[str, Any]],
+    refreshed_at: str,
+) -> int:
+    """Atomically replace a tier's rows in `bloom_entry_points_materialized`."""
+    with db.transaction() as (_, cursor):
+        cursor.execute(
+            "DELETE FROM bloom_entry_points_materialized WHERE tier = %s",
+            (tier,),
+        )
+        for rank, row in enumerate(rows, start=1):
+            cursor.execute(
+                """
+                INSERT INTO bloom_entry_points_materialized (
+                    tier, rank_in_tier, entity_ref_type, entity_ref_id,
+                    entity_name, score, detail_json, refreshed_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    tier,
+                    rank,
+                    row["entity_ref_type"],
+                    row["entity_ref_id"],
+                    row.get("entity_name"),
+                    row.get("score"),
+                    json_dumps_safe(row.get("detail") or {}),
+                    refreshed_at,
+                ),
+            )
+    return len(rows)
+
+
 def run_compute_bloom_entry_points(
     db: SupplyCoreDb,
     neo4j_raw: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Refresh Bloom smart entry-point labels on the Neo4j graph.
+    """Refresh Bloom smart entry-point labels on the Neo4j graph and
+    materialize the top-N of each tier into MariaDB for the dashboard.
 
     Parameters
     ----------
     db
-        SupplyCore DB handle.  Unused today but kept in the signature for
-        parity with other graph jobs and for future MariaDB snapshotting.
+        SupplyCore DB handle, used for writing the read-side projection
+        to `bloom_entry_points_materialized`.
     neo4j_raw
         Raw Neo4j runtime config section.
     """
-    del db  # reserved for future freshness snapshots
     started = time.perf_counter()
     runtime = neo4j_raw or {}
     config = Neo4jConfig.from_runtime(runtime)
@@ -351,6 +557,14 @@ def run_compute_bloom_entry_points(
             min_engagements=hot_alliance_min_engagements,
             max_tags=max_tags_per_label,
         )
+
+        # Dashboard read-side projection — pull top-N of each tier and
+        # write them to MariaDB so the PHP dashboard can render the
+        # tiers with a single fast SQL read.
+        top_hot_battles = _query_top_hot_battles(client, top_n=DASHBOARD_TOP_N)
+        top_high_risk_pilots = _query_top_high_risk_pilots(client, top_n=DASHBOARD_TOP_N)
+        top_strategic_systems = _query_top_strategic_systems(client, top_n=DASHBOARD_TOP_N)
+        top_hot_alliances = _query_top_hot_alliances(client, top_n=DASHBOARD_TOP_N)
     except Neo4jError as error:
         duration_ms = int((time.perf_counter() - started) * 1000)
         logger.warning("compute_bloom_entry_points failed: %s", error)
@@ -359,6 +573,15 @@ def run_compute_bloom_entry_points(
             error=error,
             duration_ms=duration_ms,
         ).to_dict()
+
+    refreshed_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    materialized_counts = {
+        "HotBattle": _materialize_tier(db, tier="HotBattle", rows=top_hot_battles, refreshed_at=refreshed_at),
+        "HighRiskPilot": _materialize_tier(db, tier="HighRiskPilot", rows=top_high_risk_pilots, refreshed_at=refreshed_at),
+        "StrategicSystem": _materialize_tier(db, tier="StrategicSystem", rows=top_strategic_systems, refreshed_at=refreshed_at),
+        "HotAlliance": _materialize_tier(db, tier="HotAlliance", rows=top_hot_alliances, refreshed_at=refreshed_at),
+    }
+    materialized_total = sum(materialized_counts.values())
 
     duration_ms = int((time.perf_counter() - started) * 1000)
 
@@ -380,14 +603,15 @@ def run_compute_bloom_entry_points(
         f"(HotBattle +{hot_battles['added']}/-{hot_battles['removed']}, "
         f"HighRiskPilot +{high_risk_pilots['added']}/-{high_risk_pilots['removed']}, "
         f"StrategicSystem +{strategic_systems['added']}/-{strategic_systems['removed']}, "
-        f"HotAlliance +{hot_alliances['added']}/-{hot_alliances['removed']})."
+        f"HotAlliance +{hot_alliances['added']}/-{hot_alliances['removed']}); "
+        f"dashboard top-{DASHBOARD_TOP_N} materialized: {materialized_total} rows."
     )
 
     return JobResult.success(
         job_key=JOB_KEY,
         summary=summary,
         rows_processed=added_total + removed_total,
-        rows_written=added_total,
+        rows_written=added_total + materialized_total,
         duration_ms=duration_ms,
         meta={
             "execution_mode": "python",
@@ -400,10 +624,12 @@ def run_compute_bloom_entry_points(
                 "hot_alliance_window_days": hot_alliance_window,
                 "hot_alliance_min_engagements": hot_alliance_min_engagements,
                 "max_tags_per_label": max_tags_per_label,
+                "dashboard_top_n": DASHBOARD_TOP_N,
             },
             "hot_battles": hot_battles,
             "high_risk_pilots": high_risk_pilots,
             "strategic_systems": strategic_systems,
             "hot_alliances": hot_alliances,
+            "materialized_counts": materialized_counts,
         },
     ).to_dict()

--- a/src/db.php
+++ b/src/db.php
@@ -17660,6 +17660,55 @@ function db_alliance_relationship_graph_neo4j(array $allianceIds, int $limit = 5
     ];
 }
 
+/**
+ * Bloom Operational Intelligence — read-side projection for the dashboard.
+ *
+ * Reads pre-ranked rows from `bloom_entry_points_materialized`, which is
+ * maintained by the `compute_bloom_entry_points` job. The job writes the
+ * same top-N that the Neo4j tier labels (:HotBattle, :HighRiskPilot,
+ * :StrategicSystem, :HotAlliance) represent, so the PHP dashboard can
+ * render the four tiers with one cheap indexed SQL read per panel — no
+ * Neo4j HTTP round-trip on the request path.
+ *
+ * The `detail_json` column is decoded into `detail` for the caller; keys
+ * inside it are tier-specific (e.g. started_at/participant_count for
+ * HotBattle, region_name for StrategicSystem).
+ */
+function db_bloom_entry_points_by_tier(string $tier, int $limit = 10): array
+{
+    $tier = trim($tier);
+    if ($tier === '') {
+        return [];
+    }
+
+    $safeLimit = max(1, min(50, $limit));
+
+    $rows = db_select(
+        'SELECT tier, rank_in_tier, entity_ref_type, entity_ref_id,
+                entity_name, score, detail_json, refreshed_at
+           FROM bloom_entry_points_materialized
+          WHERE tier = :tier
+          ORDER BY rank_in_tier ASC
+          LIMIT ' . (int) $safeLimit,
+        ['tier' => $tier]
+    );
+
+    foreach ($rows as &$row) {
+        $detail = [];
+        if (!empty($row['detail_json']) && is_string($row['detail_json'])) {
+            $decoded = json_decode($row['detail_json'], true);
+            if (is_array($decoded)) {
+                $detail = $decoded;
+            }
+        }
+        $row['detail'] = $detail;
+        unset($row['detail_json']);
+    }
+    unset($row);
+
+    return $rows;
+}
+
 // ===========================================================================
 // Wrappers: Neo4j-preferred with MariaDB fallback
 // ===========================================================================


### PR DESCRIPTION
…dition

Neo4j Bloom is Enterprise-only, so operators on Community Edition have no UI for the four entry-point tiers maintained by compute_bloom_entry_points. This ships two operator-facing surfaces that cover ~90% of the Bloom workflow without the commercial license.

- docs/BLOOM_CYPHER_CHEATSHEET.md: every phrase from setup/neo4j_bloom_perspective.json reproduced as pasteable Cypher for the free Neo4j Browser (http://<host>:7474/browser/). Sections cover discovery, locational, investigation, and validation queries.

- database/migrations/20260425_bloom_entry_points_materialized.sql: read-side projection table keyed on (tier, rank_in_tier) so the PHP dashboard can render the four tiers with O(1) indexed SQL reads, decoupled from Neo4j HTTP latency.

- python/orchestrator/jobs/compute_bloom_entry_points.py: after the Neo4j label refresh, re-query top-10 of each tier and atomically replace that tier's rows via db.transaction(). json_dumps_safe carries tier-specific detail (started_at, region_name, suspicion scores, …).

- src/db.php: new db_bloom_entry_points_by_tier() helper reads one tier ordered by rank_in_tier, decoding detail_json into a structured array.

- public/index.php: new "Bloom Entry Points" dashboard panel rendering all four tiers as intelligence-row cards that link into the canonical PHP views (/character.php, /system.php, /alliance.php, theater intelligence). Guarded against a missing table so the dashboard still works before the migration runs.

https://claude.ai/code/session_01X9KALy4YQAZ38BMvHMFcTC