### PR TITLE
fix(retry): harden ESI/Neo4j/stream paths against transient connection drops

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -153,17 +153,73 @@ class SupplyCoreDb:
                 raise
         return 0  # unreachable
 
-    def iterate_batches(self, sql: str, params: Sequence[Any] | None = None, *, batch_size: int = 1000) -> Generator[list[dict[str, Any]], None, None]:
-        with self.cursor(stream=True) as (_, cursor):
-            if params is None:
-                cursor.execute(sql)
-            else:
-                cursor.execute(sql, params)
-            while True:
-                rows = cursor.fetchmany(batch_size)
-                if not rows:
-                    break
-                yield [dict(row) for row in rows]
+    def iterate_batches(
+        self,
+        sql: str,
+        params: Sequence[Any] | None = None,
+        *,
+        batch_size: int = 1000,
+        restart_on_conn_drop: bool = False,
+    ) -> Generator[list[dict[str, Any]], None, None]:
+        """Stream a large result set in chunks.
+
+        The server-side cursor used by the streaming path holds a single
+        network connection open for the duration of the iteration.  When
+        that connection drops mid-stream — e.g. ``wait_timeout`` fires or
+        the DB restarts — pymysql raises ``InterfaceError(0, '')`` on the
+        next ``fetchmany`` call.
+
+        ``restart_on_conn_drop`` (default ``False``) keeps the legacy
+        fail-fast behaviour for callers whose consumers are not idempotent
+        (bulk inserts without ON DUPLICATE KEY UPDATE, counters, etc).
+        Set it to ``True`` when the consumer is keyed by a primary key or
+        is otherwise safe to re-see already-yielded rows: on a drop the
+        stream is restarted from scratch, duplicate batches and all.
+        """
+        if not restart_on_conn_drop:
+            with self.cursor(stream=True) as (_, cursor):
+                if params is None:
+                    cursor.execute(sql)
+                else:
+                    cursor.execute(sql, params)
+                while True:
+                    rows = cursor.fetchmany(batch_size)
+                    if not rows:
+                        return
+                    yield [dict(row) for row in rows]
+            return
+
+        for attempt in range(_SIMPLE_MAX_RETRIES + 1):
+            seen_offset = 0
+            try:
+                with self.cursor(stream=True) as (_, cursor):
+                    if params is None:
+                        cursor.execute(sql)
+                    else:
+                        cursor.execute(sql, params)
+                    while True:
+                        rows = cursor.fetchmany(batch_size)
+                        if not rows:
+                            return
+                        seen_offset += len(rows)
+                        yield [dict(row) for row in rows]
+                return
+            except (pymysql.err.OperationalError, pymysql.err.InterfaceError) as exc:
+                # InterfaceError(0, '') → the underlying connection is
+                # already closed. OperationalError → server gone / lost
+                # connection.  Both are retryable for a streaming read.
+                code = exc.args[0] if exc.args else 0
+                is_interface_error = isinstance(exc, pymysql.err.InterfaceError)
+                is_retryable = is_interface_error or code in _CONNLOSS_ERRORS
+                if attempt >= _SIMPLE_MAX_RETRIES or not is_retryable:
+                    raise
+                logger.warning(
+                    "Retryable MariaDB error in iterate_batches after %d rows "
+                    "(attempt %d/%d, code=%s): %s — restarting stream",
+                    seen_offset, attempt + 1, _SIMPLE_MAX_RETRIES + 1, code, exc,
+                )
+                time.sleep(_SIMPLE_BASE_DELAY * (2 ** attempt))
+                continue
 
     @contextmanager
     def transaction(self):

--- a/python/orchestrator/esi_client.py
+++ b/python/orchestrator/esi_client.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from dataclasses import dataclass
 from typing import Any
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request
 
 from .esi_rate_limiter import EsiRateLimiter, shared_limiter, token_cost_for_status
@@ -21,6 +22,13 @@ logger = logging.getLogger("supplycore.esi_client")
 ESI_BASE = "https://esi.evetech.net"
 ESI_COMPATIBILITY_DATE = "2025-12-16"
 DEFAULT_USER_AGENT = "SupplyCore-Orchestrator/1.0"
+
+# Transient network errors (ConnectionResetError, BrokenPipeError, timeouts,
+# URLError wrapping socket errors) get retried before we give up and return
+# ``status_code=0``.  Without this, a single dropped keepalive terminates
+# long-running graph-crawl jobs like `evewho_alliance_member_sync`.
+_NETWORK_MAX_RETRIES = 2
+_NETWORK_RETRY_BASE_SLEEP = 1.0
 
 
 @dataclass(slots=True)
@@ -104,41 +112,80 @@ class EsiClient:
         if extra_headers:
             headers.update(extra_headers)
 
-        # Wait for rate-limit budget before sending.
-        self._limiter.acquire(group)
-
         request = Request(url, headers=headers, method="GET")
-        try:
-            with ipv4_opener.open(request, timeout=self._timeout) as response:
-                raw_body = response.read()
-                # Handle gzip
-                if response.headers.get("Content-Encoding") == "gzip":
-                    import gzip
-                    raw_body = gzip.decompress(raw_body)
-                body_str = raw_body.decode("utf-8", errors="replace") if isinstance(raw_body, bytes) else raw_body
-                resp_headers = {k: v for k, v in response.headers.items()} if hasattr(response.headers, 'items') else {}
-                status = int(response.status)
+        for attempt in range(_NETWORK_MAX_RETRIES + 1):
+            # Wait for rate-limit budget before every attempt.
+            self._limiter.acquire(group)
+            try:
+                with ipv4_opener.open(request, timeout=self._timeout) as response:
+                    raw_body = response.read()
+                    # Handle gzip
+                    if response.headers.get("Content-Encoding") == "gzip":
+                        import gzip
+                        raw_body = gzip.decompress(raw_body)
+                    body_str = raw_body.decode("utf-8", errors="replace") if isinstance(raw_body, bytes) else raw_body
+                    resp_headers = {k: v for k, v in response.headers.items()} if hasattr(response.headers, 'items') else {}
+                    status = int(response.status)
 
-                parsed = self._parse_json(body_str)
-                esi_response = EsiResponse(status_code=status, body=parsed, headers=resp_headers)
-                self._limiter.update_from_response(status, resp_headers)
-                return esi_response
+                    parsed = self._parse_json(body_str)
+                    esi_response = EsiResponse(status_code=status, body=parsed, headers=resp_headers)
+                    self._limiter.update_from_response(status, resp_headers)
+                    return esi_response
 
-        except HTTPError as exc:
-            exc_headers = {}
-            if hasattr(exc, "headers") and exc.headers:
-                exc_headers = {k: v for k, v in exc.headers.items()} if hasattr(exc.headers, 'items') else {}
-            status = int(exc.code)
-            self._limiter.update_from_response(status, exc_headers)
+            except HTTPError as exc:
+                exc_headers = {}
+                if hasattr(exc, "headers") and exc.headers:
+                    exc_headers = {k: v for k, v in exc.headers.items()} if hasattr(exc.headers, 'items') else {}
+                status = int(exc.code)
+                self._limiter.update_from_response(status, exc_headers)
 
-            if status == 304:
-                return EsiResponse(status_code=304, body=None, headers=exc_headers)
+                if status == 304:
+                    return EsiResponse(status_code=304, body=None, headers=exc_headers)
 
-            return EsiResponse(status_code=status, body=None, headers=exc_headers)
+                return EsiResponse(status_code=status, body=None, headers=exc_headers)
 
-        except (OSError, TimeoutError) as exc:
-            logger.warning("ESI request failed for %s: %s", url, exc)
-            return EsiResponse(status_code=0, body=None, headers={})
+            except URLError as exc:
+                # URLError wraps socket-level problems during connect.  Retry
+                # transient failures before surrendering.
+                if attempt < _NETWORK_MAX_RETRIES:
+                    logger.warning(
+                        "ESI request transient URLError for %s (attempt %d/%d): %s",
+                        url, attempt + 1, _NETWORK_MAX_RETRIES + 1, exc,
+                    )
+                    time.sleep(_NETWORK_RETRY_BASE_SLEEP * (2 ** attempt))
+                    continue
+                logger.warning("ESI request failed for %s: %s", url, exc)
+                return EsiResponse(status_code=0, body=None, headers={})
+
+            except (ConnectionResetError, BrokenPipeError, TimeoutError) as exc:
+                # The peer dropped the TCP connection mid-read, or the
+                # handshake/read timed out.  Retry with exponential backoff.
+                if attempt < _NETWORK_MAX_RETRIES:
+                    logger.warning(
+                        "ESI request connection dropped for %s (attempt %d/%d): %s",
+                        url, attempt + 1, _NETWORK_MAX_RETRIES + 1, exc,
+                    )
+                    time.sleep(_NETWORK_RETRY_BASE_SLEEP * (2 ** attempt))
+                    continue
+                logger.warning("ESI request failed for %s: %s", url, exc)
+                return EsiResponse(status_code=0, body=None, headers={})
+
+            except OSError as exc:
+                # Any other socket-level error bubbling up as a bare OSError
+                # (Errno 104/32/111/…).  Retry on the same schedule.
+                if attempt < _NETWORK_MAX_RETRIES:
+                    logger.warning(
+                        "ESI request OSError for %s (attempt %d/%d): %s",
+                        url, attempt + 1, _NETWORK_MAX_RETRIES + 1, exc,
+                    )
+                    time.sleep(_NETWORK_RETRY_BASE_SLEEP * (2 ** attempt))
+                    continue
+                logger.warning("ESI request failed for %s: %s", url, exc)
+                return EsiResponse(status_code=0, body=None, headers={})
+
+        # All retries exhausted — should be unreachable because the last
+        # attempt in the loop already returns inside its `except`.
+        return EsiResponse(status_code=0, body=None, headers={})
 
     def post(
         self,
@@ -162,36 +209,67 @@ class EsiClient:
         if extra_headers:
             headers.update(extra_headers)
 
-        self._limiter.acquire(group)
-
         encoded_body = json.dumps(body).encode("utf-8") if body is not None else None
         request = Request(url, data=encoded_body, headers=headers, method="POST")
-        try:
-            with ipv4_opener.open(request, timeout=self._timeout) as response:
-                raw_body = response.read()
-                if response.headers.get("Content-Encoding") == "gzip":
-                    import gzip
-                    raw_body = gzip.decompress(raw_body)
-                body_str = raw_body.decode("utf-8", errors="replace") if isinstance(raw_body, bytes) else raw_body
-                resp_headers = {k: v for k, v in response.headers.items()} if hasattr(response.headers, 'items') else {}
-                status = int(response.status)
+        for attempt in range(_NETWORK_MAX_RETRIES + 1):
+            self._limiter.acquire(group)
+            try:
+                with ipv4_opener.open(request, timeout=self._timeout) as response:
+                    raw_body = response.read()
+                    if response.headers.get("Content-Encoding") == "gzip":
+                        import gzip
+                        raw_body = gzip.decompress(raw_body)
+                    body_str = raw_body.decode("utf-8", errors="replace") if isinstance(raw_body, bytes) else raw_body
+                    resp_headers = {k: v for k, v in response.headers.items()} if hasattr(response.headers, 'items') else {}
+                    status = int(response.status)
 
-                parsed = self._parse_json(body_str)
-                esi_response = EsiResponse(status_code=status, body=parsed, headers=resp_headers)
-                self._limiter.update_from_response(status, resp_headers)
-                return esi_response
+                    parsed = self._parse_json(body_str)
+                    esi_response = EsiResponse(status_code=status, body=parsed, headers=resp_headers)
+                    self._limiter.update_from_response(status, resp_headers)
+                    return esi_response
 
-        except HTTPError as exc:
-            exc_headers = {}
-            if hasattr(exc, "headers") and exc.headers:
-                exc_headers = {k: v for k, v in exc.headers.items()} if hasattr(exc.headers, 'items') else {}
-            status = int(exc.code)
-            self._limiter.update_from_response(status, exc_headers)
-            return EsiResponse(status_code=status, body=None, headers=exc_headers)
+            except HTTPError as exc:
+                exc_headers = {}
+                if hasattr(exc, "headers") and exc.headers:
+                    exc_headers = {k: v for k, v in exc.headers.items()} if hasattr(exc.headers, 'items') else {}
+                status = int(exc.code)
+                self._limiter.update_from_response(status, exc_headers)
+                return EsiResponse(status_code=status, body=None, headers=exc_headers)
 
-        except (OSError, TimeoutError) as exc:
-            logger.warning("ESI POST request failed for %s: %s", url, exc)
-            return EsiResponse(status_code=0, body=None, headers={})
+            except URLError as exc:
+                if attempt < _NETWORK_MAX_RETRIES:
+                    logger.warning(
+                        "ESI POST transient URLError for %s (attempt %d/%d): %s",
+                        url, attempt + 1, _NETWORK_MAX_RETRIES + 1, exc,
+                    )
+                    time.sleep(_NETWORK_RETRY_BASE_SLEEP * (2 ** attempt))
+                    continue
+                logger.warning("ESI POST request failed for %s: %s", url, exc)
+                return EsiResponse(status_code=0, body=None, headers={})
+
+            except (ConnectionResetError, BrokenPipeError, TimeoutError) as exc:
+                if attempt < _NETWORK_MAX_RETRIES:
+                    logger.warning(
+                        "ESI POST connection dropped for %s (attempt %d/%d): %s",
+                        url, attempt + 1, _NETWORK_MAX_RETRIES + 1, exc,
+                    )
+                    time.sleep(_NETWORK_RETRY_BASE_SLEEP * (2 ** attempt))
+                    continue
+                logger.warning("ESI POST request failed for %s: %s", url, exc)
+                return EsiResponse(status_code=0, body=None, headers={})
+
+            except OSError as exc:
+                if attempt < _NETWORK_MAX_RETRIES:
+                    logger.warning(
+                        "ESI POST OSError for %s (attempt %d/%d): %s",
+                        url, attempt + 1, _NETWORK_MAX_RETRIES + 1, exc,
+                    )
+                    time.sleep(_NETWORK_RETRY_BASE_SLEEP * (2 ** attempt))
+                    continue
+                logger.warning("ESI POST request failed for %s: %s", url, exc)
+                return EsiResponse(status_code=0, body=None, headers={})
+
+        return EsiResponse(status_code=0, body=None, headers={})
 
     def _build_url(self, path: str, params: dict[str, str | int] | None) -> str:
         url = f"{ESI_BASE}{path}"

--- a/python/orchestrator/jobs/compute_economic_warfare.py
+++ b/python/orchestrator/jobs/compute_economic_warfare.py
@@ -69,7 +69,14 @@ def _extract_opponent_fits(db: Any, window_days: int) -> dict[int, dict]:
         ORDER BY ke.sequence_id
     """
     kills: dict[int, dict] = {}
-    for batch in db.iterate_batches(sql, (window_days,), batch_size=5000):
+    # Opt into restart_on_conn_drop: the consumer is keyed by sequence_id and
+    # re-seeing already-processed rows just overwrites existing entries with
+    # identical data.  Without this, a mid-stream InterfaceError(0, '') (e.g.
+    # a wait_timeout or MariaDB restart) aborts the whole compute job.
+    seen_modules: set[tuple[int, int, int]] = set()
+    for batch in db.iterate_batches(
+        sql, (window_days,), batch_size=5000, restart_on_conn_drop=True
+    ):
         for row in batch:
             seq_id = int(row["sequence_id"])
             if seq_id not in kills:
@@ -78,8 +85,16 @@ def _extract_opponent_fits(db: Any, window_days: int) -> dict[int, dict]:
                     "alliance_id": int(row["victim_alliance_id"] or 0),
                     "modules": [],
                 }
+            type_id = int(row["item_type_id"])
             flag_cat = _flag_category(int(row["item_flag"] or 0))
-            kills[seq_id]["modules"].append((int(row["item_type_id"]), flag_cat))
+            # Dedupe on retry: without this, a stream restart would add
+            # duplicate (type_id, flag_cat) entries to the same kill's
+            # module list and skew downstream clustering scores.
+            dedupe_key = (seq_id, type_id, flag_cat)
+            if dedupe_key in seen_modules:
+                continue
+            seen_modules.add(dedupe_key)
+            kills[seq_id]["modules"].append((type_id, flag_cat))
 
     logger.info("Phase 1: extracted %d opponent kills with fitted modules", len(kills))
     return kills

--- a/python/orchestrator/neo4j.py
+++ b/python/orchestrator/neo4j.py
@@ -153,7 +153,32 @@ class Neo4jClient:
                 details = error.read().decode("utf-8", errors="replace")
                 raise Neo4jError(f"Neo4j query failed ({error.code}): {details}") from error
             except urllib.error.URLError as error:
+                # URLError wraps socket errors raised during connect()/handshake
+                # (connection refused, DNS failure, timeouts, etc).  Retry
+                # transient network problems before giving up — Neo4j restarts
+                # and brief network hiccups should not fail an entire compute
+                # job.
+                if attempt < _TRANSIENT_RETRY_LIMIT:
+                    time.sleep(_TRANSIENT_BASE_SLEEP * (2 ** attempt))
+                    continue
                 raise Neo4jError(f"Neo4j query failed: {error.reason}") from error
+            except (ConnectionResetError, BrokenPipeError, TimeoutError) as error:
+                # Raised directly (not wrapped in URLError) when the peer
+                # drops the TCP connection mid-read — e.g. a Neo4j restart
+                # between `open()` and `read()`, or an idle keepalive that
+                # the OS reaped.  Retry with backoff on the same schedule
+                # as other transient errors.
+                if attempt < _TRANSIENT_RETRY_LIMIT:
+                    time.sleep(_TRANSIENT_BASE_SLEEP * (2 ** attempt))
+                    continue
+                raise Neo4jError(f"Neo4j query failed: {error}") from error
+            except OSError as error:
+                # Catch-all for any other socket-level error that bubbles up
+                # as a bare OSError (Errno 111/104/32/…).  Retry with backoff.
+                if attempt < _TRANSIENT_RETRY_LIMIT:
+                    time.sleep(_TRANSIENT_BASE_SLEEP * (2 ** attempt))
+                    continue
+                raise Neo4jError(f"Neo4j query failed: {error}") from error
 
             errors = body.get("errors") or []
             if errors:


### PR DESCRIPTION
## Summary

Addresses two recurring auto-log failures that both reduce to a transient network/connection-lifetime problem outside the job's control:

- **#903** `evewho_alliance_member_sync`: `[Errno 104] Connection reset by peer` — the graph crawl hits ESI, EveWho and Neo4j in sequence, and a single dropped keepalive on any of them was enough to tear down the whole 4-minute run. The EveWho adapter already retried, but `EsiClient` returned `status_code=0` on the first `OSError`, and the Neo4j client re-raised a raw `URLError` / `OSError` without retrying.
- **#909** `compute_economic_warfare`: `InterfaceError: (0, '')` — the job streams ~90 days of `killmail_items` via `db.iterate_batches`, and if MariaDB's `wait_timeout` fires (or the server restarts) the SS cursor's connection is already closed when the next `fetchmany` runs, which pymysql surfaces as a bare `InterfaceError(0, '')`.

## Changes

1. **`python/orchestrator/neo4j.py`** — `_execute_payload` now retries `urllib.error.URLError`, `ConnectionResetError`, `BrokenPipeError`, `TimeoutError` and any residual bare `OSError` with the same exponential-backoff schedule as the existing transient-error handler.
2. **`python/orchestrator/esi_client.py`** — `EsiClient.get` and `.post` now retry transient `URLError`, `ConnectionResetError`, `BrokenPipeError`, `TimeoutError` and residual `OSError` up to 2 extra attempts with 1s/2s backoff. Rate-limit budget is re-acquired on each attempt so we stay within ESI's per-window quota.
3. **`python/orchestrator/db.py`** — `iterate_batches` gains an opt-in `restart_on_conn_drop` flag that catches `OperationalError` AND `InterfaceError` and restarts the stream from scratch on connection loss. Default is still fail-fast so existing callers whose consumers are not idempotent keep their current semantics.
4. **`python/orchestrator/jobs/compute_economic_warfare.py`** — `_extract_opponent_fits` opts into `restart_on_conn_drop=True` and adds a `(sequence_id, type_id, flag_cat)` dedupe set so a mid-stream restart cannot double-count modules in a kill's fit vector.

## Collateral benefit

The Neo4j client retry also defends the rest of the compute chain against the same symptom family. The auto-log queue has several `ConnectionResetError` / `Broken pipe` hits from Neo4j-facing jobs that should now retry at the client layer instead of failing the whole job:

- #904 `compute_graph_topology_metrics: Broken pipe`
- #905 `compute_graph_sync_battle_intelligence: Broken pipe`
- #921 `compute_battle_actor_features: Connection reset by peer`
- #922 `compute_battle_actor_features: Connection reset by peer`
- #923 `compute_graph_sync_killmail_edges: Connection reset by peer`

Pure "service is down" issues (Neo4j `Errno 111 Connection refused`, MariaDB `2003 Can't connect`) will still fail after the retry budget is exhausted — those need Neo4j/MariaDB to actually come back up and are being closed as infrastructure.

## Test plan

- [x] Python compile (`py_compile` on all 4 edited files)
- [x] `python/tests/test_battle_stats_ledger.py` — 8 tests, all passing
- [ ] On a target host: run `evewho-alliance-member-sync` and `compute-economic-warfare` once MariaDB/Neo4j are back up; confirm no `InterfaceError(0, '')` or `[Errno 104]` in the next sync window
- [ ] Watch the auto-log queue for 1 scan window; transient errors should no longer open new issues

Addresses #903, #909. Helps #904, #905, #921, #922, #923.

https://claude.ai/code/session_01PKXpAeD1m8RJGJ4KcDocQh