### PR TITLE
Fix alliance dossier overflow and auto-queue unresolved names

### DIFF
--- a/database/migrations/20260511_widen_alliance_dossier_rate_columns.sql
+++ b/database/migrations/20260511_widen_alliance_dossier_rate_columns.sql
@@ -1,0 +1,22 @@
+-- Widen alliance_dossiers behavioral metric columns.
+--
+-- The previous DECIMAL(8,4) ceiling of 9999.9999 overflowed for very active
+-- alliances where kills_per_week exceeds 9999 (avg_engagement_rate) or the
+-- kill/loss ratio exceeds 9999 (avg_overperformance, when total_losses is
+-- very low relative to total_kills). The compute_alliance_dossiers job then
+-- failed with MariaDB error 1264 ("Out of range value for column
+-- 'avg_engagement_rate'") and wrote zero rows.
+--
+-- DECIMAL(14,4) gives a ceiling of 9,999,999,999.9999, which comfortably
+-- covers any realistic kills_per_week or kill/loss ratio value we could
+-- observe from killmail aggregation.
+ALTER TABLE alliance_dossiers
+    MODIFY COLUMN avg_engagement_rate DECIMAL(14,4) DEFAULT NULL,
+    MODIFY COLUMN avg_token_participation DECIMAL(14,4) DEFAULT NULL,
+    MODIFY COLUMN avg_overperformance DECIMAL(14,4) DEFAULT NULL;
+
+-- Keep the downstream opposition_daily_snapshots column aligned with the
+-- widened source so compute_opposition_daily_snapshots doesn't have to
+-- clamp values at DECIMAL(8,4) precision.
+ALTER TABLE opposition_daily_snapshots
+    MODIFY COLUMN engagement_rate DECIMAL(14,4) DEFAULT NULL;

--- a/python/orchestrator/jobs/compute_alliance_dossiers.py
+++ b/python/orchestrator/jobs/compute_alliance_dossiers.py
@@ -89,6 +89,28 @@ BATCH_SIZE = 200
 RECENT_DAYS = 30
 TOP_K = 10
 
+# Upper bound for DECIMAL(14,4) columns (alliance_dossiers.avg_engagement_rate,
+# avg_token_participation, avg_overperformance). Values derived from raw
+# killmail aggregation (kills_per_week, kill/loss ratio) can spike for very
+# active alliances; clamping here is a defensive guard so a single outlier
+# never aborts the entire batch with MariaDB error 1264.
+_DECIMAL_14_4_MAX = 9_999_999_999.9999
+
+
+def _clamp_decimal(value: Any) -> float | None:
+    """Clamp a numeric value to the DECIMAL(14,4) representable range."""
+    if value is None:
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    if num > _DECIMAL_14_4_MAX:
+        return _DECIMAL_14_4_MAX
+    if num < -_DECIMAL_14_4_MAX:
+        return -_DECIMAL_14_4_MAX
+    return num
+
 
 def _dossier_log(runtime: dict[str, Any] | None, event: str, payload: dict[str, Any]) -> None:
     log_path = str(((runtime or {}).get("log_file") or "")).strip()
@@ -703,6 +725,37 @@ def _resolve_alliance_names(db: SupplyCoreDb, alliance_ids: list[int]) -> dict[i
     return {int(r["entity_id"]): str(r["entity_name"]) for r in rows if r.get("entity_name")}
 
 
+def _queue_pending_alliance_names(db: SupplyCoreDb, alliance_ids: list[int]) -> int:
+    """Enqueue alliance IDs as 'pending' in entity_metadata_cache.
+
+    Alliance IDs that surface via Neo4j / relationship-graph lookups but
+    have never been seen in killmail ingestion won't exist in
+    ``entity_metadata_cache`` yet, so name resolution falls back to the
+    ``Alliance #<id>`` placeholder. Inserting a ``pending`` row ensures
+    the next ``entity_metadata_resolve_sync`` run picks them up via ESI,
+    so subsequent dossier runs produce real names without manual
+    intervention.
+    """
+    ids = sorted({int(aid) for aid in alliance_ids if int(aid) > 0})
+    if not ids:
+        return 0
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    queued = 0
+    for eid in ids:
+        try:
+            db.execute(
+                """INSERT INTO entity_metadata_cache
+                   (entity_type, entity_id, source_system, resolution_status, last_requested_at)
+                   VALUES ('alliance', %s, 'queue', 'pending', %s)
+                   ON DUPLICATE KEY UPDATE last_requested_at = VALUES(last_requested_at)""",
+                (eid, now),
+            )
+            queued += 1
+        except Exception as exc:
+            logger.warning("Failed to queue alliance %d for name resolution: %s", eid, exc)
+    return queued
+
+
 def _flush_dossiers(db: SupplyCoreDb, dossiers: list[dict[str, Any]]) -> int:
     """Write dossier rows to MariaDB using batched executemany."""
     if not dossiers:
@@ -879,9 +932,9 @@ def run_compute_alliance_dossiers(
                 "last_seen_at": a.get("last_seen_at"),
                 "primary_region_id": geo["primary_region_id"],
                 "primary_system_id": geo["primary_system_id"],
-                "avg_engagement_rate": behavior.get("kills_per_week", 0),
-                "avg_token_participation": behavior.get("solo_ratio", 0),
-                "avg_overperformance": behavior.get("kill_loss_ratio"),
+                "avg_engagement_rate": _clamp_decimal(behavior.get("kills_per_week", 0)),
+                "avg_token_participation": _clamp_decimal(behavior.get("solo_ratio", 0)),
+                "avg_overperformance": _clamp_decimal(behavior.get("kill_loss_ratio")),
                 "posture": behavior["posture"],
                 "top_co_present_json": json_dumps_safe(co_present),
                 "top_enemies_json": json_dumps_safe(enemies),
@@ -916,10 +969,12 @@ def run_compute_alliance_dossiers(
 
         if unresolved_ids:
             unique_unresolved = sorted(set(unresolved_ids))
+            queued = _queue_pending_alliance_names(db, unique_unresolved)
             logger.warning(
                 "Could not resolve names for %d alliance IDs (first 10: %s). "
-                "These will display as 'Alliance #ID'. Check entity_metadata_cache population.",
-                len(unique_unresolved), unique_unresolved[:10],
+                "These will display as 'Alliance #ID'. Queued %d for background "
+                "ESI resolution via entity_metadata_resolve_sync.",
+                len(unique_unresolved), unique_unresolved[:10], queued,
             )
 
         if not dry_run:

--- a/python/orchestrator/jobs/compute_opposition_daily_snapshots.py
+++ b/python/orchestrator/jobs/compute_opposition_daily_snapshots.py
@@ -602,7 +602,7 @@ def _processor(db: SupplyCoreDb) -> dict[str, Any]:
             "ship_classes": ship.get("ship_classes", []),
             "ship_types": ship.get("ship_types", []),
             "posture": dos.get("posture"),
-            "engagement_rate": min(dos["engagement_rate"], 9999.9999) if dos.get("engagement_rate") is not None else None,
+            "engagement_rate": dos.get("engagement_rate"),
             "allies": rel.get("allies", []),
             "enemies": rel.get("hostiles", []),
             "theaters": theaters.get(aid, []),


### PR DESCRIPTION
## Summary
This PR addresses two issues in alliance dossier computation:
1. **Column overflow**: Behavioral metrics (kills_per_week, kill/loss ratio) can exceed the previous DECIMAL(8,4) limit for very active alliances, causing MariaDB error 1264 and batch failures
2. **Unresolved alliance names**: Alliance IDs discovered via Neo4j lookups but missing from killmail data fall back to placeholder names; now they're automatically queued for ESI resolution

## Key Changes

- **Widen database columns**: Increased `alliance_dossiers` behavioral metric columns from DECIMAL(8,4) to DECIMAL(14,4), raising the ceiling from 9,999.9999 to 9,999,999,999.9999. Also widened the downstream `opposition_daily_snapshots.engagement_rate` column for consistency.

- **Add defensive clamping**: Introduced `_clamp_decimal()` function to clamp computed values to the DECIMAL(14,4) representable range before database insertion, preventing any single outlier from aborting the entire batch.

- **Auto-queue unresolved names**: New `_queue_pending_alliance_names()` function inserts unresolved alliance IDs into `entity_metadata_cache` with `pending` status, allowing the background `entity_metadata_resolve_sync` job to fetch real names via ESI without manual intervention.

- **Simplify downstream logic**: Removed manual clamping in `compute_opposition_daily_snapshots.py` since the source column now safely accommodates all values.

## Implementation Details

- The `_clamp_decimal()` function handles None values, type conversion errors, and symmetric bounds (positive and negative).
- Alliance name queueing uses `ON DUPLICATE KEY UPDATE` to avoid constraint violations while updating the request timestamp.
- Logging updated to report how many alliance IDs were queued for background resolution.

https://claude.ai/code/session_0122kBTumTmdvEpihFSAjxKS