### PR TITLE
ops(systemd): double lane memory ceilings again + drop compute-bg parallelism to 2

### DIFF
--- a/ops/systemd/supplycore-lane-compute-bg.service
+++ b/ops/systemd/supplycore-lane-compute-bg.service
@@ -10,13 +10,13 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 3 --background-pause 30 --background-only --memory-max-gb 12.0 --no-tier-barriers
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 3 --background-pause 30 --background-only --memory-max-gb 24.0 --no-tier-barriers
 Nice=10
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=16G
+MemoryMax=32G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-compute-bg.service
+++ b/ops/systemd/supplycore-lane-compute-bg.service
@@ -10,7 +10,7 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 3 --background-pause 30 --background-only --memory-max-gb 24.0 --no-tier-barriers
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 2 --background-pause 30 --background-only --memory-max-gb 24.0 --no-tier-barriers
 Nice=10
 Restart=always
 RestartSec=5

--- a/ops/systemd/supplycore-lane-compute.service
+++ b/ops/systemd/supplycore-lane-compute.service
@@ -10,13 +10,13 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 4 --fast-pause 15 --fast-only --memory-max-gb 6.0
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute --max-parallel 4 --fast-pause 15 --fast-only --memory-max-gb 12.0
 Nice=5
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=8G
+MemoryMax=16G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-ingestion.service
+++ b/ops/systemd/supplycore-lane-ingestion.service
@@ -15,7 +15,7 @@ Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=4G
+MemoryMax=8G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-realtime.service
+++ b/ops/systemd/supplycore-lane-realtime.service
@@ -15,7 +15,7 @@ Restart=always
 RestartSec=3
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=6G
+MemoryMax=12G
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Summary

Third round of compute-bg headroom tuning. After #1035 landed (doubling from #1034), production showed compute-bg still tripping its graceful abort guard mid-cycle — only a couple of minutes into a fresh cycle, at 12.9 GiB against the new 12.0 GiB threshold:

```
background: cycle 1 starting
background: 37 jobs due, 14 not yet due (skipped)
job finished: compute_graph_prune            (14.5s)
job finished: compute_graph_topology_metrics (65.8s)
background: memory abort threshold reached mid-cycle (12.9 GiB),
draining 3 in-flight job(s) before shutdown
in_flight: 3   remaining: 32
```

A single graph/CIP-heavy compute-bg cycle alone exceeds the post-#1035 cap, so we're doubling the ceilings one more time and, for the first time, also tuning concurrency.

## Memory changes (×2 from the #1035 values)

| Lane | `--memory-max-gb` | `MemoryMax` |
|---|---|---|
| compute-bg | 12.0 → **24.0** | 16G → **32G** |
| compute (fast) | 6.0 → **12.0** | 8G → **16G** |
| realtime | — | 6G → **12G** |
| ingestion | — | 4G → **8G** |
| maintenance | (unchanged) | 512M (unchanged) |

These are per-lane caps enforced by the cgroup — they are **ceilings, not reservations**. realtime, ingestion, and compute-fast rarely approach their limits under normal load, so worst-case simultaneous peak across all lanes is well below the sum. Host still has ample headroom.

## Parallelism change (compute-bg only)

`--max-parallel 3 → **2**` on `supplycore-lane-compute-bg.service`.

Running three heavy graph/CIP jobs concurrently is what drives the mid-cycle RSS spike. Dropping to two in-flight jobs reduces peak concurrent working set while still keeping the bg lane ahead of the other lanes for throughput. Net effect: slightly slower steady-state backlog drain, but far fewer mid-cycle aborts and restart loops. Other lanes keep their existing parallelism.

## Test plan

- [ ] Merge, pull on production, run `./scripts/update-and-restart.sh`
- [ ] `systemctl show supplycore-lane-compute-bg.service -p MemoryMax` reports `34359738368` (32G)
- [ ] `systemctl cat supplycore-lane-compute-bg.service | grep ExecStart` shows `--max-parallel 2` and `--memory-max-gb 24.0`
- [ ] `journalctl -u supplycore-lane-compute-bg.service -f` — no `loop_runner.memory_abort_midcycle` events over at least two full cycles of the compute-bg backlog
- [ ] `free -g` stays comfortably positive under steady state
- [ ] `vmstat 5` — `si`/`so` remain `0` (no swap activity)
