### PR TITLE
feat(horizon): wire reporting into PHP time-series refresh functions

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -1823,6 +1823,12 @@ function db_time_series_refresh_killmail_item_loss(string $resolution = '1h', in
     $batch = db_time_series_source_batch('killmail_events', 'effective_killmail_at', 'sequence_id', $cursorStart, $safeLimit);
 
     if ($batch === []) {
+        // Empty batch still feeds the horizon stall counter: if the cursor
+        // never advances we want operators to see it flagged in the
+        // freshness report.  The helper is a no-op when sync_state has no
+        // row yet, so first-ever runs are safe.
+        db_horizon_advance_cursor($datasetKey, $cursorStart);
+
         return [
             'rows_seen' => 0,
             'rows_written' => 0,
@@ -1938,6 +1944,17 @@ function db_time_series_refresh_killmail_item_loss(string $resolution = '1h', in
         ];
     });
 
+    // Advance the horizon watermark and stall tracking alongside the
+    // forward cursor.  Note: we do NOT apply db_horizon_read_from_cursor
+    // here because the INSERT ... ON DUPLICATE KEY UPDATE above uses
+    // accumulative expressions (loss_count = loss_count + VALUES(...))
+    // that would double-count on re-read.  Late-arriving killmails are
+    // already handled correctly by the existing design: new rows get
+    // new sequence_ids above the cursor and bucket_start derives from
+    // effective_killmail_at (event time), so they naturally accumulate
+    // into the correct historical bucket.
+    db_horizon_advance_cursor($datasetKey, (string) ($result['cursor_end'] ?? $cursorStart));
+
     return $result + [
         'has_more' => count($batch) >= $safeLimit,
     ];
@@ -1957,6 +1974,10 @@ function db_time_series_refresh_market_aggregates(string $resolution = '1h', int
     $batch = db_time_series_source_batch($summaryTable, 'observed_at', 'id', $cursorStart, $safeLimit);
 
     if ($batch === []) {
+        // Empty batch still feeds the horizon stall counter so operators
+        // can see stalled market aggregates in the freshness report.
+        db_horizon_advance_cursor($datasetKey, $cursorStart);
+
         return [
             'rows_seen' => 0,
             'rows_written' => 0,
@@ -2104,6 +2125,17 @@ function db_time_series_refresh_market_aggregates(string $resolution = '1h', int
             'duration_ms' => (int) round((microtime(true) - $startedAt) * 1000),
         ];
     });
+
+    // Advance the horizon watermark and stall tracking.  As with
+    // killmail_item_loss above, we deliberately do NOT apply the
+    // rolling repair window here: the market stock / price UPSERTs
+    // are accumulative (sample_count = sample_count + VALUES(...),
+    // weighted_price_numerator = weighted_price_numerator + VALUES(...))
+    // so re-reading the tail would double-count the averages and
+    // weighted prices.  Late market observations still land in the
+    // correct bucket via their new sequence id and event-time bucket
+    // expression.
+    db_horizon_advance_cursor($datasetKey, (string) ($result['cursor_end'] ?? $cursorStart));
 
     return $result + [
         'has_more' => count($batch) >= $safeLimit,


### PR DESCRIPTION
## Summary

Phase 3.2 of the horizon rollout — first exercise of the PHP side of the horizon infrastructure that shipped in #987 but hasn't been called yet.

Adds `db_horizon_advance_cursor()` calls to both PHP time-series refresh functions so they surface in the freshness report with accurate watermark, stall tracking, and horizon status.

## Changes

`src/db.php`:
- `db_time_series_refresh_killmail_item_loss` — calls `db_horizon_advance_cursor` on both the empty-batch branch (stall increment) and the success path (watermark + stall reset)
- `db_time_series_refresh_market_aggregates` — same pattern

## Why no repair window here

Both functions use **accumulative** `INSERT ... ON DUPLICATE KEY UPDATE` expressions:

```sql
loss_count = loss_count + VALUES(loss_count)
weighted_price_numerator = weighted_price_numerator + VALUES(weighted_price_numerator)
```

Re-reading the tail via a 24h repair window would **double-count** the metrics. So this PR deliberately does **not** call `db_horizon_read_from_cursor()` — it only wires the reporting helpers.

This is still correct and useful because:

1. **Sources are append-only** — `killmail_events` and the market snapshots summary table never mutate existing rows. Late arrivals get new `sequence_id`s / `id`s above the cursor and flow through the normal incremental path.
2. **`bucket_start` is derived from event time**, not sync time (`effective_killmail_at`, `observed_at`). Late rows accumulate into the correct historical bucket automatically.
3. **The monotonic guard** inside `db_horizon_advance_cursor` makes the redundant `last_cursor` write (from `db_sync_run_with_state` → `db_sync_state_upsert`) harmless.

A future change can switch the UPSERTs to replacement semantics (or add a batch-idempotency key), at which point the read-window can be enabled here too.

## What this PR delivers

- Both datasets show up in `db_calculation_freshness_report()` with accurate `horizon_status` (`caught_up` / `catching_up` / `stalled`)
- Stall detection: idle source → `stall_count` increments each run via the empty-batch branch → resets to 0 when data resumes
- `watermark_event_time` updates in lockstep with `last_cursor` so the freshness dashboard lag calculation works

## Test plan

- [x] `php -l src/db.php` — no syntax errors
- [ ] After deployment: confirm `db_calculation_freshness_report()` includes `killmail:1h`, `killmail:1d`, `market:1h`, `market:1d` rows with populated `watermark_event_time`
- [ ] Idle-source drill: disable the data source briefly, confirm `stall_count` increments on empty-batch runs and resets once data flows again
- [ ] Late-data sanity: confirm late-arriving killmails / market snapshots still land in their correct event-time bucket (unchanged behavior — just verifying the reporting wiring didn't break it)

## No enable-step needed

Unlike #988 and #989, this PR doesn't gate behavior on `backfill_complete`. The reporting helpers run unconditionally on every refresh, which is what we want — the freshness dashboard should work regardless of the gate state.