### PR TITLE
Fix recent killmail count to use insertion timestamp

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -12959,10 +12959,21 @@ function db_killmail_overview_summary(int $recentHours = 24, string $startDate =
     // UPDATE, so there is never more than one row per identity. Scanning
     // killmail_events directly is safe and orders of magnitude faster than
     // wrapping it in a GROUP BY derived table (db_killmail_latest_sequences_sql).
+    //
+    // `recent_count` powers the "Recent Ingestion — Stored in the last N hours"
+    // card on the overview dashboard, so it must filter on the row-insertion
+    // timestamp (`created_at`), NOT `effective_killmail_at`. The latter is a
+    // generated column `COALESCE(killmail_time, created_at)` that resolves to
+    // the in-game kill time, so every backfill write (EveRef tarball imports,
+    // character_killmail_sync, killmail_history_backfill, ...) lands with an
+    // old `effective_killmail_at` and was invisible to this counter even
+    // though the row had just been stored. The end result was a permanent
+    // "Recent Ingestion: 0" display whenever the R2Z2 live stream happened
+    // to be quiet, despite the total count and sync freshness both moving.
     $summary = db_select_one(
         "SELECT
             COUNT(*) AS total_count,
-            SUM(CASE WHEN e.effective_killmail_at >= (UTC_TIMESTAMP() - INTERVAL {$safeRecentHours} HOUR) THEN 1 ELSE 0 END) AS recent_count,
+            SUM(CASE WHEN e.created_at >= (UTC_TIMESTAMP() - INTERVAL {$safeRecentHours} HOUR) THEN 1 ELSE 0 END) AS recent_count,
             MAX(e.sequence_id) AS max_sequence_id,
             MAX(e.created_at) AS last_ingested_at,
             MAX(e.uploaded_at) AS latest_uploaded_at


### PR DESCRIPTION
## Summary
Fixed the "Recent Ingestion" counter on the overview dashboard to correctly count killmails based on when they were stored in the database, rather than their in-game kill time.

## Key Changes
- Changed `recent_count` calculation in `db_killmail_overview_summary()` to filter on `created_at` (row insertion timestamp) instead of `effective_killmail_at` (in-game kill time)
- Added detailed comment explaining why this distinction matters for backfilled killmails

## Implementation Details
The `effective_killmail_at` column is a generated column that resolves to the in-game kill time via `COALESCE(killmail_time, created_at)`. When killmails are backfilled (via EveRef tarball imports, character_killmail_sync, killmail_history_backfill, etc.), they are inserted with old `effective_killmail_at` values, making them invisible to the recent count filter even though they were just stored.

This caused the "Recent Ingestion: 0" display to appear permanently during quiet periods on the R2Z2 live stream, despite the total count and sync freshness metrics updating correctly. Using `created_at` ensures the counter accurately reflects recently stored data regardless of the killmail's in-game timestamp.

https://claude.ai/code/session_01EYrAjzw5ZwqgqTzMeSU356