### PR TITLE
Document migrations system and recent schema changes

### DIFF
--- a/database/OPTIMIZATION_AUDIT.md
+++ b/database/OPTIMIZATION_AUDIT.md
@@ -248,6 +248,8 @@ High-impact indexes added in the migration:
 |---|---|---|
 | `killmail_events` | `(effective_killmail_at)` | Overview page ORDER BY, time-range filters |
 | `killmail_events` | `(mail_type, effective_killmail_at)` | Overview page mail_type filter |
+| `killmail_events` | `(mail_type, effective_killmail_at, sequence_id)` | Overview page `mail_type` filter + `(effective_killmail_at DESC, sequence_id DESC)` order-by in `db_killmail_overview_page()`. Covers the composite access pattern that caused `/killmail-intelligence` to time out during backload. Added in `database/migrations/20260410_killmail_overview_mailtype_effective.sql`. |
+| `killmail_attackers` | `(character_id)` | Temporal-behavior worker joins `killmail_attackers → killmail_events` to build per-character timestamp lists. Without this index the `WHERE character_id IS NOT NULL AND character_id > 0` filter full-scans the multi-million row attackers table. Added in `database/migrations/20260409_temporal_behavior_attacker_index.sql`. |
 | `killmail_events` | `(victim_alliance_id, effective_killmail_at)` | Alliance filter on overview |
 | `killmail_events` | `(victim_corporation_id, effective_killmail_at)` | Corp filter on overview |
 | `killmail_attackers` | `(sequence_id, final_blow, attacker_index)` | Correlated subquery for final_blow lookup |

--- a/database/README.md
+++ b/database/README.md
@@ -2,13 +2,62 @@
 
 Files:
 - `export-schema.sql` — schema-only dump
+- `schema.sql` — authoritative canonical schema (source of truth for fresh installs)
 - `table-counts.txt` — approximate row counts per table
 - `sample_ref.sql` — reference/static tables
 - `sample_app.sql` — sampled application-owned operational tables
 - `sample_heavy_recent.sql` — sampled recent rows from heavy killmail/market/history tables
 - `OPTIMIZATION_AUDIT.md` — architecture map, hot-path findings, implemented DB optimizations, and phased follow-up plan
+- `migrations/` — append-only, timestamped schema migrations applied by `bin/run-migrations.php`
 
 Notes:
 - These files are intended for schema review, query planning, and DB optimization.
 - Samples are intentionally limited and do not represent full production volume.
 - Secrets/tokens are intentionally excluded from these exports.
+
+---
+
+## Migrations directory
+
+`database/migrations/` contains forward-only SQL migrations, named
+`YYYYMMDD_<slug>.sql`. They are applied in filename order by:
+
+```bash
+php bin/run-migrations.php --status    # show what's pending
+php bin/run-migrations.php --dry-run   # preview
+php bin/run-migrations.php             # apply
+```
+
+Every migration should be idempotent (`CREATE TABLE IF NOT EXISTS`,
+`ON DUPLICATE KEY UPDATE`, guarded `ALTER` statements) so re-running
+the migration runner against an already-applied database is a no-op.
+
+### Recent migrations (latest first)
+
+Capability-level summary of what the most recent migrations add. See
+the SQL file for the authoritative DDL and inline comments.
+
+| Migration | Purpose | Runbook |
+|---|---|---|
+| `20260510_horizon_auto_approve.sql` | Adds `sync_state.auto_approve_blocked` so `detect_backfill_complete` can propose a dataset but skip auto-flipping it. Per-dataset opt-out for the horizon auto-approval loop. | [OPERATIONS_GUIDE — Auto-Approval](../docs/OPERATIONS_GUIDE.md#horizon-auto-approval) |
+| `20260426_incremental_horizon.sql` | Per-dataset progress/horizon model on `sync_state` (`watermark_event_time`, `backfill_complete`, `backfill_proposed_at`, `incremental_horizon_seconds`, `repair_window_seconds`, `stall_cursor`, `stall_count`) plus freshness-report indexes. Enables incremental-only compute with a rolling repair window. | [OPERATIONS_GUIDE — Incremental Horizon Mode](../docs/OPERATIONS_GUIDE.md#incremental-horizon-mode) |
+| `20260425_bloom_entry_points_materialized.sql` | Adds `bloom_entry_points_materialized` — the read-side projection of the four Bloom tiers (HotBattle, HighRiskPilot, StrategicSystem, HotAlliance) for the PHP dashboard Intelligence Anchors panel. Populated by the same `compute_bloom_entry_points` job that maintains the Neo4j labels. | [BLOOM_OPERATIONAL_INTELLIGENCE](../docs/BLOOM_OPERATIONAL_INTELLIGENCE.md) |
+| `20260424_bloom_entry_points.sql` | Registers `compute_bloom_entry_points` on the Python scheduler (15 min cadence). Maintains additive `:HotBattle` / `:HighRiskPilot` / `:StrategicSystem` / `:HotAlliance` labels on the Neo4j graph for Bloom search phrases. | [BLOOM_OPERATIONAL_INTELLIGENCE](../docs/BLOOM_OPERATIONAL_INTELLIGENCE.md) |
+| `20260424_auto_log_missing_tables.sql` | Remediation for auto-log issues #824–#831: brings the live database back in sync with `schema.sql` by creating any previously-missed tables (battle type classification, escalation sequences, shell-corp indicators, staging candidates, CIP signals/profiles/labels, CIP incident log). Fully idempotent. | — |
+| `20260410_killmail_overview_mailtype_effective.sql` | Composite index `idx_killmail_mailtype_effective_seq` on `killmail_events (mail_type, effective_killmail_at, sequence_id)` so `db_killmail_overview_page()` stops scanning the whole table. Fixes the `/killmail-intelligence` timeout during backload. | — |
+| `20260410_widen_participation_count.sql` | Widens `battle_participants.participation_count` and `battle_side_metrics.participant_count` to `BIGINT UNSIGNED`. Fixes the `compute_battle_anomalies` `Out of range value` failure caused by historical drift when the rollup cursor was rewound and killmails were double-counted. | [BATTLE_INTELLIGENCE_RUNBOOK §9-I](../docs/BATTLE_INTELLIGENCE_RUNBOOK.md) |
+| `20260409_temporal_behavior_attacker_index.sql` | Index on `killmail_attackers.character_id` so the temporal-behavior worker no longer full-scans the attackers table when building per-character timestamp lists. | — |
+
+For the full history, list the directory:
+
+```bash
+ls database/migrations/
+```
+
+### Adding a new migration
+
+1. Pick a filename: `YYYYMMDD_<short_slug>.sql` (UTC date).
+2. Keep statements idempotent (`IF NOT EXISTS`, `IF EXISTS`, `ON DUPLICATE KEY UPDATE`).
+3. Add a top-of-file comment explaining the motivation, referenced job/feature, and rollback notes.
+4. If the migration adds or modifies tables, also update `database/schema.sql` so fresh installs stay in sync.
+5. Cross-link the migration from the relevant runbook in `docs/` (see the table above for examples).

--- a/docs/BLOOM_OPERATIONAL_INTELLIGENCE.md
+++ b/docs/BLOOM_OPERATIONAL_INTELLIGENCE.md
@@ -44,6 +44,7 @@ entry points — all of which are now shipped in this repository.
 | `setup/neo4j_bloom_entry_points.cypher`                 | Indexes backing the smart entry-point labels.                           |
 | `python/orchestrator/jobs/compute_bloom_entry_points.py`| Python worker that maintains the entry-point labels (batch, idempotent).|
 | `database/migrations/20260424_bloom_entry_points.sql`   | Registers the job on the Python scheduler (15 minute cadence).          |
+| `database/migrations/20260425_bloom_entry_points_materialized.sql` | Creates `bloom_entry_points_materialized`, the read-side MariaDB projection of the four tiers that backs the PHP dashboard Intelligence Anchors panel. Populated by the same `compute_bloom_entry_points` job. |
 
 Registration points covered:
 
@@ -51,6 +52,18 @@ Registration points covered:
 - `python/orchestrator/processor_registry.py` — dispatch
 - `python/orchestrator/worker_registry.py` — scheduling + deps
 - `src/functions.php` — authoritative job registry + dashboard grouping
+
+### Dual-surface rendering
+
+`compute_bloom_entry_points` writes to **two** sinks in a single run:
+
+1. **Neo4j** — additive labels (`:HotBattle`, `:HighRiskPilot`,
+   `:StrategicSystem`, `:HotAlliance`) for Bloom search phrases.
+2. **MariaDB** — ranked top-N rows per tier in
+   `bloom_entry_points_materialized` (see
+   `20260425_bloom_entry_points_materialized.sql`). The PHP dashboard
+   Intelligence Anchors panel reads directly from this table so the
+   operator cockpit stays decoupled from Neo4j HTTP latency.
 
 ---
 

--- a/docs/OPERATIONS_GUIDE.md
+++ b/docs/OPERATIONS_GUIDE.md
@@ -596,6 +596,19 @@ itself advances monotonically forward.
 
 This is opt-in, gated, and fully reversible. Nothing ships enabled.
 
+**Schema sources of truth:**
+- `database/migrations/20260426_incremental_horizon.sql` — adds the
+  per-dataset horizon columns (`watermark_event_time`,
+  `backfill_complete`, `backfill_proposed_at`,
+  `backfill_proposed_reason`, `incremental_horizon_seconds`,
+  `repair_window_seconds`, `stall_cursor`, `stall_count`) and the
+  `idx_sync_state_horizon` / `idx_sync_state_backfill_proposed`
+  indexes used by the freshness report.
+- `database/migrations/20260510_horizon_auto_approve.sql` — adds the
+  `auto_approve_blocked` opt-out column so
+  `detect_backfill_complete` still proposes a dataset for review but
+  never auto-flips `backfill_complete` for the blocked ones.
+
 ### <a id="horizon-how-it-works"></a>How It Works
 
 The `sync_state` table carries per-dataset progress and policy:


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the database migrations system and cross-links recent schema changes across the codebase. It establishes the migrations directory as the source of truth for incremental schema evolution and provides operators with clear guidance on migration management and recent capability additions.

## Key Changes

- **database/README.md**: 
  - Introduced `schema.sql` as the authoritative canonical schema for fresh installs
  - Added `migrations/` directory documentation with usage examples for the migration runner
  - Created a "Recent migrations" table documenting the 8 most recent migrations with their purpose, capability summary, and links to relevant runbooks
  - Added guidelines for creating new migrations (naming, idempotency, documentation, schema.sql sync)

- **docs/BLOOM_OPERATIONAL_INTELLIGENCE.md**:
  - Added reference to `20260425_bloom_entry_points_materialized.sql` migration in the artifacts table
  - Documented the dual-surface rendering pattern where `compute_bloom_entry_points` writes to both Neo4j (labels) and MariaDB (`bloom_entry_points_materialized` table)
  - Clarified that the PHP dashboard Intelligence Anchors panel reads from MariaDB to stay decoupled from Neo4j HTTP latency

- **docs/OPERATIONS_GUIDE.md**:
  - Added "Schema sources of truth" section under Incremental Horizon Mode
  - Cross-linked the two migrations that implement incremental horizon (`20260426_incremental_horizon.sql` and `20260510_horizon_auto_approve.sql`)
  - Documented the specific columns and indexes added by each migration

- **database/OPTIMIZATION_AUDIT.md**:
  - Added two new high-impact indexes to the migration table:
    - Composite index on `killmail_events (mail_type, effective_killmail_at, sequence_id)` that fixed `/killmail-intelligence` timeout during backload
    - Index on `killmail_attackers (character_id)` that eliminated full-table scans in the temporal-behavior worker

## Notable Implementation Details

- All migrations are documented as idempotent, enabling safe re-runs against already-applied databases
- The recent migrations table provides a capability-level summary with direct links to operational runbooks for each feature
- Migration naming follows `YYYYMMDD_<slug>.sql` convention for deterministic ordering
- The documentation establishes a clear pattern: migrations add schema changes, and runbooks document operational procedures for those changes

https://claude.ai/code/session_0153rFHNpEoU4SQ2EWSZrXue