### PR TITLE
fix(loop_runner): skip thread-join on shutdown to stay under TimeoutStopSec

### DIFF
--- a/python/orchestrator/loop_runner.py
+++ b/python/orchestrator/loop_runner.py
@@ -1078,18 +1078,6 @@ def main(argv: list[str] | None = None) -> int:
     except KeyboardInterrupt:
         shutdown_event.set()
 
-    # Wait for loops to finish.
-    for t in threads:
-        t.join(timeout=30)
-
-    _write_state_file(state_file, {
-        "ts": utc_now_iso(),
-        "worker_id": worker_id,
-        "status": "stopped",
-    })
-
-    logger.info("loop runner stopped", payload={"event": "loop_runner.stopped", "worker_id": worker_id})
-
     # When shutting down on a signal (SIGTERM/SIGINT) or a memory-abort
     # request, the inner ThreadPoolExecutors used by run_tier() and
     # _run_cycle_dependency_aware() were torn down with
@@ -1104,13 +1092,43 @@ def main(argv: list[str] | None = None) -> int:
     # `Failed with result 'timeout'` / SIGKILL on the lane services
     # (#1001 lane-compute-bg, #1003 lane-compute).
     #
-    # Force-exit instead so systemd records a clean stop.  All per-job DB
-    # state was finalised by `_finalize_job` before this point and the JSON
-    # log handlers flush line-by-line, so nothing material is lost.  The
-    # `--once` path returns normally because shutdown_event stays unset
-    # there.
+    # The existing force-exit below (`os._exit(0)`) bypasses that atexit
+    # handler, but it only runs *after* the sequential `t.join(timeout=30)`
+    # loop finishes.  Neither run_tier()'s `as_completed(..., timeout=...)`
+    # nor _run_cycle_dependency_aware()'s dispatch loop wake on
+    # `shutdown_event`, so each lane thread typically burns its full 30s
+    # join budget before falling through.  Lane-ingestion runs *both* a
+    # fast-loop and a background-loop thread (no `--fast-only`), so the
+    # join burns up to 60s — add the 15s shutdown_event.wait() wakeup
+    # window and we are right at systemd's TimeoutStopSec=90s, which is
+    # how #1005 `supplycore-lane-ingestion.service: Failed with result
+    # 'timeout'` keeps recurring on hourly restart.
+    #
+    # Skip the join loop entirely on shutdown — per-job DB state was
+    # finalised by `_finalize_job` before this point and the JSON log
+    # handlers flush line-by-line, so nothing material is lost.  The
+    # `--once` path still joins normally because `shutdown_event` stays
+    # unset there.
     if shutdown_event.is_set():
+        _write_state_file(state_file, {
+            "ts": utc_now_iso(),
+            "worker_id": worker_id,
+            "status": "stopped",
+        })
+        logger.info("loop runner stopped", payload={"event": "loop_runner.stopped", "worker_id": worker_id})
         os._exit(0)
+
+    # Normal --once path: wait for loops to finish naturally.
+    for t in threads:
+        t.join(timeout=30)
+
+    _write_state_file(state_file, {
+        "ts": utc_now_iso(),
+        "worker_id": worker_id,
+        "status": "stopped",
+    })
+
+    logger.info("loop runner stopped", payload={"event": "loop_runner.stopped", "worker_id": worker_id})
 
     return 0
 


### PR DESCRIPTION
## Summary

Follow-up to `dddb0a2` (force-exit on shutdown). The `os._exit(0)` safety
net at the bottom of `loop_runner.main()` bypasses Python's
`concurrent.futures` atexit join, but it only runs *after* the sequential
`t.join(timeout=30)` loop finishes. Neither `run_tier()`'s
`as_completed(..., timeout=tier_timeout)` nor `_run_cycle_dependency_aware()`'s
dispatch loop wakes on `shutdown_event`, so each lane thread typically
burns its full 30s join budget before falling through to the force-exit.

`supplycore-lane-ingestion.service` runs **both** a fast-loop and a
background-loop thread (no `--fast-only`), so the join burns up to 60s.
Add the 15s `shutdown_event.wait()` wakeup window at the top of the
heartbeat loop and we are right at systemd's `TimeoutStopSec=90s`. On a
loaded host that's enough to trip `Failed with result 'timeout'` /
SIGKILL, which is how #1005 keeps recurring on hourly
`update-and-restart.sh` runs.

## Fix

Skip the `t.join(timeout=30)` loop entirely when `shutdown_event` is
set, and go straight to:
1. final heartbeat write (`status=stopped`)
2. stopped log line
3. `os._exit(0)`

Shutdown path budget drops from ~75s to ~1s. Per-job DB rows were
finalised by `_finalize_job` before this point and the JSON log handlers
flush line-by-line, so nothing material is lost.

The `--once` path is unaffected — `shutdown_event` stays unset there,
so the normal join fallthrough (preserved below the new early-exit
block) still runs.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('python/orchestrator/loop_runner.py').read())"` — parses clean
- [ ] Hourly `update-and-restart.sh` no longer logs
  `supplycore-lane-ingestion.service: Failed with result 'timeout'` /
  `Main process exited, code=killed, status=9/KILL` for the ingestion
  lane
- [ ] `--once` CLI runs (used by `scripts/test-all-sync-jobs.sh`) still
  exit normally

Closes #1005
