### PR TITLE
ops(systemd): raise lane memory ceilings to match host capacity

### DIFF
--- a/ops/systemd/supplycore-lane-compute-bg.service
+++ b/ops/systemd/supplycore-lane-compute-bg.service
@@ -10,13 +10,13 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 3 --background-pause 30 --background-only --memory-max-gb 2.5 --no-tier-barriers
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 3 --background-pause 30 --background-only --memory-max-gb 6.0 --no-tier-barriers
 Nice=10
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=3G
+MemoryMax=8G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-compute.service
+++ b/ops/systemd/supplycore-lane-compute.service
@@ -10,13 +10,13 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 4 --fast-pause 15 --fast-only --memory-max-gb 1.5
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 4 --fast-pause 15 --fast-only --memory-max-gb 3.0
 Nice=5
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=2G
+MemoryMax=4G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-ingestion.service
+++ b/ops/systemd/supplycore-lane-ingestion.service
@@ -15,7 +15,7 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=1G
+MemoryMax=2G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-realtime.service
+++ b/ops/systemd/supplycore-lane-realtime.service
@@ -15,7 +15,7 @@ Restart=always
 RestartSec=3
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=2G
+MemoryMax=3G
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Summary

The lane memory limits were defensive picks from the compute-lane split in 0276ae1, where the goal was "don't OOM-kill the combined fast+bg process again" — the 3G + 2G chosen for compute-bg + compute stayed close to the old 3G combined ceiling. On a host with 28 GiB free, the background compute lane was tripping its own `--memory-max-gb 2.5` graceful-abort guard mid-cycle while draining the CIP / graph-motif / theater-clustering / threat-corridor backlog, forcing a systemd restart every couple of minutes.

Observed in production just after the compute-bg service was wired up:

```
background: memory abort threshold reached mid-cycle (2.7 GiB),
draining 3 in-flight job(s) before shutdown
in_flight: 3   remaining: 38
```

## Changes

Raise the ceilings so memory-hungry compute jobs have real headroom:

| Lane | `--memory-max-gb` | `MemoryMax` |
|---|---|---|
| compute-bg | 2.5 → **6.0** | 3G → **8G** |
| compute (fast) | 1.5 → **3.0** | 2G → **4G** |
| realtime | — | 2G → **3G** |
| ingestion | — | 1G → **2G** |
| maintenance | (unchanged) | 512M (unchanged) |

Combined ceiling across all five lanes is now **~19 GiB** (up from ~8.5 GiB), still leaving **~17 GiB** for the MariaDB buffer pool, Neo4j, PHP-FPM, zkill consumer, and kernel page cache on a 36+ GiB host. The maintenance lane is left alone — it's I/O-bound and already comfortable at 512 MiB.

`--max-parallel` is intentionally unchanged. Memory and concurrency are separate knobs, and the jobs were finishing successfully before the mid-cycle abort — this PR just gives them room to run. Parallelism can be bumped later if the new headroom sits idle.

## Test plan

- [ ] Pull on production and run `./scripts/update-and-restart.sh`
- [ ] `systemctl status supplycore-lane-compute-bg.service` shows `MemoryMax=8G` and is active
- [ ] `journalctl -u supplycore-lane-compute-bg.service -f` — no `memory_abort_midcycle` events under normal load for at least one full cycle
- [ ] `systemctl show supplycore-lane-compute.service -p MemoryMax` reports `4G`
- [ ] `free -g` on the host still shows ample free memory (expect ≥15 GiB free under steady state)
- [ ] The stuck compute-bg backlog (CIP pipeline, graph motif detection, theater clustering, threat corridors) drains without restart-looping
