### PR TITLE
fix(battle): stop participant_count overflow in compute_battle_anomalies

### DIFF
--- a/bin/recompute_battle_participation_counts.py
+++ b/bin/recompute_battle_participation_counts.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Recompute `battle_participants.participation_count` from raw killmail data.
+
+The `compute_battle_rollups` job historically accumulated `participation_count`
+via `ON DUPLICATE KEY UPDATE participation_count = participation_count + …` and
+the cursor-rewind logic in `_validate_killmail_cursor` could cause the same
+killmails to be processed multiple times across runs.  When that happens, the
+per-character count drifts upward and the per-side SUM in
+`compute_battle_anomalies` eventually overflows the column type, manifesting as
+auto-log issues like:
+
+    DataError: (1264, "Out of range value for column 'participant_count' at row N")
+
+The 20260410 schema migration widens both columns to `BIGINT UNSIGNED` so the
+crash can no longer happen, and `compute_battle_rollups` is now idempotent
+(killmails with `battle_id IS NOT NULL` are excluded from the rollup SELECT).
+This script is the one-shot cleanup for databases that already accumulated
+inflated values: it rebuilds `participation_count` from scratch by counting how
+many `killmail_events` rows reference each `(battle_id, character_id)` pair as
+either victim or attacker.
+
+Usage:
+    python bin/recompute_battle_participation_counts.py [--app-root /var/www/SupplyCore]
+                                                        [--dry-run]
+                                                        [--limit 100000]
+                                                        [--threshold 1000000]
+
+Flags:
+    --dry-run    Report drift without writing.
+    --threshold  Only rewrite rows whose current count exceeds this value
+                 (default: 0, i.e. rewrite every drift).
+    --limit      Cap the number of rows updated per pass (default: unlimited).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Recompute battle_participants.participation_count")
+    parser.add_argument("--app-root", default=None,
+                        help="Path to SupplyCore root (default: auto-detect)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report drift without writing")
+    parser.add_argument("--threshold", type=int, default=0,
+                        help="Only rewrite rows whose stored count exceeds this value (default: 0)")
+    parser.add_argument("--limit", type=int, default=0,
+                        help="Maximum rows to update (0 = unlimited)")
+    args = parser.parse_args()
+
+    repo_root = Path(args.app_root).resolve() if args.app_root else Path(__file__).resolve().parents[1]
+    python_root = repo_root / "python"
+    if str(python_root) not in sys.path:
+        sys.path.insert(0, str(python_root))
+
+    from orchestrator.config import load_php_runtime_config
+    from orchestrator.db import SupplyCoreDb
+
+    raw_config = load_php_runtime_config(repo_root).raw
+    db = SupplyCoreDb(dict(raw_config.get("db") or {}))
+
+    # ── Step 1: Compute the actual count per (battle_id, character_id) ───
+    # We union victim and attacker contributions, group, and compare against
+    # the stored value.  The query is bounded by the rollup itself: only
+    # killmails with `battle_id IS NOT NULL` participate.
+    drift_rows = db.fetch_all(
+        """
+        SELECT bp.battle_id,
+               bp.character_id,
+               bp.participation_count AS stored,
+               COALESCE(actual.total, 0) AS actual
+          FROM battle_participants bp
+          LEFT JOIN (
+              SELECT battle_id, character_id, SUM(cnt) AS total
+                FROM (
+                    SELECT battle_id,
+                           victim_character_id AS character_id,
+                           COUNT(*) AS cnt
+                      FROM killmail_events
+                     WHERE battle_id IS NOT NULL
+                       AND victim_character_id > 0
+                  GROUP BY battle_id, victim_character_id
+                  UNION ALL
+                    SELECT ke.battle_id,
+                           ka.character_id,
+                           COUNT(*) AS cnt
+                      FROM killmail_events ke
+                      JOIN killmail_attackers ka ON ka.sequence_id = ke.sequence_id
+                     WHERE ke.battle_id IS NOT NULL
+                       AND ka.character_id > 0
+                  GROUP BY ke.battle_id, ka.character_id
+                ) parts
+            GROUP BY battle_id, character_id
+          ) actual
+            ON actual.battle_id = bp.battle_id
+           AND actual.character_id = bp.character_id
+         WHERE bp.participation_count > %s
+           AND bp.participation_count <> COALESCE(actual.total, 0)
+         ORDER BY bp.participation_count DESC
+        """,
+        (max(0, args.threshold),),
+    )
+
+    if args.limit > 0:
+        drift_rows = drift_rows[: args.limit]
+
+    if not drift_rows:
+        print("No drift detected; participation_count is already correct.")
+        return 0
+
+    print(f"Found {len(drift_rows)} battle_participants row(s) with drift.\n")
+    print(f"  {'battle_id':<64s}  {'char_id':>12s}  {'stored':>15s}  {'actual':>15s}")
+    print(f"  {'─' * 64}  {'─' * 12}  {'─' * 15}  {'─' * 15}")
+    for row in drift_rows[:25]:
+        print(
+            f"  {str(row['battle_id']):<64s}  "
+            f"{int(row['character_id']):>12d}  "
+            f"{int(row['stored']):>15d}  "
+            f"{int(row['actual']):>15d}"
+        )
+    if len(drift_rows) > 25:
+        print(f"  … and {len(drift_rows) - 25} more")
+
+    if args.dry_run:
+        print(f"\n[dry-run] Would rewrite {len(drift_rows)} row(s). Pass without --dry-run to apply.")
+        return 0
+
+    # ── Step 2: Apply the corrected counts ───────────────────────────────
+    update_sql = (
+        "UPDATE battle_participants "
+        "   SET participation_count = %s "
+        " WHERE battle_id = %s AND character_id = %s"
+    )
+    written = 0
+    for row in drift_rows:
+        db.execute(update_sql, (int(row["actual"]), row["battle_id"], int(row["character_id"])))
+        written += 1
+
+    print(f"\nRewrote participation_count on {written} row(s).")
+    print("Re-run `compute_battle_anomalies` to refresh `battle_side_metrics`.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/database/migrations/20260410_widen_participation_count.sql
+++ b/database/migrations/20260410_widen_participation_count.sql
@@ -1,0 +1,29 @@
+-- ---------------------------------------------------------------------------
+-- Fix auto-log issues for `compute_battle_anomalies`:
+--   DataError (1264, "Out of range value for column 'participant_count' at row N")
+--
+-- Root cause:
+--   `compute_battle_rollups` accumulates `battle_participants.participation_count`
+--   via `ON DUPLICATE KEY UPDATE participation_count = participation_count + ...`.
+--   Whenever the rollup cursor is reset by `_validate_killmail_cursor` (e.g. when
+--   the live R2Z2 stream interleaves with backfill data), the same killmails are
+--   reprocessed and the per-character count keeps growing across runs.
+--   `compute_battle_anomalies` then SUMs those inflated values across a side and
+--   the result overflows the old `INT UNSIGNED` ceiling (4 294 967 295) when
+--   inserted into `battle_side_metrics.participant_count`.
+--
+-- Fix:
+--   Widen the two affected columns to `BIGINT UNSIGNED` so the per-side SUM can
+--   never overflow.  The companion code change in
+--   `python/orchestrator/jobs/battle_intelligence.py` adds an idempotency filter
+--   so future rollups don't re-count already-assigned killmails, and the
+--   `bin/recompute_battle_participation_counts.py` helper rebuilds historical
+--   counts from the killmail tables for operators who want to scrub the inflated
+--   values out of an existing database.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE battle_participants
+    MODIFY COLUMN participation_count BIGINT UNSIGNED NOT NULL DEFAULT 0;
+
+ALTER TABLE battle_side_metrics
+    MODIFY COLUMN participant_count BIGINT UNSIGNED NOT NULL DEFAULT 0;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1828,7 +1828,7 @@ CREATE TABLE IF NOT EXISTS battle_participants (
     is_logi TINYINT(1) NOT NULL DEFAULT 0,
     is_command TINYINT(1) NOT NULL DEFAULT 0,
     is_capital TINYINT(1) NOT NULL DEFAULT 0,
-    participation_count INT UNSIGNED NOT NULL DEFAULT 0,
+    participation_count BIGINT UNSIGNED NOT NULL DEFAULT 0,
     computed_at DATETIME NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -1864,7 +1864,7 @@ CREATE TABLE IF NOT EXISTS battle_target_metrics (
 CREATE TABLE IF NOT EXISTS battle_side_metrics (
     battle_id CHAR(64) NOT NULL,
     side_key VARCHAR(80) NOT NULL,
-    participant_count INT UNSIGNED NOT NULL DEFAULT 0,
+    participant_count BIGINT UNSIGNED NOT NULL DEFAULT 0,
     logi_count INT UNSIGNED NOT NULL DEFAULT 0,
     command_count INT UNSIGNED NOT NULL DEFAULT 0,
     capital_count INT UNSIGNED NOT NULL DEFAULT 0,

--- a/docs/BATTLE_INTELLIGENCE_RUNBOOK.md
+++ b/docs/BATTLE_INTELLIGENCE_RUNBOOK.md
@@ -215,6 +215,42 @@ Check:
 Action:
 - enable/fix Neo4j config, rerun `compute-battle-actor-features`.
 
+### I) `compute_battle_anomalies` fails with `Out of range value for column 'participant_count'`
+
+```
+DataError: (1264, "Out of range value for column 'participant_count' at row N")
+```
+
+Possible cause:
+- Historical drift on `battle_participants.participation_count` from when
+  `compute_battle_rollups` re-counted killmails after a cursor rewind. The
+  per-side `SUM(participation_count)` then exceeded the old `INT UNSIGNED`
+  ceiling (4 294 967 295) when written into `battle_side_metrics`.
+
+Fixed in:
+- Migration `database/migrations/20260410_widen_participation_count.sql`
+  widens both columns to `BIGINT UNSIGNED` so the SUM can no longer overflow.
+- `compute_battle_rollups` now skips killmails with a non-NULL `battle_id`
+  so reprocessing after a cursor rewind never double-counts.
+
+Check:
+```sql
+SELECT MAX(participation_count) FROM battle_participants;
+-- A healthy max is in the low thousands. Anything > 1e9 indicates drift.
+```
+
+Action:
+- Apply the schema migration (`bin/run-migrations.php`) on the affected database.
+- If historical drift is severe, run the cleanup script to rebuild the counts
+  from `killmail_events`/`killmail_attackers`:
+
+```bash
+python bin/recompute_battle_participation_counts.py --dry-run
+python bin/recompute_battle_participation_counts.py --threshold 1000000
+```
+
+- Re-run `compute-battle-anomalies` to refresh `battle_side_metrics`.
+
 ## 10) Validation SQL
 
 Use: `docs/BATTLE_INTELLIGENCE_VALIDATION.md`.

--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -300,6 +300,14 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
 
         while True:
             batch_started = datetime.now(UTC)
+            # The `battle_id IS NULL` filter is critical for idempotency: when
+            # `_validate_killmail_cursor` rewinds the cursor (because the live
+            # R2Z2 stream interleaves with backfilled history), we must skip
+            # killmails that have already been rolled up.  Without this guard,
+            # `participation_count` accumulates across runs via the
+            # `ON DUPLICATE KEY UPDATE participation_count = participation_count + …`
+            # clause below and eventually overflows the SUM in
+            # `compute_battle_anomalies`.
             killmails = db.fetch_all(
                 """
                 SELECT
@@ -319,6 +327,7 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
                 LEFT JOIN killmail_attackers ka ON ka.sequence_id = ke.sequence_id
                 WHERE ke.sequence_id > %s
                   AND ke.solar_system_id IS NOT NULL
+                  AND ke.battle_id IS NULL
                 ORDER BY ke.sequence_id ASC
                 LIMIT %s
                 """,


### PR DESCRIPTION
## Summary

Fixes the recurring auto-log failures on `compute_battle_anomalies`:

```
DataError: (1264, "Out of range value for column 'participant_count' at row N")
```

Closing #937, #938, #942, #943, #944, #945, #946, #947, #948, #949, #950, #951, #954, #955, #956, #957, #958, #959.

## Root cause

`compute_battle_rollups` keeps `battle_participants.participation_count` in sync with new killmails using

```sql
ON DUPLICATE KEY UPDATE participation_count = participation_count + VALUES(participation_count)
```

Whenever `_validate_killmail_cursor` rewinds the rollup cursor (e.g. when the live R2Z2 stream interleaves with backfilled history), the same killmails get processed again and the per-character count drifts upward across runs. `compute_battle_anomalies` then writes `SUM(bp.participation_count)` per side into `battle_side_metrics.participant_count`, and the sum eventually exceeds the old `INT UNSIGNED` ceiling (4 294 967 295). The INSERT then fails with the auto-log signature above.

## Fix

1. **Schema widening** — `database/migrations/20260410_widen_participation_count.sql` and `database/schema.sql` widen both columns to `BIGINT UNSIGNED` so the per-side SUM can no longer overflow.
2. **Idempotency guard** — `compute_battle_rollups` now adds `AND ke.battle_id IS NULL` to its rollup SELECT, so killmails that have already been assigned a battle are skipped. This makes the job idempotent against cursor rewinds and prevents the runaway accumulation in the first place.
3. **Historical cleanup helper** — `bin/recompute_battle_participation_counts.py` rebuilds drifted historical counts from `killmail_events`/`killmail_attackers` for operators whose database already inflated the field. Supports `--dry-run`, `--threshold`, `--limit`.
4. **Runbook** — `docs/BATTLE_INTELLIGENCE_RUNBOOK.md` gains a new troubleshooting entry **(I)** that documents the failure signature, the fix, and the cleanup procedure.

## Test plan

- [x] Python compile (`py_compile battle_intelligence.py`, `py_compile recompute_battle_participation_counts.py`)
- [x] `python/tests/test_battle_stats_ledger.py` — 8 tests, all passing
- [ ] On a target host: apply migration, run `compute-battle-rollups` and `compute-battle-anomalies`, confirm no `1264` errors in the next sync window
- [ ] (Optional) `python bin/recompute_battle_participation_counts.py --dry-run` to inspect drift before scrubbing inflated values

https://claude.ai/code/session_01PKXpAeD1m8RJGJ4KcDocQh