### PR TITLE
fix: unique gateway identity per killmail to prevent endpoint-key col…

### DIFF
--- a/python/orchestrator/jobs/character_killmail_sync.py
+++ b/python/orchestrator/jobs/character_killmail_sync.py
@@ -172,6 +172,7 @@ def _fetch_esi_killmail(
             resp = gateway.get(
                 path,
                 route_template="/latest/killmails/{killmail_id}/{killmail_hash}/",
+                identity=f"km:{killmail_id}",
             )
         except Exception:
             return None

--- a/python/orchestrator/jobs/killmail_history_backfill.py
+++ b/python/orchestrator/jobs/killmail_history_backfill.py
@@ -62,7 +62,11 @@ def _fetch_esi_killmail(killmail_id: int, killmail_hash: str, esi_client: EsiCli
     """
     path = f"/latest/killmails/{killmail_id}/{killmail_hash}/"
     if gateway is not None:
-        resp = gateway.get(path, route_template="/latest/killmails/{killmail_id}/{killmail_hash}/")
+        resp = gateway.get(
+            path,
+            route_template="/latest/killmails/{killmail_id}/{killmail_hash}/",
+            identity=f"km:{killmail_id}",
+        )
         if resp.from_cache or resp.not_modified:
             if isinstance(resp.body, dict):
                 pass  # Use cached payload — fall through to body extraction


### PR DESCRIPTION
…lision

The ESI compliance gateway builds its endpoint_key from route_template + params + identity. Because the killmail_id and killmail_hash live in the PATH (not params), and we were passing a parameterised route_template with the default identity="anonymous", every killmail fetch collapsed to the same key:

    GET:/latest/killmails/{killmail_id}/{killmail_hash}/:none:anonymous:p1

Consequences:
- The first successful fetch populated the Redis payload/meta under that shared key.
- Every subsequent fetch was Expires-gated and returned the SAME body, regardless of which killmail was requested -> silent data corruption: victim/attackers/items/solar_system_id/killmail_time from whichever killmail populated the cache first were written under every other killmail's id/hash.
- Telemetry reported 100% cache hits, masking the bug.

Fix: pass identity=f"km:{killmail_id}" so each killmail gets a distinct endpoint_key. corp_standings_sync already uses this pattern (identity=f"char:{character_id}").

Applied to both character_killmail_sync and killmail_history_backfill (the latter had the same preexisting bug).

https://claude.ai/code/session_01UCrpzts95aphK7saGdAFru