### PR TITLE
feat(horizon): pilot incremental-only mode on compute_battle_rollups

### DIFF
--- a/python/orchestrator/horizon.py
+++ b/python/orchestrator/horizon.py
@@ -343,6 +343,55 @@ def rewind_cursor(db: SupplyCoreDb, dataset_key: str, cursor: str) -> None:
     )
 
 
+def update_watermark_and_stall(
+    db: SupplyCoreDb,
+    dataset_key: str,
+    *,
+    new_cursor: str,
+    event_time: str | datetime | None,
+) -> None:
+    """Update ``watermark_event_time`` and stall tracking alongside an
+    externally-managed ``last_cursor`` write.
+
+    Unlike :func:`advance_cursor_with_stall_detection`, this helper does
+    NOT touch ``last_cursor`` itself -- that's expected to be written by
+    the calling job's existing upsert (e.g. battle intelligence uses its
+    own integer-sequence-id upsert). The helper only compares cursors
+    for equality to detect stalls (equal -> increment, different -> reset),
+    so it works for any cursor format including plain integers.
+
+    Call this on successful runs only. Failed runs should leave stall
+    tracking alone so the next retry doesn't inherit a bumped counter.
+    """
+    row = db.fetch_one(
+        "SELECT last_cursor, stall_cursor FROM sync_state WHERE dataset_key = %s LIMIT 1",
+        (dataset_key,),
+    ) or {}
+    existing_stall_cursor = _coerce_str(row.get("stall_cursor")) or _coerce_str(row.get("last_cursor")) or ""
+
+    advanced = str(new_cursor) != existing_stall_cursor
+    if advanced:
+        stall_cursor: str | None = new_cursor
+        stall_count_expr = "0"
+    else:
+        stall_cursor = existing_stall_cursor or None
+        stall_count_expr = "(stall_count + 1)"
+
+    event_time_str = _coerce_event_time(event_time, new_cursor) if event_time is not None else None
+
+    db.execute(
+        f"""
+        UPDATE sync_state
+           SET watermark_event_time = COALESCE(%s, watermark_event_time),
+               stall_cursor = %s,
+               stall_count = {stall_count_expr},
+               updated_at = CURRENT_TIMESTAMP
+         WHERE dataset_key = %s
+        """,
+        (event_time_str, stall_cursor, dataset_key),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Backfill-complete gate helpers.
 # ---------------------------------------------------------------------------

--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -16,6 +16,12 @@ if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
     from orchestrator.config import resolve_app_root  # noqa: F401
     from orchestrator.db import SupplyCoreDb
+    from orchestrator.horizon import (
+        HorizonState,
+        horizon_state_get,
+        should_use_incremental_only,
+        update_watermark_and_stall,
+    )
     from orchestrator.job_result import JobResult
     from orchestrator.json_utils import json_dumps_safe
     from orchestrator.job_utils import finish_job_run, start_job_run
@@ -23,6 +29,12 @@ if __package__ in (None, ""):
 else:
     from ..config import resolve_app_root  # noqa: F401
     from ..db import SupplyCoreDb
+    from ..horizon import (
+        HorizonState,
+        horizon_state_get,
+        should_use_incremental_only,
+        update_watermark_and_stall,
+    )
     from ..job_result import JobResult
     from ..json_utils import json_dumps_safe
     from ..job_utils import finish_job_run, start_job_run
@@ -165,6 +177,67 @@ def _validate_killmail_cursor(db: SupplyCoreDb, cursor: int) -> int:
     return cursor
 
 
+def _horizon_apply_repair_window(
+    db: SupplyCoreDb,
+    state: HorizonState | None,
+    cursor: int,
+) -> tuple[int, dict[str, Any]]:
+    """Apply the horizon rolling-repair-window to a killmail sequence cursor.
+
+    When the dataset is gated into incremental-only horizon mode, drop
+    the read-from sequence id to the smallest killmail recorded within
+    the last ``repair_window_seconds`` window. That lets late-arriving
+    killmails (inside the window) flow through on every run -- the
+    existing ``battle_id IS NULL`` filter on the rollup query keeps it
+    idempotent, so re-reading the tail costs nothing correctness-wise.
+
+    Returns the (possibly lowered) cursor and a meta dict describing
+    what happened for observability.
+
+    When horizon mode is off (the default), returns the cursor unchanged
+    and meta = ``{"applied": False, ...}``.
+    """
+    meta: dict[str, Any] = {
+        "applied": False,
+        "reason": "gate_off",
+        "repair_window_seconds": None,
+        "rewound_to": None,
+    }
+    if not should_use_incremental_only(state):
+        return cursor, meta
+
+    assert state is not None  # for type-checkers
+    repair_window = max(0, state.repair_window_seconds)
+    meta["repair_window_seconds"] = repair_window
+    if repair_window == 0:
+        meta["reason"] = "zero_window"
+        return cursor, meta
+
+    row = db.fetch_one(
+        """
+        SELECT MIN(sequence_id) AS min_seq
+          FROM killmail_events
+         WHERE effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL %s SECOND)
+        """,
+        (repair_window,),
+    ) or {}
+    min_seq = row.get("min_seq")
+    if min_seq is None:
+        meta["reason"] = "no_killmails_in_window"
+        return cursor, meta
+
+    window_start = max(0, int(min_seq) - 1)
+    if window_start >= cursor:
+        meta["reason"] = "window_start_not_lower"
+        return cursor, meta
+
+    meta["applied"] = True
+    meta["reason"] = "window_applied"
+    meta["rewound_to"] = window_start
+    meta["rewound_from"] = cursor
+    return window_start, meta
+
+
 def _sync_state_cursor_upsert(
     db: SupplyCoreDb,
     dataset_key: str,
@@ -267,12 +340,24 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
     rows_processed = 0
     rows_written = 0
     computed_at = _now_sql()
-    cursor_start = _sync_state_cursor_get(db, SYNC_STATE_KEY_BATTLE_ROLLUPS_CURSOR)
-    cursor_start = _validate_killmail_cursor(db, cursor_start)
+    raw_cursor = _sync_state_cursor_get(db, SYNC_STATE_KEY_BATTLE_ROLLUPS_CURSOR)
+    raw_cursor = _validate_killmail_cursor(db, raw_cursor)
+    horizon_state = horizon_state_get(db, SYNC_STATE_KEY_BATTLE_ROLLUPS_CURSOR)
+    cursor_start, horizon_meta = _horizon_apply_repair_window(db, horizon_state, raw_cursor)
     cursor_end = cursor_start
+    watermark_event_time: str | None = None
     batch_count = 0
     _sync_state_cursor_upsert(db, SYNC_STATE_KEY_BATTLE_ROLLUPS_CURSOR, status="running", last_cursor=cursor_start, last_row_count=0)
-    _battle_log(runtime, "battle_intelligence.job.started", {"job_name": "compute_battle_rollups", "dry_run": dry_run, "computed_at": computed_at})
+    _battle_log(
+        runtime,
+        "battle_intelligence.job.started",
+        {
+            "job_name": "compute_battle_rollups",
+            "dry_run": dry_run,
+            "computed_at": computed_at,
+            "horizon": horizon_meta,
+        },
+    )
     try:
         role_rows = db.fetch_all(
             """
@@ -354,6 +439,10 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
                 killmail_time = str(row.get("killmail_time") or "")
                 if system_id <= 0 or killmail_id <= 0 or killmail_time == "":
                     continue
+                # Track the latest source event time for the horizon
+                # watermark (used by the freshness report + SLA checks).
+                if watermark_event_time is None or killmail_time > watermark_event_time:
+                    watermark_event_time = killmail_time
 
                 bucket_unix = int(datetime.strptime(killmail_time, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC).timestamp() // WINDOW_SECONDS * WINDOW_SECONDS)
                 battle_id = f"{system_id}:{bucket_unix}"
@@ -566,6 +655,17 @@ def run_compute_battle_rollups(db: SupplyCoreDb, runtime: dict[str, Any] | None 
                 status="success",
                 last_cursor=cursor_end,
                 last_row_count=len(killmails),
+            )
+            # Horizon watermark update runs after the cursor upsert so the
+            # freshness report reflects the newest source event time we
+            # actually rolled up this batch.  compute_battle_rollups uses a
+            # plain integer sequence_id cursor, so we pass the stringified
+            # cursor for equality-only stall detection.
+            update_watermark_and_stall(
+                db,
+                SYNC_STATE_KEY_BATTLE_ROLLUPS_CURSOR,
+                new_cursor=str(cursor_end),
+                event_time=watermark_event_time,
             )
             _battle_log(
                 runtime,

--- a/python/tests/test_horizon.py
+++ b/python/tests/test_horizon.py
@@ -27,6 +27,7 @@ from orchestrator.horizon import (  # noqa: E402
     read_from_cursor,
     rewind_cursor,
     should_use_incremental_only,
+    update_watermark_and_stall,
 )
 
 
@@ -77,6 +78,24 @@ class FakeDb:
             new_cursor, event_time, stall_cursor, _dataset_key = params_tuple
             row["last_cursor"] = new_cursor
             row["watermark_event_time"] = event_time
+            row["stall_cursor"] = stall_cursor
+            if "STALL_COUNT = 0" in upper:
+                row["stall_count"] = 0
+            else:
+                row["stall_count"] = int(row.get("stall_count") or 0) + 1
+            return 1
+
+        # Watermark-and-stall-only update: does not touch last_cursor.
+        # Shape: SET watermark_event_time = COALESCE(%s, ...), stall_cursor = %s,
+        #        stall_count = (0 | stall_count + 1) WHERE dataset_key = %s
+        if (
+            "WATERMARK_EVENT_TIME = COALESCE" in upper
+            and "STALL_CURSOR = %S" in upper
+            and "LAST_CURSOR" not in upper
+        ):
+            event_time, stall_cursor, _dataset_key = params_tuple
+            if event_time is not None:
+                row["watermark_event_time"] = event_time
             row["stall_cursor"] = stall_cursor
             if "STALL_COUNT = 0" in upper:
                 row["stall_count"] = 0
@@ -262,6 +281,96 @@ class AdvanceCursorTests(unittest.TestCase):
         self.assertEqual(updated["watermark_event_time"], "2026-04-05 00:00:00")
         self.assertEqual(updated["stall_count"], 0)
         self.assertIsNone(updated["stall_cursor"])
+
+
+class UpdateWatermarkAndStallTests(unittest.TestCase):
+    """Covers the helper used by jobs that manage last_cursor themselves
+    (e.g. compute_battle_rollups uses a plain integer sequence_id cursor
+    so it must keep its own upsert for ordering, while still getting
+    horizon watermark + stall tracking)."""
+
+    def test_advance_updates_watermark_and_resets_stall(self) -> None:
+        db = FakeDb({"test.dataset": _make_row(
+            last_cursor="12345",
+            stall_cursor="12340",
+            stall_count=2,
+            watermark_event_time=None,
+        )})
+        update_watermark_and_stall(
+            db,
+            "test.dataset",
+            new_cursor="12345",
+            event_time="2026-04-10 11:00:00",
+        )
+
+        updated = db.rows["test.dataset"]
+        # last_cursor must not be touched by this helper.
+        self.assertEqual(updated["last_cursor"], "12345")
+        self.assertEqual(updated["stall_cursor"], "12345")
+        self.assertEqual(updated["stall_count"], 0)
+        self.assertEqual(updated["watermark_event_time"], "2026-04-10 11:00:00")
+
+    def test_no_advance_increments_stall_counter(self) -> None:
+        db = FakeDb({"test.dataset": _make_row(
+            last_cursor="12345",
+            stall_cursor="12345",
+            stall_count=1,
+        )})
+        update_watermark_and_stall(
+            db,
+            "test.dataset",
+            new_cursor="12345",
+            event_time="2026-04-10 10:30:00",
+        )
+
+        updated = db.rows["test.dataset"]
+        self.assertEqual(updated["last_cursor"], "12345")
+        self.assertEqual(updated["stall_cursor"], "12345")
+        self.assertEqual(updated["stall_count"], 2)
+
+    def test_none_event_time_preserves_existing_watermark(self) -> None:
+        existing_watermark = datetime(2026, 4, 10, 9, 0, 0)
+        db = FakeDb({"test.dataset": _make_row(
+            last_cursor="12345",
+            stall_cursor="12340",
+            stall_count=0,
+            watermark_event_time=existing_watermark,
+        )})
+        update_watermark_and_stall(
+            db,
+            "test.dataset",
+            new_cursor="12345",
+            event_time=None,
+        )
+
+        # COALESCE(NULL, existing) -> existing; FakeDb models this by
+        # only overwriting when event_time is not None.
+        updated = db.rows["test.dataset"]
+        self.assertEqual(updated["watermark_event_time"], existing_watermark)
+        # Stall tracking still updates.
+        self.assertEqual(updated["stall_cursor"], "12345")
+        self.assertEqual(updated["stall_count"], 0)
+
+    def test_does_not_touch_last_cursor_on_any_path(self) -> None:
+        db = FakeDb({"test.dataset": _make_row(
+            last_cursor="99999",
+            stall_cursor="99999",
+            stall_count=0,
+        )})
+        # "Rewind" attempt: caller passes a lower cursor. The helper
+        # must still not touch last_cursor and must reset stall tracking
+        # because the cursor differs from the latched stall_cursor.
+        update_watermark_and_stall(
+            db,
+            "test.dataset",
+            new_cursor="500",
+            event_time="2026-04-05 00:00:00",
+        )
+
+        updated = db.rows["test.dataset"]
+        self.assertEqual(updated["last_cursor"], "99999")
+        self.assertEqual(updated["stall_cursor"], "500")
+        self.assertEqual(updated["stall_count"], 0)
 
 
 class FreshnessStatusTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Phase 2 of the incremental-horizon rollout: wires the Phase 1 primitives (#987) into `compute_battle_rollups` as the pilot for the rolling-repair-window model.

When an admin approves `compute_battle_rollups:last_sequence_id`, the job starts reading from a cursor rewound by `repair_window_seconds` (default 24h). Late-arriving killmails inside that window flow through every run, and the existing `battle_id IS NULL` filter on the rollup query keeps re-reading the tail idempotent. When the gate is off (default), behavior is unchanged.

## Changes

- **`python/orchestrator/horizon.py`** — new `update_watermark_and_stall()` helper that updates `watermark_event_time` + stall tracking **without touching `last_cursor`**. Uses equality-only comparison so it works with any cursor format, including the plain integer `sequence_id` used by battle rollups (the generic `advance_cursor_with_stall_detection` does string comparison, which is wrong for integer monotonicity).
- **`python/orchestrator/jobs/battle_intelligence.py`**:
  - New `_horizon_apply_repair_window()` helper translates `repair_window_seconds` → a `sequence_id` by querying `MIN(sequence_id)` from `killmail_events` inside the window.
  - `run_compute_battle_rollups` now fetches horizon state, applies the repair window on start, tracks `watermark_event_time` inside the batch loop, logs horizon meta in the start event, and calls `update_watermark_and_stall` after each successful per-batch `_sync_state_cursor_upsert`.
  - `_validate_killmail_cursor` still runs as the out-of-window escape hatch (complementary to the rolling window).
- **`python/tests/test_horizon.py`** — 4 new tests for the helper covering: advance-resets-stall, non-advance-increments-stall, None `event_time` preserves existing watermark, and `last_cursor` is never touched on any path. FakeDb also gained a new branch for the watermark-only UPDATE shape. **All 29 tests pass.**

## How to enable (post-merge)

From the Settings → Data Sync admin panel's "Incremental horizon mode" section, approve `compute_battle_rollups:last_sequence_id`, or via CLI:

```
php bin/horizon-approve.php compute_battle_rollups:last_sequence_id
```

Rollback:

```
php bin/horizon-reset.php compute_battle_rollups:last_sequence_id
```

## Test plan

- [x] `python3 -m unittest python.tests.test_horizon` — 29/29 pass
- [x] `ast.parse` syntax check on `battle_intelligence.py`
- [ ] Observe first run after approval in the data-sync log — confirm `battle_intelligence.job.started` event carries `horizon.applied = true` and `horizon.rewound_to` matches `MIN(sequence_id)` for the last 24h
- [ ] Freshness report: `compute_battle_rollups:last_sequence_id` shows `horizon_status = caught_up` and `stall_count = 0` after approval
- [ ] Late-data injection: insert a killmail with `effective_killmail_at` 12h in the past — next rollup run should pick it up (it falls inside the default repair window)
- [ ] Stall detection: simulate an idle source — `stall_count` should increment per run while no new killmails arrive