### PR TITLE
fix: wire per-character killmail backfill end to end

### DIFF
--- a/bin/python_scheduler_bridge.php
+++ b/bin/python_scheduler_bridge.php
@@ -135,6 +135,121 @@ try {
         python_scheduler_bridge_output(['ok' => true, 'result' => $result]);
     }
 
+    if ($action === 'character-killmail-sync-context') {
+        $appName = trim((string) get_setting('app_name', 'SupplyCore'));
+        if ($appName === '') {
+            $appName = 'SupplyCore';
+        }
+        $userAgent = $appName . ' character-killmail-sync/1.0 (+https://github.com/cvweiss/supplycore)';
+        python_scheduler_bridge_output([
+            'ok' => true,
+            'context' => ['user_agent' => $userAgent],
+        ]);
+    }
+
+    if ($action === 'character-killmail-queue-pending') {
+        $input = python_scheduler_bridge_read_stdin_json();
+        $limit = max(1, min(500, (int) ($input['limit'] ?? 50)));
+        $rows = db_select(
+            "SELECT character_id, priority, priority_reason, status, mode,
+                    last_page_fetched, last_killmail_id_seen, last_killmail_at_seen,
+                    killmails_found, backfill_complete, queued_at, last_success_at,
+                    last_incremental_at, last_full_backfill_at
+             FROM character_killmail_queue
+             WHERE status IN ('pending', 'error')
+             ORDER BY priority DESC, queued_at ASC
+             LIMIT ?",
+            [$limit]
+        );
+        // Mark these rows as 'processing' so concurrent runs don't grab them.
+        if ($rows) {
+            $ids = array_map(static fn (array $row): int => (int) $row['character_id'], $rows);
+            $placeholders = implode(',', array_fill(0, count($ids), '?'));
+            db_execute(
+                "UPDATE character_killmail_queue
+                 SET status = 'processing'
+                 WHERE character_id IN ({$placeholders})",
+                $ids
+            );
+        }
+        python_scheduler_bridge_output(['ok' => true, 'rows' => $rows]);
+    }
+
+    if ($action === 'character-killmail-queue-update') {
+        $input = python_scheduler_bridge_read_stdin_json();
+        $characterId = (int) ($input['character_id'] ?? 0);
+        if ($characterId <= 0) {
+            throw new InvalidArgumentException('character_id is required for character-killmail-queue-update.');
+        }
+
+        $sets = [];
+        $params = [];
+
+        $status = (string) ($input['status'] ?? '');
+        if ($status !== '' && in_array($status, ['pending', 'processing', 'done', 'error'], true)) {
+            $sets[] = 'status = ?';
+            $params[] = $status;
+            if ($status === 'done') {
+                $sets[] = 'last_success_at = UTC_TIMESTAMP()';
+                $sets[] = 'processed_at = UTC_TIMESTAMP()';
+            } elseif ($status === 'error') {
+                $sets[] = 'processed_at = UTC_TIMESTAMP()';
+            }
+        }
+        if (array_key_exists('last_page_fetched', $input)) {
+            $sets[] = 'last_page_fetched = ?';
+            $params[] = max(0, (int) $input['last_page_fetched']);
+        }
+        if (array_key_exists('last_killmail_id_seen', $input) && $input['last_killmail_id_seen'] !== null) {
+            $sets[] = 'last_killmail_id_seen = ?';
+            $params[] = (int) $input['last_killmail_id_seen'];
+        }
+        if (array_key_exists('last_killmail_at_seen', $input) && $input['last_killmail_at_seen'] !== null) {
+            $seenRaw = (string) $input['last_killmail_at_seen'];
+            $seenTs = $seenRaw !== '' ? strtotime($seenRaw) : false;
+            if ($seenTs !== false) {
+                $sets[] = 'last_killmail_at_seen = ?';
+                $params[] = gmdate('Y-m-d H:i:s', $seenTs);
+            }
+        }
+        if (array_key_exists('killmails_found_delta', $input)) {
+            $delta = max(0, (int) $input['killmails_found_delta']);
+            if ($delta > 0) {
+                $sets[] = 'killmails_found = killmails_found + ?';
+                $params[] = $delta;
+            }
+        }
+        if (array_key_exists('backfill_complete', $input)) {
+            $sets[] = 'backfill_complete = ?';
+            $params[] = ((bool) $input['backfill_complete']) ? 1 : 0;
+            if ((bool) $input['backfill_complete']) {
+                $sets[] = 'last_full_backfill_at = UTC_TIMESTAMP()';
+            }
+        }
+        if (array_key_exists('mode', $input) && in_array($input['mode'], ['incremental', 'backfill'], true)) {
+            $sets[] = 'mode = ?';
+            $params[] = (string) $input['mode'];
+            if ($input['mode'] === 'incremental') {
+                $sets[] = 'last_incremental_at = UTC_TIMESTAMP()';
+            }
+        }
+        if (array_key_exists('last_error', $input) && $input['last_error'] !== null) {
+            $sets[] = 'last_error = ?';
+            $params[] = substr((string) $input['last_error'], 0, 500);
+        } elseif ($status === 'done') {
+            $sets[] = 'last_error = NULL';
+        }
+
+        if ($sets === []) {
+            python_scheduler_bridge_output(['ok' => true, 'updated' => 0]);
+        } else {
+            $params[] = $characterId;
+            $sql = 'UPDATE character_killmail_queue SET ' . implode(', ', $sets) . ' WHERE character_id = ?';
+            $updated = db_execute($sql, $params);
+            python_scheduler_bridge_output(['ok' => true, 'updated' => (int) $updated]);
+        }
+    }
+
     if ($action === 'repair-killmail-zkb') {
         $input = python_scheduler_bridge_read_stdin_json();
         $updates = (array) ($input['updates'] ?? []);


### PR DESCRIPTION
## Summary

Verifying killmail + alliance ingestion coverage on production (2024+) surfaced two independent bugs that together meant the per-character killmail backfill path had never actually run, even though the job was fully registered per `docs/schedule.md` and enabled in the scheduler.

**Bug 1 — nothing was enrolling participants for per-character backfill**

`character_killmail_queue` was completely empty (`SELECT COUNT(*) = 0`) while `esi_character_queue` held 68,894 participants. The inline ingest path in `python_bridge_process_killmail_batch` only wrote to `esi_character_queue` (for affiliation/history lookups) and the periodic repair job only seeded that same queue. Nothing ever inserted participant characters into `character_killmail_queue`, which is the queue the `character_killmail_sync` job drains.

As a consequence, any killmail that didn't happen to arrive via the live R2Z2 stream while the worker was running was lost — which is why the 2024+ monthly loss histogram was empty until 2025-09 despite the overview being scoped from 2024-01-01.

**Bug 2 — `character_killmail_sync` was a silent no-op**

Once Bug 1 was fixed and 68,939 characters were seeded into `character_killmail_queue`, none of them started processing. Tracing through `python/orchestrator/jobs/character_killmail_sync.py` revealed it calls three PHP bridge endpoints that never existed:

- `character-killmail-sync-context`
- `character-killmail-queue-pending`
- `character-killmail-queue-update`

`_fetch_queue()` wraps the bridge call in `try/except Exception: return []`, so every run logged `"No characters pending in killmail queue"` and exited successfully — the job appeared healthy in the scheduler but processed zero characters. The 11-point `docs/schedule.md` registration checklist was otherwise fully satisfied; only these three custom RPC handlers were missing.

## What this PR changes

**`src/functions.php` — `python_bridge_process_killmail_batch`**
Every participant character is now also `INSERT IGNORE`d into `character_killmail_queue` with `mode='backfill'`, `priority=1.0000`, `priority_reason='killmail_participant'` at ingest time, alongside the existing `esi_character_queue` write.

**`python/orchestrator/jobs/esi_character_queue_sync.py`**
The repair/backfill job now also seeds `character_killmail_queue` from every `killmail_attackers.character_id` and `killmail_events.victim_character_id`. On its next run it closes the historical gap for all existing 2024+ participants.

**`bin/python_scheduler_bridge.php` — three new bridge actions**
- `character-killmail-sync-context` returns the user agent derived from the `app_name` setting, matching `python_bridge_killmail_backfill_context`.
- `character-killmail-queue-pending` claims up to `limit` rows where `status IN ('pending','error')`, ordered by `priority DESC, queued_at ASC`, and atomically transitions them to `processing` to avoid double-claim from concurrent runs.
- `character-killmail-queue-update` persists the checkpoint payload (`status`, `last_page_fetched`, `last_killmail_id_seen`, `last_killmail_at_seen`, `killmails_found` incremented by delta, `backfill_complete`, `mode`, `last_error`). Terminal statuses set `processed_at`/`last_success_at`/`last_full_backfill_at` as appropriate.

**`src/db.php` — `db_killmail_esi_coverage_snapshot`**
The original snapshot counted `esi_character_queue` rows regardless of `fetch_status`, so "100% queued" masked whether the drain was actually running. It also used `character_alliance_history` row count as the health signal, but `esi_alliance_history_sync` deliberately writes zero rows for characters with no alliance periods while still marking them processed via `character_current_affiliation.last_history_refresh_at`. The snapshot now reports:

- `esi_character_queue` split by `fetch_status` (`pending`/`done`/`error`)
- `history_refresh_completed` via `character_current_affiliation.last_history_refresh_at IS NOT NULL` — the true pipeline-health signal
- `with_alliance_history_row` (kept `with_alliance_history` as backwards-compatible alias)
- `enrolled_for_killmail_backfill` plus `character_killmail_queue` status split (`pending`/`processing`/`done`/`error`) and `backfill_complete` flag count, all joined to 2024+ participants

**`public/killmail-intelligence/index.php`**
Diagnostics card surfaces the new metrics with explanatory copy distinguishing "history sync processed" from "has alliance history rows" and exposing the per-character killmail backfill queue state.

## Test plan

- [x] `php -l src/functions.php`
- [x] `php -l src/db.php`
- [x] `php -l public/killmail-intelligence/index.php`
- [x] `php -l bin/python_scheduler_bridge.php`
- [x] `python3 -c "import ast; ast.parse(...)"` on `esi_character_queue_sync.py`
- [x] Repair job verified on production — `character_killmail_queue` grew from `0 → 4 → 9 → 70 → 68,939` as the repair job seeded participants
- [ ] After deploy: confirm `sync_schedules.last_status = 'success'` for `character_killmail_sync` and `last_error` empty
- [ ] After deploy: confirm `character_killmail_queue.status` starts transitioning `pending → processing → done`
- [ ] After deploy: confirm `killmails_found > 0` climbing and 2024/2025 buckets appearing in the loss histogram

## Verification SQL

```sql
-- Queue should start transitioning pending → processing → done
SELECT status, COUNT(*) FROM character_killmail_queue GROUP BY status;

-- backfill_complete flag should start flipping to 1
SELECT backfill_complete, COUNT(*) FROM character_killmail_queue GROUP BY backfill_complete;

-- Rows should start landing with killmails_found > 0
SELECT COUNT(*) AS with_kills FROM character_killmail_queue WHERE killmails_found > 0;

-- 2024/2025 histogram buckets should start filling as backfill walks zKB pages
SELECT DATE_FORMAT(effective_killmail_at, '%Y-%m') AS m, COUNT(*) AS n
FROM killmail_events
WHERE mail_type = 'loss' AND effective_killmail_at >= '2024-01-01'
GROUP BY m ORDER BY m;

-- Scheduler health for the newly-working job
SELECT job_key, enabled, last_run_at, last_status, last_error
FROM sync_schedules WHERE job_key = 'character_killmail_sync';
```

## Throughput expectations

- `_MAX_CHARACTERS_PER_RUN = 50` × 2-minute interval → 1,500 chars/hour
- Each backfilling character fetches up to 10 pages/run at 1 req/sec (zKB rate limit)
- First full pass over the 68,939 backlog: realistically 2–5 days, bounded by the zKB rate limit and multi-run backfill per character

https://claude.ai/code/session_01UCrpzts95aphK7saGdAFru