### PR TITLE
docs: truth-up killmail storage policy in UI and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,8 +794,13 @@ SupplyCore now includes a first-pass killmail intelligence ingestion foundation 
   - treat feed as an ordered stream (not query API)
   - resume from last processed sequence cursor
   - iterate forward until 404 (no new sequence yet)
-  - store killmails when a tracked alliance or corporation appears on the victim or attacker side
-  - keep victim-side tracked matches available for loss-demand analytics
+  - store every stream killmail, classifying them into `mail_type` buckets:
+    - `loss` — tracked alliance/corp on the victim side
+    - `kill` — tracked alliance/corp on the attacker side
+    - `opponent_loss` / `opponent_kill` — opponent alliance/corp on victim / attacker side
+    - `third_party` — per-character backfill kill with no tracked/opponent entity
+    - `untracked` — R2Z2 stream kill with no tracked/opponent entity; pruned after 90 days by `killmail_untracked_retention`
+  - tracked-victim matches stay available for loss-demand analytics via a dedicated subset counter
 - Local persistence tables:
   - `killmail_events`
   - `killmail_attackers`

--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../../src/bootstrap.php';
 $title = 'Killmail Loss Overview';
 $data = killmail_overview_data();
 $summary = $data['summary'] ?? [];
+$mailTypeBreakdown = $data['mail_type_breakdown'] ?? [];
 $status = $data['status'] ?? [];
 $rows = $data['rows'] ?? [];
 $filters = $data['filters'] ?? [];
@@ -82,6 +83,35 @@ if (function_exists('ob_flush')) { @ob_flush(); }
     <?php endforeach; ?>
 </section>
 <!-- ui-section:killmail-overview-summary:end -->
+
+<?php if ($mailTypeBreakdown !== []): ?>
+    <!-- ui-section:killmail-overview-mail-types:start -->
+    <section class="mt-6 surface-secondary" data-ui-section="killmail-overview-mail-types">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+            <div>
+                <h2 class="text-base font-medium text-slate-50">Storage breakdown by mail_type</h2>
+                <p class="mt-1 text-sm text-muted">
+                    Every R2Z2 stream killmail and every per-character backfill killmail is stored, classified into one of these buckets.
+                    <span class="text-slate-100">Tracked and opponent rows are retained indefinitely; <code>untracked</code> rows are pruned after 90 days</span>
+                    by the <code>killmail_untracked_retention</code> job, so their count reflects the rolling window not the all-time total.
+                </p>
+            </div>
+        </div>
+        <div class="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            <?php foreach ($mailTypeBreakdown as $bucket): ?>
+                <article class="rounded-lg border px-3 py-3 <?= htmlspecialchars((string) ($bucket['tone'] ?? 'border-border bg-black/20 text-slate-200'), ENT_QUOTES) ?>">
+                    <div class="flex items-baseline justify-between gap-3">
+                        <p class="text-xs uppercase tracking-[0.2em]"><?= htmlspecialchars((string) ($bucket['label'] ?? ''), ENT_QUOTES) ?></p>
+                        <p class="text-xl font-semibold"><?= number_format((int) ($bucket['count'] ?? 0)) ?></p>
+                    </div>
+                    <p class="mt-1 text-xs opacity-80"><?= htmlspecialchars((string) ($bucket['description'] ?? ''), ENT_QUOTES) ?></p>
+                    <p class="mt-1 font-mono text-[10px] uppercase tracking-[0.2em] opacity-60">mail_type = <?= htmlspecialchars((string) ($bucket['key'] ?? ''), ENT_QUOTES) ?></p>
+                </article>
+            <?php endforeach; ?>
+        </div>
+    </section>
+    <!-- ui-section:killmail-overview-mail-types:end -->
+<?php endif; ?>
 
 <section class="mt-6 surface-secondary">
     <div class="flex flex-wrap items-start justify-between gap-3">

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -3126,7 +3126,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                     </div>
                 <?php endif; ?>
 
-                <p class="text-sm text-muted">Ingestion consumes R2Z2 as an ordered stream and keeps killmails only when a tracked alliance or corporation appears on the victim side. That keeps the board focused on tracked losses while leaving attacker details available only inside each stored loss.</p>
+                <p class="text-sm text-muted">Ingestion consumes R2Z2 as an ordered stream and stores every killmail. Kills involving a tracked or opponent entity are retained indefinitely as <code>loss</code>/<code>kill</code>/<code>opponent_loss</code>/<code>opponent_kill</code>; every other stream killmail is stored as <code>untracked</code> to power the alliance relationship graph and is pruned after 90 days. Per-character backfills also store all involved kills (as <code>third_party</code> when no tracked or opponent entity is present) back to 2024-01-01.</p>
                 <button class="btn-primary">Save Killmail Intelligence Settings</button>
             </form>
         <?php elseif ($activeSubsection === 'automation-control'): ?>

--- a/src/db.php
+++ b/src/db.php
@@ -12487,6 +12487,35 @@ function db_killmail_overview_summary(int $recentHours = 24, string $startDate =
     $summary['tracked_match_count'] = (int) ($trackedCountRow['tracked_match_count'] ?? 0);
     $summary['start_date'] = $startDate;
 
+    // Breakdown by mail_type so the UI can show what we're actually
+    // storing (tracked losses/kills vs. opponent vs. third_party vs.
+    // untracked).  Untracked rows are pruned after 90 days by the
+    // killmail_untracked_retention job, so their count reflects the
+    // rolling window not the all-time total.
+    $mailTypeRows = db_select(
+        "SELECT e.mail_type, COUNT(*) AS mail_count
+         FROM {$latestSequencesSql} latest
+         INNER JOIN killmail_events e ON e.sequence_id = latest.sequence_id
+         WHERE e.effective_killmail_at >= ?
+         GROUP BY e.mail_type",
+        [$startDate]
+    ) ?? [];
+    $mailTypeCounts = [
+        'loss' => 0,
+        'kill' => 0,
+        'opponent_loss' => 0,
+        'opponent_kill' => 0,
+        'third_party' => 0,
+        'untracked' => 0,
+    ];
+    foreach ($mailTypeRows as $mailTypeRow) {
+        $type = (string) ($mailTypeRow['mail_type'] ?? '');
+        if ($type !== '' && array_key_exists($type, $mailTypeCounts)) {
+            $mailTypeCounts[$type] = (int) ($mailTypeRow['mail_count'] ?? 0);
+        }
+    }
+    $summary['mail_type_counts'] = $mailTypeCounts;
+
     return $summary;
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -11670,6 +11670,9 @@ function killmail_overview_data(): array
         $totalCount = (int) ($summaryRow['total_count'] ?? 0);
         $recentCount = (int) ($summaryRow['recent_count'] ?? 0);
         $trackedMatchCount = (int) ($summaryRow['tracked_match_count'] ?? 0);
+        $mailTypeCounts = is_array($summaryRow['mail_type_counts'] ?? null)
+            ? $summaryRow['mail_type_counts']
+            : [];
         $maxSequenceId = (int) ($summaryRow['max_sequence_id'] ?? ($status['max_sequence_id'] ?? 0));
         $state = is_array($status['state'] ?? null) ? $status['state'] : [];
         $latestRun = is_array($status['latest_run'] ?? null) ? $status['latest_run'] : null;
@@ -11956,15 +11959,61 @@ function killmail_overview_data(): array
             ];
         }, $histogramRows);
 
+        $mailTypeBreakdown = [
+            [
+                'key' => 'loss',
+                'label' => 'Losses',
+                'count' => (int) ($mailTypeCounts['loss'] ?? 0),
+                'tone' => 'border-rose-400/40 bg-rose-500/10 text-rose-100',
+                'description' => 'Tracked alliance or corporation on the victim side.',
+            ],
+            [
+                'key' => 'kill',
+                'label' => 'Kills',
+                'count' => (int) ($mailTypeCounts['kill'] ?? 0),
+                'tone' => 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100',
+                'description' => 'Tracked alliance or corporation on the attacker side.',
+            ],
+            [
+                'key' => 'opponent_loss',
+                'label' => 'Opponent losses',
+                'count' => (int) ($mailTypeCounts['opponent_loss'] ?? 0),
+                'tone' => 'border-amber-400/40 bg-amber-500/10 text-amber-100',
+                'description' => 'Opponent alliance or corporation on the victim side.',
+            ],
+            [
+                'key' => 'opponent_kill',
+                'label' => 'Opponent kills',
+                'count' => (int) ($mailTypeCounts['opponent_kill'] ?? 0),
+                'tone' => 'border-orange-400/40 bg-orange-500/10 text-orange-100',
+                'description' => 'Opponent alliance or corporation on the attacker side.',
+            ],
+            [
+                'key' => 'third_party',
+                'label' => 'Third-party',
+                'count' => (int) ($mailTypeCounts['third_party'] ?? 0),
+                'tone' => 'border-sky-400/40 bg-sky-500/10 text-sky-100',
+                'description' => 'Per-character backfill kill with no tracked or opponent entity involved.',
+            ],
+            [
+                'key' => 'untracked',
+                'label' => 'Untracked (90d)',
+                'count' => (int) ($mailTypeCounts['untracked'] ?? 0),
+                'tone' => 'border-slate-400/40 bg-slate-500/10 text-slate-100',
+                'description' => 'R2Z2 stream kill with no tracked or opponent entity. Pruned after 90 days by killmail_untracked_retention.',
+            ],
+        ];
+
         return [
             'error' => null,
             'summary' => [
-                ['label' => 'Total Ingested', 'value' => number_format($totalCount), 'context' => 'Killmails stored locally since ' . $overviewStartDate],
+                ['label' => 'Total Ingested', 'value' => number_format($totalCount), 'context' => 'All killmails stored locally since ' . $overviewStartDate . ' — see the breakdown below for the split by mail_type'],
                 ['label' => 'Recent Ingestion', 'value' => number_format($recentCount), 'context' => 'Stored in the last ' . $recentHours . ' hours'],
-                ['label' => 'Tracked Entity Killmails', 'value' => number_format($trackedMatchCount), 'context' => 'Stored killmails since ' . $overviewStartDate . ' where a tracked alliance or corporation appears on the victim side'],
+                ['label' => 'Tracked Losses (victim-side)', 'value' => number_format($trackedMatchCount), 'context' => 'Subset counter: killmails since ' . $overviewStartDate . ' where a tracked alliance or corporation is on the victim side. This is a display filter — the full stored dataset is under Total Ingested.'],
                 ['label' => 'Last Processed Sequence', 'value' => $maxSequenceId > 0 ? number_format($maxSequenceId) : '—', 'context' => $cursor !== '' ? ('Cursor ' . $cursor) : 'Cursor not recorded yet'],
                 ['label' => 'Sync Freshness', 'value' => killmail_relative_datetime($lastSuccessAt), 'context' => $lastSuccessAt !== null ? ('Last success ' . killmail_format_datetime($lastSuccessAt)) : 'No successful sync recorded'],
             ],
+            'mail_type_breakdown' => $mailTypeBreakdown,
             'status' => $statusView,
             'rows' => $rows,
             'histogram' => $histogram,


### PR DESCRIPTION
Every killmail is stored since PR #815 / migration 20260402_killmail_ingest_all.sql, but several user-facing surfaces still claimed we "only keep killmails when a tracked alliance or corporation appears on the victim side".  That misled the operator into thinking the board was filtering at ingestion time.

Three fixes, no behaviour changes to the ingest path:

1. **Stale copy**
   - `public/settings/index.php` — rewrite the killmail intelligence description to match what actually happens: every stream killmail is stored, classified into `loss` / `kill` / `opponent_loss` / `opponent_kill` / `third_party` / `untracked`, and `untracked` is pruned after 90 days.
   - `README.md` — expand the stream ingestion bullet into a per- mail_type table with the 90-day untracked retention noted.

2. **Mail_type breakdown**
   - `db_killmail_overview_summary` now runs a second query grouping by `mail_type` and returns `mail_type_counts` alongside the existing totals.
   - `killmail_overview_data` exposes a `mail_type_breakdown` array (one entry per bucket, with label/description/tone) for the overview view.
   - The "Tracked Entity Killmails" summary card is relabelled to "Tracked Losses (victim-side)" with context that explicitly calls out that it's a subset counter, not the full stored dataset.

3. **Retention visibility**
   - New "Storage breakdown by mail_type" section on `/killmail-intelligence/` renders all six buckets with colour- coded pill cards and inline copy explaining that tracked/opponent rows are retained indefinitely while `untracked` rows are pruned after 90 days by `killmail_untracked_retention`.

No SQL schema changes.  The new summary query hits the same indices the existing `total_count` query uses.