### PR TITLE
feat(horizon): wire incremental-only mode into compute_battle_target_metrics

### DIFF
--- a/python/orchestrator/jobs/battle_intelligence.py
+++ b/python/orchestrator/jobs/battle_intelligence.py
@@ -728,12 +728,24 @@ def run_compute_battle_target_metrics(db: SupplyCoreDb, runtime: dict[str, Any] 
     rows_written = 0
     computed_at = _now_sql()
     unscored_targets = 0
-    cursor_start = _sync_state_cursor_get(db, SYNC_STATE_KEY_BATTLE_TARGET_CURSOR)
-    cursor_start = _validate_killmail_cursor(db, cursor_start)
+    raw_cursor = _sync_state_cursor_get(db, SYNC_STATE_KEY_BATTLE_TARGET_CURSOR)
+    raw_cursor = _validate_killmail_cursor(db, raw_cursor)
+    horizon_state = horizon_state_get(db, SYNC_STATE_KEY_BATTLE_TARGET_CURSOR)
+    cursor_start, horizon_meta = _horizon_apply_repair_window(db, horizon_state, raw_cursor)
     cursor_end = cursor_start
+    watermark_event_time: str | None = None
     batch_count = 0
     _sync_state_cursor_upsert(db, SYNC_STATE_KEY_BATTLE_TARGET_CURSOR, status="running", last_cursor=cursor_start, last_row_count=0)
-    _battle_log(runtime, "battle_intelligence.job.started", {"job_name": "compute_battle_target_metrics", "dry_run": dry_run, "computed_at": computed_at})
+    _battle_log(
+        runtime,
+        "battle_intelligence.job.started",
+        {
+            "job_name": "compute_battle_target_metrics",
+            "dry_run": dry_run,
+            "computed_at": computed_at,
+            "horizon": horizon_meta,
+        },
+    )
     try:
         while True:
             batch_started = datetime.now(UTC)
@@ -776,6 +788,11 @@ def run_compute_battle_target_metrics(db: SupplyCoreDb, runtime: dict[str, Any] 
                 damage = max(0.0, float(damage_value or 0.0))
                 started_at = datetime.strptime(str(row.get("started_at")), "%Y-%m-%d %H:%M:%S")
                 killmail_time = datetime.strptime(str(row.get("killmail_time")), "%Y-%m-%d %H:%M:%S")
+                # Track the newest source event time for the horizon
+                # watermark (used by the freshness report + SLA checks).
+                killmail_time_str = killmail_time.strftime("%Y-%m-%d %H:%M:%S")
+                if watermark_event_time is None or killmail_time_str > watermark_event_time:
+                    watermark_event_time = killmail_time_str
                 ttd = max(1.0, (killmail_time - started_at).total_seconds())
                 dps = _safe_div(damage, ttd, 0.0)
                 ship_type_id = int(row.get("victim_ship_type_id") or 0)
@@ -863,6 +880,18 @@ def run_compute_battle_target_metrics(db: SupplyCoreDb, runtime: dict[str, Any] 
                 status="success",
                 last_cursor=cursor_end,
                 last_row_count=len(rows),
+            )
+            # Horizon watermark update runs after the cursor upsert so
+            # the freshness report reflects the newest source event
+            # time actually scored by this batch.  This job uses the
+            # same killmail sequence_id cursor as compute_battle_rollups
+            # so we pass the stringified cursor for equality-only stall
+            # detection.
+            update_watermark_and_stall(
+                db,
+                SYNC_STATE_KEY_BATTLE_TARGET_CURSOR,
+                new_cursor=str(cursor_end),
+                event_time=watermark_event_time,
             )
             _battle_log(
                 runtime,


### PR DESCRIPTION
## Summary

Phase 3.1 of the horizon rollout. Mirrors the pilot wiring landed in #988 for `compute_battle_rollups`, applied to `compute_battle_target_metrics` which lives in the same file and uses the same killmail `sequence_id` cursor format.

Both jobs now share the `_horizon_apply_repair_window` helper that maps `repair_window_seconds` to a sequence_id via `MIN(sequence_id)` on `killmail_events` inside the window.

## Changes

`python/orchestrator/jobs/battle_intelligence.py` — `run_compute_battle_target_metrics`:
- Fetches horizon state on start
- Applies the repair window to the read cursor (no-op when gate is off)
- Tracks `watermark_event_time` inside the row loop (newest `killmail_time`)
- Calls `update_watermark_and_stall` after each successful per-batch `_sync_state_cursor_upsert`
- Logs horizon meta in the `job.started` event for observability

No behavior change until an admin flips `backfill_complete` for `compute_battle_target_metrics:last_sequence_id`.

## Semantic nuance (worth calling out)

`expected_time_to_die_seconds` and `sustain_factor` are computed from a **per-batch baseline median** over `(ship_type_id, dps_bucket)`. When the repair window causes re-reads, the batch composition can shift on each run, so stored baseline values for existing rows may drift slightly between runs.

This is acceptable because:
1. The metric is a relative sustain score, not an absolute truth
2. Drift is bounded by the within-batch median variation
3. The `ON DUPLICATE KEY UPDATE` on `battle_target_metrics` is fully idempotent at the row level — no accumulation bugs

Admins who want stable baselines can simply leave the gate off for this dataset.

## How to enable (post-merge)

```
php bin/horizon-approve.php compute_battle_target_metrics:last_sequence_id
```

Rollback:

```
php bin/horizon-reset.php compute_battle_target_metrics:last_sequence_id
```

## Test plan

- [x] `python3 -m unittest python.tests.test_horizon` — 29/29 pass (shared helpers already covered by the #988 test suite)
- [x] `ast.parse` syntax check on `battle_intelligence.py`
- [ ] After approval: `battle_intelligence.job.started` event carries `horizon.applied = true` for the target-metrics key
- [ ] Freshness report: `compute_battle_target_metrics:last_sequence_id` shows `horizon_status = caught_up` post-approval
- [ ] Confirm `battle_target_metrics` rows for recent killmails have updated `computed_at` values on subsequent runs