### PR TITLE
feat(ops): hourly Claude triage timer for auto-log issues

### DIFF
--- a/ops/systemd/supplycore-claude-triage.service
+++ b/ops/systemd/supplycore-claude-triage.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=SupplyCore Claude triage — tag @claude on the next open auto-log issue
+Documentation=file:///var/www/SupplyCore/scripts/claude-triage.sh
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Runs as root to match the hourly-loop service. The script itself only
+# makes GitHub API calls and writes to storage/logs/hourly-loop/, so it
+# does not require privileged operations — but keeping root matches the
+# file-ownership expectations of the rest of the automation chain.
+User=root
+Group=root
+WorkingDirectory=/var/www/SupplyCore
+Environment=APP_ROOT=/var/www/SupplyCore
+# Optional overrides (MAX_CLAUDE_INVOCATIONS_PER_RUN, CLAUDE_TRIAGE_LABEL)
+# can be set in /etc/default/supplycore-claude-triage.
+EnvironmentFile=-/etc/default/supplycore-claude-triage
+ExecStart=/var/www/SupplyCore/scripts/claude-triage.sh
+StandardOutput=append:/var/www/SupplyCore/storage/logs/hourly-loop/claude-triage.systemd.log
+StandardError=append:/var/www/SupplyCore/storage/logs/hourly-loop/claude-triage.systemd.log
+TimeoutStartSec=300
+Nice=10
+IOSchedulingClass=best-effort
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/supplycore-claude-triage.timer
+++ b/ops/systemd/supplycore-claude-triage.timer
@@ -1,0 +1,18 @@
+[Unit]
+Description=Run the SupplyCore Claude triage script every hour
+
+[Timer]
+# Fire at :30 past every hour. This is intentionally offset from
+# supplycore-hourly-loop.timer (which fires at :00) so the two
+# automations never hit the GitHub API at the same second — and so the
+# triage run sees any freshly-filed auto-log issues from the log-to-issues
+# sweep that just finished 30 minutes earlier.
+OnCalendar=*-*-* *:30:00
+AccuracySec=1m
+RandomizedDelaySec=60
+# If the box was off when a run was due, fire once on boot to catch up.
+Persistent=true
+Unit=supplycore-claude-triage.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/claude-triage.sh
+++ b/scripts/claude-triage.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+#
+# SupplyCore Claude triage loop — picks the next open auto-log issue(s)
+# and kicks off a Claude Code on GitHub session by posting an @claude
+# mention.
+#
+# Runs on supplycore-claude-triage.timer, offset 30 min from the hourly
+# loop so the two automations don't hit GitHub at the same second.
+#
+# Policy:
+#   - Only issues labeled `auto-log` are eligible.
+#   - The pinned tracker issue (label `hourly-loop`) is always skipped.
+#   - Issues already marked `claude-triage-started` are skipped so we
+#     never re-tag the same issue.
+#   - Issues that already have a comment containing `@claude` (e.g. from
+#     a manual tag) are labeled `claude-triage-started` and skipped.
+#   - Remaining candidates are tagged oldest-first, up to
+#     MAX_CLAUDE_INVOCATIONS_PER_RUN (default 1).
+#
+# This keeps the Claude Code on GitHub workload bounded — one issue per
+# hour by default. Bump MAX_CLAUDE_INVOCATIONS_PER_RUN in
+# /etc/default/supplycore-claude-triage to go faster.
+#
+# Environment:
+#   GITHUB_TOKEN (required)
+#   GITHUB_REPO  (default: maferick/SupplyCore)
+#   MAX_CLAUDE_INVOCATIONS_PER_RUN (default: 1)
+#   CLAUDE_TRIAGE_LABEL            (default: claude-triage-started)
+#
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+APP_ROOT=${APP_ROOT:-$(cd -- "${SCRIPT_DIR}/.." && pwd)}
+
+LOG_DIR="${APP_ROOT}/storage/logs/hourly-loop"
+RUN_TS=$(date -u +'%Y%m%dT%H%M%SZ')
+RUN_LOG="${LOG_DIR}/triage-${RUN_TS}.log"
+LOG_RETENTION_DAYS=${CLAUDE_TRIAGE_LOG_RETENTION_DAYS:-7}
+
+MAX_PER_RUN=${MAX_CLAUDE_INVOCATIONS_PER_RUN:-1}
+CLAUDE_LABEL=${CLAUDE_TRIAGE_LABEL:-claude-triage-started}
+
+mkdir -p "${LOG_DIR}"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" | tee -a "${RUN_LOG}"
+}
+
+# Load .env so GITHUB_TOKEN / GITHUB_REPO are picked up the same way as
+# the hourly loop script.
+if [[ -f "${APP_ROOT}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1090,SC1091
+  source "${APP_ROOT}/.env"
+  set +a
+fi
+
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
+GITHUB_REPO=${GITHUB_REPO:-maferick/SupplyCore}
+
+log "Claude triage run started (repo=${GITHUB_REPO} max_per_run=${MAX_PER_RUN} label=${CLAUDE_LABEL})"
+
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+  log "GITHUB_TOKEN not set — cannot triage. Exiting cleanly."
+  exit 0
+fi
+
+PYTHON_BIN=""
+if [[ -x "${APP_ROOT}/.venv-orchestrator/bin/python" ]]; then
+  PYTHON_BIN="${APP_ROOT}/.venv-orchestrator/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN=$(command -v python3)
+fi
+
+if [[ -z "${PYTHON_BIN}" ]]; then
+  log "No python3 available — cannot triage. Exiting."
+  exit 1
+fi
+
+REPO="${GITHUB_REPO}" TOKEN="${GITHUB_TOKEN}" MAX_PER_RUN="${MAX_PER_RUN}" \
+  CLAUDE_LABEL="${CLAUDE_LABEL}" RUN_LOG_PATH="${RUN_LOG}" \
+  "${PYTHON_BIN}" - <<'PY'
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from urllib.parse import urlencode
+
+repo = os.environ["REPO"]
+token = os.environ["TOKEN"]
+max_per_run = int(os.environ.get("MAX_PER_RUN", "1"))
+claude_label = os.environ["CLAUDE_LABEL"]
+log_path = os.environ["RUN_LOG_PATH"]
+
+HEADERS = {
+    "Authorization": f"token {token}",
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "SupplyCore-ClaudeTriage/1.0",
+    "Content-Type": "application/json",
+}
+
+
+def log(msg):
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = f"[{ts}] {msg}"
+    print(line)
+    with open(log_path, "a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+
+def api(method, path, payload=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        data=data,
+        headers=HEADERS,
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+        return json.loads(raw) if raw else None
+
+
+def has_existing_claude_mention(issue_number):
+    """Return True if any comment on the issue already mentions @claude.
+
+    Used to avoid double-tagging issues the operator manually asked Claude
+    to look at — and to idempotently label them so we don't check again
+    next hour.
+    """
+    try:
+        comments = api(
+            "GET",
+            f"/repos/{repo}/issues/{issue_number}/comments?per_page=100",
+        ) or []
+    except urllib.error.HTTPError as exc:
+        log(f"   WARN could not fetch comments for #{issue_number}: {exc.code}")
+        return False
+    for comment in comments:
+        body = str(comment.get("body") or "")
+        if "@claude" in body.lower():
+            return True
+    return False
+
+
+# 1. Fetch open issues labeled auto-log, oldest first.
+try:
+    params = urlencode({
+        "state": "open",
+        "labels": "auto-log",
+        "per_page": "100",
+        "sort": "created",
+        "direction": "asc",
+    })
+    issues = api("GET", f"/repos/{repo}/issues?{params}") or []
+except urllib.error.HTTPError as exc:
+    body = exc.read().decode("utf-8", errors="replace")[:300]
+    log(f"Failed to list issues: {exc.code} {body}")
+    sys.exit(1)
+
+log(f"Fetched {len(issues)} open auto-log issue(s)")
+
+# 2. Filter out PRs, the pinned hourly-loop tracker, and issues already
+#    marked claude-triage-started.
+candidates = []
+for issue in issues:
+    if "pull_request" in issue:
+        continue
+    labels = {str((label or {}).get("name") or "") for label in (issue.get("labels") or [])}
+    if "hourly-loop" in labels:
+        continue
+    if claude_label in labels:
+        continue
+    candidates.append(issue)
+
+log(f"After label filter: {len(candidates)} candidate(s)")
+
+# 3. Walk candidates oldest-first until we've picked max_per_run.
+#    If we hit one that already has a manual @claude mention, label it
+#    and move on so we don't re-check it next hour.
+picks = []
+for issue in candidates:
+    if len(picks) >= max_per_run:
+        break
+    num = int(issue["number"])
+    if has_existing_claude_mention(num):
+        log(f"   skipping #{num} — already has an @claude mention")
+        try:
+            api(
+                "POST",
+                f"/repos/{repo}/issues/{num}/labels",
+                {"labels": [claude_label]},
+            )
+            log(f"   applied '{claude_label}' label to #{num} to suppress future checks")
+        except urllib.error.HTTPError as exc:
+            log(f"   WARN could not label #{num}: {exc.code}")
+        continue
+    picks.append(issue)
+
+if not picks:
+    log("No eligible issues to triage this run.")
+    sys.exit(0)
+
+pick_labels = ", ".join("#" + str(p["number"]) for p in picks)
+log(f"Triaging {len(picks)} issue(s): {pick_labels}")
+
+triaged = []
+failed = []
+
+for issue in picks:
+    num = int(issue["number"])
+    title = str(issue.get("title") or "")[:80]
+    log(f"-> #{num}: {title}")
+
+    branch_slug = f"claude/fix-auto-log-{num}"
+    comment_body = (
+        "@claude please investigate this auto-detected failure.\n\n"
+        "**Instructions:**\n"
+        "1. Read the error pattern and recent occurrences in the issue body above.\n"
+        "2. Find the code path that produced this error — search the repo for the "
+        "job name, error message, or any stack frame present in the log.\n"
+        "3. Identify the root cause. If the issue body is not enough, check the "
+        "`job_runs` / `sync_runs` tables or the relevant log file under "
+        "`storage/logs/` on the host.\n"
+        f"4. If you have **high confidence** in a minimal fix, open a PR on a new "
+        f"branch `{branch_slug}` with the smallest change that addresses the root "
+        "cause. Add a test or reproducer if feasible. Keep the change scoped — do "
+        "not refactor surrounding code or add speculative defensive handling.\n"
+        "5. If the root cause is **ambiguous** or would require a large refactor, "
+        "post a comment here with your findings and what additional information "
+        "you'd need to proceed — do NOT open a speculative PR.\n\n"
+        "Do not close the issue yourself. The hourly `log_to_issues` worker will "
+        "auto-close it 72 hours after the failure stops recurring, and will "
+        "reopen it automatically if the failure returns.\n\n"
+        "_Tagged automatically by `scripts/claude-triage.sh` — the hourly "
+        "autonomous triage loop. See the pinned `[Auto] Hourly loop — run log` "
+        "tracker issue for the full timeline of automated runs._"
+    )
+
+    try:
+        api(
+            "POST",
+            f"/repos/{repo}/issues/{num}/comments",
+            {"body": comment_body},
+        )
+        log(f"   OK posted @claude comment on #{num}")
+    except urllib.error.HTTPError as exc:
+        err_body = exc.read().decode("utf-8", errors="replace")[:300]
+        log(f"   ERR comment failed on #{num}: {exc.code} {err_body}")
+        failed.append(num)
+        continue
+
+    try:
+        api(
+            "POST",
+            f"/repos/{repo}/issues/{num}/labels",
+            {"labels": [claude_label]},
+        )
+        log(f"   OK applied '{claude_label}' label to #{num}")
+    except urllib.error.HTTPError as exc:
+        log(f"   WARN label add failed on #{num}: {exc.code} — next run may re-tag")
+
+    triaged.append(num)
+
+log(f"Triage complete: triaged={triaged} failed={failed}")
+PY
+
+# Prune old triage logs.
+find "${LOG_DIR}" -name 'triage-*.log' -type f -mtime "+${LOG_RETENTION_DAYS}" -delete 2>/dev/null || true
+
+log "Claude triage run finished"

--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -40,6 +40,7 @@ HEALTH_CHECK_TIMEOUT=30
 # The hourly-loop unit files are synced here too, but the timer is NOT
 # enabled automatically. Operators enable it with:
 #   sudo systemctl enable --now supplycore-hourly-loop.timer
+#   sudo systemctl enable --now supplycore-claude-triage.timer
 # after reviewing one manual run.
 CORE_UNITS=(
   supplycore-loop-runner.service
@@ -55,6 +56,8 @@ CORE_UNITS=(
   supplycore-influx-rollup-export.timer
   supplycore-hourly-loop.service
   supplycore-hourly-loop.timer
+  supplycore-claude-triage.service
+  supplycore-claude-triage.timer
 )
 
 # Units that are opt-in only — update if already installed, but don't install.


### PR DESCRIPTION
## Summary

Adds the second half of the autonomous loop: a new hourly systemd timer that picks the oldest open `auto-log` issue, posts a structured `@claude` triage prompt, and labels it `claude-triage-started` so the same issue is never re-tagged.

This pairs with `supplycore-hourly-loop.timer` (merged in #998) which fires at `:00` each hour to file `auto-log` issues. The new triage timer fires at `:30` past each hour so the two loops never hit the GitHub API at the same second, and so triage runs always see issues that were freshly filed 30 minutes earlier.

- **`scripts/claude-triage.sh`** — fetches open `auto-log` issues, filters out the pinned `hourly-loop` tracker and any issue already marked `claude-triage-started`, walks remaining candidates oldest-first, skips ones that already have a manual `@claude` mention (and labels them so they aren't re-checked next hour), then posts a triage comment + label on up to `MAX_CLAUDE_INVOCATIONS_PER_RUN` issues per run (default **1**).
- **`ops/systemd/supplycore-claude-triage.{service,timer}`** — oneshot service + `OnCalendar=*-*-* *:30:00` timer with `Persistent=true` and `RandomizedDelaySec=60`.
- **`scripts/update-and-restart.sh`** — adds the two new units to `CORE_UNITS` so they get installed on the next deploy run. Timer is intentionally **not** auto-enabled; operator flips it on after eyeballing one manual run.

## Why one issue per run

The first hourly-loop run filed 12 new `auto-log` issues. Tagging all 12 immediately would spawn 12 parallel Claude Code on GitHub sessions. Conservative default of 1/run lets you watch one full triage cycle (issue → PR → merge → next hourly loop verifies the failure stops recurring) before bumping the dial. Override per-host in `/etc/default/supplycore-claude-triage`:

```
MAX_CLAUDE_INVOCATIONS_PER_RUN=3
```

## Idempotency / robustness

- Comment is posted **before** the label is applied. If the run dies between the two, next hour will re-comment (noisy) but never silently drop an issue.
- Manual `@claude` mentions are detected per-candidate and labeled to suppress future checks — so a human-tagged issue isn't re-pinged by the script.
- The pinned `[Auto] Hourly loop — run log` tracker (label `hourly-loop`) is always skipped.
- All output written to `storage/logs/hourly-loop/triage-<TS>.log`; logs older than 7 days pruned automatically.

## Test plan

- [x] `bash -n scripts/claude-triage.sh` — passes.
- [x] `bash -n scripts/update-and-restart.sh` — passes.
- [x] Embedded Python heredoc parses with `ast.parse` (186 lines).
- [ ] On host: pull this branch, run `sudo ./scripts/update-and-restart.sh` to install the new unit files.
- [ ] On host: dry-cycle with `sudo ./scripts/claude-triage.sh` and verify it picks one of the 12 open `auto-log` issues, posts the `@claude` comment, and applies the label.
- [ ] On host: confirm Claude Code on GitHub starts a session on the tagged issue.
- [ ] On host: enable the timer with `sudo systemctl enable --now supplycore-claude-triage.timer` and verify with `systemctl list-timers supplycore-claude-triage.timer`.

https://claude.ai/code/session_014wiDAXwu2QWdXGtJDBavQC