### PR TITLE
feat(horizon): auto-approve backfill-complete gate after soak

### DIFF
--- a/bin/horizon-block.php
+++ b/bin/horizon-block.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * bin/horizon-block <dataset_key>
+ *
+ * Opt a dataset out of the detect_backfill_complete auto-approval loop.
+ * Sets sync_state.auto_approve_blocked = 1.
+ *
+ * When blocked, detect_backfill_complete will still *propose* the
+ * dataset for backfill_complete (so it shows up in the admin review
+ * queue) but will never auto-flip the gate regardless of how long the
+ * proposal has been soaking. A human must run bin/horizon-approve.php
+ * to flip the gate, or bin/horizon-unblock.php to re-enable
+ * auto-approval.
+ *
+ * Use this for datasets that need a human eye on the cutover -- e.g.
+ * a new compute job whose correctness hasn't been validated against a
+ * shadow run yet.
+ */
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+$datasetKey = trim((string) ($argv[1] ?? ''));
+if ($datasetKey === '') {
+    fwrite(STDERR, "Usage: php bin/horizon-block.php <dataset_key>\n");
+    exit(2);
+}
+
+$state = db_horizon_state_get($datasetKey);
+if ($state === null) {
+    fwrite(STDERR, sprintf("No sync_state row for dataset '%s'.\n", $datasetKey));
+    exit(1);
+}
+
+if (!empty($state['auto_approve_blocked'])) {
+    fwrite(
+        STDOUT,
+        sprintf("Dataset '%s' already has auto_approve_blocked = 1. Nothing to do.\n", $datasetKey)
+    );
+    exit(0);
+}
+
+$ok = db_horizon_block_auto_approve($datasetKey);
+if (!$ok) {
+    fwrite(STDERR, sprintf("Failed to block auto-approval for dataset '%s'.\n", $datasetKey));
+    exit(1);
+}
+
+fwrite(
+    STDOUT,
+    sprintf(
+        "Blocked auto-approval for dataset '%s'. detect_backfill_complete will still propose but never auto-approve.\n",
+        $datasetKey
+    )
+);
+exit(0);

--- a/bin/horizon-unblock.php
+++ b/bin/horizon-unblock.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * bin/horizon-unblock <dataset_key>
+ *
+ * Clear a previously-set auto-approval block. Sets
+ * sync_state.auto_approve_blocked = 0.
+ *
+ * The dataset becomes eligible for auto-approval again on the next
+ * detect_backfill_complete run (subject to the usual soak and health
+ * criteria -- see python/orchestrator/jobs/detect_backfill_complete.py
+ * for the full timeline).
+ */
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+$datasetKey = trim((string) ($argv[1] ?? ''));
+if ($datasetKey === '') {
+    fwrite(STDERR, "Usage: php bin/horizon-unblock.php <dataset_key>\n");
+    exit(2);
+}
+
+$state = db_horizon_state_get($datasetKey);
+if ($state === null) {
+    fwrite(STDERR, sprintf("No sync_state row for dataset '%s'.\n", $datasetKey));
+    exit(1);
+}
+
+if (empty($state['auto_approve_blocked'])) {
+    fwrite(
+        STDOUT,
+        sprintf("Dataset '%s' already has auto_approve_blocked = 0. Nothing to do.\n", $datasetKey)
+    );
+    exit(0);
+}
+
+$ok = db_horizon_unblock_auto_approve($datasetKey);
+if (!$ok) {
+    fwrite(STDERR, sprintf("Failed to unblock auto-approval for dataset '%s'.\n", $datasetKey));
+    exit(1);
+}
+
+fwrite(
+    STDOUT,
+    sprintf(
+        "Unblocked auto-approval for dataset '%s'. Next detect_backfill_complete run may auto-approve.\n",
+        $datasetKey
+    )
+);
+exit(0);

--- a/database/migrations/20260510_horizon_auto_approve.sql
+++ b/database/migrations/20260510_horizon_auto_approve.sql
@@ -1,0 +1,40 @@
+-- Auto-approval for the incremental-horizon backfill gate.
+--
+-- Extends the per-dataset horizon model (see
+-- database/migrations/20260426_incremental_horizon.sql) with a single
+-- opt-out column so that detect_backfill_complete can close the loop
+-- between proposing a dataset and flipping backfill_complete without a
+-- human in the middle for boring cases.
+--
+-- Column:
+--   auto_approve_blocked          When 1, detect_backfill_complete will
+--                                 still *propose* the dataset (so it
+--                                 shows up in the admin review queue)
+--                                 but will never auto-flip
+--                                 backfill_complete regardless of how
+--                                 long the proposal has been sitting.
+--                                 Default 0 -- auto-approval is opt-out,
+--                                 not opt-in.
+--
+-- Timeline for a well-behaved dataset once backfill finishes:
+--
+--   T+0         Backfill completes.
+--   T+24h       detect_backfill_complete runs, dataset meets the
+--               "propose" criteria, stamps backfill_proposed_at.
+--   T+24h..T+72h  Proposal sits. Freshness report shows it as a
+--               pending candidate. Operator can approve faster via
+--               bin/horizon-approve.php, block forever via
+--               bin/horizon-block.php, or just wait.
+--   T+72h       detect_backfill_complete runs again, proposal is >48h
+--               old, dataset still passes all health criteria, and
+--               auto_approve_blocked = 0 -> auto-approve. Next run
+--               uses incremental-only horizon mode.
+--
+-- The proposal re-check at auto-approval time is the critical safety
+-- layer: if the dataset has regressed (stall, failed run, lag outside
+-- the SLA) between proposal and auto-approval, the auto-approver
+-- leaves the proposal pending and the dashboard reflects the
+-- regression.
+
+ALTER TABLE sync_state
+    ADD COLUMN auto_approve_blocked TINYINT(1) NOT NULL DEFAULT 0 AFTER stall_count;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -322,6 +322,7 @@ CREATE TABLE IF NOT EXISTS sync_state (
     repair_window_seconds INT UNSIGNED NOT NULL DEFAULT 86400,
     stall_cursor VARCHAR(190) DEFAULT NULL,
     stall_count INT UNSIGNED NOT NULL DEFAULT 0,
+    auto_approve_blocked TINYINT(1) NOT NULL DEFAULT 0,
     last_row_count INT UNSIGNED NOT NULL DEFAULT 0,
     last_checksum CHAR(64) DEFAULT NULL,
     last_error_message VARCHAR(500) DEFAULT NULL,

--- a/docs/OPERATIONS_GUIDE.md
+++ b/docs/OPERATIONS_GUIDE.md
@@ -36,6 +36,7 @@ Procedures for deployment, reset, rebuild, maintenance, and troubleshooting.
   - [How It Works](#horizon-how-it-works)
   - [Freshness Report](#horizon-freshness-report)
   - [Approving a Dataset](#horizon-approving-a-dataset)
+  - [Auto-Approval](#horizon-auto-approval)
   - [Out-of-Window Late Data](#horizon-out-of-window-late-data)
   - [Rollback](#horizon-rollback)
 
@@ -607,6 +608,7 @@ The `sync_state` table carries per-dataset progress and policy:
 | `incremental_horizon_seconds` | SLA for "caught up" (default 86400 / 24h) |
 | `repair_window_seconds` | How far back to rewind the read cursor each run (default 86400 / 24h) |
 | `stall_cursor` / `stall_count` | Consecutive runs where the cursor did not advance |
+| `auto_approve_blocked` | Opt-out flag. `1` = `detect_backfill_complete` will still propose but will never auto-approve this dataset (see [Auto-Approval](#horizon-auto-approval)) |
 
 Derived status (from `db_calculation_freshness_report()`):
 
@@ -653,6 +655,50 @@ php bin/horizon-reject.php compute_battle_rollups
 
 Or use the settings page: **Sync Operations → Incremental horizon
 mode → Pending proposals → Approve/Reject**.
+
+### <a id="horizon-auto-approval"></a>Auto-Approval
+
+`detect_backfill_complete` also runs a second pass on every invocation
+that auto-flips `backfill_complete` for proposals that have soaked long
+enough *and* still satisfy the health check at approval time. The
+full timeline for a well-behaved dataset is:
+
+| Time | Event |
+|---|---|
+| T+0 | Backfill completes; job starts running cleanly in full/backfill + incremental mode |
+| T+24h | First `detect_backfill_complete` pass proposes the dataset (stamps `backfill_proposed_at`); appears in the admin review queue |
+| T+24h..T+72h | Proposal soaks. An admin can approve early via `bin/horizon-approve.php`, block forever via `bin/horizon-block.php`, reject via `bin/horizon-reject.php`, or just wait |
+| T+72h | Second `detect_backfill_complete` pass confirms the dataset is still healthy and the proposal is ≥ 48h old; auto-flips `backfill_complete = 1`. Next run uses incremental-only horizon mode |
+
+The re-check at approval time is the critical safety layer: if the
+dataset regressed (stall, failed run, lag outside SLA) between proposal
+and auto-approval, the auto-approver leaves the proposal pending and
+the freshness dashboard reflects the regression. Auto-approval skips
+with a `recheck_failed:...` reason in the job meta.
+
+To opt a dataset out of auto-approval entirely (e.g. a new compute job
+whose correctness hasn't been validated against a shadow run yet):
+
+```bash
+# Block auto-approval -- detector still proposes but never auto-flips
+php bin/horizon-block.php compute_battle_target_metrics
+
+# Re-enable auto-approval once validation is done
+php bin/horizon-unblock.php compute_battle_target_metrics
+```
+
+Or from the settings UI: the pending-proposal card has **Block auto**
+and **Unblock auto** buttons next to Approve/Reject. Blocked proposals
+get a visible `auto-approve blocked` badge in the review queue.
+
+Tunables live at the top of
+`python/orchestrator/jobs/detect_backfill_complete.py`:
+
+- `_SOAK_SECONDS` (24h) — minimum clean-run soak before proposing
+- `_AUTO_APPROVE_SOAK_SECONDS` (48h) — minimum proposal age before
+  auto-flipping
+- `_MIN_CLEAN_RUNS` (5) — consecutive successful `sync_runs` required
+- `_MAX_STALL` (2) — stall-counter ceiling for candidacy
 
 ### <a id="horizon-out-of-window-late-data"></a>Out-of-Window Late Data
 

--- a/public/settings/index.php
+++ b/public/settings/index.php
@@ -857,6 +857,40 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 exit;
             }
 
+            if ($dataSyncAction === 'horizon-block') {
+                $horizonDataset = trim((string) ($_POST['horizon_dataset_key'] ?? ''));
+                if ($horizonDataset === '') {
+                    flash('success', 'Horizon auto-approve block skipped: no dataset selected.');
+                } else {
+                    $ok = db_horizon_block_auto_approve($horizonDataset);
+                    flash(
+                        'success',
+                        $ok
+                            ? sprintf("Blocked auto-approval for '%s'. Proposal will stay pending until a human approves.", $horizonDataset)
+                            : sprintf("Failed to block auto-approval for '%s'.", $horizonDataset)
+                    );
+                }
+                header('Location: /settings?section=' . urlencode($submittedSection) . '&subsection=data-sync');
+                exit;
+            }
+
+            if ($dataSyncAction === 'horizon-unblock') {
+                $horizonDataset = trim((string) ($_POST['horizon_dataset_key'] ?? ''));
+                if ($horizonDataset === '') {
+                    flash('success', 'Horizon auto-approve unblock skipped: no dataset selected.');
+                } else {
+                    $ok = db_horizon_unblock_auto_approve($horizonDataset);
+                    flash(
+                        'success',
+                        $ok
+                            ? sprintf("Unblocked auto-approval for '%s'. Next detector run may auto-approve.", $horizonDataset)
+                            : sprintf("Failed to unblock auto-approval for '%s'.", $horizonDataset)
+                    );
+                }
+                header('Location: /settings?section=' . urlencode($submittedSection) . '&subsection=data-sync');
+                exit;
+            }
+
             $dataSyncSave = save_data_sync_settings($_POST);
             $saved = (bool) ($dataSyncSave['ok'] ?? false);
             $saveMessage = (string) ($dataSyncSave['message'] ?? 'Settings saved successfully.');
@@ -3827,7 +3861,7 @@ include __DIR__ . '/../../src/views/partials/header.php';
                         <div class="flex items-start justify-between gap-3">
                             <div>
                                 <p class="text-sm font-semibold text-slate-100">Incremental horizon mode</p>
-                                <p class="mt-1 text-xs text-muted">Datasets that are backfill-complete may switch to incremental-only reads with a rolling repair window. Proposals come from the <code class="text-slate-300">detect_backfill_complete</code> job and require explicit admin approval before the job-side policy flips. CLI equivalents: <code class="text-slate-300">bin/horizon-approve.php</code>, <code class="text-slate-300">bin/horizon-reject.php</code>, <code class="text-slate-300">bin/horizon-reset.php</code>, <code class="text-slate-300">bin/horizon-rewind.php</code>.</p>
+                                <p class="mt-1 text-xs text-muted">Datasets that are backfill-complete may switch to incremental-only reads with a rolling repair window. Proposals come from the <code class="text-slate-300">detect_backfill_complete</code> job; proposals soak for 48h and auto-approve if they still pass the health check. Use <strong>Block auto</strong> to keep a proposal pending indefinitely for manual review. CLI equivalents: <code class="text-slate-300">bin/horizon-approve.php</code>, <code class="text-slate-300">bin/horizon-reject.php</code>, <code class="text-slate-300">bin/horizon-reset.php</code>, <code class="text-slate-300">bin/horizon-rewind.php</code>, <code class="text-slate-300">bin/horizon-block.php</code>, <code class="text-slate-300">bin/horizon-unblock.php</code>.</p>
                             </div>
                             <span class="inline-flex items-center rounded-full border border-cyan-400/30 bg-cyan-500/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.16em] text-cyan-100"><?= count($horizonProposals) ?> pending</span>
                         </div>
@@ -3839,19 +3873,32 @@ include __DIR__ . '/../../src/views/partials/header.php';
                             <?php else: ?>
                                 <div class="mt-2 space-y-2">
                                     <?php foreach ($horizonProposals as $proposal): ?>
-                                        <?php $proposalKey = (string) ($proposal['dataset_key'] ?? ''); ?>
+                                        <?php
+                                            $proposalKey = (string) ($proposal['dataset_key'] ?? '');
+                                            $autoBlocked = !empty($proposal['auto_approve_blocked']);
+                                        ?>
                                         <div class="rounded-lg border border-amber-400/30 bg-amber-500/5 p-3 text-xs text-amber-100">
                                             <div class="flex flex-wrap items-start justify-between gap-3">
                                                 <div>
-                                                    <p class="font-semibold text-slate-100"><?= htmlspecialchars($proposalKey, ENT_QUOTES) ?></p>
+                                                    <p class="font-semibold text-slate-100">
+                                                        <?= htmlspecialchars($proposalKey, ENT_QUOTES) ?>
+                                                        <?php if ($autoBlocked): ?>
+                                                            <span class="ml-2 inline-flex items-center rounded-full border border-rose-400/40 bg-rose-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-rose-100">auto-approve blocked</span>
+                                                        <?php endif; ?>
+                                                    </p>
                                                     <p class="mt-1 text-muted">Proposed at <?= htmlspecialchars((string) ($proposal['backfill_proposed_at'] ?? '-'), ENT_QUOTES) ?></p>
                                                     <?php if (!empty($proposal['backfill_proposed_reason'])): ?>
                                                         <p class="mt-1"><span class="text-amber-200/80 uppercase tracking-[0.14em] mr-1">reason</span><?= htmlspecialchars((string) $proposal['backfill_proposed_reason'], ENT_QUOTES) ?></p>
                                                     <?php endif; ?>
                                                 </div>
-                                                <div class="flex gap-2">
+                                                <div class="flex flex-wrap gap-2">
                                                     <button type="submit" name="data_sync_action" value="horizon-approve" class="inline-flex items-center rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 font-medium uppercase tracking-[0.14em] text-emerald-100 hover:bg-emerald-500/20" onclick="document.getElementById('horizon_dataset_key_input').value='<?= htmlspecialchars($proposalKey, ENT_QUOTES) ?>';">Approve</button>
                                                     <button type="submit" name="data_sync_action" value="horizon-reject" class="inline-flex items-center rounded-full border border-rose-400/40 bg-rose-500/10 px-3 py-1 font-medium uppercase tracking-[0.14em] text-rose-100 hover:bg-rose-500/20" onclick="document.getElementById('horizon_dataset_key_input').value='<?= htmlspecialchars($proposalKey, ENT_QUOTES) ?>';">Reject</button>
+                                                    <?php if ($autoBlocked): ?>
+                                                        <button type="submit" name="data_sync_action" value="horizon-unblock" class="inline-flex items-center rounded-full border border-slate-400/40 bg-slate-500/10 px-3 py-1 font-medium uppercase tracking-[0.14em] text-slate-100 hover:bg-slate-500/20" onclick="document.getElementById('horizon_dataset_key_input').value='<?= htmlspecialchars($proposalKey, ENT_QUOTES) ?>';">Unblock auto</button>
+                                                    <?php else: ?>
+                                                        <button type="submit" name="data_sync_action" value="horizon-block" class="inline-flex items-center rounded-full border border-slate-400/40 bg-slate-500/10 px-3 py-1 font-medium uppercase tracking-[0.14em] text-slate-100 hover:bg-slate-500/20" onclick="document.getElementById('horizon_dataset_key_input').value='<?= htmlspecialchars($proposalKey, ENT_QUOTES) ?>';">Block auto</button>
+                                                    <?php endif; ?>
                                                 </div>
                                             </div>
                                         </div>

--- a/python/orchestrator/horizon.py
+++ b/python/orchestrator/horizon.py
@@ -113,6 +113,7 @@ class HorizonState:
     repair_window_seconds: int
     stall_cursor: str | None
     stall_count: int
+    auto_approve_blocked: bool = False
 
     @classmethod
     def from_row(cls, row: dict[str, Any]) -> "HorizonState":
@@ -133,6 +134,7 @@ class HorizonState:
             ),
             stall_cursor=_coerce_str(row.get("stall_cursor")),
             stall_count=int(row.get("stall_count") or 0),
+            auto_approve_blocked=bool(int(row.get("auto_approve_blocked") or 0)),
         )
 
 
@@ -187,7 +189,8 @@ def horizon_state_get(db: SupplyCoreDb, dataset_key: str) -> HorizonState | None
                incremental_horizon_seconds,
                repair_window_seconds,
                stall_cursor,
-               stall_count
+               stall_count,
+               auto_approve_blocked
           FROM sync_state
          WHERE dataset_key = %s
          LIMIT 1
@@ -464,6 +467,44 @@ def reset_backfill_complete(db: SupplyCoreDb, dataset_key: str) -> None:
     )
 
 
+def block_auto_approve(db: SupplyCoreDb, dataset_key: str) -> None:
+    """Opt a dataset out of the detect_backfill_complete auto-approval loop.
+
+    When set, detect_backfill_complete will still *propose* the dataset
+    for backfill_complete (so it still shows up in the admin review
+    queue) but will never auto-flip the gate regardless of how long the
+    proposal has been soaking. Use for datasets that need a human eye
+    on the cutover.
+    """
+    db.execute(
+        """
+        UPDATE sync_state
+           SET auto_approve_blocked = 1,
+               updated_at = CURRENT_TIMESTAMP
+         WHERE dataset_key = %s
+        """,
+        (dataset_key,),
+    )
+
+
+def unblock_auto_approve(db: SupplyCoreDb, dataset_key: str) -> None:
+    """Clear a previously-set auto-approval block.
+
+    The dataset becomes eligible for auto-approval again on the next
+    detect_backfill_complete run (subject to the usual soak and health
+    criteria).
+    """
+    db.execute(
+        """
+        UPDATE sync_state
+           SET auto_approve_blocked = 0,
+               updated_at = CURRENT_TIMESTAMP
+         WHERE dataset_key = %s
+        """,
+        (dataset_key,),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Freshness / reporting.
 # ---------------------------------------------------------------------------
@@ -556,6 +597,7 @@ def freshness_report(
                ss.repair_window_seconds,
                ss.stall_cursor,
                ss.stall_count,
+               ss.auto_approve_blocked,
                latest.run_status   AS last_run_status,
                latest.source_rows  AS last_run_source_rows,
                latest.written_rows AS last_run_written_rows,
@@ -589,6 +631,7 @@ def freshness_report(
                 "incremental_horizon_seconds": state.incremental_horizon_seconds,
                 "repair_window_seconds": state.repair_window_seconds,
                 "stall_count": state.stall_count,
+                "auto_approve_blocked": state.auto_approve_blocked,
                 **derived,
             }
         )
@@ -606,7 +649,8 @@ def list_pending_proposals(db: SupplyCoreDb) -> list[dict[str, Any]]:
                last_success_at,
                watermark_event_time,
                last_cursor,
-               stall_count
+               stall_count,
+               auto_approve_blocked
           FROM sync_state
          WHERE backfill_complete = 0
            AND backfill_proposed_at IS NOT NULL

--- a/python/orchestrator/jobs/detect_backfill_complete.py
+++ b/python/orchestrator/jobs/detect_backfill_complete.py
@@ -1,20 +1,51 @@
-"""Backfill-complete proposal detector.
+"""Backfill-complete proposal detector and auto-approver.
 
-Scans ``sync_state`` for datasets that look ready to transition from
-full/backfill + incremental into incremental-only horizon mode, and
-*proposes* them for admin review by stamping ``backfill_proposed_at``
-and ``backfill_proposed_reason``.
+This job runs two passes against ``sync_state`` every time it runs:
 
-The detector intentionally never flips ``backfill_complete`` itself --
-humans approve via ``bin/horizon-approve.php`` (or the settings UI).
-This matches the plan in ``/root/.claude/plans/breezy-toasting-wind.md``
-(section 4 -- "Backfill-done gate").
+1. **Propose** new horizon-ready datasets by stamping
+   ``backfill_proposed_at`` and ``backfill_proposed_reason`` on datasets
+   that meet the health criteria but have no pending proposal yet.
 
-Heuristics for proposing a dataset
-----------------------------------
+2. **Auto-approve** existing proposals that have been soaking long
+   enough *and* still satisfy the same health criteria at approval time.
+   Any dataset with ``auto_approve_blocked = 1`` is left alone; the
+   proposal will sit in the review queue until a human acts.
+
+The detector intentionally never flips ``backfill_complete`` on a
+brand-new proposal -- every dataset goes through the propose → soak →
+re-check → approve cycle. This matches the plan in
+``/root/.claude/plans/breezy-toasting-wind.md`` (section 4 -- "Backfill-
+done gate") and extends it with a self-driving approval loop.
+
+Timeline for a well-behaved dataset once backfill finishes
+----------------------------------------------------------
+::
+
+    T+0         Backfill completes, job starts running cleanly in
+                full/backfill + incremental mode.
+    T+24h       First detect_backfill_complete pass meets all criteria
+                and proposes the dataset (``backfill_proposed_at``
+                stamped). Dataset shows up in the admin review queue.
+    T+24h..T+72h  Proposal soaks. Any human can approve early via
+                ``bin/horizon-approve.php``, block forever via
+                ``bin/horizon-block.php``, reject via
+                ``bin/horizon-reject.php``, or just wait.
+    T+72h       Second detect_backfill_complete pass re-runs the health
+                check, confirms still-ready and proposal age ≥
+                ``_AUTO_APPROVE_SOAK_SECONDS``, and auto-flips
+                ``backfill_complete = 1``. Next run uses
+                incremental-only horizon mode.
+
+The re-check at approval time is the critical safety layer: if the
+dataset has regressed (stall, failed run, lag outside the SLA) between
+proposal and auto-approval, the auto-approver leaves the proposal
+pending so the freshness dashboard reflects the regression.
+
+Heuristics for proposing / approving a dataset
+-----------------------------------------------
 A dataset becomes a candidate when **all** of the following hold:
 
-1. ``backfill_complete = 0`` and no pending proposal yet.
+1. ``backfill_complete = 0``.
 2. ``last_success_at`` is older than the soak period (default 24h).
 3. At least ``_MIN_CLEAN_RUNS`` consecutive recent ``sync_runs`` rows
    are ``run_status = 'success'`` (no recent failures).
@@ -23,8 +54,11 @@ A dataset becomes a candidate when **all** of the following hold:
 5. The freshness watermark is inside the dataset's incremental horizon
    window (i.e. the job is already caught up to its SLA).
 
-Datasets that already have a pending proposal are left alone so repeated
-runs don't clobber an admin's review queue.
+Auto-approval additionally requires:
+
+6. ``backfill_proposed_at`` is at least ``_AUTO_APPROVE_SOAK_SECONDS``
+   old (default 48h after the proposal).
+7. ``auto_approve_blocked = 0`` (opt-out column on ``sync_state``).
 """
 from __future__ import annotations
 
@@ -35,6 +69,7 @@ from ..db import SupplyCoreDb
 from ..horizon import (
     DEFAULT_HORIZON_SECONDS,
     HorizonState,
+    approve_backfill_complete,
     propose_backfill_complete,
 )
 from .sync_runtime import run_sync_phase_job
@@ -49,6 +84,15 @@ logger = logging.getLogger(__name__)
 #: incremental horizon.
 _SOAK_SECONDS = 24 * 3600
 
+#: How long a proposal must sit in the admin review queue before
+#: auto-approval kicks in. 48h gives a human two weekdays to eyeball
+#: the freshness dashboard and either approve early, block, or reject
+#: before the system decides for itself. The re-check of the health
+#: criteria at approval time (see ``_evaluate_candidate``) is the
+#: critical safety layer -- if anything regressed during the soak, the
+#: auto-approver leaves the proposal pending.
+_AUTO_APPROVE_SOAK_SECONDS = 48 * 3600
+
 #: Minimum number of recent ``sync_runs`` rows that must all be clean
 #: (``run_status = 'success'``) for the detector to propose a dataset.
 _MIN_CLEAN_RUNS = 5
@@ -58,21 +102,28 @@ _MIN_CLEAN_RUNS = 5
 _MAX_STALL = 2
 
 
+_COMMON_STATE_COLUMNS = """
+    dataset_key,
+    sync_mode,
+    status,
+    last_success_at,
+    last_cursor,
+    watermark_event_time,
+    backfill_complete,
+    backfill_proposed_at,
+    incremental_horizon_seconds,
+    repair_window_seconds,
+    stall_cursor,
+    stall_count,
+    auto_approve_blocked
+""".strip()
+
+
 def _processor(db: SupplyCoreDb) -> dict[str, Any]:
-    rows = db.fetch_all(
-        """
-        SELECT dataset_key,
-               sync_mode,
-               status,
-               last_success_at,
-               last_cursor,
-               watermark_event_time,
-               backfill_complete,
-               backfill_proposed_at,
-               incremental_horizon_seconds,
-               repair_window_seconds,
-               stall_cursor,
-               stall_count
+    # Pass 1: propose new candidates.
+    propose_rows = db.fetch_all(
+        f"""
+        SELECT {_COMMON_STATE_COLUMNS}
           FROM sync_state
          WHERE backfill_complete = 0
            AND backfill_proposed_at IS NULL
@@ -80,9 +131,9 @@ def _processor(db: SupplyCoreDb) -> dict[str, Any]:
     )
 
     proposed: list[dict[str, Any]] = []
-    skipped: list[dict[str, Any]] = []
+    propose_skipped: list[dict[str, Any]] = []
 
-    for row in rows:
+    for row in propose_rows:
         state = HorizonState.from_row(row)
         verdict = _evaluate_candidate(db, state)
 
@@ -99,26 +150,99 @@ def _processor(db: SupplyCoreDb) -> dict[str, Any]:
                 reason,
             )
         else:
-            skipped.append({
+            propose_skipped.append({
                 "dataset_key": state.dataset_key,
                 "reason": verdict["reason"],
             })
 
+    # Pass 2: auto-approve soaked proposals that still look healthy.
+    #
+    # We re-fetch here instead of chaining through pass-1 results so
+    # that proposals made on earlier runs (not just this run) are
+    # considered, and so that a dataset proposed in pass 1 cannot be
+    # instantly approved in pass 2 within the same job invocation --
+    # the soak check (``proposal_age_seconds >= _AUTO_APPROVE_SOAK_SECONDS``)
+    # will naturally reject it because ``backfill_proposed_at`` was
+    # just stamped to ``UTC_TIMESTAMP()``.
+    approve_rows = db.fetch_all(
+        f"""
+        SELECT {_COMMON_STATE_COLUMNS},
+               TIMESTAMPDIFF(SECOND, backfill_proposed_at, UTC_TIMESTAMP())
+                   AS proposal_age_seconds
+          FROM sync_state
+         WHERE backfill_complete = 0
+           AND backfill_proposed_at IS NOT NULL
+           AND auto_approve_blocked = 0
+        """,
+    )
+
+    approved: list[dict[str, Any]] = []
+    approve_skipped: list[dict[str, Any]] = []
+
+    for row in approve_rows:
+        state = HorizonState.from_row(row)
+        proposal_age = int(row.get("proposal_age_seconds") or 0)
+
+        if proposal_age < _AUTO_APPROVE_SOAK_SECONDS:
+            approve_skipped.append({
+                "dataset_key": state.dataset_key,
+                "reason": f"soaking:{proposal_age}s<{_AUTO_APPROVE_SOAK_SECONDS}s",
+            })
+            continue
+
+        # Re-run the same health check at approval time. This is the
+        # safety layer: if the dataset regressed (stall, failed run,
+        # lag outside SLA) since the proposal, leave it pending so the
+        # freshness dashboard reflects the regression and a human can
+        # decide what to do.
+        verdict = _evaluate_candidate(db, state)
+        if not verdict["ready"]:
+            approve_skipped.append({
+                "dataset_key": state.dataset_key,
+                "reason": f"recheck_failed:{verdict['reason']}",
+            })
+            logger.info(
+                "Auto-approve re-check failed for dataset %s: %s",
+                state.dataset_key,
+                verdict["reason"],
+            )
+            continue
+
+        approve_backfill_complete(db, state.dataset_key)
+        approved.append({
+            "dataset_key": state.dataset_key,
+            "proposal_age_seconds": proposal_age,
+            "reason": str(verdict["reason"]),
+        })
+        logger.info(
+            "Auto-approved backfill_complete for dataset %s (age=%ds; %s)",
+            state.dataset_key,
+            proposal_age,
+            verdict["reason"],
+        )
+
+    rows_processed = len(propose_rows) + len(approve_rows)
+    rows_written = len(proposed) + len(approved)
     summary = (
-        f"Scanned {len(rows)} candidate dataset(s); "
-        f"proposed {len(proposed)}, skipped {len(skipped)}."
+        f"Scanned {len(propose_rows)} new + {len(approve_rows)} pending; "
+        f"proposed {len(proposed)}, auto-approved {len(approved)}, "
+        f"skipped {len(propose_skipped) + len(approve_skipped)}."
     )
 
     return {
-        "rows_processed": len(rows),
-        "rows_written": len(proposed),
+        "rows_processed": rows_processed,
+        "rows_written": rows_written,
         "warnings": [],
         "summary": summary,
         "meta": {
             "dataset_key": "detect_backfill_complete",
             "proposed": proposed,
-            "skipped_count": len(skipped),
+            "auto_approved": approved,
+            "propose_skipped_count": len(propose_skipped),
+            "approve_skipped_count": len(approve_skipped),
+            "approve_skipped": approve_skipped,
             "soak_seconds": _SOAK_SECONDS,
+            "auto_approve_soak_seconds": _AUTO_APPROVE_SOAK_SECONDS,
             "min_clean_runs": _MIN_CLEAN_RUNS,
         },
     }

--- a/python/tests/test_detect_backfill_complete.py
+++ b/python/tests/test_detect_backfill_complete.py
@@ -1,0 +1,462 @@
+"""Tests for the detect_backfill_complete auto-approval loop.
+
+Covers the two-stage flow:
+  1. Fresh sync_state row  -> proposal stamped, gate not flipped.
+  2. Proposal age < soak    -> skipped, proposal intact.
+  3. Proposal age >= soak   -> gate auto-flipped (if health still OK).
+  4. Regression during soak -> recheck fails, gate stays closed.
+  5. auto_approve_blocked   -> excluded from the approval scan entirely.
+
+The detector itself runs against a small in-memory ``FakeDb`` that
+models just enough of the ``sync_state`` / ``sync_runs`` query shapes
+used by the job. We intentionally avoid spinning up MariaDB here --
+the column additions / schema migrations are covered separately.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+_PYTHON_DIR = Path(__file__).resolve().parents[1]
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+# Load detect_backfill_complete.py as a standalone module without going
+# through ``orchestrator.jobs.__init__`` (which eagerly imports every
+# job in the catalog, dragging pymysql into the test environment).
+#
+# We stub minimal placeholder packages for ``orchestrator`` /
+# ``orchestrator.jobs`` so the relative imports inside
+# detect_backfill_complete.py (``from ..horizon import ...`` and
+# ``from .sync_runtime import ...``) resolve. The horizon module loads
+# cleanly because it has no heavy deps; sync_runtime is stubbed with a
+# no-op ``run_sync_phase_job`` that just calls the processor.
+
+def _bootstrap_detector() -> types.ModuleType:
+    orchestrator_pkg = sys.modules.get("orchestrator")
+    if orchestrator_pkg is None:
+        orchestrator_pkg = types.ModuleType("orchestrator")
+        orchestrator_pkg.__path__ = [str(_PYTHON_DIR / "orchestrator")]  # type: ignore[attr-defined]
+        sys.modules["orchestrator"] = orchestrator_pkg
+
+    # Load the real horizon module so HorizonState + propose/approve
+    # helpers match production behavior.
+    if "orchestrator.horizon" not in sys.modules:
+        horizon_spec = importlib.util.spec_from_file_location(
+            "orchestrator.horizon",
+            _PYTHON_DIR / "orchestrator" / "horizon.py",
+        )
+        assert horizon_spec is not None and horizon_spec.loader is not None
+        horizon_mod = importlib.util.module_from_spec(horizon_spec)
+        sys.modules["orchestrator.horizon"] = horizon_mod
+        horizon_spec.loader.exec_module(horizon_mod)
+
+    # Stub the db module so ``from ..db import SupplyCoreDb`` succeeds.
+    if "orchestrator.db" not in sys.modules:
+        db_stub = types.ModuleType("orchestrator.db")
+        db_stub.SupplyCoreDb = object  # type: ignore[attr-defined]
+        sys.modules["orchestrator.db"] = db_stub
+
+    # Stub the jobs package with a minimal sync_runtime that just calls
+    # the processor inline (production wraps the processor in phase
+    # metadata; here we only care about the meta dict the processor
+    # returns).
+    jobs_pkg = sys.modules.get("orchestrator.jobs")
+    if jobs_pkg is None:
+        jobs_pkg = types.ModuleType("orchestrator.jobs")
+        jobs_pkg.__path__ = [str(_PYTHON_DIR / "orchestrator" / "jobs")]  # type: ignore[attr-defined]
+        sys.modules["orchestrator.jobs"] = jobs_pkg
+
+    if "orchestrator.jobs.sync_runtime" not in sys.modules:
+        sync_runtime_stub = types.ModuleType("orchestrator.jobs.sync_runtime")
+
+        def run_sync_phase_job(db, *, job_key, phase, objective, processor):  # noqa: ANN001
+            return processor(db)
+
+        sync_runtime_stub.run_sync_phase_job = run_sync_phase_job  # type: ignore[attr-defined]
+        sys.modules["orchestrator.jobs.sync_runtime"] = sync_runtime_stub
+
+    spec = importlib.util.spec_from_file_location(
+        "orchestrator.jobs.detect_backfill_complete",
+        _PYTHON_DIR / "orchestrator" / "jobs" / "detect_backfill_complete.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["orchestrator.jobs.detect_backfill_complete"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+detector = _bootstrap_detector()
+
+
+class DetectorFakeDb:
+    """In-memory stand-in for SupplyCoreDb focused on the detector's
+    query shapes.
+
+    Understands four query patterns used by detect_backfill_complete:
+      - ``SELECT ... FROM sync_state WHERE backfill_complete = 0 AND backfill_proposed_at IS NULL``
+      - ``SELECT ... FROM sync_state WHERE backfill_complete = 0 AND backfill_proposed_at IS NOT NULL AND auto_approve_blocked = 0``
+      - ``SELECT UTC_TIMESTAMP() AS now_utc``
+      - ``SELECT TIMESTAMPDIFF(SECOND, %s, UTC_TIMESTAMP()) AS lag_seconds, TIMESTAMPDIFF(SECOND, %s, UTC_TIMESTAMP()) AS soak_seconds``
+      - ``SELECT run_status FROM sync_runs WHERE dataset_key = %s ORDER BY started_at DESC LIMIT %s``
+
+    Plus the two execute shapes from propose/approve_backfill_complete.
+    """
+
+    def __init__(
+        self,
+        *,
+        now: datetime,
+        sync_state: dict[str, dict[str, Any]],
+        sync_runs: dict[str, list[dict[str, Any]]] | None = None,
+    ) -> None:
+        self.now = now
+        self.sync_state: dict[str, dict[str, Any]] = {
+            key: dict(row) for key, row in sync_state.items()
+        }
+        self.sync_runs = sync_runs or {}
+        self.executes: list[tuple[str, tuple[Any, ...]]] = []
+
+    # -- fetch -----------------------------------------------------------
+
+    def fetch_all(self, sql: str, params: Any = None) -> list[dict[str, Any]]:
+        compact = " ".join(sql.split()).upper()
+        params_tuple = tuple(params or ())
+
+        if "FROM SYNC_STATE" in compact and "BACKFILL_PROPOSED_AT IS NULL" in compact:
+            # Pass 1: candidates to propose.
+            return [
+                dict(row) for row in self.sync_state.values()
+                if int(row.get("backfill_complete") or 0) == 0
+                and row.get("backfill_proposed_at") is None
+            ]
+
+        if (
+            "FROM SYNC_STATE" in compact
+            and "BACKFILL_PROPOSED_AT IS NOT NULL" in compact
+            and "AUTO_APPROVE_BLOCKED = 0" in compact
+        ):
+            # Pass 2: candidates to auto-approve.
+            rows: list[dict[str, Any]] = []
+            for row in self.sync_state.values():
+                if int(row.get("backfill_complete") or 0) != 0:
+                    continue
+                if row.get("backfill_proposed_at") is None:
+                    continue
+                if int(row.get("auto_approve_blocked") or 0) != 0:
+                    continue
+                copy = dict(row)
+                proposed_at = row.get("backfill_proposed_at")
+                if isinstance(proposed_at, datetime):
+                    age = int((self.now - proposed_at).total_seconds())
+                else:
+                    age = 0
+                copy["proposal_age_seconds"] = age
+                rows.append(copy)
+            return rows
+
+        if "FROM SYNC_RUNS" in compact:
+            # SELECT run_status FROM sync_runs WHERE dataset_key = %s ORDER BY started_at DESC LIMIT %s
+            dataset_key = str(params_tuple[0]) if params_tuple else ""
+            limit = int(params_tuple[1]) if len(params_tuple) > 1 else 0
+            runs = self.sync_runs.get(dataset_key, [])
+            return [dict(r) for r in runs[:limit]]
+
+        raise AssertionError(f"Unexpected fetch_all SQL: {compact}")
+
+    def fetch_one(self, sql: str, params: Any = None) -> dict[str, Any] | None:
+        compact = " ".join(sql.split()).upper()
+        params_tuple = tuple(params or ())
+
+        if "UTC_TIMESTAMP() AS NOW_UTC" in compact:
+            return {"now_utc": self.now}
+
+        if "LAG_SECONDS" in compact and "SOAK_SECONDS" in compact:
+            watermark = params_tuple[0]
+            last_success = params_tuple[1]
+            lag = int((self.now - watermark).total_seconds()) if isinstance(watermark, datetime) else 0
+            soak = int((self.now - last_success).total_seconds()) if isinstance(last_success, datetime) else 0
+            return {"lag_seconds": lag, "soak_seconds": soak}
+
+        raise AssertionError(f"Unexpected fetch_one SQL: {compact}")
+
+    # -- execute ---------------------------------------------------------
+
+    def execute(self, sql: str, params: Any = None) -> int:
+        params_tuple = tuple(params or ())
+        self.executes.append((sql, params_tuple))
+        compact = " ".join(sql.split()).upper()
+
+        if "BACKFILL_PROPOSED_AT = COALESCE" in compact:
+            reason, dataset_key = params_tuple
+            row = self.sync_state.get(str(dataset_key))
+            if row is None or int(row.get("backfill_complete") or 0) != 0:
+                return 0
+            # COALESCE(existing, UTC_TIMESTAMP()): only stamp when unset.
+            if row.get("backfill_proposed_at") is None:
+                row["backfill_proposed_at"] = self.now
+            row["backfill_proposed_reason"] = reason
+            return 1
+
+        if "BACKFILL_COMPLETE = 1" in compact:
+            (dataset_key,) = params_tuple
+            row = self.sync_state.get(str(dataset_key))
+            if row is None:
+                return 0
+            row["backfill_complete"] = 1
+            row["backfill_proposed_at"] = None
+            row["backfill_proposed_reason"] = None
+            return 1
+
+        raise AssertionError(f"Unexpected execute SQL: {compact}")
+
+
+NOW = datetime(2026, 4, 10, 12, 0, 0)
+
+
+def _healthy_state(
+    dataset_key: str,
+    *,
+    backfill_proposed_at: datetime | None = None,
+    stall_count: int = 0,
+    auto_approve_blocked: int = 0,
+    watermark_offset: timedelta = timedelta(hours=2),
+    success_offset: timedelta = timedelta(hours=30),
+) -> dict[str, Any]:
+    """Build a sync_state row that passes every health criterion."""
+    return {
+        "dataset_key": dataset_key,
+        "sync_mode": "incremental",
+        "status": "success",
+        "last_success_at": NOW - success_offset,
+        "last_cursor": "2026-04-10 10:00:00|100",
+        "watermark_event_time": NOW - watermark_offset,
+        "backfill_complete": 0,
+        "backfill_proposed_at": backfill_proposed_at,
+        "backfill_proposed_reason": None,
+        "incremental_horizon_seconds": 86400,
+        "repair_window_seconds": 86400,
+        "stall_cursor": "2026-04-10 10:00:00|100",
+        "stall_count": stall_count,
+        "auto_approve_blocked": auto_approve_blocked,
+    }
+
+
+def _clean_runs(count: int = 5) -> list[dict[str, Any]]:
+    return [{"run_status": "success"} for _ in range(count)]
+
+
+class ProposalPassTests(unittest.TestCase):
+    def test_healthy_dataset_is_proposed_not_approved(self) -> None:
+        db = DetectorFakeDb(
+            now=NOW,
+            sync_state={"test.dataset": _healthy_state("test.dataset")},
+            sync_runs={"test.dataset": _clean_runs()},
+        )
+
+        result = detector._processor(db)
+
+        self.assertEqual(result["meta"]["proposed"][0]["dataset_key"], "test.dataset")
+        self.assertEqual(result["meta"]["auto_approved"], [])
+        self.assertEqual(db.sync_state["test.dataset"]["backfill_complete"], 0)
+        self.assertEqual(
+            db.sync_state["test.dataset"]["backfill_proposed_at"], NOW
+        )
+
+    def test_stalled_dataset_is_skipped(self) -> None:
+        db = DetectorFakeDb(
+            now=NOW,
+            sync_state={"test.dataset": _healthy_state("test.dataset", stall_count=5)},
+            sync_runs={"test.dataset": _clean_runs()},
+        )
+
+        result = detector._processor(db)
+
+        self.assertEqual(result["meta"]["proposed"], [])
+        self.assertEqual(result["meta"]["propose_skipped_count"], 1)
+
+    def test_fresh_proposal_in_same_run_is_not_auto_approved(self) -> None:
+        # Propose pass stamps backfill_proposed_at = NOW, so the approval
+        # pass sees proposal_age_seconds = 0 and skips on the soak check.
+        db = DetectorFakeDb(
+            now=NOW,
+            sync_state={"test.dataset": _healthy_state("test.dataset")},
+            sync_runs={"test.dataset": _clean_runs()},
+        )
+
+        result = detector._processor(db)
+
+        self.assertEqual(len(result["meta"]["proposed"]), 1)
+        self.assertEqual(result["meta"]["auto_approved"], [])
+        self.assertEqual(db.sync_state["test.dataset"]["backfill_complete"], 0)
+
+
+class AutoApproveSoakTests(unittest.TestCase):
+    def test_soaked_proposal_is_auto_approved(self) -> None:
+        old_proposal = NOW - timedelta(seconds=detector._AUTO_APPROVE_SOAK_SECONDS + 60)
+        db = DetectorFakeDb(
+            now=NOW,
+            sync_state={
+                "test.dataset": _healthy_state(
+                    "test.dataset",
+                    backfill_proposed_at=old_proposal,
+                )
+            },
+            sync_runs={"test.dataset": _clean_runs()},
+        )
+
+        result = detector._processor(db)
+
+        self.assertEqual(result["meta"]["proposed"], [])
+        self.assertEqual(len(result["meta"]["auto_approved"]), 1)
+        self.assertEqual(
+            result["meta"]["auto_approved"][0]["dataset_key"], "test.dataset"
+        )
+        self.assertEqual(db.sync_state["test.dataset"]["backfill_complete"], 1)
+        self.assertIsNone(db.sync_state["test.dataset"]["backfill_proposed_at"])
+
+    def test_proposal_still_soaking_is_skipped(self) -> None:
+        recent_proposal = NOW - timedelta(seconds=detector._AUTO_APPROVE_SOAK_SECONDS - 3600)
+        db = DetectorFakeDb(
+            now=NOW,
+            sync_state={
+                "test.dataset": _healthy_state(
+                    "test.dataset",
+                    backfill_proposed_at=recent_proposal,
+                )
+            },
+            sync_runs={"test.dataset": _clean_runs()},
+        )
+
+        result = detector._processor(db)
+
+        self.assertEqual(result["meta"]["auto_approved"], [])
+        self.assertEqual(result["meta"]["approve_skipped_count"], 1)
+        skip = result["meta"]["approve_skipped"][0]
+        self.assertEqual(skip["dataset_key"], "test.dataset")
+        self.assertTrue(skip["reason"].startswith("soaking:"))
+        # Gate stays closed, proposal stays intact.
+        self.assertEqual(db.sync_state["test.dataset"]["backfill_complete"], 0)
+        self.assertEqual(
+            db.sync_state["test.dataset"]["backfill_proposed_at"], recent_proposal
+        )
+
+
+class AutoApproveRecheckTests(unittest.TestCase):
+    def test_recheck_fails_when_dataset_regressed_into_stall(self) -> None:
+        old_proposal = NOW - timedelta(seconds=detector._AUTO_APPROVE_SOAK_SECONDS + 3600)
+        db = DetectorFakeDb(
+            now=NOW,
+            sync_state={
+                "test.dataset": _healthy_state(
+                    "test.dataset",
+                    backfill_proposed_at=old_proposal,
+                    stall_count=detector._MAX_STALL + 1,
+                )
+            },
+            sync_runs={"test.dataset": _clean_runs()},
+        )
+
+        result = detector._processor(db)
+
+        self.assertEqual(result["meta"]["auto_approved"], [])
+        skip = result["meta"]["approve_skipped"][0]
+        self.assertTrue(skip["reason"].startswith("recheck_failed:"))
+        # Gate stays closed; proposal stays intact so the admin can see
+        # the regression in the review queue.
+        self.assertEqual(db.sync_state["test.dataset"]["backfill_complete"], 0)
+        self.assertEqual(
+            db.sync_state["test.dataset"]["backfill_proposed_at"], old_proposal
+        )
+
+    def test_recheck_fails_when_recent_run_failed(self) -> None:
+        old_proposal = NOW - timedelta(seconds=detector._AUTO_APPROVE_SOAK_SECONDS + 60)
+        runs = _clean_runs(4) + [{"run_status": "failed"}]
+        db = DetectorFakeDb(
+            now=NOW,
+            sync_state={
+                "test.dataset": _healthy_state(
+                    "test.dataset",
+                    backfill_proposed_at=old_proposal,
+                )
+            },
+            sync_runs={"test.dataset": runs},
+        )
+
+        result = detector._processor(db)
+
+        self.assertEqual(result["meta"]["auto_approved"], [])
+        skip = result["meta"]["approve_skipped"][0]
+        self.assertIn("recent_failure", skip["reason"])
+        self.assertEqual(db.sync_state["test.dataset"]["backfill_complete"], 0)
+
+    def test_recheck_fails_when_watermark_drifted_outside_horizon(self) -> None:
+        old_proposal = NOW - timedelta(seconds=detector._AUTO_APPROVE_SOAK_SECONDS + 60)
+        db = DetectorFakeDb(
+            now=NOW,
+            sync_state={
+                "test.dataset": _healthy_state(
+                    "test.dataset",
+                    backfill_proposed_at=old_proposal,
+                    watermark_offset=timedelta(hours=48),  # 48h > 24h horizon
+                )
+            },
+            sync_runs={"test.dataset": _clean_runs()},
+        )
+
+        result = detector._processor(db)
+
+        self.assertEqual(result["meta"]["auto_approved"], [])
+        skip = result["meta"]["approve_skipped"][0]
+        self.assertIn("behind_horizon", skip["reason"])
+
+
+class AutoApproveBlockTests(unittest.TestCase):
+    def test_blocked_dataset_is_not_scanned_for_approval(self) -> None:
+        old_proposal = NOW - timedelta(seconds=detector._AUTO_APPROVE_SOAK_SECONDS * 10)
+        db = DetectorFakeDb(
+            now=NOW,
+            sync_state={
+                "test.dataset": _healthy_state(
+                    "test.dataset",
+                    backfill_proposed_at=old_proposal,
+                    auto_approve_blocked=1,
+                )
+            },
+            sync_runs={"test.dataset": _clean_runs()},
+        )
+
+        result = detector._processor(db)
+
+        # Excluded from the approval scan by the SQL WHERE clause.
+        self.assertEqual(result["meta"]["auto_approved"], [])
+        self.assertEqual(result["meta"]["approve_skipped_count"], 0)
+        # Gate stays closed, proposal unchanged.
+        self.assertEqual(db.sync_state["test.dataset"]["backfill_complete"], 0)
+        self.assertEqual(
+            db.sync_state["test.dataset"]["backfill_proposed_at"], old_proposal
+        )
+
+
+class SoakConstantSanityTests(unittest.TestCase):
+    def test_auto_approve_soak_is_longer_than_initial_soak(self) -> None:
+        # The approval soak should dominate the initial propose soak so
+        # a dataset that clears both gates has had time to run cleanly
+        # *and* sit in the review queue.
+        self.assertGreaterEqual(
+            detector._AUTO_APPROVE_SOAK_SECONDS,
+            detector._SOAK_SECONDS,
+        )
+
+    def test_auto_approve_soak_is_at_least_24_hours(self) -> None:
+        self.assertGreaterEqual(detector._AUTO_APPROVE_SOAK_SECONDS, 24 * 3600)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/db.php
+++ b/src/db.php
@@ -2549,6 +2549,7 @@ function db_sync_state_horizon_columns_ensure(): void
     db_ensure_table_column('sync_state', 'repair_window_seconds', 'INT UNSIGNED NOT NULL DEFAULT 86400 AFTER incremental_horizon_seconds');
     db_ensure_table_column('sync_state', 'stall_cursor', 'VARCHAR(190) DEFAULT NULL AFTER repair_window_seconds');
     db_ensure_table_column('sync_state', 'stall_count', 'INT UNSIGNED NOT NULL DEFAULT 0 AFTER stall_cursor');
+    db_ensure_table_column('sync_state', 'auto_approve_blocked', 'TINYINT(1) NOT NULL DEFAULT 0 AFTER stall_count');
 }
 
 /**
@@ -2573,6 +2574,7 @@ function db_horizon_state_get(string $datasetKey): ?array
                 repair_window_seconds,
                 stall_cursor,
                 stall_count,
+                auto_approve_blocked,
                 updated_at
          FROM sync_state
          WHERE dataset_key = ?
@@ -2588,6 +2590,7 @@ function db_horizon_state_get(string $datasetKey): ?array
     $row['incremental_horizon_seconds'] = (int) $row['incremental_horizon_seconds'];
     $row['repair_window_seconds'] = (int) $row['repair_window_seconds'];
     $row['stall_count'] = (int) $row['stall_count'];
+    $row['auto_approve_blocked'] = (int) $row['auto_approve_blocked'] === 1;
 
     return $row;
 }
@@ -2776,6 +2779,45 @@ function db_horizon_reset_backfill_complete(string $datasetKey): bool
 }
 
 /**
+ * Opt a dataset out of the detect_backfill_complete auto-approval loop.
+ *
+ * When set, detect_backfill_complete will still *propose* the dataset for
+ * backfill_complete (so it shows up in the admin review queue) but will
+ * never auto-flip the gate regardless of how long the proposal has been
+ * soaking. Useful for datasets that need a human eye on the cutover.
+ */
+function db_horizon_block_auto_approve(string $datasetKey): bool
+{
+    db_sync_state_horizon_columns_ensure();
+
+    return db_execute(
+        'UPDATE sync_state
+            SET auto_approve_blocked = 1,
+                updated_at = CURRENT_TIMESTAMP
+          WHERE dataset_key = ?',
+        [$datasetKey]
+    );
+}
+
+/**
+ * Clear a previously-set auto-approval block. The dataset becomes eligible
+ * for auto-approval again on the next detect_backfill_complete run (subject
+ * to the usual soak and health criteria).
+ */
+function db_horizon_unblock_auto_approve(string $datasetKey): bool
+{
+    db_sync_state_horizon_columns_ensure();
+
+    return db_execute(
+        'UPDATE sync_state
+            SET auto_approve_blocked = 0,
+                updated_at = CURRENT_TIMESTAMP
+          WHERE dataset_key = ?',
+        [$datasetKey]
+    );
+}
+
+/**
  * Manually rewind a dataset's forward cursor. Used when out-of-window late
  * data lands (bigger than repair_window_seconds) and we need to re-process
  * a range of source events. Bypasses the monotonic guard.
@@ -2836,6 +2878,7 @@ function db_calculation_freshness_report(?string $datasetPrefix = null): array
             ss.incremental_horizon_seconds,
             ss.repair_window_seconds,
             ss.stall_count,
+            ss.auto_approve_blocked,
             CASE
                 WHEN ss.watermark_event_time IS NULL THEN NULL
                 ELSE TIMESTAMPDIFF(SECOND, ss.watermark_event_time, UTC_TIMESTAMP())
@@ -2867,6 +2910,7 @@ function db_calculation_freshness_report(?string $datasetPrefix = null): array
         $row['incremental_horizon_seconds'] = (int) $row['incremental_horizon_seconds'];
         $row['repair_window_seconds'] = (int) $row['repair_window_seconds'];
         $row['stall_count'] = (int) $row['stall_count'];
+        $row['auto_approve_blocked'] = (int) $row['auto_approve_blocked'] === 1;
         $row['freshness_lag_seconds'] = $row['freshness_lag_seconds'] === null
             ? null
             : (int) $row['freshness_lag_seconds'];
@@ -2901,7 +2945,7 @@ function db_horizon_list_pending_proposals(): array
 {
     db_sync_state_horizon_columns_ensure();
 
-    return db_select(
+    $rows = db_select(
         'SELECT dataset_key,
                 sync_mode,
                 backfill_proposed_at,
@@ -2909,12 +2953,21 @@ function db_horizon_list_pending_proposals(): array
                 last_success_at,
                 watermark_event_time,
                 last_cursor,
-                stall_count
+                stall_count,
+                auto_approve_blocked
          FROM sync_state
          WHERE backfill_complete = 0
            AND backfill_proposed_at IS NOT NULL
          ORDER BY backfill_proposed_at ASC'
     );
+
+    foreach ($rows as &$row) {
+        $row['stall_count'] = (int) $row['stall_count'];
+        $row['auto_approve_blocked'] = (int) $row['auto_approve_blocked'] === 1;
+    }
+    unset($row);
+
+    return $rows;
 }
 
 function db_market_orders_history_legacy_table(): string


### PR DESCRIPTION
## Summary

Extends `detect_backfill_complete` with a second pass that auto-flips `backfill_complete` for proposals that have soaked long enough **and** still pass the health check at approval time. Operators no longer have to manually run `bin/horizon-approve.php` for boring cases — the system proposes, waits, re-checks, and approves on its own. Block auto-approval per-dataset for anything that still needs a human eye.

## Timeline for a well-behaved dataset

| Time | Event |
|---|---|
| T+0 | Backfill completes, job runs cleanly in full/backfill + incremental |
| T+24h | First `detect_backfill_complete` pass stamps `backfill_proposed_at` |
| T+24h..T+72h | Proposal soaks; admin can approve early, block forever, reject, or wait |
| T+72h | Second pass re-runs the health check; auto-flips `backfill_complete = 1` if still healthy |

The **re-check at approval time** is the critical safety layer: if the dataset regressed during the soak (stall, failed run, lag outside SLA), the auto-approver leaves the proposal pending and the freshness dashboard reflects the regression (skip reason: `recheck_failed:...`).

## What's in the box

- **Migration**: `database/migrations/20260510_horizon_auto_approve.sql` adds `sync_state.auto_approve_blocked TINYINT(1) NOT NULL DEFAULT 0` (opt-out, not opt-in).
- **Detector**: `python/orchestrator/jobs/detect_backfill_complete.py` now runs two passes. New `_AUTO_APPROVE_SOAK_SECONDS = 48h` constant gates approval.
- **PHP/Python helpers**: `db_horizon_block_auto_approve` / `db_horizon_unblock_auto_approve` and matching Python mirrors; column wired through `db_horizon_state_get`, `db_calculation_freshness_report`, `db_horizon_list_pending_proposals` and the Python `HorizonState` dataclass.
- **CLIs**: `bin/horizon-block.php` and `bin/horizon-unblock.php` for ops overrides.
- **Admin UI** (`public/settings/index.php`): Block / Unblock buttons on pending proposals and a visible `auto-approve blocked` badge. Helper text updated with the new workflow.
- **Tests**: 11 new unit tests in `python/tests/test_detect_backfill_complete.py` covering:
  - Healthy dataset → proposed (not auto-approved in same run)
  - Stalled dataset → skipped
  - Soaked proposal + still healthy → auto-approved
  - Soaking proposal (age < 48h) → skipped with `soaking:...` reason
  - Regressed via stall → `recheck_failed:stalled:...`
  - Regressed via recent failure → `recheck_failed:recent_failure`
  - Regressed via watermark drift → `recheck_failed:behind_horizon:...`
  - `auto_approve_blocked = 1` → excluded from approval scan entirely
  - Soak-constant sanity (auto-soak ≥ propose-soak, ≥ 24h)
- **Docs**: `docs/OPERATIONS_GUIDE.md` gets a new Auto-Approval section with the T+0 → T+72h timeline, the block/unblock workflow, and the full tunables list.

## Test plan

- [x] `python -m unittest python.tests.test_detect_backfill_complete python.tests.test_horizon` — 40/40 passing
- [x] `php -l` on all modified PHP files
- [x] `python -m py_compile` on modified Python files
- [ ] Migration applies cleanly on a fresh database
- [ ] Admin UI: pending proposal card renders with Block/Unblock buttons and the badge shows when blocked
- [ ] CLI: `bin/horizon-block.php <dataset>` and `bin/horizon-unblock.php <dataset>` round-trip cleanly
- [ ] End-to-end: stamp a test dataset's `backfill_proposed_at` to `NOW() - INTERVAL 49 HOUR`, run `detect_backfill_complete`, confirm `backfill_complete` flips to 1
- [ ] End-to-end: same setup but stall the dataset first, confirm the auto-approver skips with `recheck_failed:stalled:...`

## Operational notes

- Default behavior is **opt-out**: every dataset is eligible for auto-approval unless explicitly blocked. If you want a dataset to always require manual approval, run `php bin/horizon-unblock.php` — wait, `php bin/horizon-block.php <dataset_key>`.
- Existing rows get `auto_approve_blocked = 0` from the `DEFAULT 0` on the migration.
- Tunables live at the top of `detect_backfill_complete.py`: `_SOAK_SECONDS`, `_AUTO_APPROVE_SOAK_SECONDS`, `_MIN_CLEAN_RUNS`, `_MAX_STALL`.
- Rollback: `bin/horizon-reset.php <dataset_key>` still works — flips `backfill_complete` back to 0 and clears the proposal, regardless of how approval happened.

https://claude.ai/code/session_012LcKLSmFojWtMSN9aPgDH7