### PR TITLE
feat(horizon): add watermark + stall reporting to graph battle intelligence sync

### DIFF
--- a/python/orchestrator/jobs/graph_pipeline.py
+++ b/python/orchestrator/jobs/graph_pipeline.py
@@ -10,6 +10,7 @@ import logging
 
 from ..db import SupplyCoreDb
 from ..eve_constants import FLEET_FUNCTION_BY_GROUP, SHIP_SIZE_BY_GROUP
+from ..horizon import update_watermark_and_stall
 from ..influx import InfluxClient, InfluxConfig, InfluxQueryError
 from ..job_result import JobResult
 from ..json_utils import json_dumps_safe
@@ -289,6 +290,11 @@ def run_compute_graph_sync_battle_intelligence(db: SupplyCoreDb, neo4j_raw: dict
     rows_processed = 0
     rows_written = 0
     batch_count = 0
+    # Horizon watermark: newest battle start time we've actually merged
+    # into the graph.  Neo4j MERGE makes the write idempotent, but we
+    # only need the watermark for the freshness report -- not a
+    # rewind-safe read path.
+    watermark_event_time: str | None = None
     latest_checkpoint = _format_int_cursor(cursor_id) if participant_has_id else _format_battle_participant_cursor(cursor_battle_id, cursor_character_id)
     while batch_count < max_batches:
         batch_started = time.perf_counter()
@@ -426,6 +432,13 @@ def run_compute_graph_sync_battle_intelligence(db: SupplyCoreDb, neo4j_raw: dict
             cursor_battle_id = str(rows[-1].get("battle_id") or cursor_battle_id)
             cursor_character_id = int(rows[-1].get("character_id") or cursor_character_id)
             latest_checkpoint = _format_battle_participant_cursor(cursor_battle_id, cursor_character_id)
+        # Track the newest battle start time in this batch for the
+        # horizon watermark.  battle_rollups.started_at is the source
+        # event time once a battle has been sealed.
+        for row in rows:
+            started_at = str(row.get("started_at") or "")
+            if started_at and (watermark_event_time is None or started_at > watermark_event_time):
+                watermark_event_time = started_at
         batch_count += 1
         rows_processed += len(rows)
         rows_written += len(rows)
@@ -462,6 +475,17 @@ def run_compute_graph_sync_battle_intelligence(db: SupplyCoreDb, neo4j_raw: dict
         last_cursor=latest_checkpoint,
         last_row_count=rows_written,
         last_error_message=None,
+    )
+    # Horizon watermark + stall tracking on top of the graph sync
+    # cursor.  The cursor itself is either an integer participant id or
+    # a "battle_id|character_id" composite, so the generic timestamp|id
+    # advance helper doesn't apply -- update_watermark_and_stall only
+    # compares cursors for equality, which is safe for any format.
+    update_watermark_and_stall(
+        db,
+        GRAPH_BATCH_STATE_KEYS["battle_cursor"],
+        new_cursor=latest_checkpoint,
+        event_time=watermark_event_time,
     )
     result = _job_payload(
         job_name,


### PR DESCRIPTION
## Summary

Phase 3.3 of the horizon rollout. Adds Flavor B (reporting-only) horizon wiring to `run_compute_graph_sync_battle_intelligence` so the graph sync shows up in the freshness report alongside the other datasets wired in #988, #989, #991.

## Changes

`python/orchestrator/jobs/graph_pipeline.py`:
- Imports `update_watermark_and_stall` from the horizon module
- Tracks `watermark_event_time` inside the batch loop using `battle_rollups.started_at` (the source event time for sealed battles)
- Calls `update_watermark_and_stall` after the final success `_sync_state_upsert` on completion

## Why Flavor B (no repair-window read)

Two reasons:

1. **Cursor format mismatch** — the graph sync cursor is either an integer `battle_participants.id` or a composite `"battle_id|character_id"` string. Neither matches the `"timestamp|id"` format expected by `db_horizon_read_from_cursor()`. Translating the horizon repair window into a participant id would require extra query logic for little benefit.

2. **Neo4j MERGE is idempotent by design** — the whole "accumulative UPSERT required for rewind safety" concern doesn't apply here. Late-arriving battles and participants flow through the existing forward cursor advance naturally.

The `update_watermark_and_stall` helper added in #988 only compares cursors for equality (stall detection) and never touches `last_cursor` itself, so it composes cleanly with the existing `_sync_state_upsert` without any double-write concerns.

## What this delivers

- `graph_sync_battle_intelligence_cursor` shows up in `db_calculation_freshness_report()` with an accurate `watermark_event_time` derived from the newest merged battle's `started_at`
- Stall detection for the graph sync: if no new battles are sealed between runs, `stall_count` increments and the dashboard flags it
- No behavior change for admins who haven't flipped the backfill gate

## Test plan

- [x] `python3 -m unittest python.tests.test_horizon` — 29/29 pass
- [x] `ast.parse` syntax check on `graph_pipeline.py`
- [ ] After deployment: `graph_sync_battle_intelligence_cursor` appears in the freshness report with a populated `watermark_event_time`
- [ ] Idle-source drill: if no new battles are rolled up, confirm `stall_count` increments between runs on this dataset