### PR TITLE
perf(killmail): lazy-load ESI coverage panel via AJAX + single-flight cache

### DIFF
--- a/public/api/killmail-intelligence/esi-coverage.php
+++ b/public/api/killmail-intelligence/esi-coverage.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+// AJAX endpoint for the /killmail-intelligence ESI coverage panel.
+//
+// Why this exists: db_killmail_esi_coverage_snapshot() is a ~200 second query
+// on the current dataset (see src/functions.php comments for details). It
+// used to run inline on every /killmail-intelligence page render, making the
+// page time out. This endpoint decouples that work from the page render:
+// the page always loads fast and the coverage panel fetches its data here.
+//
+// Response shapes:
+//
+//   HTTP 200 { ok:true, coverage:{...}, refreshed:true|false }
+//     - Cache hit (warm or stale), or we successfully recomputed
+//
+//   HTTP 202 { ok:true, coverage:{...}, refreshed:false, refreshing:true,
+//              retry_after_seconds:15 }
+//     - Another request is already recomputing the snapshot. We return
+//       whatever cached value we have (possibly the empty stub) so the
+//       panel still renders something, and the JS is expected to poll
+//       after retry_after_seconds.
+//
+//   HTTP 500 { ok:false, error:"..." }
+//     - Unhandled exception during compute or cache I/O
+//
+// Query parameters:
+//
+//   force=1   Skip the "cache warm → return immediately" fast path and
+//             attempt a refresh regardless. Still respects single-flight:
+//             if another request holds the lock, returns 202.
+//
+// Nginx note: because the cold-path compute can take minutes, the nginx
+// location serving this endpoint should have a higher proxy_read_timeout
+// than the default 60s. Suggested: proxy_read_timeout 300s. See the PR
+// description for the snippet.
+
+require_once __DIR__ . '/../../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: private, no-store');
+
+try {
+    $startDate = '2024-01-01';
+    $force = isset($_GET['force']) && (string) $_GET['force'] === '1';
+
+    // 1. Fast path: cache hit and not a forced refresh → return immediately.
+    $cached = killmail_esi_coverage_cache_read($startDate);
+    if (!$force && ($cached['cache_status'] ?? 'empty') === 'warm') {
+        echo json_encode([
+            'ok' => true,
+            'coverage' => $cached,
+            'refreshed' => false,
+        ], JSON_UNESCAPED_SLASHES);
+        exit;
+    }
+
+    // 2. Stale, empty, or forced. Try to acquire the single-flight lock.
+    //    If another request is holding it, return the cached value (even
+    //    if stale/empty) with a refreshing hint so the JS polls.
+    $fresh = killmail_esi_coverage_refresh_with_singleflight($startDate);
+    if ($fresh === null) {
+        http_response_code(202);
+        $cached['cache_status'] = 'refreshing';
+        echo json_encode([
+            'ok' => true,
+            'coverage' => $cached,
+            'refreshed' => false,
+            'refreshing' => true,
+            'retry_after_seconds' => 15,
+        ], JSON_UNESCAPED_SLASHES);
+        exit;
+    }
+
+    // 3. We held the lock and produced a fresh snapshot.
+    echo json_encode([
+        'ok' => true,
+        'coverage' => $fresh,
+        'refreshed' => true,
+    ], JSON_UNESCAPED_SLASHES);
+} catch (Throwable $exception) {
+    http_response_code(500);
+    echo json_encode([
+        'ok' => false,
+        'error' => $exception->getMessage(),
+    ], JSON_UNESCAPED_SLASHES);
+}

--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -222,12 +222,31 @@ if (function_exists('ob_flush')) { @ob_flush(); }
                 <?php if ((string) ($status['worker_no_write_reason'] ?? '') !== ''): ?>
                     <p class="sm:col-span-2"><span class="text-slate-500">Zero-write reason</span><br><span class="mt-1 inline-block text-slate-100"><?= htmlspecialchars((string) ($status['worker_no_write_reason'] ?? ''), ENT_QUOTES) ?></span></p>
                 <?php endif; ?>
-                <p><span class="text-slate-500">Participant characters</span><br><span class="mt-1 inline-block text-slate-100"><?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span><br><span class="text-xs text-muted">Distinct victim + attacker IDs on losses since <?= htmlspecialchars((string) ($coverage['start_date'] ?? '2024-01-01'), ENT_QUOTES) ?>.</span></p>
-                <p><span class="text-slate-500">ESI queue coverage</span><br><span class="mt-1 inline-block text-slate-100"><?= number_format((int) ($coverage['queued_in_esi_character_queue'] ?? 0)) ?> / <?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span><br><span class="text-xs text-muted">pending <?= number_format((int) ($coverage['esi_queue_pending'] ?? 0)) ?> · done <?= number_format((int) ($coverage['esi_queue_done'] ?? 0)) ?> · error <?= number_format((int) ($coverage['esi_queue_error'] ?? 0)) ?></span></p>
-                <p><span class="text-slate-500">Current affiliation coverage</span><br><span class="mt-1 inline-block text-slate-100"><?= number_format((int) ($coverage['with_current_affiliation'] ?? 0)) ?> / <?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span><br><span class="text-xs text-muted">Participants with ESI current corp/alliance rows.</span></p>
-                <p><span class="text-slate-500">History sync processed</span><br><span class="mt-1 inline-block text-slate-100"><?= number_format((int) ($coverage['history_refresh_completed'] ?? 0)) ?> / <?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span><br><span class="text-xs text-muted">Participants whose alliance-history sync has run at least once (<code>last_history_refresh_at</code> set).</span></p>
-                <p><span class="text-slate-500">Alliance history rows</span><br><span class="mt-1 inline-block text-slate-100"><?= number_format((int) ($coverage['with_alliance_history_row'] ?? $coverage['with_alliance_history'] ?? 0)) ?> / <?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span><br><span class="text-xs text-muted">Participants with at least one historical alliance period. Lower than "history sync processed" is expected: characters who were never in an alliance produce zero rows.</span></p>
-                <p class="sm:col-span-2"><span class="text-slate-500">Per-character killmail backfill</span><br><span class="mt-1 inline-block text-slate-100"><?= number_format((int) ($coverage['enrolled_for_killmail_backfill'] ?? 0)) ?> / <?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?> enrolled</span><br><span class="text-xs text-muted">queue: pending <?= number_format((int) ($coverage['killmail_backfill_pending'] ?? 0)) ?> · processing <?= number_format((int) ($coverage['killmail_backfill_processing'] ?? 0)) ?> · done <?= number_format((int) ($coverage['killmail_backfill_done'] ?? 0)) ?> · error <?= number_format((int) ($coverage['killmail_backfill_error'] ?? 0)) ?> · backfill_complete <?= number_format((int) ($coverage['killmail_backfill_complete_flag'] ?? 0)) ?>. Passive R2Z2 ingest alone does not guarantee historical coverage — participants must be enrolled in <code>character_killmail_queue</code> for per-character zKB backfill.</span></p>
+                <!--
+                    ESI coverage panel — lazy-loaded via
+                    /api/killmail-intelligence/esi-coverage.php to keep the main
+                    page render off the ~200s snapshot query. The initial paint
+                    comes from whatever is in page_cache (warm = real numbers,
+                    empty = zeros) and the JS fetch in the inline <script> at
+                    the bottom of this file overwrites with fresh values. Each
+                    number carries a data-esi-coverage-field attribute so the
+                    JS can target it without rebuilding the markup.
+                -->
+                <p class="sm:col-span-2" data-esi-coverage-header>
+                    <span class="flex flex-wrap items-center justify-between gap-2">
+                        <span class="text-slate-500">ESI coverage</span>
+                        <span class="flex items-center gap-2">
+                            <span data-esi-coverage-status class="text-xs text-muted">Loading…</span>
+                            <button type="button" data-esi-coverage-refresh class="rounded border border-white/10 px-2 py-0.5 text-xs text-slate-200 hover:bg-white/5 disabled:opacity-40" aria-label="Refresh ESI coverage">↻ Refresh</button>
+                        </span>
+                    </span>
+                </p>
+                <p><span class="text-slate-500">Participant characters</span><br><span class="mt-1 inline-block text-slate-100" data-esi-coverage-field="participant_characters"><?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span><br><span class="text-xs text-muted">Distinct victim + attacker IDs on losses since <?= htmlspecialchars((string) ($coverage['start_date'] ?? '2024-01-01'), ENT_QUOTES) ?>.</span></p>
+                <p><span class="text-slate-500">ESI queue coverage</span><br><span class="mt-1 inline-block text-slate-100"><span data-esi-coverage-field="queued_in_esi_character_queue"><?= number_format((int) ($coverage['queued_in_esi_character_queue'] ?? 0)) ?></span> / <span data-esi-coverage-field="participant_characters"><?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span></span><br><span class="text-xs text-muted">pending <span data-esi-coverage-field="esi_queue_pending"><?= number_format((int) ($coverage['esi_queue_pending'] ?? 0)) ?></span> · done <span data-esi-coverage-field="esi_queue_done"><?= number_format((int) ($coverage['esi_queue_done'] ?? 0)) ?></span> · error <span data-esi-coverage-field="esi_queue_error"><?= number_format((int) ($coverage['esi_queue_error'] ?? 0)) ?></span></span></p>
+                <p><span class="text-slate-500">Current affiliation coverage</span><br><span class="mt-1 inline-block text-slate-100"><span data-esi-coverage-field="with_current_affiliation"><?= number_format((int) ($coverage['with_current_affiliation'] ?? 0)) ?></span> / <span data-esi-coverage-field="participant_characters"><?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span></span><br><span class="text-xs text-muted">Participants with ESI current corp/alliance rows.</span></p>
+                <p><span class="text-slate-500">History sync processed</span><br><span class="mt-1 inline-block text-slate-100"><span data-esi-coverage-field="history_refresh_completed"><?= number_format((int) ($coverage['history_refresh_completed'] ?? 0)) ?></span> / <span data-esi-coverage-field="participant_characters"><?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span></span><br><span class="text-xs text-muted">Participants whose alliance-history sync has run at least once (<code>last_history_refresh_at</code> set).</span></p>
+                <p><span class="text-slate-500">Alliance history rows</span><br><span class="mt-1 inline-block text-slate-100"><span data-esi-coverage-field="with_alliance_history_row"><?= number_format((int) ($coverage['with_alliance_history_row'] ?? $coverage['with_alliance_history'] ?? 0)) ?></span> / <span data-esi-coverage-field="participant_characters"><?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span></span><br><span class="text-xs text-muted">Participants with at least one historical alliance period. Lower than "history sync processed" is expected: characters who were never in an alliance produce zero rows.</span></p>
+                <p class="sm:col-span-2"><span class="text-slate-500">Per-character killmail backfill</span><br><span class="mt-1 inline-block text-slate-100"><span data-esi-coverage-field="enrolled_for_killmail_backfill"><?= number_format((int) ($coverage['enrolled_for_killmail_backfill'] ?? 0)) ?></span> / <span data-esi-coverage-field="participant_characters"><?= number_format((int) ($coverage['participant_characters'] ?? 0)) ?></span> enrolled</span><br><span class="text-xs text-muted">queue: pending <span data-esi-coverage-field="killmail_backfill_pending"><?= number_format((int) ($coverage['killmail_backfill_pending'] ?? 0)) ?></span> · processing <span data-esi-coverage-field="killmail_backfill_processing"><?= number_format((int) ($coverage['killmail_backfill_processing'] ?? 0)) ?></span> · done <span data-esi-coverage-field="killmail_backfill_done"><?= number_format((int) ($coverage['killmail_backfill_done'] ?? 0)) ?></span> · error <span data-esi-coverage-field="killmail_backfill_error"><?= number_format((int) ($coverage['killmail_backfill_error'] ?? 0)) ?></span> · backfill_complete <span data-esi-coverage-field="killmail_backfill_complete_flag"><?= number_format((int) ($coverage['killmail_backfill_complete_flag'] ?? 0)) ?></span>. Passive R2Z2 ingest alone does not guarantee historical coverage — participants must be enrolled in <code>character_killmail_queue</code> for per-character zKB backfill.</span></p>
             </div>
         </details>
     </article>
@@ -498,6 +517,130 @@ if (function_exists('ob_flush')) { @ob_flush(); }
             }
         });
     });
+
+    // -----------------------------------------------------------------------
+    // ESI coverage panel — lazy loader
+    //
+    // Keeps the main page off the ~200s ESI coverage snapshot query.
+    // Fetches /api/killmail-intelligence/esi-coverage.php on load, populates
+    // every [data-esi-coverage-field] span, and surfaces cache age + a
+    // refresh button. Handles HTTP 202 (single-flight in progress) by
+    // polling until the refresh completes.
+    // -----------------------------------------------------------------------
+    const coverageEndpoint = '/api/killmail-intelligence/esi-coverage.php';
+    const coverageStatusEl = document.querySelector('[data-esi-coverage-status]');
+    const coverageRefreshBtn = document.querySelector('[data-esi-coverage-refresh]');
+    const coverageFieldEls = document.querySelectorAll('[data-esi-coverage-field]');
+    let coveragePollTimer = null;
+    let coverageInFlight = false;
+
+    function formatCoverageNumber(value) {
+        const n = typeof value === 'number' ? value : parseInt(value, 10);
+        return Number.isFinite(n) ? n.toLocaleString() : '—';
+    }
+
+    function formatCoverageAge(seconds) {
+        if (seconds == null) return 'never';
+        if (seconds < 60) return seconds + 's ago';
+        if (seconds < 3600) return Math.floor(seconds / 60) + 'm ago';
+        if (seconds < 86400) return Math.floor(seconds / 3600) + 'h ago';
+        return Math.floor(seconds / 86400) + 'd ago';
+    }
+
+    function setCoverageStatus(text, tone) {
+        if (!coverageStatusEl) return;
+        coverageStatusEl.textContent = text;
+        coverageStatusEl.className = 'text-xs ' + (tone === 'error' ? 'text-amber-300' : (tone === 'fresh' ? 'text-emerald-300' : 'text-muted'));
+    }
+
+    function applyCoverageData(coverage) {
+        if (!coverage || typeof coverage !== 'object') return;
+        coverageFieldEls.forEach(el => {
+            const key = el.getAttribute('data-esi-coverage-field');
+            if (key && Object.prototype.hasOwnProperty.call(coverage, key)) {
+                el.textContent = formatCoverageNumber(coverage[key]);
+            }
+        });
+    }
+
+    function applyCoverageStatusFromResponse(coverage, refreshing) {
+        const status = coverage && coverage.cache_status;
+        const age = coverage && coverage.cache_age_seconds;
+        if (refreshing) {
+            setCoverageStatus('Refreshing… (last updated ' + formatCoverageAge(age) + ')', 'muted');
+            return;
+        }
+        if (status === 'empty') {
+            setCoverageStatus('No data yet — click ↻ Refresh', 'muted');
+            return;
+        }
+        if (status === 'warm') {
+            setCoverageStatus('Updated ' + formatCoverageAge(age), 'fresh');
+            return;
+        }
+        if (status === 'stale') {
+            setCoverageStatus('Updated ' + formatCoverageAge(age) + ' (stale)', 'muted');
+            return;
+        }
+        setCoverageStatus('Updated ' + formatCoverageAge(age), 'muted');
+    }
+
+    function scheduleCoveragePoll(seconds) {
+        if (coveragePollTimer) clearTimeout(coveragePollTimer);
+        coveragePollTimer = setTimeout(() => loadCoverage(false), Math.max(1, seconds) * 1000);
+    }
+
+    async function loadCoverage(force) {
+        if (coverageInFlight) return;
+        if (!coverageFieldEls.length) return;
+        coverageInFlight = true;
+        if (coverageRefreshBtn) coverageRefreshBtn.disabled = true;
+        setCoverageStatus(force ? 'Forcing refresh…' : 'Loading…', 'muted');
+
+        try {
+            const url = coverageEndpoint + (force ? '?force=1' : '');
+            const response = await fetch(url, { headers: { 'Accept': 'application/json' } });
+            const data = await response.json().catch(() => null);
+
+            if (response.status === 202 && data && data.ok) {
+                applyCoverageData(data.coverage);
+                applyCoverageStatusFromResponse(data.coverage, true);
+                scheduleCoveragePoll(data.retry_after_seconds || 15);
+                return;
+            }
+            if (!response.ok || !data || !data.ok) {
+                setCoverageStatus('Load failed — retry with ↻', 'error');
+                return;
+            }
+
+            applyCoverageData(data.coverage);
+            applyCoverageStatusFromResponse(data.coverage, false);
+        } catch (err) {
+            setCoverageStatus('Load failed — retry with ↻', 'error');
+        } finally {
+            coverageInFlight = false;
+            if (coverageRefreshBtn) coverageRefreshBtn.disabled = false;
+        }
+    }
+
+    if (coverageRefreshBtn) {
+        coverageRefreshBtn.addEventListener('click', () => {
+            if (coveragePollTimer) {
+                clearTimeout(coveragePollTimer);
+                coveragePollTimer = null;
+            }
+            loadCoverage(true);
+        });
+    }
+
+    if (coverageFieldEls.length) {
+        // Kick off the initial fetch after the main page has rendered.
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => loadCoverage(false));
+        } else {
+            loadCoverage(false);
+        }
+    }
 })();
 </script>
 <?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/src/functions.php
+++ b/src/functions.php
@@ -11668,6 +11668,159 @@ function killmail_detail_data(): array
     ]);
 }
 
+/**
+ * ESI coverage snapshot — cache + single-flight.
+ *
+ * db_killmail_esi_coverage_snapshot() runs 7+ queries that UNION over
+ * killmail_events + killmail_attackers for every participant in the window.
+ * On the live dataset it takes ~200 seconds per invocation, which made
+ * /killmail-intelligence stall on every cold render.
+ *
+ * Fix: the main page render no longer blocks on this. The coverage panel
+ * is lazy-loaded by the browser via /api/killmail-intelligence/esi-coverage.php,
+ * which reads a cached snapshot from the page_cache table. The endpoint uses
+ * a MySQL advisory lock (GET_LOCK) as a single-flight so that only one PHP
+ * request at a time recomputes the snapshot — everyone else returns the
+ * existing cached value (even if stale) with a status=refreshing hint so the
+ * browser JS can poll and pick up the fresh data when it lands.
+ */
+function killmail_esi_coverage_cache_key(string $startDate): string
+{
+    return 'killmail_esi_coverage:' . trim($startDate);
+}
+
+function killmail_esi_coverage_singleflight_lock_name(): string
+{
+    return 'supplycore:killmail_esi_coverage_refresh';
+}
+
+/**
+ * Zero-valued snapshot with the shape db_killmail_esi_coverage_snapshot()
+ * returns, plus cache metadata fields the UI can surface. Used as the
+ * fallback whenever the cache is empty and nothing else is available.
+ */
+function killmail_esi_coverage_empty_snapshot(string $startDate): array
+{
+    return [
+        'start_date' => $startDate,
+        'participant_characters' => 0,
+        'queued_in_esi_character_queue' => 0,
+        'esi_queue_pending' => 0,
+        'esi_queue_done' => 0,
+        'esi_queue_error' => 0,
+        'with_current_affiliation' => 0,
+        'with_alliance_history_row' => 0,
+        'with_alliance_history' => 0,
+        'history_refresh_completed' => 0,
+        'enrolled_for_killmail_backfill' => 0,
+        'killmail_backfill_pending' => 0,
+        'killmail_backfill_processing' => 0,
+        'killmail_backfill_done' => 0,
+        'killmail_backfill_error' => 0,
+        'killmail_backfill_complete_flag' => 0,
+        'missing_current_affiliation' => 0,
+        'missing_alliance_history' => 0,
+        'missing_history_refresh' => 0,
+        'missing_killmail_backfill_enrollment' => 0,
+        'cache_status' => 'empty',
+        'cache_computed_at' => null,
+        'cache_age_seconds' => null,
+        'cache_duration_ms' => null,
+    ];
+}
+
+/**
+ * Read the cached ESI coverage snapshot from page_cache, decorated with
+ * cache metadata. Returns a zero-valued stub on miss — the UI shows
+ * "Loading…" and the JS fetch will populate real values.
+ *
+ * cache_status values:
+ *   'warm'       — computed within the last 2 minutes
+ *   'stale'      — older than 2 minutes, still rendered so the operator
+ *                  always has *something* to look at
+ *   'empty'      — no cache entry at all (first load after deploy)
+ *   'refreshing' — set by the endpoint when a single-flight refresh is
+ *                  already in progress elsewhere
+ */
+function killmail_esi_coverage_cache_read(string $startDate): array
+{
+    $row = db_select_one(
+        "SELECT cache_value, computed_at FROM page_cache WHERE cache_key = ?",
+        [killmail_esi_coverage_cache_key($startDate)]
+    );
+    if ($row === null) {
+        return killmail_esi_coverage_empty_snapshot($startDate);
+    }
+
+    $decoded = json_decode((string) ($row['cache_value'] ?? ''), true);
+    if (!is_array($decoded)) {
+        return killmail_esi_coverage_empty_snapshot($startDate);
+    }
+
+    $computedAt = isset($row['computed_at']) ? (string) $row['computed_at'] : null;
+    $ageSeconds = null;
+    if ($computedAt !== null && $computedAt !== '') {
+        $computedTs = strtotime($computedAt);
+        if ($computedTs !== false) {
+            $ageSeconds = max(0, time() - $computedTs);
+        }
+    }
+
+    $decoded['cache_computed_at'] = $computedAt;
+    $decoded['cache_age_seconds'] = $ageSeconds;
+    $decoded['cache_status'] = ($ageSeconds !== null && $ageSeconds <= 120) ? 'warm' : 'stale';
+
+    return $decoded;
+}
+
+/**
+ * Single-flight refresh: acquire a MySQL advisory lock (non-blocking),
+ * compute a fresh snapshot, write it to page_cache, release the lock.
+ *
+ * Returns the fresh snapshot on success, or null if another session is
+ * already holding the lock. Callers should treat null as "someone else is
+ * computing it, return whatever cached value you have" rather than as an
+ * error — GET_LOCK with a 0-second timeout is explicitly non-blocking.
+ *
+ * Uses GET_LOCK/RELEASE_LOCK (always available on MariaDB/MySQL 5.5+)
+ * rather than Redis locking so we don't depend on Redis being enabled in
+ * every deploy environment.
+ */
+function killmail_esi_coverage_refresh_with_singleflight(string $startDate): ?array
+{
+    $lockName = killmail_esi_coverage_singleflight_lock_name();
+    $acquired = (int) db_fetch_single_value('SELECT GET_LOCK(?, 0)', [$lockName]);
+    if ($acquired !== 1) {
+        return null;
+    }
+
+    try {
+        // The underlying snapshot query can take several minutes on a cold
+        // backload. Bump PHP's execution limit so the refresh isn't aborted
+        // mid-query. @-prefix because some hosting setups disallow this.
+        @set_time_limit(600);
+
+        $startedAt = microtime(true);
+        $snapshot = db_killmail_esi_coverage_snapshot($startDate);
+        $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
+        $snapshot['cache_duration_ms'] = $durationMs;
+
+        page_cache_set(
+            killmail_esi_coverage_cache_key($startDate),
+            $snapshot,
+            86400 // 24h safety net — overwritten on every refresh
+        );
+
+        $snapshot['cache_status'] = 'warm';
+        $snapshot['cache_computed_at'] = gmdate('Y-m-d H:i:s');
+        $snapshot['cache_age_seconds'] = 0;
+
+        return $snapshot;
+    } finally {
+        db_fetch_single_value('SELECT RELEASE_LOCK(?)', [$lockName]);
+    }
+}
+
 function killmail_overview_data(): array
 {
     $recentHours = 24;
@@ -11702,7 +11855,13 @@ function killmail_overview_data(): array
             $options = db_killmail_overview_filter_options($overviewStartDateTime);
             $listing = db_killmail_overview_page($filters + ['start_date' => $overviewStartDateTime]);
             $histogramRows = db_killmail_overview_monthly_histogram($overviewStartDate);
-            $esiCoverage = db_killmail_esi_coverage_snapshot($overviewStartDate);
+            // ESI coverage is lazy-loaded by the browser via the AJAX endpoint
+            // /api/killmail-intelligence/esi-coverage.php, so the page render
+            // never blocks on the ~200s snapshot query. We serve whatever is
+            // already in page_cache as the initial paint (warm = real numbers
+            // immediately, empty = zeros until JS fetch populates), then JS
+            // overwrites the panel with the freshest data on load.
+            $esiCoverage = killmail_esi_coverage_cache_read($overviewStartDate);
             $storageDuplicateRows = db_killmail_duplicate_identities(50);
         } catch (Throwable $exception) {
             return [


### PR DESCRIPTION
## Summary

Replaces closed #992 (CLI+cron approach). After measuring the actual cold-hit behavior (206s first load, 2.2s warm) and discussing the tradeoffs, the right shape for the ESI coverage panel turned out to be an AJAX-loaded panel with single-flight concurrency control on the endpoint. This gets us:

- **Main page always loads fast** — never blocks on the ~200s snapshot query
- **Coverage data is never artificially stale** — no long TTL hiding progress from operators actively watching the backload
- **No thundering herd** — MySQL `GET_LOCK` ensures only one PHP request ever recomputes at a time, even with 50 concurrent page loads
- **No external infrastructure** — no cron, no CLI, no scheduler registration; self-warming from normal user traffic

## Why not the other approaches

| Option | Rejected because |
|---|---|
| Simple 15-min TTL cache wrap | Stale data defeats the purpose of the panel, which operators use to watch backfill progress in real time |
| CLI + cron refresh (original #992) | Adds external infrastructure (cron wiring, log rotation, supervision) and still has a stale window between refreshes |
| Full rewrite of the snapshot query | Out of scope; the query is correct, it's just expensive to run |

## Components

### `src/functions.php`
Four new helpers clustered near `killmail_overview_data()`:
- `killmail_esi_coverage_cache_key()` — deterministic cache key
- `killmail_esi_coverage_empty_snapshot()` — zero-valued fallback with full shape (20 fields) so the UI never needs to special-case a missing snapshot
- `killmail_esi_coverage_cache_read()` — reads `page_cache` and decorates with `cache_status` / `cache_computed_at` / `cache_age_seconds`. Soft freshness window is 2 minutes; older entries are marked stale but still rendered
- `killmail_esi_coverage_refresh_with_singleflight()` — acquires `SELECT GET_LOCK(?, 0)` (non-blocking, per-session, auto-released on disconnect), bumps `set_time_limit(600)`, runs the snapshot, writes to cache, releases. Returns `null` if the lock is already held — caller treats that as "someone else is on it" rather than an error

And a one-line change in `killmail_overview_data()` to read from the cache for the initial page paint instead of running the query inline.

### `public/api/killmail-intelligence/esi-coverage.php`
The AJAX endpoint. Three response paths:

| Scenario | HTTP | Body |
|---|---|---|
| Cache hit, warm (<2 min old) | 200 | `{ok:true, coverage:{...}, refreshed:false}` |
| Cache miss or stale, lock acquired | 200 | `{ok:true, coverage:{...}, refreshed:true}` |
| Cache anything, lock held by another | 202 | `{ok:true, coverage:{...}, refreshed:false, refreshing:true, retry_after_seconds:15}` |
| Unhandled exception | 500 | `{ok:false, error:"..."}` |

`?force=1` on the URL bypasses the fast path and attempts a refresh regardless (still respects single-flight — can't double-compute).

### `public/killmail-intelligence/index.php`
- Coverage panel `<p>` elements now have a `data-esi-coverage-field="<key>"` attribute on every `<span>` that contains a number. PHP still renders the cached value (or empty stub) on initial paint, and JS overwrites each span individually when the fetch resolves — no layout shift or markup rebuild.
- New header row with a status pill (`Loading…` → `Updated 45s ago` → etc.) and a `↻ Refresh` button for operators who want forced recompute.
- Inline JS added to the existing `<script>` IIFE at the bottom of the file:
  - Kicks off on `DOMContentLoaded`
  - Handles 200 (apply and done), 202 (apply stale + poll), error (show "retry with ↻")
  - Refresh button calls with `?force=1`
  - Formats numbers with `toLocaleString()` and cache age in human units

## Concurrency correctness

The worry was thundering herd: if 50 users hit `/killmail-intelligence` while the cache is cold, does each of them run the 200s snapshot? No.

- User 1 → cache miss → acquires `GET_LOCK` → runs snapshot (200s) → writes cache → releases lock → returns fresh data
- Users 2–50 → cache miss → `GET_LOCK(?, 0)` returns 0 (held by user 1's session) → return HTTP 202 with empty/stale cached value + `retry_after_seconds: 15`
- JS for users 2–50 sees the 202, shows "Refreshing…", polls after 15s
- When user 1 finishes, the cache is warm, and everyone's next poll returns the fresh data instantly

`GET_LOCK` is per-session. If user 1's PHP process crashes or their connection dies mid-query, the lock is automatically released and the next request's `GET_LOCK` call succeeds.

## nginx configuration (operator action required)

The cold-path compute can take 200+ seconds. nginx defaults `proxy_read_timeout` to 60 seconds, which would cause the first user to see a 504 on cold start (though the PHP process would keep running and warm the cache — so subsequent polls would recover). Better to bump the timeout just for this endpoint so the first user gets a clean experience:

```nginx
location = /api/killmail-intelligence/esi-coverage.php {
    include fastcgi_params;  # or whatever your stack uses
    fastcgi_pass <your-php-fpm-socket>;
    fastcgi_read_timeout 300s;
    # If you proxy through another layer:
    # proxy_read_timeout 300s;
}
```

If you skip this step, the endpoint still works — users on cold start will see a 504 in the panel, but the JS will show "Load failed — retry with ↻" and clicking the refresh button after the background compute finishes will succeed. Not great UX for the unlucky first user, but nothing is broken.

## Test plan

- [ ] Deploy to staging
- [ ] `curl -o /dev/null -s -w "total: %{time_total}s\n" https://host/killmail-intelligence` returns in <5s even on the first hit (no synchronous coverage)
- [ ] Open the page in a browser, observe coverage panel starts as "Loading…" then populates
- [ ] `SELECT cache_key, computed_at, LENGTH(cache_value) FROM page_cache WHERE cache_key LIKE 'killmail_esi_coverage%'` — new row after first load
- [ ] Click the ↻ Refresh button, verify it triggers a forced recompute (new `computed_at` in page_cache)
- [ ] Open the page in two browser windows nearly simultaneously while cache is cold — verify both eventually populate, only one runs the underlying query (check `SHOW FULL PROCESSLIST` for exactly one snapshot query running)
- [ ] `SELECT IS_FREE_LOCK('supplycore:killmail_esi_coverage_refresh')` while a refresh is in progress → should return `0`; after it finishes → should return `1`
- [ ] Corrupt a cache row (`UPDATE page_cache SET cache_value='{' WHERE cache_key LIKE 'killmail_esi_coverage%'`), reload page — should fall back to empty stub and refetch without erroring
- [ ] Apply the nginx timeout snippet, verify first cold hit on a fresh deploy doesn't 504

https://claude.ai/code/session_01DpcitBxn1Fya47r8TvHnz2