### PR TITLE
Add outlier rejection to deal alert baseline calculation

### DIFF
--- a/bin/test_deal_alert_baseline.php
+++ b/bin/test_deal_alert_baseline.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/functions.php';
+
+function deal_alert_baseline_assert(bool $condition, string $message): void
+{
+    if (!$condition) {
+        fwrite(STDERR, "FAIL: {$message}\n");
+        exit(1);
+    }
+}
+
+function deal_alert_baseline_assert_near(float $expected, float $actual, float $tolerance, string $message): void
+{
+    deal_alert_baseline_assert(
+        abs($expected - $actual) <= $tolerance,
+        sprintf('%s (expected ~%.4f, got %.4f)', $message, $expected, $actual)
+    );
+}
+
+// Regression: Plagioclase III-Grade trades at ~38 ISK but one history row
+// carries a trap / manipulation price of ~800k ISK. The legacy blend pushed
+// normal_price to ~800_000 ISK and fired a CRITICAL MISPRICE alert for every
+// legitimate listing. With outlier rejection the baseline must stay anchored
+// to the typical price.
+$rows = [];
+for ($i = 0; $i < 13; $i++) {
+    $rows[] = [
+        'price' => 38.0 + ($i * 0.1),
+        'weight' => 1_000_000,
+        'origin' => 'market_hub_local_history_daily',
+    ];
+}
+$rows[] = [
+    'price' => 799_984.25,
+    'weight' => 1001,
+    'origin' => 'market_hub_local_history_daily',
+];
+
+$baseline = deal_alert_baseline_from_rows($rows);
+deal_alert_baseline_assert($baseline !== null, 'Plagioclase: baseline must be computed');
+deal_alert_baseline_assert_near(38.6, (float) $baseline['normal_price'], 1.0, 'Plagioclase: normal_price must track the cluster, not the outlier');
+deal_alert_baseline_assert((int) $baseline['points'] === 13, 'Plagioclase: outlier row must be rejected');
+
+// Two-sided outliers: both a 0.01 ISK misprint and an 800M ISK trap order in
+// history should be ignored.
+$rows = [];
+for ($i = 0; $i < 12; $i++) {
+    $rows[] = [
+        'price' => 40.0 + ($i * 0.5),
+        'weight' => 1000,
+        'origin' => 'market_hub_local_history_daily',
+    ];
+}
+$rows[] = ['price' => 0.01, 'weight' => 1, 'origin' => 'market_hub_local_history_daily'];
+$rows[] = ['price' => 800_000_000.0, 'weight' => 1, 'origin' => 'market_hub_local_history_daily'];
+$baseline = deal_alert_baseline_from_rows($rows);
+deal_alert_baseline_assert($baseline !== null, 'Two-sided: baseline must be computed');
+deal_alert_baseline_assert_near(42.75, (float) $baseline['normal_price'], 1.0, 'Two-sided: both outliers must be rejected');
+deal_alert_baseline_assert((int) $baseline['points'] === 12, 'Two-sided: both outliers must drop from points');
+
+// Legitimate 2x spike within the outlier band should still influence the blend.
+$rows = [];
+for ($i = 0; $i < 10; $i++) {
+    $rows[] = ['price' => 100.0, 'weight' => 1000, 'origin' => 'market_history_daily'];
+}
+$rows[] = ['price' => 200.0, 'weight' => 3000, 'origin' => 'market_history_daily'];
+$baseline = deal_alert_baseline_from_rows($rows);
+deal_alert_baseline_assert($baseline !== null, 'Legit spike: baseline must be computed');
+deal_alert_baseline_assert((int) $baseline['points'] === 11, 'Legit spike: no rows rejected');
+deal_alert_baseline_assert((float) $baseline['normal_price'] > 100.0, 'Legit spike: blend must react to the upward shift');
+deal_alert_baseline_assert((float) $baseline['normal_price'] < 150.0, 'Legit spike: blend must stay median-anchored');
+
+// Stable market: baseline unchanged vs. the pre-fix behaviour.
+$rows = [];
+for ($i = 0; $i < 10; $i++) {
+    $rows[] = ['price' => 1000.0 + ($i * 5), 'weight' => 2000, 'origin' => 'market_history_daily'];
+}
+$baseline = deal_alert_baseline_from_rows($rows);
+deal_alert_baseline_assert($baseline !== null, 'Stable: baseline must be computed');
+deal_alert_baseline_assert_near(1022.5, (float) $baseline['normal_price'], 0.5, 'Stable: blend unchanged on clean inputs');
+deal_alert_baseline_assert((int) $baseline['points'] === 10, 'Stable: all rows retained');
+
+// Degenerate input still returns null.
+deal_alert_baseline_assert(deal_alert_baseline_from_rows([]) === null, 'Empty: returns null');
+deal_alert_baseline_assert(
+    deal_alert_baseline_from_rows([
+        ['price' => 0.0, 'weight' => 1, 'origin' => 'market_history_daily'],
+    ]) === null,
+    'Zero-price: returns null'
+);
+
+// Small sample (3 points) from an alliance structure with close prices.
+$rows = [
+    ['price' => 1500.0, 'weight' => 100, 'origin' => 'market_history_daily'],
+    ['price' => 1505.0, 'weight' => 100, 'origin' => 'market_history_daily'],
+    ['price' => 1495.0, 'weight' => 100, 'origin' => 'market_history_daily'],
+];
+$baseline = deal_alert_baseline_from_rows($rows);
+deal_alert_baseline_assert($baseline !== null, 'Small sample: baseline must be computed');
+deal_alert_baseline_assert((int) $baseline['points'] === 3, 'Small sample: all points retained');
+deal_alert_baseline_assert_near(1500.0, (float) $baseline['normal_price'], 5.0, 'Small sample: baseline stays close to median');
+
+fwrite(STDOUT, "deal_alert_baseline_from_rows: all assertions passed\n");

--- a/src/functions.php
+++ b/src/functions.php
@@ -8571,9 +8571,7 @@ function deal_alert_baseline_from_rows(array $rows): ?array
         return null;
     }
 
-    $prices = [];
-    $weightedNumerator = 0.0;
-    $weightedDenominator = 0.0;
+    $entries = [];
     $origins = [];
 
     foreach ($rows as $row) {
@@ -8582,11 +8580,59 @@ function deal_alert_baseline_from_rows(array $rows): ?array
             continue;
         }
 
-        $prices[] = $price;
-        $weight = max(1, (int) ($row['weight'] ?? 1));
-        $weightedNumerator += ($price * $weight);
-        $weightedDenominator += $weight;
+        $entries[] = [
+            'price' => $price,
+            'weight' => max(1, (int) ($row['weight'] ?? 1)),
+        ];
         $origins[(string) ($row['origin'] ?? 'history')] = true;
+    }
+
+    if ($entries === []) {
+        return null;
+    }
+
+    // Compute a preliminary median across every valid price to anchor an
+    // outlier-rejection window. The median is robust, but the original
+    // weighted-average blend was not: a single fat-finger "trap" listing or
+    // manipulation trade leaking into history (e.g. an 800M ISK Plagioclase
+    // sell order) could dominate the weighted component and push the normal
+    // price into the hundreds of thousands of ISK for an item that actually
+    // trades at ~40 ISK.
+    $allPrices = array_map(static fn (array $entry): float => $entry['price'], $entries);
+    sort($allPrices, SORT_NUMERIC);
+    $allCount = count($allPrices);
+    $allMidpoint = intdiv($allCount, 2);
+    $prelimMedian = $allCount % 2 === 1
+        ? $allPrices[$allMidpoint]
+        : (($allPrices[$allMidpoint - 1] + $allPrices[$allMidpoint]) / 2.0);
+
+    if ($prelimMedian <= 0.0) {
+        return null;
+    }
+
+    $outlierCap = 4.0;
+    $lowerBound = $prelimMedian / $outlierCap;
+    $upperBound = $prelimMedian * $outlierCap;
+
+    $filtered = array_values(array_filter(
+        $entries,
+        static fn (array $entry): bool => $entry['price'] >= $lowerBound && $entry['price'] <= $upperBound
+    ));
+
+    // If more than half of the points are rejected the prelim median itself is
+    // likely unreliable (very noisy or non-stationary market). Fall back to the
+    // raw entries; the weighted-average clamp below still bounds the blend.
+    if (count($filtered) < max(1, (int) floor($allCount * 0.5))) {
+        $filtered = $entries;
+    }
+
+    $prices = [];
+    $weightedNumerator = 0.0;
+    $weightedDenominator = 0.0;
+    foreach ($filtered as $entry) {
+        $prices[] = $entry['price'];
+        $weightedNumerator += ($entry['price'] * $entry['weight']);
+        $weightedDenominator += $entry['weight'];
     }
 
     if ($prices === [] || $weightedDenominator <= 0.0) {
@@ -8600,6 +8646,12 @@ function deal_alert_baseline_from_rows(array $rows): ?array
         ? $prices[$midpoint]
         : (($prices[$midpoint - 1] + $prices[$midpoint]) / 2.0);
     $weightedAverage = $weightedNumerator / $weightedDenominator;
+
+    // Clamp the weighted average into a symmetrical band around the filtered
+    // median so the blend cannot explode even when the fallback path above is
+    // taken or a surviving outlier still drags the mean upward.
+    $weightedAverage = max($median / $outlierCap, min($median * $outlierCap, $weightedAverage));
+
     $normalPrice = ($median * 0.7) + ($weightedAverage * 0.3);
 
     return [


### PR DESCRIPTION
## Summary
Improve the robustness of deal alert baseline pricing by implementing outlier rejection. The previous weighted-average approach was vulnerable to manipulation trades and fat-finger listings in market history, causing false CRITICAL MISPRICE alerts for legitimate listings.

## Key Changes
- **Outlier Detection**: Compute a preliminary median across all valid prices and establish a 4x symmetrical rejection band (lower bound = median/4, upper bound = median*4)
- **Filtered Baseline**: Calculate the weighted average and median using only prices within the outlier band
- **Fallback Logic**: If more than 50% of points are rejected (indicating an unreliable market), revert to using all entries to avoid over-filtering
- **Clamping**: Apply a final 4x symmetrical clamp around the filtered median to the weighted average, preventing the blend from exploding even in edge cases
- **Test Coverage**: Add comprehensive regression test suite (`bin/test_deal_alert_baseline.php`) covering:
  - High-weight outliers (e.g., Plagioclase with 800k ISK trap order)
  - Two-sided outliers (both underpriced and overpriced anomalies)
  - Legitimate price spikes within acceptable ranges
  - Stable markets (ensuring backward compatibility)
  - Degenerate inputs (empty, zero-price)
  - Small samples from alliance structures

## Implementation Details
- The median is computed first as a robust anchor point, independent of weights
- Outlier rejection uses a 4x multiplier threshold, which is conservative enough to preserve legitimate market movements while filtering extreme anomalies
- The weighted average is clamped to prevent a single surviving outlier from dominating the final blend
- The normal price blend remains 70% median + 30% weighted average, but now operates on filtered data

https://claude.ai/code/session_01NmLozJnU6KBndgBHeAeeEC