### PR TITLE
Add hourly autonomous update + issue-triage loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ public-proxy/storage/*.sqlite-journal
 public-proxy/storage/*.sqlite-wal
 public-proxy/storage/*.sqlite-shm
 /logs/
+storage/logs/hourly-loop/

--- a/ops/systemd/supplycore-hourly-loop.service
+++ b/ops/systemd/supplycore-hourly-loop.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=SupplyCore hourly autonomous update + issue-triage loop
+Documentation=file:///var/www/SupplyCore/scripts/hourly-loop.sh
+After=network-online.target mariadb.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# This unit invokes scripts/update-and-restart.sh which manages systemd
+# units and restarts other services — it therefore requires root.
+User=root
+Group=root
+WorkingDirectory=/var/www/SupplyCore
+Environment=APP_ROOT=/var/www/SupplyCore
+# Pick up GITHUB_TOKEN / GITHUB_REPO from .env; the script also sources
+# .env itself, but this keeps systemd-unit-level overrides possible.
+EnvironmentFile=-/etc/default/supplycore-hourly-loop
+ExecStart=/var/www/SupplyCore/scripts/hourly-loop.sh
+# The script manages its own per-run logs under storage/logs/hourly-loop/.
+# systemd stdout/stderr is appended for journalctl-level visibility.
+StandardOutput=append:/var/www/SupplyCore/storage/logs/hourly-loop/systemd.log
+StandardError=append:/var/www/SupplyCore/storage/logs/hourly-loop/systemd.log
+# Give the update/migration/restart phase headroom but don't hang forever.
+TimeoutStartSec=1800
+Nice=10
+IOSchedulingClass=best-effort
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/supplycore-hourly-loop.timer
+++ b/ops/systemd/supplycore-hourly-loop.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Run the SupplyCore hourly loop once per hour
+Documentation=file:///var/www/SupplyCore/scripts/hourly-loop.sh
+
+[Timer]
+# Fire every hour on the hour, with a small random offset so multiple
+# hosts never hit GitHub's API at the exact same second.
+OnCalendar=hourly
+RandomizedDelaySec=60
+# If the system was off when a run was due, run once on boot to catch up.
+Persistent=true
+AccuracySec=1m
+Unit=supplycore-hourly-loop.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/hourly-loop.sh
+++ b/scripts/hourly-loop.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+#
+# SupplyCore hourly loop — autonomous update + issue-triage cron.
+#
+# What this script does, once per hour (driven by supplycore-hourly-loop.timer):
+#
+#   1. Header the run log with the last N run summaries so Claude or a human
+#      reading the log sees cross-run context without chasing files.
+#   2. Run scripts/update-and-restart.sh --smart (git pull, sync units;
+#      only restart services when git SHA or unit files actually changed).
+#   3. Run the orchestrator log-to-issues worker directly (not via the
+#      in-process scheduler), so failures still get filed as GitHub issues
+#      even when the orchestrator itself is broken.
+#   4. Build a combined JSON summary and append it to summary.jsonl.
+#   5. Create (or reuse) a pinned GitHub tracker issue and post the summary
+#      + run-log tail as a comment. That tracker issue is the durable,
+#      cross-session memory: anyone (or any future Claude run) can read
+#      the last comments to know what was tried, what failed, and whether
+#      the latest fix stuck.
+#   6. Prune run logs older than ${HOURLY_LOOP_LOG_RETENTION_DAYS:-7} days.
+#
+# The script is intentionally idempotent and safe to run manually for a
+# dry-cycle before enabling the timer:
+#
+#   sudo /var/www/SupplyCore/scripts/hourly-loop.sh
+#
+# Environment:
+#   GITHUB_TOKEN (optional but required to post to the tracker issue)
+#   GITHUB_REPO  (default: maferick/SupplyCore)
+#   APP_ROOT     (default: repo root relative to this script)
+#   HOURLY_LOOP_CONTEXT_TAIL          (default: 5)
+#   HOURLY_LOOP_LOG_RETENTION_DAYS    (default: 7)
+#
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+APP_ROOT=${APP_ROOT:-$(cd -- "${SCRIPT_DIR}/.." && pwd)}
+
+LOG_DIR="${APP_ROOT}/storage/logs/hourly-loop"
+SUMMARY_FILE="${LOG_DIR}/summary.jsonl"
+TRACKER_FILE="${LOG_DIR}/tracker_issue.txt"
+RUN_TS=$(date -u +'%Y%m%dT%H%M%SZ')
+RUN_LOG="${LOG_DIR}/run-${RUN_TS}.log"
+CONTEXT_TAIL=${HOURLY_LOOP_CONTEXT_TAIL:-5}
+RUN_LOG_RETENTION_DAYS=${HOURLY_LOOP_LOG_RETENTION_DAYS:-7}
+
+mkdir -p "${LOG_DIR}"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+err() {
+  printf '[%s] ERROR: %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" >&2
+}
+
+# ── Load .env (for GITHUB_TOKEN / GITHUB_REPO) ────────────────────────
+if [[ -f "${APP_ROOT}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1090,SC1091
+  source "${APP_ROOT}/.env"
+  set +a
+fi
+
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
+GITHUB_REPO=${GITHUB_REPO:-maferick/SupplyCore}
+
+# ── Decide which branch the hourly loop should track ─────────────────
+# Policy: default to main, but if the working tree is currently on a
+# feature branch (claude/*, codex/*, anything non-main), stay on it —
+# we cannot auto-merge feature branches back to main from this loop.
+cd "${APP_ROOT}"
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ -z "${CURRENT_BRANCH}" || "${CURRENT_BRANCH}" == "HEAD" ]]; then
+  TARGET_BRANCH="main"
+else
+  TARGET_BRANCH="${CURRENT_BRANCH}"
+fi
+
+# ── Pick the python interpreter for orchestrator calls ───────────────
+PYTHON_BIN=""
+if [[ -x "${APP_ROOT}/.venv-orchestrator/bin/python" ]]; then
+  PYTHON_BIN="${APP_ROOT}/.venv-orchestrator/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN=$(command -v python3)
+fi
+
+# ── Seed the run log with cross-run context ──────────────────────────
+{
+  echo "=== SupplyCore hourly loop ==="
+  echo "run_ts=${RUN_TS}"
+  echo "target_branch=${TARGET_BRANCH}"
+  echo "current_branch=${CURRENT_BRANCH}"
+  echo "app_root=${APP_ROOT}"
+  echo "python_bin=${PYTHON_BIN:-<none>}"
+  echo "github_repo=${GITHUB_REPO}"
+  echo "github_token_set=$([[ -n "${GITHUB_TOKEN}" ]] && echo yes || echo no)"
+  echo
+  if [[ -s "${SUMMARY_FILE}" ]]; then
+    echo "--- Previous ${CONTEXT_TAIL} run summaries (tail of summary.jsonl) ---"
+    tail -n "${CONTEXT_TAIL}" "${SUMMARY_FILE}" || true
+    echo
+  else
+    echo "--- No previous run summaries (first hourly run) ---"
+    echo
+  fi
+  echo "--- update-and-restart.sh output ---"
+} >"${RUN_LOG}"
+
+log "Hourly loop started (run ${RUN_TS}, branch ${TARGET_BRANCH})" | tee -a "${RUN_LOG}"
+
+# ── Step 1: update-and-restart (smart mode) ──────────────────────────
+UPDATE_EXIT=0
+set +e
+"${APP_ROOT}/scripts/update-and-restart.sh" \
+  --branch "${TARGET_BRANCH}" \
+  --smart \
+  2>&1 | tee -a "${RUN_LOG}"
+UPDATE_EXIT=${PIPESTATUS[0]}
+set -e
+
+UPDATE_SUMMARY_LINE=$(grep '^HOURLY_LOOP_SUMMARY: ' "${RUN_LOG}" | tail -n1 || true)
+UPDATE_SUMMARY_JSON="${UPDATE_SUMMARY_LINE#HOURLY_LOOP_SUMMARY: }"
+if [[ -z "${UPDATE_SUMMARY_JSON}" ]]; then
+  UPDATE_SUMMARY_JSON='{}'
+fi
+
+# ── Step 2: log-to-issues worker (direct, not via scheduler) ─────────
+{
+  echo
+  echo "--- log_to_issues worker output ---"
+} >>"${RUN_LOG}"
+
+ISSUES_EXIT=0
+ISSUES_SUMMARY_JSON='{}'
+if [[ -n "${PYTHON_BIN}" ]]; then
+  set +e
+  "${PYTHON_BIN}" "${APP_ROOT}/bin/python_orchestrator.py" log-to-issues \
+    --app-root "${APP_ROOT}" \
+    2>&1 | tee -a "${RUN_LOG}"
+  ISSUES_EXIT=${PIPESTATUS[0]}
+  set -e
+
+  # _print_cli_result prints a single JSON dict line with "command":"log-to-issues".
+  # It's unique in the log because structured log entries use different keys.
+  ISSUES_SUMMARY_LINE=$(grep -E '^\{"command": *"log-to-issues"' "${RUN_LOG}" | tail -n1 || true)
+  if [[ -n "${ISSUES_SUMMARY_LINE}" ]]; then
+    ISSUES_SUMMARY_JSON="${ISSUES_SUMMARY_LINE}"
+  fi
+else
+  err "No python3 or .venv-orchestrator interpreter found — skipping log-to-issues" \
+    | tee -a "${RUN_LOG}"
+  ISSUES_EXIT=127
+fi
+
+# ── Step 3: combine into a single JSONL summary record ───────────────
+COMBINED_JSON=$(
+  UPDATE_SUMMARY_JSON="${UPDATE_SUMMARY_JSON}" \
+  ISSUES_SUMMARY_JSON="${ISSUES_SUMMARY_JSON}" \
+  RUN_TS="${RUN_TS}" \
+  TARGET_BRANCH="${TARGET_BRANCH}" \
+  UPDATE_EXIT="${UPDATE_EXIT}" \
+  ISSUES_EXIT="${ISSUES_EXIT}" \
+  RUN_LOG_NAME="$(basename "${RUN_LOG}")" \
+  "${PYTHON_BIN:-python3}" - <<'PY'
+import json, os
+
+def safe_loads(s):
+    s = (s or "").strip()
+    if not s:
+        return {}
+    try:
+        return json.loads(s)
+    except Exception:
+        return {"raw": s[:500]}
+
+u = safe_loads(os.environ.get("UPDATE_SUMMARY_JSON", ""))
+i = safe_loads(os.environ.get("ISSUES_SUMMARY_JSON", ""))
+
+i_result = i.get("result", {}) if isinstance(i, dict) else {}
+if not isinstance(i_result, dict):
+    i_result = {}
+
+out = {
+    "ts": os.environ["RUN_TS"],
+    "branch": os.environ["TARGET_BRANCH"],
+    "run_log": os.environ["RUN_LOG_NAME"],
+    "update_exit": int(os.environ.get("UPDATE_EXIT", "0") or 0),
+    "issues_exit": int(os.environ.get("ISSUES_EXIT", "0") or 0),
+    "update": u,
+    "log_to_issues": {
+        "status": i.get("status") if isinstance(i, dict) else None,
+        "duration_ms": i.get("duration_ms") if isinstance(i, dict) else None,
+        "rows_processed": i.get("rows_processed") if isinstance(i, dict) else None,
+        "rows_written": i.get("rows_written") if isinstance(i, dict) else None,
+        "summary": i_result.get("summary"),
+        "meta": i_result.get("meta"),
+        "warnings": i_result.get("warnings"),
+    },
+}
+print(json.dumps(out, default=str))
+PY
+)
+
+if [[ -z "${COMBINED_JSON}" ]]; then
+  COMBINED_JSON="{\"ts\":\"${RUN_TS}\",\"error\":\"combine_failed\"}"
+fi
+
+echo "${COMBINED_JSON}" >>"${SUMMARY_FILE}"
+{
+  echo
+  echo "--- combined summary ---"
+  echo "${COMBINED_JSON}"
+} >>"${RUN_LOG}"
+
+# ── Step 4: post to GitHub tracker issue ─────────────────────────────
+post_to_tracker() {
+  local repo="$1" token="$2"
+
+  if [[ -z "${token}" ]]; then
+    log "GITHUB_TOKEN not set — skipping tracker post" | tee -a "${RUN_LOG}"
+    return 0
+  fi
+  if [[ -z "${PYTHON_BIN}" ]]; then
+    err "No python available for tracker API calls — skipping" | tee -a "${RUN_LOG}"
+    return 0
+  fi
+
+  local tracker_number=""
+  if [[ -f "${TRACKER_FILE}" ]]; then
+    tracker_number=$(<"${TRACKER_FILE}")
+    tracker_number="${tracker_number//[[:space:]]/}"
+  fi
+
+  # Render the comment body into a tempfile so we don't have to worry about
+  # shell-escaping JSON/markdown.
+  local body_file
+  body_file=$(mktemp)
+  {
+    echo "## Run ${RUN_TS}"
+    echo
+    echo "- **Branch:** \`${TARGET_BRANCH}\`"
+    echo "- **Update exit:** \`${UPDATE_EXIT}\`"
+    echo "- **Log-to-issues exit:** \`${ISSUES_EXIT}\`"
+    echo
+    echo "### Combined summary"
+    echo '```json'
+    echo "${COMBINED_JSON}"
+    echo '```'
+    echo
+    echo "### Run log tail (last 120 lines)"
+    echo '```'
+    tail -n 120 "${RUN_LOG}" | sed 's/```/ˋˋˋ/g'
+    echo '```'
+    echo
+    echo "_Automated post by \`scripts/hourly-loop.sh\`. Full log on host: \`storage/logs/hourly-loop/${RUN_LOG##*/}\`._"
+  } >"${body_file}"
+
+  TRACKER_NUMBER="${tracker_number}" \
+  TRACKER_FILE_PATH="${TRACKER_FILE}" \
+  REPO="${repo}" \
+  TOKEN="${token}" \
+  BODY_FILE="${body_file}" \
+    "${PYTHON_BIN}" - <<'PY'
+import json, os, sys, urllib.request, urllib.error
+
+repo = os.environ["REPO"]
+token = os.environ["TOKEN"]
+tracker_file = os.environ["TRACKER_FILE_PATH"]
+tracker_number = os.environ.get("TRACKER_NUMBER", "").strip()
+with open(os.environ["BODY_FILE"], "r", encoding="utf-8") as fh:
+    body = fh.read()
+
+HEADERS = {
+    "Authorization": f"token {token}",
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "SupplyCore-HourlyLoop/1.0",
+    "Content-Type": "application/json",
+}
+
+
+def api(method, path, payload=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        data=data,
+        headers=HEADERS,
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        return json.loads(raw) if raw else None
+
+
+# Create the pinned tracker issue on first run.
+if not tracker_number:
+    try:
+        created = api(
+            "POST",
+            f"/repos/{repo}/issues",
+            {
+                "title": "[Auto] Hourly loop — run log",
+                "body": (
+                    "**Pinned meta-issue — do not close manually.**\n\n"
+                    "Each hourly run of `scripts/hourly-loop.sh` adds a comment here "
+                    "with its summary, run-log tail, and links to any `auto-log` issues "
+                    "filed during the run.\n\n"
+                    "This issue is the cross-run memory for the automated "
+                    "update / issue-triage loop. Claude Code and human operators can "
+                    "read the last few comments to see what was tried, what failed, and "
+                    "whether the latest fix is sticking.\n"
+                ),
+                "labels": ["auto-log", "hourly-loop"],
+            },
+        )
+    except urllib.error.HTTPError as exc:
+        err_body = exc.read().decode("utf-8", errors="replace")[:300]
+        sys.stderr.write(f"Failed to create tracker issue: {exc.code} {err_body}\n")
+        sys.exit(2)
+    tracker_number = str((created or {}).get("number") or "")
+    if not tracker_number:
+        sys.stderr.write(f"Tracker creation returned no issue number: {created}\n")
+        sys.exit(2)
+    with open(tracker_file, "w", encoding="utf-8") as fh:
+        fh.write(tracker_number + "\n")
+    print(f"Created tracker issue #{tracker_number}")
+
+# Reopen if the tracker was accidentally closed.
+try:
+    issue = api("GET", f"/repos/{repo}/issues/{tracker_number}")
+    if isinstance(issue, dict) and issue.get("state") == "closed":
+        api("PATCH", f"/repos/{repo}/issues/{tracker_number}", {"state": "open"})
+        print(f"Reopened tracker issue #{tracker_number}")
+except urllib.error.HTTPError as exc:
+    sys.stderr.write(f"Tracker fetch/reopen failed: {exc.code}\n")
+
+# Post the run comment.
+try:
+    api(
+        "POST",
+        f"/repos/{repo}/issues/{tracker_number}/comments",
+        {"body": body},
+    )
+    print(f"Posted comment to tracker issue #{tracker_number}")
+except urllib.error.HTTPError as exc:
+    err_body = exc.read().decode("utf-8", errors="replace")[:300]
+    sys.stderr.write(f"Tracker comment failed: {exc.code} {err_body}\n")
+    sys.exit(2)
+PY
+  local rc=$?
+  rm -f "${body_file}"
+  return ${rc}
+}
+
+if ! post_to_tracker "${GITHUB_REPO}" "${GITHUB_TOKEN}" 2>&1 | tee -a "${RUN_LOG}"; then
+  err "Tracker post failed (non-fatal)" | tee -a "${RUN_LOG}"
+fi
+
+# ── Step 5: prune run logs older than retention window ───────────────
+find "${LOG_DIR}" -name 'run-*.log' -type f -mtime "+${RUN_LOG_RETENTION_DAYS}" -delete 2>/dev/null || true
+
+log "Hourly loop finished (update_exit=${UPDATE_EXIT} issues_exit=${ISSUES_EXIT})" \
+  | tee -a "${RUN_LOG}"
+
+# Exit non-zero so systemd flags a failure if either critical step broke.
+if [[ ${UPDATE_EXIT} -ne 0 || ${ISSUES_EXIT} -ne 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -15,8 +15,20 @@ BUILD_ASSETS=0
 ANALYZE_TABLES=0
 GRACEFUL_STOP=0
 HEALTH_CHECK=1
+SMART_MODE=0
 BRANCH=""
 EXPLICIT_SERVICES=()
+
+# Smart-mode bookkeeping (tracked across phases, consumed at end for
+# the HOURLY_LOOP_SUMMARY emission so scripts/hourly-loop.sh can adapt).
+GIT_SHA_BEFORE=""
+GIT_SHA_AFTER=""
+GIT_CHANGED=0
+UNITS_CHANGED=0
+SMART_SKIP_RESTART=0
+RESTART_SERVICES=()
+FAILED_SERVICES=()
+UNHEALTHY_SERVICES=()
 
 # Timeout (seconds) to wait for a service to become active after restart.
 HEALTH_CHECK_TIMEOUT=30
@@ -24,6 +36,11 @@ HEALTH_CHECK_TIMEOUT=30
 # Services that should always be installed if not already present.
 # The orchestrator and legacy worker@ are opt-in only (installed via
 # install-services.sh) — they are NOT auto-installed here.
+#
+# The hourly-loop unit files are synced here too, but the timer is NOT
+# enabled automatically. Operators enable it with:
+#   sudo systemctl enable --now supplycore-hourly-loop.timer
+# after reviewing one manual run.
 CORE_UNITS=(
   supplycore-loop-runner.service
   supplycore-lane-realtime.service
@@ -36,6 +53,8 @@ CORE_UNITS=(
   supplycore-backfill-runner.service
   supplycore-influx-rollup-export.service
   supplycore-influx-rollup-export.timer
+  supplycore-hourly-loop.service
+  supplycore-hourly-loop.timer
 )
 
 # Units that are opt-in only — update if already installed, but don't install.
@@ -73,6 +92,11 @@ Options:
   --no-migrations        Skip running database migrations
   --no-sync-units        Skip syncing systemd unit files from ops/systemd/
   --no-health-check      Skip post-restart health verification
+  --smart                Smart mode: if neither the git HEAD SHA nor any
+                         systemd unit file changed during this run, skip
+                         migrations, daemon-reload, and service restarts.
+                         Used by scripts/hourly-loop.sh to avoid hourly
+                         restart churn when there is nothing to deploy.
   --dry-run              Print actions without executing mutating commands
   --verbose              Print each command before executing
   -h, --help             Show this help
@@ -158,6 +182,10 @@ parse_args() {
         HEALTH_CHECK=0
         shift
         ;;
+      --smart)
+        SMART_MODE=1
+        shift
+        ;;
       --dry-run)
         DRY_RUN=1
         shift
@@ -199,6 +227,8 @@ preflight_checks() {
 git_update() {
   cd "${APP_ROOT}"
 
+  GIT_SHA_BEFORE=$(git rev-parse HEAD 2>/dev/null || echo "")
+
   # Stash any uncommitted changes before pull to avoid failures
   local stashed=0
   if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
@@ -213,16 +243,32 @@ git_update() {
 
   run_cmd git fetch --all --prune
 
-  # Try fast-forward first; if that fails (diverged), let the user know
-  if ! run_cmd git pull --ff-only 2>/dev/null; then
-    log_warn "Fast-forward pull failed (branch may have diverged). Attempting merge pull."
-    run_cmd git pull --no-edit
+  # Only attempt to pull if the current branch has an upstream configured.
+  # Local-only branches (common during dev) have no tracking ref and would
+  # fail both ff-only and merge pulls — skip cleanly instead.
+  local current_branch
+  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if git rev-parse --abbrev-ref "@{u}" >/dev/null 2>&1; then
+    if ! run_cmd git pull --ff-only 2>/dev/null; then
+      log_warn "Fast-forward pull failed (branch may have diverged). Attempting merge pull."
+      run_cmd git pull --no-edit
+    fi
+  else
+    log_warn "Current branch '${current_branch}' has no upstream; skipping git pull."
   fi
 
   # Restore stashed changes
   if [[ ${stashed} -eq 1 ]]; then
     log "Restoring stashed local changes"
     run_cmd git stash pop || log_warn "Could not restore stash cleanly. Check 'git stash list'."
+  fi
+
+  GIT_SHA_AFTER=$(git rev-parse HEAD 2>/dev/null || echo "")
+  if [[ -n "${GIT_SHA_BEFORE}" && -n "${GIT_SHA_AFTER}" && "${GIT_SHA_BEFORE}" != "${GIT_SHA_AFTER}" ]]; then
+    GIT_CHANGED=1
+    log "Git HEAD changed: ${GIT_SHA_BEFORE:0:8} -> ${GIT_SHA_AFTER:0:8}"
+  else
+    log "Git HEAD unchanged at ${GIT_SHA_AFTER:0:8}"
   fi
 }
 
@@ -247,6 +293,7 @@ sync_systemd_units() {
     fi
     log "Installing ${unit}"
     run_cmd cp "${src}" "${dest}"
+    UNITS_CHANGED=1
   done
 
   # Update opt-in units only if already installed
@@ -264,6 +311,7 @@ sync_systemd_units() {
     fi
     log "Updating opt-in unit ${unit}"
     run_cmd cp "${src}" "${dest}"
+    UNITS_CHANGED=1
   done
 
   # Remove known stale units
@@ -276,6 +324,7 @@ sync_systemd_units() {
     run_cmd systemctl stop "${unit}" 2>/dev/null || true
     run_cmd systemctl disable "${unit}" 2>/dev/null || true
     run_cmd rm -f "${dest}"
+    UNITS_CHANGED=1
   done
 
   # Also clean up any stale templated instances of stale units
@@ -525,112 +574,135 @@ if [[ ${SYNC_UNITS} -eq 1 ]]; then
   sync_systemd_units
 fi
 
-# ------- Database migrations -------
-if [[ ${RUN_MIGRATIONS} -eq 1 ]]; then
-  run_migrations
+# ------- Smart mode: decide whether to skip migrations + restart -------
+if [[ ${SMART_MODE} -eq 1 && ${GIT_CHANGED} -eq 0 && ${UNITS_CHANGED} -eq 0 ]]; then
+  SMART_SKIP_RESTART=1
+  log "Smart mode: git HEAD unchanged and no systemd unit file updates — skipping migrations, daemon-reload, and service restarts."
 fi
 
-# ------- ANALYZE TABLE (optional) -------
-if [[ ${ANALYZE_TABLES} -eq 1 ]]; then
-  run_analyze_tables
-fi
-
-# ------- Reset overdue job schedules -------
-# After code update + migrations, reset any overdue next_due_at values so
-# the loop runner picks them up immediately when services restart.
-reset_overdue_jobs() {
-  local python_bin=""
-  if [[ -x "${APP_ROOT}/.venv-orchestrator/bin/python" ]]; then
-    python_bin="${APP_ROOT}/.venv-orchestrator/bin/python"
-  elif command -v python3 >/dev/null 2>&1; then
-    python_bin="python3"
+if [[ ${SMART_SKIP_RESTART} -eq 0 ]]; then
+  # ------- Database migrations -------
+  if [[ ${RUN_MIGRATIONS} -eq 1 ]]; then
+    run_migrations
   fi
-  if [[ -z "${python_bin}" ]]; then
-    log_warn "No python3 found; skipping overdue job reset."
-    return 0
+
+  # ------- ANALYZE TABLE (optional) -------
+  if [[ ${ANALYZE_TABLES} -eq 1 ]]; then
+    run_analyze_tables
   fi
-  local reset_script="${APP_ROOT}/bin/reset_overdue_jobs.py"
-  if [[ ! -f "${reset_script}" ]]; then
-    log "No reset_overdue_jobs.py found; skipping."
-    return 0
+
+  # ------- Reset overdue job schedules -------
+  # After code update + migrations, reset any overdue next_due_at values so
+  # the loop runner picks them up immediately when services restart.
+  reset_overdue_jobs() {
+    local python_bin=""
+    if [[ -x "${APP_ROOT}/.venv-orchestrator/bin/python" ]]; then
+      python_bin="${APP_ROOT}/.venv-orchestrator/bin/python"
+    elif command -v python3 >/dev/null 2>&1; then
+      python_bin="python3"
+    fi
+    if [[ -z "${python_bin}" ]]; then
+      log_warn "No python3 found; skipping overdue job reset."
+      return 0
+    fi
+    local reset_script="${APP_ROOT}/bin/reset_overdue_jobs.py"
+    if [[ ! -f "${reset_script}" ]]; then
+      log "No reset_overdue_jobs.py found; skipping."
+      return 0
+    fi
+    log "Resetting overdue job schedules"
+    run_cmd "${python_bin}" "${reset_script}" --app-root "${APP_ROOT}"
+  }
+  reset_overdue_jobs
+
+  # ------- Service discovery and restart -------
+  run_cmd systemctl daemon-reload
+
+  if [[ ${#EXPLICIT_SERVICES[@]} -gt 0 ]]; then
+    RESTART_SERVICES=("${EXPLICIT_SERVICES[@]}")
+    log "Using ${#RESTART_SERVICES[@]} explicitly specified service(s)"
+  else
+    while IFS= read -r svc; do
+      [[ -n "${svc}" ]] && RESTART_SERVICES+=("${svc}")
+    done < <(discover_services)
+    log "Auto-discovered ${#RESTART_SERVICES[@]} supplycore service(s)"
   fi
-  log "Resetting overdue job schedules"
-  run_cmd "${python_bin}" "${reset_script}" --app-root "${APP_ROOT}"
-}
-reset_overdue_jobs
 
-# ------- Service discovery and restart -------
-run_cmd systemctl daemon-reload
-
-RESTART_SERVICES=()
-if [[ ${#EXPLICIT_SERVICES[@]} -gt 0 ]]; then
-  RESTART_SERVICES=("${EXPLICIT_SERVICES[@]}")
-  log "Using ${#RESTART_SERVICES[@]} explicitly specified service(s)"
-else
-  while IFS= read -r svc; do
-    [[ -n "${svc}" ]] && RESTART_SERVICES+=("${svc}")
-  done < <(discover_services)
-  log "Auto-discovered ${#RESTART_SERVICES[@]} supplycore service(s)"
-fi
-
-if [[ ${#RESTART_SERVICES[@]} -eq 0 ]]; then
-  log "No services found to restart."
-fi
-
-FAILED_SERVICES=()
-for svc in "${RESTART_SERVICES[@]}"; do
-  log "Restarting ${svc}"
-  if ! run_cmd systemctl restart "${svc}"; then
-    log_warn "Failed to restart ${svc}"
-    FAILED_SERVICES+=("${svc}")
+  if [[ ${#RESTART_SERVICES[@]} -eq 0 ]]; then
+    log "No services found to restart."
   fi
-done
-
-# ------- Health verification -------
-UNHEALTHY_SERVICES=()
-if [[ ${HEALTH_CHECK} -eq 1 && ${#RESTART_SERVICES[@]} -gt 0 && ${DRY_RUN} -eq 0 ]]; then
-  log "Verifying service health (timeout: ${HEALTH_CHECK_TIMEOUT}s per service)"
-  # Short initial settle time
-  sleep 2
 
   for svc in "${RESTART_SERVICES[@]}"; do
-    # Skip already-failed services
-    skip=false
-    for failed in "${FAILED_SERVICES[@]+"${FAILED_SERVICES[@]}"}"; do
-      if [[ "${failed}" == "${svc}" ]]; then
-        skip=true
-        break
-      fi
-    done
-    [[ ${skip} == true ]] && continue
-
-    if verify_service_health "${svc}"; then
-      log "  OK: ${svc}"
-    else
-      log_warn "  UNHEALTHY: ${svc}"
-      UNHEALTHY_SERVICES+=("${svc}")
+    log "Restarting ${svc}"
+    if ! run_cmd systemctl restart "${svc}"; then
+      log_warn "Failed to restart ${svc}"
+      FAILED_SERVICES+=("${svc}")
     fi
   done
 
-  if [[ ${#UNHEALTHY_SERVICES[@]} -gt 0 || ${#FAILED_SERVICES[@]} -gt 0 ]]; then
-    log_warn "Some services are unhealthy after restart:"
-    for svc in "${FAILED_SERVICES[@]+"${FAILED_SERVICES[@]}"}"; do
-      log_warn "  FAILED:    ${svc}"
+  # ------- Health verification -------
+  if [[ ${HEALTH_CHECK} -eq 1 && ${#RESTART_SERVICES[@]} -gt 0 && ${DRY_RUN} -eq 0 ]]; then
+    log "Verifying service health (timeout: ${HEALTH_CHECK_TIMEOUT}s per service)"
+    # Short initial settle time
+    sleep 2
+
+    for svc in "${RESTART_SERVICES[@]}"; do
+      # Skip already-failed services
+      skip=false
+      for failed in "${FAILED_SERVICES[@]+"${FAILED_SERVICES[@]}"}"; do
+        if [[ "${failed}" == "${svc}" ]]; then
+          skip=true
+          break
+        fi
+      done
+      [[ ${skip} == true ]] && continue
+
+      if verify_service_health "${svc}"; then
+        log "  OK: ${svc}"
+      else
+        log_warn "  UNHEALTHY: ${svc}"
+        UNHEALTHY_SERVICES+=("${svc}")
+      fi
     done
-    for svc in "${UNHEALTHY_SERVICES[@]+"${UNHEALTHY_SERVICES[@]}"}"; do
-      log_warn "  UNHEALTHY: ${svc}"
-      # Print the last few journal lines to aid debugging
-      journalctl -u "${svc}" --no-pager -n 10 --since "-2 min" 2>/dev/null || true
+
+    if [[ ${#UNHEALTHY_SERVICES[@]} -gt 0 || ${#FAILED_SERVICES[@]} -gt 0 ]]; then
+      log_warn "Some services are unhealthy after restart:"
+      for svc in "${FAILED_SERVICES[@]+"${FAILED_SERVICES[@]}"}"; do
+        log_warn "  FAILED:    ${svc}"
+      done
+      for svc in "${UNHEALTHY_SERVICES[@]+"${UNHEALTHY_SERVICES[@]}"}"; do
+        log_warn "  UNHEALTHY: ${svc}"
+        # Print the last few journal lines to aid debugging
+        journalctl -u "${svc}" --no-pager -n 10 --since "-2 min" 2>/dev/null || true
+      done
+    fi
+  else
+    # Fallback: dump status for manual review
+    for svc in "${RESTART_SERVICES[@]}"; do
+      run_cmd systemctl --no-pager --full status "${svc}" || true
     done
   fi
-else
-  # Fallback: dump status for manual review
-  for svc in "${RESTART_SERVICES[@]}"; do
-    run_cmd systemctl --no-pager --full status "${svc}" || true
-  done
 fi
 
 TOTAL_FAILED=$(( ${#FAILED_SERVICES[@]} + ${#UNHEALTHY_SERVICES[@]} ))
+
+# ------- Machine-readable summary for scripts/hourly-loop.sh -------
+# Emitted unconditionally so the hourly wrapper can extract it with a grep.
+# Format: HOURLY_LOOP_SUMMARY: {JSON}
+_bool_json() { [[ ${1} -eq 1 ]] && printf true || printf false; }
+printf 'HOURLY_LOOP_SUMMARY: {"git_sha_before":"%s","git_sha_after":"%s","git_changed":%s,"units_changed":%s,"smart_mode":%s,"smart_skip_restart":%s,"services_restarted":%d,"services_failed":%d,"services_unhealthy":%d,"total_failed":%d,"branch":"%s"}\n' \
+  "${GIT_SHA_BEFORE:0:40}" \
+  "${GIT_SHA_AFTER:0:40}" \
+  "$(_bool_json ${GIT_CHANGED})" \
+  "$(_bool_json ${UNITS_CHANGED})" \
+  "$(_bool_json ${SMART_MODE})" \
+  "$(_bool_json ${SMART_SKIP_RESTART})" \
+  "${#RESTART_SERVICES[@]}" \
+  "${#FAILED_SERVICES[@]}" \
+  "${#UNHEALTHY_SERVICES[@]}" \
+  "${TOTAL_FAILED}" \
+  "${BRANCH}"
+
 if [[ ${TOTAL_FAILED} -gt 0 ]]; then
   log_warn "Completed update-and-restart with ${TOTAL_FAILED} issue(s)"
   exit 1


### PR DESCRIPTION
## Summary

Introduces a new hourly cron-driven loop (`scripts/hourly-loop.sh`) that autonomously updates the application, syncs systemd units, runs issue-triage workers, and maintains a durable cross-session memory via a pinned GitHub tracker issue. This enables Claude Code and human operators to see what was tried, what failed, and whether fixes are sticking without chasing multiple log files.

## Key Changes

- **New hourly loop script** (`scripts/hourly-loop.sh`):
  - Runs once per hour via systemd timer (opt-in, not auto-enabled)
  - Seeds run logs with previous run summaries for cross-run context
  - Invokes `update-and-restart.sh --smart` to avoid restart churn when nothing changed
  - Runs the `log-to-issues` worker directly (not via scheduler) so failures still get filed even if orchestrator is broken
  - Builds combined JSON summary and appends to `summary.jsonl` for historical tracking
  - Creates or reuses a pinned GitHub tracker issue and posts run summary + log tail as comments
  - Prunes run logs older than 7 days (configurable)

- **Smart mode for `update-and-restart.sh`** (`--smart` flag):
  - Tracks git HEAD SHA before/after pull and detects systemd unit file changes
  - Skips migrations, daemon-reload, and service restarts if neither git nor units changed
  - Reduces unnecessary restart churn during hourly runs when there's nothing to deploy
  - Emits machine-readable `HOURLY_LOOP_SUMMARY` JSON for the hourly loop to parse

- **Systemd unit files**:
  - `supplycore-hourly-loop.service`: oneshot service that runs the hourly loop script as root
  - `supplycore-hourly-loop.timer`: fires hourly with randomized 60-second offset to avoid thundering herd on GitHub API
  - Both units are synced by `update-and-restart.sh` but timer is not auto-enabled (operators enable manually after review)

- **Git and unit change tracking**:
  - `update-and-restart.sh` now captures git SHA before/after and detects unit file modifications
  - Supports local-only branches (no upstream) gracefully without failing
  - Tracks which services were restarted, failed, or unhealthy for summary reporting

- **GitHub integration**:
  - Hourly loop creates a pinned meta-issue on first run (labeled `auto-log` and `hourly-loop`)
  - Posts run summaries, exit codes, and log tails as comments for durable cross-session memory
  - Reopens tracker if accidentally closed
  - Uses pure Python + urllib (no external dependencies) for API calls

- **Logging and retention**:
  - Per-run logs stored in `storage/logs/hourly-loop/run-{timestamp}.log`
  - Combined JSONL summary file for historical analysis
  - Automatic pruning of logs older than retention window (default 7 days)
  - Systemd journal integration via `StandardOutput/StandardError` append

## Notable Implementation Details

- The hourly loop is intentionally idempotent and safe to run manually for dry-cycle testing before enabling the timer
- Environment variables (`GITHUB_TOKEN`, `GITHUB_REPO`, `APP_ROOT`, etc.) are sourced from `.env` and can be overridden
- The script gracefully handles missing Python interpreter or GitHub token (skips those steps, non-fatal)
- Smart mode decision is made after git pull and unit sync, so it reflects actual deployment state
- Tracker issue body includes last 120 lines of run log (with backtick escaping to prevent markdown injection)
- Exit code is non-zero if either update or log-to-issues worker failed, so systemd can flag the failure

https://claude.ai/code/session_014wiDAXwu2QWdXGtJDBavQC