### PR TITLE
ops(systemd): double lane memory ceilings

### DIFF
--- a/ops/systemd/supplycore-lane-compute-bg.service
+++ b/ops/systemd/supplycore-lane-compute-bg.service
@@ -10,13 +10,13 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 3 --background-pause 30 --background-only --memory-max-gb 6.0 --no-tier-barriers
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 3 --background-pause 30 --background-only --memory-max-gb 12.0 --no-tier-barriers
 Nice=10
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=8G
+MemoryMax=16G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-compute.service
+++ b/ops/systemd/supplycore-lane-compute.service
@@ -10,13 +10,13 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 4 --fast-pause 15 --fast-only --memory-max-gb 3.0
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 4 --fast-pause 15 --fast-only --memory-max-gb 6.0
 Nice=5
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=4G
+MemoryMax=8G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-ingestion.service
+++ b/ops/systemd/supplycore-lane-ingestion.service
@@ -15,7 +15,7 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=2G
+MemoryMax=4G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-realtime.service
+++ b/ops/systemd/supplycore-lane-realtime.service
@@ -15,7 +15,7 @@ Restart=always
 RestartSec=3
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=3G
+MemoryMax=6G
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Summary

Follow-up to #1034. That first bump was still on the conservative side — the compute-bg lane is the workhorse for the CIP pipeline, graph motif detection, theater clustering, threat corridors, and the copresence/cohort backfills, and with ~28 GiB free on the box we can afford to give it substantially more headroom without pressuring MariaDB or Neo4j.

Double every touched lane from the #1034 values:

| Lane | `--memory-max-gb` | `MemoryMax` |
|---|---|---|
| compute-bg | 6.0 → **12.0** | 8G → **16G** |
| compute (fast) | 3.0 → **6.0** | 4G → **8G** |
| realtime | — | 3G → **6G** |
| ingestion | — | 2G → **4G** |
| maintenance | (unchanged) | 512M (unchanged) |

Combined worst-case ceiling across the five lanes is now **~34.5 GiB**, but this is a per-lane cap, not a commitment — realtime and ingestion are latency/API-bound and rarely approach their limit, and compute-fast and compute-bg don't typically peak simultaneously since compute-fast pauses (`--fast-pause 15`) give its working set time to be reclaimed. Expected steady-state combined usage is well below the cap.

Maintenance lane (512 MiB) is left alone — I/O-bound, already comfortable.

`--max-parallel` is unchanged; memory and concurrency are separate knobs and none of the observed aborts were from parallelism pressure.

## Test plan

- [ ] Merge, pull on production, run `./scripts/update-and-restart.sh`
- [ ] `systemctl show supplycore-lane-compute-bg.service -p MemoryMax` reports `17179869184` (16G)
- [ ] `systemctl show supplycore-lane-compute.service -p MemoryMax` reports `8589934592` (8G)
- [ ] `journalctl -u supplycore-lane-compute-bg.service -f` shows no `loop_runner.memory_abort_midcycle` events for at least one full backlog drain cycle
- [ ] `free -g` still shows ample free memory under steady state (expect ≥10 GiB free)
- [ ] MariaDB buffer pool and Neo4j heap stay healthy — no swap pressure (`vmstat 5` — `si`/`so` should remain 0)
