### PR TITLE
Add composite index for killmail overview filtering and sorting

### DIFF
--- a/database/migrations/20260410_killmail_overview_mailtype_effective.sql
+++ b/database/migrations/20260410_killmail_overview_mailtype_effective.sql
@@ -1,0 +1,13 @@
+-- Killmail intelligence overview: composite index for mail_type + time ordering.
+--
+-- db_killmail_overview_page() filters on mail_type ('loss' by default) and
+-- orders by effective_killmail_at DESC, sequence_id DESC. No existing index
+-- on killmail_events covers that access pattern, so MySQL falls back to a
+-- full scan + filesort. During killmail backload this causes the
+-- /killmail-intelligence page to time out.
+--
+-- This composite index covers both the filter and the order-by. sequence_id
+-- is already UNIQUE on the table so no further tiebreak column is needed.
+
+CREATE INDEX IF NOT EXISTS idx_killmail_mailtype_effective_seq
+    ON killmail_events (mail_type, effective_killmail_at, sequence_id);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1353,7 +1353,8 @@ CREATE TABLE IF NOT EXISTS killmail_events (
     KEY idx_killmail_events_battle (battle_id, effective_killmail_at),
     KEY idx_killmail_effective_ship (effective_killmail_at, victim_ship_type_id),
     KEY idx_killmail_ship_effective (victim_ship_type_id, effective_killmail_at),
-    KEY idx_system_region (solar_system_id, region_id)
+    KEY idx_system_region (solar_system_id, region_id),
+    KEY idx_killmail_mailtype_effective_seq (mail_type, effective_killmail_at, sequence_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS killmail_event_payloads (
@@ -1582,6 +1583,26 @@ WHERE e.zkb_total_value IS NULL
   AND e.zkb_solo IS NULL
   AND e.zkb_awox IS NULL
   AND (p.sequence_id IS NOT NULL OR NULLIF(e.zkb_json, '') IS NOT NULL);
+
+-- Composite index matching the killmail-intelligence overview filter/order path
+-- (mail_type + effective_killmail_at ORDER BY sequence_id). Without this, the
+-- overview listing falls back to a full scan + filesort which times out at
+-- backload volumes. See db_killmail_overview_page() in src/db.php.
+SET @killmail_events_mailtype_effective_seq_idx_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'killmail_events'
+      AND INDEX_NAME = 'idx_killmail_mailtype_effective_seq'
+);
+SET @killmail_events_mailtype_effective_seq_idx_sql := IF(
+    @killmail_events_mailtype_effective_seq_idx_exists = 0,
+    'ALTER TABLE killmail_events ADD KEY idx_killmail_mailtype_effective_seq (mail_type, effective_killmail_at, sequence_id)',
+    'SELECT 1'
+);
+PREPARE killmail_events_mailtype_effective_seq_idx_stmt FROM @killmail_events_mailtype_effective_seq_idx_sql;
+EXECUTE killmail_events_mailtype_effective_seq_idx_stmt;
+DEALLOCATE PREPARE killmail_events_mailtype_effective_seq_idx_stmt;
 
 CREATE TABLE IF NOT EXISTS killmail_attackers (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## Summary
Adds a composite database index to optimize the killmail intelligence overview page query performance. The index covers the filter-by-mail_type and order-by-effective_killmail_at access pattern that was previously causing full table scans and timeouts during killmail backload operations.

## Changes
- **schema.sql**: Added composite index `idx_killmail_mailtype_effective_seq` on `killmail_events` table with columns `(mail_type, effective_killmail_at, sequence_id)`. Includes conditional creation logic to safely apply the index during migrations.
- **migrations/20260410_killmail_overview_mailtype_effective.sql**: New migration file that creates the composite index with documentation explaining the performance issue and index design rationale.

## Implementation Details
- The index directly supports the `db_killmail_overview_page()` query pattern: filtering by `mail_type` ('loss' by default) and ordering by `effective_killmail_at DESC, sequence_id DESC`
- Without this index, MySQL was falling back to full table scan + filesort, causing timeouts at scale
- The `sequence_id` column is already UNIQUE on the table, so no additional tiebreak column is needed
- Migration includes existence check to prevent duplicate index creation errors

https://claude.ai/code/session_01DpcitBxn1Fya47r8TvHnz2