### PR TITLE
log-viewer: add Last duration column to All Jobs table

### DIFF
--- a/public/log-viewer/index.php
+++ b/public/log-viewer/index.php
@@ -304,6 +304,7 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                         <th class="text-left">Status</th>
                         <th class="text-left">Last run</th>
                         <th class="text-left">Last success</th>
+                        <th class="text-right" title="Duration of the most recent run (elapsed so far if still running)">Last duration</th>
                         <th class="text-left">Interval</th>
                         <th class="text-left">Pressure</th>
                         <th class="text-left">Issue</th>
@@ -311,7 +312,7 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                 </thead>
                 <tbody>
                     <?php if ($filteredJobs === []): ?>
-                        <tr><td colspan="7" class="py-8 text-center text-slate-400">No jobs match this filter.</td></tr>
+                        <tr><td colspan="8" class="py-8 text-center text-slate-400">No jobs match this filter.</td></tr>
                     <?php endif; ?>
                     <?php foreach ($jobsByTier as $tierNum => $tierJobs):
                         $tierLabel = $tierJobs[0]['tier_label'] ?? "Tier {$tierNum}";
@@ -321,7 +322,7 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                         $tierFailed = count(array_filter($tierJobs, fn ($j) => $j['health'] === 'failed' || $j['health'] === 'stuck'));
                     ?>
                         <tr class="bg-white/[0.03]">
-                            <td colspan="7" class="py-2.5 px-4">
+                            <td colspan="8" class="py-2.5 px-4">
                                 <div class="flex items-center gap-3">
                                     <span class="inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-bold <?= $tierTone ?>">T<?= $tierNum ?></span>
                                     <span class="font-semibold text-white text-sm"><?= htmlspecialchars($tierLabel, ENT_QUOTES) ?></span>
@@ -345,6 +346,22 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
                             </td>
                             <td class="text-slate-300"><?= htmlspecialchars($job['last_run_relative'], ENT_QUOTES) ?></td>
                             <td class="text-slate-300"><?= htmlspecialchars($job['last_success_relative'], ENT_QUOTES) ?></td>
+                            <?php
+                                $lastDur = $job['last_duration_seconds'] ?? null;
+                                $interval = (int) $job['interval_seconds'];
+                                // Tone: amber if duration exceeds 80% of interval
+                                // (too slow for its schedule), rose if it exceeds
+                                // the interval entirely, slate otherwise.
+                                $durTone = 'text-slate-300';
+                                if ($lastDur !== null && $interval > 0) {
+                                    if ($lastDur >= $interval) {
+                                        $durTone = 'text-rose-300';
+                                    } elseif ($lastDur >= (int) ($interval * 0.8)) {
+                                        $durTone = 'text-amber-300';
+                                    }
+                                }
+                            ?>
+                            <td class="text-right tabular-nums <?= $durTone ?>"><?= $lastDur !== null ? htmlspecialchars(human_duration_seconds((float) $lastDur), ENT_QUOTES) : '<span class="text-slate-500">-</span>' ?></td>
                             <td class="text-slate-300"><?= $job['interval_seconds'] > 0 ? htmlspecialchars(human_duration_seconds((float) $job['interval_seconds']), ENT_QUOTES) : '-' ?></td>
                             <td>
                                 <?php

--- a/src/functions.php
+++ b/src/functions.php
@@ -26078,6 +26078,22 @@ function log_viewer_page_data(): array
             }
         }
 
+        // Compute last-run duration from cs.last_started_at / last_finished_at.
+        // If the job is still running (no finished_at), show elapsed time so far.
+        // If no start timestamp at all, null — template will render "-".
+        $lastDurationSeconds = null;
+        $lastStartedAt = $s['last_started_at'] ?? null;
+        $lastFinishedAt = $s['last_finished_at'] ?? null;
+        if ($lastStartedAt !== null) {
+            $startTs = strtotime((string) $lastStartedAt);
+            if ($startTs !== false) {
+                $endTs = $lastFinishedAt !== null ? strtotime((string) $lastFinishedAt) : time();
+                if ($endTs !== false && $endTs >= $startTs) {
+                    $lastDurationSeconds = $endTs - $startTs;
+                }
+            }
+        }
+
         $tierInfo = automation_runtime_job_tier($key);
         $jobs[] = [
             'job_key' => $key,
@@ -26087,6 +26103,7 @@ function log_viewer_page_data(): array
             'interval_seconds' => (int) $s['interval_seconds'],
             'last_run_at' => $s['last_run_at'],
             'last_run_relative' => supplycore_relative_datetime($s['last_run_at']),
+            'last_duration_seconds' => $lastDurationSeconds,
             'last_success_at' => $s['last_success_at'] ?? null,
             'last_success_relative' => supplycore_relative_datetime($s['last_success_at'] ?? null),
             'last_failure_at' => $s['last_failure_at'] ?? null,
@@ -26133,6 +26150,7 @@ function log_viewer_page_data(): array
             'interval_seconds' => ((int) ($regMeta['default_interval_minutes'] ?? 30)) * 60,
             'last_run_at' => null,
             'last_run_relative' => 'Never',
+            'last_duration_seconds' => null,
             'last_success_at' => null,
             'last_success_relative' => 'Never',
             'last_failure_at' => null,


### PR DESCRIPTION
## Summary
The log viewer's **Recent Runs** table already shows per-run duration, but the **All Jobs** table (the primary decision-making view where you decide whether an interval needs tuning) had no duration column. That made it impossible to see "last run took 240s but the schedule fires every 60s" at a glance.

- `log_viewer_page_data()` now computes `last_duration_seconds` from `scheduler_job_current_status.last_started_at` / `last_finished_at`, falling back to elapsed time for still-running jobs.
- Template gains a new **Last duration** column placed directly before **Interval** so the two line up visually, colspans bumped from 7 → 8.
- Cell is toned amber when `duration >= 80%` of interval and rose when `duration >= interval`, so jobs at risk of missing their schedule are obvious without reading numbers.
- Registry-only fallback rows (jobs that exist in the registry but not yet provisioned into `sync_schedules`) also get the new key so the template doesn't trip on a missing index.

## Test plan
- [ ] Deploy and open `/log-viewer/` — confirm the "All Jobs" table now has a "Last duration" column between "Last success" and "Interval".
- [ ] Spot-check a long-running job (e.g. `compute_behavioral_scoring`) — expect the cell to tone rose/amber if its last run took ≥ its interval.
- [ ] Confirm registry-only jobs still render as "-" in the duration cell with no PHP warnings in `storage/logs`.

https://claude.ai/code/session_01Q4X5nc7xwcgoux1F6RTPMF