### PR TITLE
fix(loop_runner): mid-cycle memory gate for no-tier-barriers dispatch

### DIFF
--- a/python/orchestrator/loop_runner.py
+++ b/python/orchestrator/loop_runner.py
@@ -377,6 +377,7 @@ def _run_cycle_dependency_aware(
     max_parallel: int,
     shutdown_event: threading.Event,
     lane: str = "",
+    memory_abort_bytes: int | None = None,
 ) -> list[JobOutcome]:
     """Run all due jobs respecting dependencies but without tier barriers.
 
@@ -416,10 +417,38 @@ def _run_cycle_dependency_aware(
         return _run_single_job(job_key, db, raw_config, logger, timeout)
 
     pool = ThreadPoolExecutor(max_workers=max_parallel)
+    memory_aborted = False
     try:
         while (remaining or in_flight) and not shutdown_event.is_set():
-            # Find jobs whose deps are all satisfied.
-            ready = [k for k in remaining if deps[k] <= completed]
+            # Memory gate: with --no-tier-barriers the dispatcher will keep
+            # feeding new jobs into the pool as soon as deps are satisfied,
+            # so a single cycle can push RSS past the systemd MemoryMax
+            # before the next cycle-start check runs.  Re-check here and,
+            # if we've crossed the abort threshold, stop dispatching new
+            # work and drain what's in flight so we exit cleanly instead
+            # of being OOM-killed mid-cycle.
+            if not memory_aborted and memory_abort_bytes is not None:
+                mem = resident_memory_bytes()
+                if mem >= memory_abort_bytes:
+                    memory_aborted = True
+                    logger.warning(
+                        f"{loop_name}: memory abort threshold reached mid-cycle "
+                        f"({mem / (1024**3):.1f} GiB), draining {len(in_flight)} "
+                        f"in-flight job(s) before shutdown",
+                        payload={
+                            "event": "loop_runner.memory_abort_midcycle",
+                            "loop": loop_name,
+                            "memory_bytes": mem,
+                            "in_flight": len(in_flight),
+                            "remaining": len(remaining),
+                        },
+                    )
+
+            # Find jobs whose deps are all satisfied — but don't dispatch
+            # any more once we've tripped the memory gate.
+            ready: list[str] = [] if memory_aborted else [
+                k for k in remaining if deps[k] <= completed
+            ]
 
             for key in ready:
                 remaining.discard(key)
@@ -428,9 +457,13 @@ def _run_cycle_dependency_aware(
                 in_flight[fut] = key
 
             if not in_flight:
-                # Nothing running and nothing ready — remaining jobs have
-                # unsatisfied deps (likely failed upstream).  Skip them.
-                if remaining:
+                if memory_aborted:
+                    # In-flight drained after tripping the memory gate —
+                    # request a graceful shutdown so systemd can restart us.
+                    shutdown_event.set()
+                elif remaining:
+                    # Nothing running and nothing ready — remaining jobs have
+                    # unsatisfied deps (likely failed upstream).  Skip them.
                     logger.warning(
                         f"{loop_name}: {len(remaining)} jobs blocked by unsatisfied deps, skipping",
                         payload={
@@ -642,6 +675,7 @@ def _run_loop(
                 max_parallel=max_parallel,
                 shutdown_event=shutdown_event,
                 lane=lane,
+                memory_abort_bytes=memory_abort_bytes,
             )
             for o in outcomes:
                 if o.status == "failed":


### PR DESCRIPTION
Closes #999 (and should also stop the paired OOM failures reported in #1000, which are the same event surfaced as `oom-kill` by systemd).

## Root cause

`supplycore-lane-compute-bg.service` runs with `--no-tier-barriers --max-parallel 3 --memory-max-gb 2.5` against a cgroup `MemoryMax=3G`. In that mode, dispatch flows through `_run_cycle_dependency_aware` in `python/orchestrator/loop_runner.py`, which keeps submitting ready jobs to the pool as soon as their deps are satisfied.

The existing memory guard only re-reads RSS at the **start** of each cycle (`loop_runner.py:547`). With 3 parallel jobs and no tier barriers, a single cycle can push the process past the 3 GiB cgroup limit long before the next cycle-start check ever runs, so the kernel kills it with `status=9/KILL` first. That matches the 257 recurrences on #999 and the 248 `oom-kill` hits on #1000 — back-to-back SIGKILL / respawn loops with no graceful exit line in the journal between them.

## Fix

Add a mid-cycle memory gate at the top of `_run_cycle_dependency_aware`'s dispatch loop and wire `memory_abort_bytes` through from `_run_loop`. Once the abort threshold is crossed:

1. Stop dispatching new jobs this cycle.
2. Let in-flight jobs drain naturally.
3. Set `shutdown_event` so the outer loop exits cleanly and systemd restarts us via `Restart=always` — instead of via SIGKILL.

Only the `--no-tier-barriers` path is touched; `run_tier` (the tier-barrier path used by the other lanes) is unchanged, and the change is a no-op when `memory_abort_bytes` isn't passed, so existing call sites and tests keep their current behavior.

Net change: `+39 / -5` in one file.

## Why this is the smallest fix

- The cycle-start check already exists and already knows the right threshold; we just need to re-check it at a finer granularity in the one path that can run unbounded dispatches per cycle.
- `ru_maxrss` (peak) is already what `resident_memory_bytes()` returns. Peak is the *right* metric for the gate: if we went over the threshold at any point during the cycle, we want to bail, even if RSS has since dropped, because the next batch will push us right back up.
- No new config surface, no systemd unit changes, no change to the `--memory-max-gb 2.5` value the service already passes.

## Test plan

- [ ] On a host running this branch, watch `journalctl -u supplycore-lane-compute-bg -f` for a full cycle and confirm `loop_runner.memory_abort_midcycle` events appear instead of `status=9/KILL`.
- [ ] Confirm the service is cycled by systemd's `Restart=always` after a memory abort (expect `Deactivated successfully` / clean exit, not `Main process exited, code=killed`).
- [ ] After ~72h of no recurrence, the hourly `log_to_issues` worker should auto-close #999 and #1000.