### PR TITLE
fix: swap axes on killmail loss histogram

### DIFF
--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -93,14 +93,25 @@ if (function_exists('ob_flush')) { @ob_flush(); }
     <?php if ($histogram === []): ?>
         <p class="mt-4 text-sm text-muted">No loss histogram buckets available yet.</p>
     <?php else: ?>
-        <div class="mt-4 grid gap-2">
-            <?php foreach ($histogram as $bucket): ?>
-                <div class="grid grid-cols-[88px_minmax(0,1fr)_56px] items-center gap-3 text-xs text-slate-300">
-                    <span class="text-muted"><?= htmlspecialchars((string) ($bucket['label'] ?? ''), ENT_QUOTES) ?></span>
-                    <div class="h-2 rounded-full bg-white/10">
-                        <div class="h-2 rounded-full bg-indigo-400/80" style="width: <?= max(0, min(100, (int) ($bucket['percent'] ?? 0))) ?>%"></div>
+        <div class="mt-4 flex items-stretch gap-2 overflow-x-auto pb-1">
+            <?php foreach ($histogram as $bucket):
+                $pct = max(0, min(100, (int) ($bucket['percent'] ?? 0)));
+                $count = (int) ($bucket['count'] ?? 0);
+                $label = (string) ($bucket['label'] ?? '');
+            ?>
+                <div class="flex min-w-[44px] flex-1 flex-col items-center gap-1 text-xs text-slate-300">
+                    <div
+                        class="flex w-full flex-col justify-end rounded-t bg-white/5"
+                        style="height: 160px;"
+                        title="<?= htmlspecialchars($label . ': ' . number_format($count), ENT_QUOTES) ?>"
+                    >
+                        <div
+                            class="w-full rounded-t bg-indigo-400/80"
+                            style="height: <?= $pct ?>%;"
+                        ></div>
                     </div>
-                    <span class="text-right text-slate-100"><?= number_format((int) ($bucket['count'] ?? 0)) ?></span>
+                    <span class="text-[10px] text-slate-100"><?= number_format($count) ?></span>
+                    <span class="whitespace-nowrap text-[10px] text-muted"><?= htmlspecialchars($label, ENT_QUOTES) ?></span>
                 </div>
             <?php endforeach; ?>
         </div>


### PR DESCRIPTION
## Problem

The monthly loss histogram on the Killmail Intelligence overview
rendered as horizontal bars: month label on the left, a horizontal
bar in the middle, count on the right. That reads more like a ranked
list than a histogram — the user expected the X and Y axes swapped.

## Fix

Switched to a proper vertical bar chart in
`public/killmail-intelligence/index.php`:

- Months laid out along the X axis (left-to-right, oldest-to-newest)
- A 160px-tall bar area per column, each bar grows upward from the
  baseline and its height is driven by the existing `percent` field
- Count label below the bar, month label beneath that
- Tooltip on the bar containing `"Month: Count"` for precise reads

Horizontally scrollable when the histogram spans many months. No
backend changes — the `$histogram` payload already contains `label`,
`count`, and `percent`.

## Test plan

- [ ] Load `/killmail-intelligence/` and verify the histogram shows
      vertical bars
- [ ] Confirm month labels read left-to-right along the X axis
- [ ] Confirm bar heights scale with the count (tallest = highest)
- [ ] Confirm hover tooltip shows `"Jan 2024: 123"` style text

https://claude.ai/code/session_01UCrpzts95aphK7saGdAFru