### PR TITLE
Refactor dashboard KPIs to list format and add priority queues

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -144,7 +144,17 @@ $kpiThemes = [
 $kpiCards = [];
 $knownKpiLabels = array_keys($kpiThemes);
 $seenKpiLabels = [];
-foreach ((array) ($intel['kpis'] ?? []) as $rawCard) {
+// `$intel['kpis']` is expected to be a list of {label, value, context} cards
+// (built by dashboard_intelligence_data_build() in PHP or by the
+// dashboard_summary_sync Python job). Detect and log regressions where a
+// caller accidentally writes a dict-of-scalars shape, which would otherwise
+// silently fall through to the "Enable market sync…" placeholder text.
+$rawKpis = $intel['kpis'] ?? [];
+if (is_array($rawKpis) && $rawKpis !== [] && !is_array(reset($rawKpis))) {
+    error_log('dashboard KPI payload has unexpected shape (expected list of cards): ' . json_encode(array_keys($rawKpis)));
+    $rawKpis = [];
+}
+foreach ((array) $rawKpis as $rawCard) {
     if (!is_array($rawCard)) {
         continue;
     }

--- a/python/orchestrator/jobs/dashboard_summary_sync.py
+++ b/python/orchestrator/jobs/dashboard_summary_sync.py
@@ -1,8 +1,40 @@
 from __future__ import annotations
 
+import json
+from typing import Any
+
 from ..db import SupplyCoreDb
 from ..json_utils import json_dumps_safe
 from .sync_runtime import run_sync_phase_job
+
+
+def _dashboard_priority_queue_item(row: dict[str, Any], signal: str, score: int) -> dict[str, Any]:
+    """Mirror of PHP dashboard_priority_queue_item() from src/functions.php."""
+    type_id = max(0, int(row.get("type_id") or 0))
+    type_name = str(row.get("type_name") or "").strip()
+    return {
+        "module": type_name if type_name != "" else f"Type #{type_id}",
+        "signal": signal,
+        "score": max(0, int(score)),
+        "type_id": type_id if type_id > 0 else None,
+        "image_url": (
+            f"https://images.evetech.net/types/{type_id}/icon?size=64"
+            if type_id > 0
+            else None
+        ),
+    }
+
+
+def _dedupe_by_type(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[int] = set()
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        tid = int(r.get("type_id") or 0)
+        if tid <= 0 or tid in seen:
+            continue
+        seen.add(tid)
+        out.append(r)
+    return out
 
 
 def _processor(db: SupplyCoreDb) -> dict[str, object]:
@@ -16,26 +48,138 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
     alert_count = db.fetch_scalar("SELECT COUNT(*) FROM market_deal_alerts_current WHERE status = 'active'")
     schedules = db.fetch_scalar("SELECT COUNT(*) FROM sync_schedules WHERE enabled = 1")
 
-    # Pull latest market comparison snapshot to embed summary KPIs in the dashboard
+    # Pull latest market comparison snapshot to derive dashboard KPIs and
+    # priority queues. The PHP dashboard (public/index.php) reads
+    # $intel['kpis'] as a LIST of {label, value, context} cards; writing a
+    # dict here would cause all cards to be filtered out and the dashboard
+    # would fall back to the "Enable market sync..." placeholder text.
     market_comparison_row = db.fetch_one(
         "SELECT payload_json, updated_at FROM intelligence_snapshots WHERE snapshot_key = 'market_comparison_summaries' ORDER BY updated_at DESC LIMIT 1"
     )
-    market_kpis: dict[str, object] = {}
+    market_rows: list[dict[str, Any]] = []
+    missing_in_alliance: list[dict[str, Any]] = []
+    in_both_markets: list[dict[str, Any]] = []
+    market_updated_at = ""
     if market_comparison_row and market_comparison_row.get("payload_json"):
-        import json
         try:
             mc = json.loads(str(market_comparison_row["payload_json"]))
-            market_kpis = {
-                "total_items_compared": len(mc.get("rows") or []),
-                "in_both_markets": len(mc.get("in_both_markets") or []),
-                "missing_in_alliance": len(mc.get("missing_in_alliance") or []),
-                "overpriced_in_alliance": len(mc.get("overpriced_in_alliance") or []),
-                "underpriced_in_alliance": len(mc.get("underpriced_in_alliance") or []),
-                "weak_or_missing_alliance_stock": len(mc.get("weak_or_missing_alliance_stock") or []),
-                "market_comparison_updated_at": str(market_comparison_row.get("updated_at") or ""),
-            }
+            if isinstance(mc, dict):
+                raw_rows = mc.get("rows") or []
+                if isinstance(raw_rows, list):
+                    market_rows = [r for r in raw_rows if isinstance(r, dict)]
+                raw_missing = mc.get("missing_in_alliance") or []
+                if isinstance(raw_missing, list):
+                    missing_in_alliance = [r for r in raw_missing if isinstance(r, dict)]
+                raw_in_both = mc.get("in_both_markets") or []
+                if isinstance(raw_in_both, list):
+                    in_both_markets = [r for r in raw_in_both if isinstance(r, dict)]
         except (json.JSONDecodeError, TypeError, KeyError):
             pass
+        market_updated_at = str(market_comparison_row.get("updated_at") or "")
+
+    row_count = len(market_rows)
+    in_both_count = len(in_both_markets)
+    missing_count = len(missing_in_alliance)
+    coverage_percent = (in_both_count / row_count * 100.0) if row_count > 0 else 0.0
+
+    top_opportunities_count = sum(
+        1 for r in market_rows if int(r.get("opportunity_score") or 0) >= 60
+    )
+    top_risks_count = sum(
+        1 for r in market_rows if int(r.get("risk_score") or 0) >= 60
+    )
+
+    # KPI cards: match the list schema expected by public/index.php.
+    kpi_cards: list[dict[str, Any]] = [
+        {
+            "label": "Top Opportunities",
+            "value": str(top_opportunities_count),
+            "context": "High-confidence import/reprice candidates",
+        },
+        {
+            "label": "Top Risks",
+            "value": str(top_risks_count),
+            "context": "High-severity pricing or stock risk",
+        },
+        {
+            "label": "Missing Seed Targets",
+            "value": str(missing_count),
+            "context": "Items in reference hub not listed in alliance",
+        },
+        {
+            "label": "Overlap Coverage",
+            "value": f"{coverage_percent:.1f}%",
+            "context": (
+                f"{in_both_count} of {row_count} items in both markets"
+                if row_count > 0
+                else "No market overlap data yet"
+            ),
+        },
+    ]
+
+    # Priority queues: rank rows the same way PHP's dashboard_intelligence_data_build does.
+    opportunities_sorted = sorted(
+        market_rows,
+        key=lambda r: (
+            int(r.get("opportunity_score") or 0),
+            int(r.get("volume_score") or 0),
+        ),
+        reverse=True,
+    )
+    risks_sorted = sorted(
+        market_rows,
+        key=lambda r: (
+            int(r.get("risk_score") or 0),
+            int(r.get("stock_score") or 0),
+        ),
+        reverse=True,
+    )
+
+    top_opportunities_rows = _dedupe_by_type(
+        [r for r in opportunities_sorted if int(r.get("opportunity_score") or 0) > 0]
+    )[:5]
+    top_risks_rows = _dedupe_by_type(
+        [r for r in risks_sorted if int(r.get("risk_score") or 0) > 0]
+    )[:5]
+    top_missing_rows = _dedupe_by_type(
+        [r for r in opportunities_sorted if bool(r.get("missing_in_alliance"))]
+    )[:5]
+
+    def _opportunity_signal(row: dict[str, Any]) -> str:
+        if bool(row.get("missing_in_alliance")):
+            return "Import seed candidate"
+        return f"{float(row.get('deviation_percent') or 0.0):+.1f}% vs hub"
+
+    def _risk_signal(row: dict[str, Any]) -> str:
+        if bool(row.get("overpriced_in_alliance")):
+            return f"{float(row.get('deviation_percent') or 0.0):+.1f}% overpriced"
+        return "Stock or freshness risk"
+
+    def _missing_signal(row: dict[str, Any]) -> str:
+        volume = int(row.get("reference_total_sell_volume") or 0)
+        score = int(row.get("opportunity_score") or 0)
+        return f"Volume {volume} · score {score}"
+
+    priority_queues: dict[str, list[dict[str, Any]]] = {
+        "opportunities": [
+            _dashboard_priority_queue_item(
+                r, _opportunity_signal(r), int(r.get("opportunity_score") or 0)
+            )
+            for r in top_opportunities_rows
+        ],
+        "risks": [
+            _dashboard_priority_queue_item(
+                r, _risk_signal(r), int(r.get("risk_score") or 0)
+            )
+            for r in top_risks_rows
+        ],
+        "missing_items": [
+            _dashboard_priority_queue_item(
+                r, _missing_signal(r), int(r.get("opportunity_score") or 0)
+            )
+            for r in top_missing_rows
+        ],
+    }
 
     # Pull freshness info from sync_state for key datasets
     freshness_rows = db.fetch_all(
@@ -50,20 +194,42 @@ def _processor(db: SupplyCoreDb) -> dict[str, object]:
             "row_count": int(row.get("last_row_count") or 0),
         }
 
-    rows_processed = int(queue_stats.get("queued_jobs") or 0) + int(queue_stats.get("running_jobs") or 0) + int(queue_stats.get("dead_jobs") or 0) + int(alert_count or 0) + int(schedules or 0)
+    rows_processed = (
+        int(queue_stats.get("queued_jobs") or 0)
+        + int(queue_stats.get("running_jobs") or 0)
+        + int(queue_stats.get("dead_jobs") or 0)
+        + int(alert_count or 0)
+        + int(schedules or 0)
+    )
+
+    # Operational queue metrics are kept under a separate key so they don't
+    # collide with the PHP-facing `kpis` list contract above.
+    operational_metrics: dict[str, Any] = {
+        "queued_jobs": int(queue_stats.get("queued_jobs") or 0),
+        "running_jobs": int(queue_stats.get("running_jobs") or 0),
+        "dead_jobs": int(queue_stats.get("dead_jobs") or 0),
+        "active_deal_alerts": int(alert_count or 0),
+        "enabled_schedules": int(schedules or 0),
+        "total_items_compared": row_count,
+        "in_both_markets": in_both_count,
+        "missing_in_alliance": missing_count,
+        "overpriced_in_alliance": sum(
+            1 for r in market_rows if bool(r.get("overpriced_in_alliance"))
+        ),
+        "underpriced_in_alliance": sum(
+            1 for r in market_rows if bool(r.get("underpriced_in_alliance"))
+        ),
+        "weak_or_missing_alliance_stock": sum(
+            1 for r in market_rows if bool(r.get("weak_alliance_stock")) or bool(r.get("missing_in_alliance"))
+        ),
+        "market_comparison_updated_at": market_updated_at,
+    }
+
     payload = {
-        "kpis": {
-            "queued_jobs": int(queue_stats.get("queued_jobs") or 0),
-            "running_jobs": int(queue_stats.get("running_jobs") or 0),
-            "dead_jobs": int(queue_stats.get("dead_jobs") or 0),
-            "active_deal_alerts": alert_count,
-            "enabled_schedules": schedules,
-            **market_kpis,
-        },
+        "kpis": kpi_cards,
+        "priority_queues": priority_queues,
         "freshness": freshness,
-        # Include priority_queues so PHP doesn't trigger an expensive inline rebuild.
-        # Full queue data is populated by the PHP build path on first bootstrap.
-        "priority_queues": {},
+        "operational_metrics": operational_metrics,
     }
     rows_written = db.upsert_intelligence_snapshot(
         snapshot_key="dashboard_summaries",

--- a/src/db.php
+++ b/src/db.php
@@ -17775,6 +17775,67 @@ function db_bloom_entry_points_by_tier(string $tier, int $limit = 10): array
     }
     unset($row);
 
+    // Enrich entity names from entity_metadata_cache for ref types that have
+    // canonical names there (alliance, character, corporation, system, type,
+    // region). The compute_bloom_entry_points job materializes names as read
+    // from Neo4j, which can be empty or out of date — resulting in placeholder
+    // labels like "Alliance 99003581" rendering on the dashboard. The cache is
+    // the authoritative source for display names, so we prefer it whenever we
+    // have a resolved row.
+    $idsByType = [];
+    foreach ($rows as $i => $row) {
+        $refType = (string) ($row['entity_ref_type'] ?? '');
+        $refId = (int) ($row['entity_ref_id'] ?? 0);
+        if ($refId <= 0) {
+            continue;
+        }
+        $cacheType = match ($refType) {
+            'alliance_id' => 'alliance',
+            'character_id' => 'character',
+            'corporation_id' => 'corporation',
+            'system_id' => 'system',
+            'type_id' => 'type',
+            'region_id' => 'region',
+            default => null,
+        };
+        if ($cacheType === null) {
+            continue;
+        }
+        $idsByType[$cacheType][$refId][] = $i;
+    }
+
+    foreach ($idsByType as $cacheType => $idIndex) {
+        $ids = array_keys($idIndex);
+        if ($ids === []) {
+            continue;
+        }
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        try {
+            $cached = db_select(
+                'SELECT entity_id, entity_name
+                   FROM entity_metadata_cache
+                  WHERE entity_type = ?
+                    AND entity_id IN (' . $placeholders . ')',
+                array_merge([$cacheType], array_map('intval', $ids))
+            );
+        } catch (Throwable) {
+            continue;
+        }
+        foreach ($cached as $cacheRow) {
+            $name = trim((string) ($cacheRow['entity_name'] ?? ''));
+            if ($name === '') {
+                continue;
+            }
+            $cid = (int) ($cacheRow['entity_id'] ?? 0);
+            if (!isset($idIndex[$cid])) {
+                continue;
+            }
+            foreach ($idIndex[$cid] as $rowIdx) {
+                $rows[$rowIdx]['entity_name'] = $name;
+            }
+        }
+    }
+
     return $rows;
 }
 


### PR DESCRIPTION
## Summary
Refactored the dashboard summary sync job to output KPI cards as a list structure (matching PHP expectations) instead of a dict, and added priority queue data for opportunities, risks, and missing items. This enables the dashboard to display ranked, actionable intelligence without requiring expensive inline rebuilds.

## Key Changes

**Python (dashboard_summary_sync.py):**
- Added `_dashboard_priority_queue_item()` helper to format queue items with module name, signal, score, type ID, and image URL
- Added `_dedupe_by_type()` helper to filter duplicate type IDs from result sets
- Refactored market comparison data extraction with explicit type checking for robustness
- Changed `kpis` output from a flat dict to a list of card objects with `label`, `value`, and `context` fields
- Added `priority_queues` dict containing three ranked lists:
  - `opportunities`: sorted by opportunity_score and volume_score
  - `risks`: sorted by risk_score and stock_score  
  - `missing_items`: items missing in alliance, sorted by opportunity_score
- Moved operational metrics (queue stats, market counts) to a separate `operational_metrics` dict to avoid collision with the PHP KPI list contract
- Improved code formatting and added clarifying comments about the list vs. dict schema distinction

**PHP (src/db.php):**
- Enhanced `db_bloom_entry_points_by_tier()` to enrich entity names from `entity_metadata_cache` for canonical types (alliance, character, corporation, system, type, region)
- Resolves stale or empty names materialized from Neo4j with authoritative cache values for better dashboard display

**PHP (public/index.php):**
- Added validation and error logging to detect regressions where KPI payload accidentally uses dict-of-scalars shape instead of list-of-cards
- Logs unexpected shapes to help catch future contract violations

## Implementation Details
- KPI cards now follow a consistent schema expected by the dashboard UI, enabling proper rendering of market intelligence summaries
- Priority queues are pre-computed and ranked server-side, eliminating the need for expensive client-side sorting
- Deduplication by type ID ensures each priority queue shows diverse items rather than multiple variants of the same type
- Signal strings are dynamically generated based on item characteristics (e.g., "Import seed candidate" vs. pricing deviation)
- Entity name enrichment in PHP ensures bloom entry points display user-friendly names from the authoritative cache

https://claude.ai/code/session_011Wb5EHqKH9pEkt7Uye6e7Y