### PR TITLE
Fix backlog reporting for loop-runner and PHP scheduler paths

### DIFF
--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -364,11 +364,38 @@ discover_services() {
     | awk '/^supplycore-/ {print $1}' \
     || true)
 
+  # Identify the service we're currently running under (if any) so we
+  # never try to restart our own invoking unit. systemd sets INVOCATION_ID
+  # for any process launched from a unit, and `systemctl status $PID`
+  # resolves that PID back to the owning unit name.
+  local self_unit=""
+  if [[ -n "${INVOCATION_ID:-}" ]]; then
+    self_unit=$(systemctl status "$$" --no-pager 2>/dev/null \
+      | awk 'NR==1 && /\.service/ {for (i=1; i<=NF; i++) if ($i ~ /\.service$/) {print $i; exit}}' \
+      || true)
+  fi
+
   while read -r unit load_state _rest; do
     [[ -z "${unit}" ]] && continue
     [[ "${unit}" == *'@.service' ]] && continue
     [[ "${load_state}" == "not-found" ]] && continue
     [[ "${load_state}" == "masked" ]] && continue
+    # Skip oneshot services — they are run-to-completion by design and
+    # are typically driven by a timer. Restarting a oneshot while it is
+    # still activating causes systemd to fail the job (classic case:
+    # the hourly-loop service restarting itself from within its own
+    # ExecStart). The timer entry is still restarted below, which is
+    # the correct handle for rescheduling oneshots.
+    local svc_type
+    svc_type=$(systemctl show -p Type --value "${unit}" 2>/dev/null || true)
+    if [[ "${svc_type}" == "oneshot" ]]; then
+      continue
+    fi
+    # Belt-and-suspenders: never restart the unit that is currently
+    # running this script (applies to non-oneshot self-invocations too).
+    if [[ -n "${self_unit}" && "${unit}" == "${self_unit}" ]]; then
+      continue
+    fi
     # Skip services that are triggered by timers — we restart the timer instead
     local is_timer_triggered=false
     for tt in "${timer_triggered[@]+"${timer_triggered[@]}"}"; do

--- a/src/functions.php
+++ b/src/functions.php
@@ -26189,15 +26189,37 @@ function log_viewer_page_data(): array
         usort($logFiles, fn (array $a, array $b) => ($b['size_bytes'] ?? 0) <=> ($a['size_bytes'] ?? 0));
     }
 
-    // ── Worker job queue depth (backlog) ─────────────────────────────────
+    // ── Backlog depth ────────────────────────────────────────────────────
+    // Two execution paths feed the backlog and they use different tables:
+    //
+    //   1. `worker_jobs` — legacy Python worker-pool path. Rows are created
+    //      when a job is enqueued and updated as workers claim/complete
+    //      them. Status values: 'queued', 'running', 'retry', plus terminal
+    //      'completed'/'failed'/'dead'. This is the ONLY source the widget
+    //      used to read, which is why deployments running primarily through
+    //      the loop-runner / PHP scheduler path saw a permanently-empty
+    //      backlog — nothing writes here in that configuration.
+    //
+    //   2. `sync_schedules` — the primary path for loop_runner (lane-*)
+    //      services and the PHP scheduler daemon. Both claim jobs by
+    //      setting `locked_until` + `current_state='running'` + `last_started_at`
+    //      and release them by setting `locked_until=NULL` + `last_finished_at`.
+    //      "Ready to pick up" = due and not locked; "Running" = currently
+    //      locked; "Retry" = last run failed and the planner has scheduled
+    //      a future retry via `next_due_at`.
+    //
+    // We read both tables and sum them so mixed deployments are still
+    // accurate, and single-path deployments (the common case today) no
+    // longer show a misleading all-zeroes backlog.
+    $backlogQueue = ['queued' => 0, 'running' => 0, 'retry' => 0, 'total' => 0];
+    $backlogByQueue = [];
+
     $workerQueueRaw = db_select(
         "SELECT status, queue_name, COUNT(*) AS cnt
          FROM worker_jobs
          WHERE status IN ('queued', 'running', 'retry')
          GROUP BY status, queue_name"
     );
-    $backlogQueue = ['queued' => 0, 'running' => 0, 'retry' => 0, 'total' => 0];
-    $backlogByQueue = [];
     foreach ($workerQueueRaw as $row) {
         $s = $row['status'];
         $q = $row['queue_name'] ?? 'default';
@@ -26205,6 +26227,57 @@ function log_viewer_page_data(): array
         $backlogQueue[$s] = ($backlogQueue[$s] ?? 0) + $cnt;
         $backlogQueue['total'] += $cnt;
         $backlogByQueue[$q][$s] = $cnt;
+    }
+
+    // Loop-runner / PHP-scheduler backlog from sync_schedules. The single
+    // aggregate query below buckets every enabled schedule row into one of
+    // running / retry / ready / (none) based on claim state and last_status.
+    // Order of the WHEN clauses matters: running wins over retry wins over
+    // ready, so a single row is never double-counted.
+    $schedQueueRow = db_select(
+        "SELECT
+            SUM(CASE
+                WHEN (locked_until IS NOT NULL AND locked_until > UTC_TIMESTAMP())
+                  OR (current_state = 'running'
+                      AND last_started_at IS NOT NULL
+                      AND (last_finished_at IS NULL OR last_finished_at < last_started_at)
+                      AND last_started_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 3 HOUR))
+                THEN 1 ELSE 0
+            END) AS running_count,
+            SUM(CASE
+                WHEN (locked_until IS NULL OR locked_until <= UTC_TIMESTAMP())
+                 AND (current_state IS NULL OR current_state <> 'running')
+                 AND last_status IN ('failed', 'error')
+                 AND next_due_at IS NOT NULL
+                 AND next_due_at > UTC_TIMESTAMP()
+                THEN 1 ELSE 0
+            END) AS retry_count,
+            SUM(CASE
+                WHEN (locked_until IS NULL OR locked_until <= UTC_TIMESTAMP())
+                 AND (current_state IS NULL OR current_state <> 'running')
+                 AND next_due_at IS NOT NULL
+                 AND next_due_at <= UTC_TIMESTAMP()
+                 AND (last_status IS NULL OR last_status NOT IN ('failed', 'error'))
+                THEN 1 ELSE 0
+            END) AS ready_count
+         FROM sync_schedules
+         WHERE enabled = 1"
+    );
+    $schedCounts = $schedQueueRow[0] ?? [];
+    $schedReady = (int) ($schedCounts['ready_count'] ?? 0);
+    $schedRunning = (int) ($schedCounts['running_count'] ?? 0);
+    $schedRetry = (int) ($schedCounts['retry_count'] ?? 0);
+
+    if (($schedReady + $schedRunning + $schedRetry) > 0) {
+        $backlogQueue['queued'] += $schedReady;
+        $backlogQueue['running'] += $schedRunning;
+        $backlogQueue['retry'] += $schedRetry;
+        $backlogQueue['total'] += $schedReady + $schedRunning + $schedRetry;
+        $backlogByQueue['loop_runner'] = [
+            'queued' => $schedReady,
+            'running' => $schedRunning,
+            'retry' => $schedRetry,
+        ];
     }
 
     // ── Overdue job details ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR fixes the job backlog widget to accurately report queue depth for deployments using the loop-runner (lane-*) services and PHP scheduler daemon, which were previously showing empty backlogs. It also adds safety checks to prevent the update-and-restart script from restarting its own invoking service.

## Key Changes

### Job Backlog Reporting (`src/functions.php`)
- **Extended backlog tracking to include `sync_schedules` table**: The backlog widget previously only read from `worker_jobs` (legacy Python worker-pool), causing deployments using the loop-runner/PHP scheduler path to show zero backlog.
- **Added comprehensive documentation**: Detailed comments explaining the two execution paths (`worker_jobs` vs `sync_schedules`), their status values, and how they differ.
- **Implemented dual-source aggregation**: Now queries both tables and sums their results, ensuring accurate backlog reporting for mixed deployments and eliminating misleading all-zero backlogs for single-path deployments.
- **Added loop-runner queue tracking**: Schedules ready to run are bucketed as "queued", currently locked schedules as "running", and failed schedules with future retries as "retry".

### Service Restart Safety (`scripts/update-and-restart.sh`)
- **Added self-unit detection**: Uses `INVOCATION_ID` environment variable (set by systemd) to identify the currently running service and prevent it from restarting itself.
- **Added oneshot service filtering**: Skips oneshot services during restart since they are run-to-completion by design and restarting them mid-execution causes systemd job failures. Timers that trigger oneshots are still restarted (the correct control point).
- **Implemented belt-and-suspenders safety**: Combines both oneshot filtering and explicit self-unit checks to prevent self-restart scenarios.

## Implementation Details
- The `sync_schedules` query uses a single aggregate statement with ordered CASE clauses to avoid double-counting schedules that match multiple conditions.
- Running state detection for `sync_schedules` includes a 3-hour lookback window to account for long-running schedules.
- The self-unit detection gracefully handles cases where `INVOCATION_ID` is not set or systemd queries fail.

https://claude.ai/code/session_01Xfb13xgNJVXrYSWv44cMKN