### PR TITLE
fix(loop_runner): force-exit on shutdown to bypass orphaned pool join

### DIFF
--- a/python/orchestrator/loop_runner.py
+++ b/python/orchestrator/loop_runner.py
@@ -1057,6 +1057,29 @@ def main(argv: list[str] | None = None) -> int:
     })
 
     logger.info("loop runner stopped", payload={"event": "loop_runner.stopped", "worker_id": worker_id})
+
+    # When shutting down on a signal (SIGTERM/SIGINT) or a memory-abort
+    # request, the inner ThreadPoolExecutors used by run_tier() and
+    # _run_cycle_dependency_aware() were torn down with
+    # `pool.shutdown(wait=False, cancel_futures=True)` so the dispatcher
+    # could exit promptly without blocking on long-running jobs.  Their
+    # already-running worker threads, however, remain registered in
+    # concurrent.futures._threads_queues, and Python's atexit handler will
+    # join them before the interpreter actually exits.  For compute-bg jobs
+    # that routinely run for minutes (killmail backfills, CIP pipeline,
+    # horizon forecasts) that join easily exceeds systemd
+    # `TimeoutStopSec=90s`, which then trips
+    # `Failed with result 'timeout'` / SIGKILL on the lane services
+    # (#1001 lane-compute-bg, #1003 lane-compute).
+    #
+    # Force-exit instead so systemd records a clean stop.  All per-job DB
+    # state was finalised by `_finalize_job` before this point and the JSON
+    # log handlers flush line-by-line, so nothing material is lost.  The
+    # `--once` path returns normally because shutdown_event stays unset
+    # there.
+    if shutdown_event.is_set():
+        os._exit(0)
+
     return 0
 
 


### PR DESCRIPTION
## Summary

`supplycore-lane-compute-bg.service` (and the other lane services to a lesser
extent) keeps tripping `Failed with result 'timeout'` on systemctl restart —
9 occurrences in the latest scan window for #1001, plus partner KILL/9
events on #1002, #1004, #1006, #1009.

### Root cause

When SIGTERM/SIGINT (or a memory abort) sets `shutdown_event`, the
dispatcher loops in `run_tier()` and `_run_cycle_dependency_aware()` tear
down their `ThreadPoolExecutor`s with
`pool.shutdown(wait=False, cancel_futures=True)` so the loop runner can
respond promptly.  The pool object is dropped, but the workers it spawned
remain registered in `concurrent.futures._threads_queues` and Python's
atexit handler joins them before the interpreter actually exits.  For
compute-bg jobs that routinely run for minutes (killmail backfills, CIP
pipeline, horizon forecasts) that join easily exceeds systemd
`TimeoutStopSec=90s`, after which systemd SIGKILLs the unit and records
`Failed with result 'timeout'`.

This is the same root cause behind the paired
`Main process exited, code=killed, status=9/KILL` reports on the lane
services.

### Fix

Force-exit with `os._exit(0)` once we have written the final heartbeat,
emitted the stopped log line, and confirmed `shutdown_event.is_set()`.
All per-job DB rows are finalised by `_finalize_job` before this point and
the JSON log handlers flush line-by-line (and `Environment=PYTHONUNBUFFERED=1`
is set in every lane unit), so nothing material is lost.  The `--once`
path returns normally because `shutdown_event` stays unset there.

The change is a single 4-line guard at the very end of `loop_runner.main()`;
dispatcher behaviour, signal handling, the heartbeat loop, and all in-cycle
shutdown checks are unchanged.

## Test plan

- [x] `python3 -m py_compile python/orchestrator/loop_runner.py`
- [x] AST parse + import audit (`os` already imported at module top)
- [ ] Live: `sudo systemctl restart supplycore-lane-compute-bg.service` and
      confirm `journalctl -u supplycore-lane-compute-bg.service` shows
      `loop runner stopped` followed by a clean restart instead of
      `Failed with result 'timeout'`.
- [ ] Live soak: auto-log worker should auto-close #1001 / #1003 after
      72h with no recurrence.

Closes #1001