### PR TITLE
Add background compute lane and auto-enable newly installed units

### DIFF
--- a/python/orchestrator/db.py
+++ b/python/orchestrator/db.py
@@ -1217,6 +1217,21 @@ class SupplyCoreDb:
         ui_sections_json: str | None = None,
         section_versions_json: str | None = None,
     ) -> int:
+        # Include a UTC timestamp in event_key so each job finish creates a
+        # new row. Without this, the UNIQUE constraint on event_key (see
+        # ``uniq_ui_refresh_event_key`` in src/db.php) collapses every
+        # subsequent run of the same job into an UPDATE of the first row —
+        # and because the ON DUPLICATE KEY UPDATE clause below does not
+        # touch ``finished_at``, ``MAX(finished_at)`` (which drives the Log
+        # Viewer's "Live refresh · X ago" indicator and the
+        # ``db_ui_refresh_events_after`` SSE stream used for dashboard
+        # auto-refresh) would freeze the moment every job had run once
+        # under the Python loop-runner. The format matches
+        # ``supplycore_ui_refresh_publish_for_job_result`` in
+        # src/functions.php so both execution paths produce compatible
+        # rows. ``finished_at=VALUES(finished_at)`` is kept as belt-and-
+        # braces for the rare same-second collision case.
+        event_key = f"{job_key}:{job_status}:{time.strftime('%Y%m%d%H%M%S', time.gmtime())}"
         return self.insert(
             """INSERT INTO ui_refresh_events (
                     event_type, event_key, job_key, job_status, finished_at,
@@ -1227,9 +1242,11 @@ class SupplyCoreDb:
                 ON DUPLICATE KEY UPDATE
                     updated_at=CURRENT_TIMESTAMP,
                     id=LAST_INSERT_ID(id),
+                    finished_at=VALUES(finished_at),
+                    job_status=VALUES(job_status),
                     section_versions_json=COALESCE(VALUES(section_versions_json), section_versions_json)""",
             (
-                f"worker_pool:{job_key}"[:190],
+                event_key[:190],
                 job_key[:190],
                 job_status[:40],
                 domains_json,

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -469,7 +469,7 @@ fi
 # ===========================  Render and install units  ====================
 
 # Lane-based services (always render so they're available if user switches later)
-for lane_unit in supplycore-lane-realtime.service supplycore-lane-ingestion.service supplycore-lane-compute.service supplycore-lane-maintenance.service; do
+for lane_unit in supplycore-lane-realtime.service supplycore-lane-ingestion.service supplycore-lane-compute.service supplycore-lane-compute-bg.service supplycore-lane-maintenance.service; do
   render_unit "${REPO_ROOT}/ops/systemd/${lane_unit}" "${SYSTEMD_DIR}/${lane_unit}"
 done
 
@@ -503,6 +503,7 @@ if [[ ${RUNNER_MODE} == "lanes" ]]; then
     "supplycore-lane-realtime.service"
     "supplycore-lane-ingestion.service"
     "supplycore-lane-compute.service"
+    "supplycore-lane-compute-bg.service"
     "supplycore-lane-maintenance.service"
   )
   # Disable the monolithic runner if it was previously enabled.
@@ -514,7 +515,7 @@ if [[ ${RUNNER_MODE} == "lanes" ]]; then
 else
   services_to_enable+=("supplycore-loop-runner.service")
   # Disable lane services if they were previously enabled.
-  for lane_svc in supplycore-lane-realtime.service supplycore-lane-ingestion.service supplycore-lane-compute.service supplycore-lane-maintenance.service; do
+  for lane_svc in supplycore-lane-realtime.service supplycore-lane-ingestion.service supplycore-lane-compute.service supplycore-lane-compute-bg.service supplycore-lane-maintenance.service; do
     if systemctl is-enabled "${lane_svc}" >/dev/null 2>&1; then
       echo "Disabling lane service ${lane_svc} (using monolithic runner)"
       systemctl stop "${lane_svc}" 2>/dev/null || true
@@ -557,6 +558,7 @@ if [[ ${RUNNER_MODE} == "lanes" ]]; then
   echo "  systemctl status supplycore-lane-realtime.service"
   echo "  systemctl status supplycore-lane-ingestion.service"
   echo "  systemctl status supplycore-lane-compute.service"
+  echo "  systemctl status supplycore-lane-compute-bg.service"
   echo "  systemctl status supplycore-lane-maintenance.service"
 else
   echo "  systemctl status supplycore-loop-runner.service"

--- a/scripts/update-and-restart.sh
+++ b/scripts/update-and-restart.sh
@@ -29,6 +29,10 @@ SMART_SKIP_RESTART=0
 RESTART_SERVICES=()
 FAILED_SERVICES=()
 UNHEALTHY_SERVICES=()
+# Core units that were newly installed this run (dest file did not exist
+# before sync). These get enable --now'd after daemon-reload, because the
+# normal service discovery only sees units that are already loaded.
+NEW_CORE_UNITS=()
 
 # Timeout (seconds) to wait for a service to become active after restart.
 HEALTH_CHECK_TIMEOUT=30
@@ -294,6 +298,12 @@ sync_systemd_units() {
     if [[ -f "${dest}" ]] && cmp -s "${src}" "${dest}"; then
       continue  # already up to date
     fi
+    # Track fresh installs (dest previously absent) so we can enable them
+    # after daemon-reload. systemctl discover only sees loaded units, so a
+    # brand-new unit file would otherwise sit unused in /etc/systemd/system.
+    if [[ ! -f "${dest}" ]]; then
+      NEW_CORE_UNITS+=("${unit}")
+    fi
     log "Installing ${unit}"
     run_cmd cp "${src}" "${dest}"
     UNITS_CHANGED=1
@@ -342,6 +352,74 @@ sync_systemd_units() {
       | awk '{print $1}' \
       | grep -E "^${base_name}@" \
       || true)
+  done
+}
+
+# Enable and start newly-installed core units after daemon-reload.
+#
+# discover_services() only picks up units that systemd already knows about,
+# so a newly-copied unit file (e.g. supplycore-lane-compute-bg.service on
+# a host that never had it) would otherwise be copied but never started.
+# This function runs `systemctl enable --now` for each fresh install, with
+# guards for opt-in timers and the lanes-vs-monolithic runner conflict.
+enable_new_core_units() {
+  if [[ ${#NEW_CORE_UNITS[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  # Detect which runner mode the host is using so we don't start a service
+  # that conflicts with the active mode (lanes vs monolithic).
+  local lanes_active=false
+  for lane_svc in \
+      supplycore-lane-realtime.service \
+      supplycore-lane-ingestion.service \
+      supplycore-lane-compute.service \
+      supplycore-lane-compute-bg.service \
+      supplycore-lane-maintenance.service; do
+    if systemctl is-active --quiet "${lane_svc}" 2>/dev/null \
+        || systemctl is-enabled --quiet "${lane_svc}" 2>/dev/null; then
+      lanes_active=true
+      break
+    fi
+  done
+
+  local monolithic_active=false
+  if systemctl is-active --quiet supplycore-loop-runner.service 2>/dev/null \
+      || systemctl is-enabled --quiet supplycore-loop-runner.service 2>/dev/null; then
+    monolithic_active=true
+  fi
+
+  local unit
+  for unit in "${NEW_CORE_UNITS[@]}"; do
+    # Hourly-loop and claude-triage timers are opt-in per the CORE_UNITS
+    # comment above — sync the files but never auto-enable.
+    case "${unit}" in
+      supplycore-hourly-loop.service|supplycore-hourly-loop.timer| \
+      supplycore-claude-triage.service|supplycore-claude-triage.timer)
+        log "Skipping auto-enable of opt-in unit ${unit} (enable manually after review)"
+        continue
+        ;;
+    esac
+
+    # Lane vs monolithic conflict guards.
+    if [[ "${unit}" == supplycore-lane-*.service ]]; then
+      if [[ ${monolithic_active} == true && ${lanes_active} == false ]]; then
+        log "Skipping auto-enable of ${unit}: monolithic loop-runner is active (lanes mode not in use)"
+        continue
+      fi
+    fi
+    if [[ "${unit}" == "supplycore-loop-runner.service" ]]; then
+      if [[ ${lanes_active} == true ]]; then
+        log "Skipping auto-enable of ${unit}: lane services are active (monolithic mode not in use)"
+        continue
+      fi
+    fi
+
+    log "Enabling newly-installed unit ${unit}"
+    if ! run_cmd systemctl enable --now "${unit}"; then
+      log_warn "Failed to enable ${unit}"
+      FAILED_SERVICES+=("${unit}")
+    fi
   done
 }
 
@@ -647,6 +725,11 @@ if [[ ${SMART_SKIP_RESTART} -eq 0 ]]; then
 
   # ------- Service discovery and restart -------
   run_cmd systemctl daemon-reload
+
+  # Enable & start any core units that were freshly installed this run.
+  # Must happen after daemon-reload so systemd picks up the new unit files,
+  # and before discover_services so the new units become visible to it.
+  enable_new_core_units
 
   if [[ ${#EXPLICIT_SERVICES[@]} -gt 0 ]]; then
     RESTART_SERVICES=("${EXPLICIT_SERVICES[@]}")


### PR DESCRIPTION
## Summary
This PR adds support for a new background compute lane service and improves the systemd unit installation process to automatically enable and start newly-installed core units. It also fixes a database issue where UI refresh events were being collapsed into single rows.

## Key Changes

### Systemd Unit Management (`scripts/update-and-restart.sh`)
- Added tracking of newly-installed core units via `NEW_CORE_UNITS` array
- Implemented `enable_new_core_units()` function that:
  - Automatically enables and starts freshly-installed unit files after `daemon-reload`
  - Includes guards to prevent conflicts between lanes and monolithic runner modes
  - Respects opt-in timers (hourly-loop, claude-triage) by skipping auto-enable
  - Detects active runner mode to avoid starting conflicting services
- Integrated new function into the update flow, running after `daemon-reload` but before service discovery

### Background Compute Lane Service (`scripts/install-services.sh`)
- Added `supplycore-lane-compute-bg.service` to the list of lane-based services
- Updated all relevant service lists and documentation to include the new background compute lane
- Ensured proper handling in both lanes and monolithic runner modes

### UI Refresh Events Database (`python/orchestrator/db.py`)
- Fixed `insert_ui_refresh_event()` to include UTC timestamp in `event_key`
- This prevents the UNIQUE constraint from collapsing multiple job runs into a single row
- Ensures `finished_at` and `job_status` are properly updated on duplicate key
- Maintains compatibility with the PHP implementation (`supplycore_ui_refresh_publish_for_job_result`)

## Implementation Details

The new `enable_new_core_units()` function solves a critical issue where newly-copied systemd unit files would not be discovered by `systemctl` until the next system boot. By explicitly enabling and starting fresh installs after `daemon-reload`, the units become immediately available without requiring a restart.

The function includes sophisticated conflict detection to handle the lanes vs. monolithic runner modes, ensuring that:
- Lane services are only enabled if lanes mode is active
- The monolithic loop-runner is only enabled if lanes mode is not active
- Opt-in services require manual enablement for safety

https://claude.ai/code/session_01Q4X5nc7xwcgoux1F6RTPMF