### PR TITLE
fix(loop_runner): tighten mid-cycle memory-gate polling to 5s

### DIFF
--- a/python/orchestrator/loop_runner.py
+++ b/python/orchestrator/loop_runner.py
@@ -474,11 +474,18 @@ def _run_cycle_dependency_aware(
                     )
                 break
 
-            # Wait for at least one future to complete.
-            done, _ = wait(in_flight.keys(), return_when=FIRST_COMPLETED, timeout=60)
+            # Wait for at least one future to complete.  The timeout doubles
+            # as the mid-cycle memory-gate polling interval: when every
+            # in-flight job is long-running (e.g. compute-bg backfills that
+            # take minutes each) we still want to notice RSS creeping toward
+            # the systemd MemoryMax before the kernel OOM-kills us, so we
+            # loop back and re-check the gate on a short cadence instead of
+            # waiting up to a full minute for a job to finish (#1000).
+            done, _ = wait(in_flight.keys(), return_when=FIRST_COMPLETED, timeout=5)
 
             if not done:
-                # Timeout on wait — just loop back to check shutdown_event.
+                # Timeout on wait — just loop back to check shutdown_event
+                # and the mid-cycle memory gate.
                 continue
 
             for fut in done:


### PR DESCRIPTION
## Summary

PR #1015 added a mid-cycle memory gate in `_run_cycle_dependency_aware` so `--no-tier-barriers` lanes stop dispatching new work once RSS crosses `--memory-max-gb`. The gate is re-evaluated once per `while` iteration, and an iteration only wakes when a future completes **or** `wait(..., timeout=60)` fires — which meant up to 60 seconds could pass before the gate polled RSS again.

For `supplycore-lane-compute-bg.service` the typical workload is a small number of long-running background jobs (killmail backfills, CIP pipeline, horizon forecasts) that each run for minutes. With `--max-parallel 3` all three slots can be busy for the full 60s before any job completes, so the collective RSS of the in-flight jobs can climb past the 2.5 GiB abort threshold **and** past `MemoryMax=3G` before the gate ever re-evaluates — at which point the kernel OOM-killer fires:

```
supplycore-lane-compute-bg.service: Failed with result 'oom-kill'.
```

Issue #1000 logged 248 occurrences of that pattern (paired with #999 which the original gate closed).

## Fix

Drop the `wait(FIRST_COMPLETED, timeout=...)` from 60s to 5s so the memory gate polls on a short cadence even when every slot is busy with a long-running job. The change is a single integer literal; dispatch semantics, concurrency-group locks, and the shutdown path are unchanged. Waking every 5s on an idle condvar in a background loop is negligible overhead.

## Test plan

- [x] `python3 -m py_compile python/orchestrator/loop_runner.py`
- [x] AST parse of the full file succeeds
- [ ] Live: confirm `supplycore-lane-compute-bg.service` stops getting OOM-killed in the 72h soak window (auto-log worker will auto-close #1000 if no recurrence)
- [ ] Live: watch for `loop_runner.memory_abort_midcycle` warnings — they should now fire before systemd's MemoryMax on compute-bg

Closes #1000