### PR TITLE
Add scheduler cycle report viewer and fix tier timeout calculation

### DIFF
--- a/public/log-viewer/index.php
+++ b/public/log-viewer/index.php
@@ -18,6 +18,7 @@ $failedRuns = $pageData['failed_runs'];
 $stuckRuns = $pageData['stuck_runs'];
 $neverRan = $pageData['never_ran'];
 $logFiles = $pageData['log_files'];
+$schedulerCycles = $pageData['scheduler_cycles'] ?? [];
 $kpi = $pageData['kpi'];
 $recentRuns = $pageData['recent_runs'];
 $backlog = $pageData['backlog'];
@@ -397,6 +398,122 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
     </div>
 </section>
 <!-- ui-section:log-viewer-jobs:end -->
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     Scheduler Cycle Report — parsed from storage/logs/scheduler-report.jsonl
+     ══════════════════════════════════════════════════════════════════════════ -->
+<?php if ($schedulerCycles !== []): ?>
+<section class="mt-8" data-ui-section="log-viewer-scheduler-cycles">
+    <h2 class="section-title mb-4">Scheduler Cycles</h2>
+    <p class="mb-3 text-xs text-slate-400">
+        Last <?= count($schedulerCycles) ?> cycles parsed from
+        <code class="text-slate-300">storage/logs/scheduler-report.jsonl</code> (one row per lane per cycle, newest first).
+    </p>
+    <div class="rounded-2xl border border-white/8 bg-white/[0.02] p-1">
+        <div class="table-shell overflow-x-auto">
+            <table class="table-ui w-full">
+                <thead>
+                    <tr>
+                        <th class="text-left">Lane</th>
+                        <th class="text-right">#</th>
+                        <th class="text-left">Started</th>
+                        <th class="text-right">Duration</th>
+                        <th class="text-right" title="ran / due / total">Ran/Due/Total</th>
+                        <th class="text-right">OK</th>
+                        <th class="text-right">Failed</th>
+                        <th class="text-right" title="due jobs whose deps weren't satisfied this cycle">Blocked</th>
+                        <th class="text-left">Slowest job</th>
+                        <th class="text-right">Memory</th>
+                        <th class="text-left">Failures</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($schedulerCycles as $sc):
+                        $rowTone = $sc['has_failures']
+                            ? 'bg-rose-500/5'
+                            : ($sc['jobs_ran'] > 0 ? '' : 'opacity-60');
+                        $startedTitle = $sc['started_at'] !== null
+                            ? $sc['started_at'] . ' (UTC)'
+                            : '';
+                        $finishedTitle = $sc['finished_at'] !== null
+                            ? 'finished ' . $sc['finished_at'] . ' (UTC)'
+                            : '';
+                        $memMb = $sc['memory_bytes'] > 0
+                            ? number_format($sc['memory_bytes'] / 1048576, 0) . ' MB'
+                            : '-';
+                    ?>
+                        <tr class="<?= $rowTone ?>">
+                            <td class="font-medium text-white">
+                                <?= htmlspecialchars($sc['lane'], ENT_QUOTES) ?>
+                            </td>
+                            <td class="text-right text-slate-400"><?= $sc['cycle'] ?></td>
+                            <td class="text-slate-300" title="<?= htmlspecialchars($startedTitle . ($finishedTitle !== '' ? ' — ' . $finishedTitle : ''), ENT_QUOTES) ?>">
+                                <?= htmlspecialchars(supplycore_relative_datetime($sc['started_at']), ENT_QUOTES) ?>
+                            </td>
+                            <td class="text-right text-slate-300">
+                                <?= htmlspecialchars(human_duration_seconds($sc['duration_seconds']), ENT_QUOTES) ?>
+                            </td>
+                            <td class="text-right text-slate-400">
+                                <?= $sc['jobs_ran'] ?> / <?= $sc['jobs_due'] ?> / <?= $sc['jobs_total'] ?>
+                            </td>
+                            <td class="text-right">
+                                <?php if ($sc['jobs_succeeded'] > 0): ?>
+                                    <span class="text-emerald-300"><?= $sc['jobs_succeeded'] ?></span>
+                                <?php else: ?>
+                                    <span class="text-slate-500">-</span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="text-right">
+                                <?php if ($sc['jobs_failed'] > 0): ?>
+                                    <span class="text-rose-300"><?= $sc['jobs_failed'] ?></span>
+                                <?php else: ?>
+                                    <span class="text-slate-500">-</span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="text-right">
+                                <?php if ($sc['jobs_blocked_by_deps'] > 0): ?>
+                                    <span class="text-amber-300"><?= $sc['jobs_blocked_by_deps'] ?></span>
+                                <?php else: ?>
+                                    <span class="text-slate-500">-</span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="max-w-xs truncate text-xs text-slate-300" title="<?= htmlspecialchars($sc['slowest_job'], ENT_QUOTES) ?>">
+                                <?php if ($sc['slowest_job'] !== ''): ?>
+                                    <?= htmlspecialchars($sc['slowest_job'], ENT_QUOTES) ?>
+                                    <span class="text-slate-500">(<?= htmlspecialchars(human_duration_seconds($sc['slowest_seconds']), ENT_QUOTES) ?>)</span>
+                                <?php else: ?>
+                                    <span class="text-slate-500">-</span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="text-right text-xs text-slate-400"><?= $memMb ?></td>
+                            <td class="max-w-md">
+                                <?php if ($sc['failures'] !== []): ?>
+                                    <ul class="space-y-0.5">
+                                        <?php foreach (array_slice($sc['failures'], 0, 4) as $f):
+                                            $jobKey = (string) ($f['job_key'] ?? '?');
+                                            $err = (string) ($f['error'] ?? '');
+                                        ?>
+                                            <li class="truncate text-xs text-rose-200" title="<?= htmlspecialchars($jobKey . ': ' . $err, ENT_QUOTES) ?>">
+                                                <span class="font-medium"><?= htmlspecialchars($jobKey, ENT_QUOTES) ?>:</span>
+                                                <?= htmlspecialchars($err, ENT_QUOTES) ?>
+                                            </li>
+                                        <?php endforeach; ?>
+                                        <?php if (count($sc['failures']) > 4): ?>
+                                            <li class="text-xs text-rose-300">+<?= count($sc['failures']) - 4 ?> more</li>
+                                        <?php endif; ?>
+                                    </ul>
+                                <?php else: ?>
+                                    <span class="text-xs text-slate-500">-</span>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+<?php endif; ?>
 
 <!-- ═══════════════════════════════════════════════════════════════════════════
      Log Files on Disk — collapsible, cleaner

--- a/python/orchestrator/loop_runner.py
+++ b/python/orchestrator/loop_runner.py
@@ -21,6 +21,7 @@ single codebase.  Without ``--lane``, all jobs run (backward compatible).
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import signal
 import socket
@@ -231,24 +232,55 @@ def _tier_timeout_seconds(
     tier_jobs: list[str],
     definitions: dict[str, dict[str, Any]],
     groups: dict[str, list[str]],
+    max_parallel: int = 1,
 ) -> int:
     """Compute the maximum wall-clock time a tier should be allowed to run.
 
-    For concurrency groups (sequential execution) we sum their members'
-    timeouts.  The tier timeout is the max across all parallel units, plus a
-    generous buffer.
+    A tier is made up of "parallel units": each independent job is one
+    unit (its cost = its own timeout), and each concurrency group is one
+    unit whose members run sequentially under a single lock (cost = sum
+    of members' timeouts).
+
+    How those units map to wall-clock time depends on how many of them
+    can run at once, which is capped by the executor's ``max_parallel``:
+
+      * ``max_parallel >= len(units)`` — everything runs in parallel and
+        the budget is ``max(units)``.
+      * ``max_parallel <= 1``         — fully serialized, budget is
+        ``sum(units)``.
+      * otherwise — the longest unit pins the lower bound and the rest
+        of the work is distributed across the available slots.
+
+    Finally, a 2-minute buffer is added for thread startup, DB
+    connection overhead, etc.  Prior to this fix the formula assumed
+    unbounded parallelism (``max(units) + 120``), which silently
+    starved ``--max-parallel 1`` deployments where multiple heavy jobs
+    share a tier.
     """
-    independent_max = max(
-        (int(definitions.get(jk, {}).get("timeout_seconds", 300)) for jk in tier_jobs if not any(jk in g for g in groups.values())),
-        default=300,
-    )
-    group_totals = [
+    independent_units = [
+        int(definitions.get(jk, {}).get("timeout_seconds", 300))
+        for jk in tier_jobs
+        if not any(jk in g for g in groups.values())
+    ]
+    group_units = [
         sum(int(definitions.get(jk, {}).get("timeout_seconds", 300)) for jk in gj)
         for gj in groups.values()
     ]
-    longest = max([independent_max] + group_totals)
-    # Add 2-minute buffer for thread startup, DB connection overhead, etc.
-    return longest + 120
+    units = independent_units + group_units
+    if not units:
+        return 300 + 120
+
+    longest = max(units)
+    parallel = max(1, int(max_parallel))
+    if parallel <= 1:
+        budget = sum(units)
+    elif parallel >= len(units):
+        budget = longest
+    else:
+        remainder = sum(units) - longest
+        budget = longest + math.ceil(remainder / parallel)
+
+    return budget + 120
 
 
 def _append_scheduler_cycle_report(path: Path, payload: dict[str, Any]) -> None:
@@ -286,7 +318,7 @@ def run_tier(
         return []
 
     independent, groups = _split_tier_by_concurrency(tier_jobs, graph_nodes)
-    tier_timeout = _tier_timeout_seconds(tier_jobs, definitions, groups)
+    tier_timeout = _tier_timeout_seconds(tier_jobs, definitions, groups, max_parallel)
 
     logger.info(
         f"tier {tier_index}: {len(tier_jobs)} jobs "
@@ -792,7 +824,7 @@ def _run_loop(
 
                 for o in outcomes:
                     cycle_outcomes.append(o)
-                    tier_budget = max(1.0, _tier_timeout_seconds(tier_due, definitions, _split_tier_by_concurrency(tier_due, graph_nodes)[1]))
+                    tier_budget = max(1.0, _tier_timeout_seconds(tier_due, definitions, _split_tier_by_concurrency(tier_due, graph_nodes)[1], max_parallel))
                     o.hog_risk = o.duration_seconds > (tier_budget * 0.5)
                     if o.status == "failed":
                         total_failed += 1

--- a/src/functions.php
+++ b/src/functions.php
@@ -26218,6 +26218,16 @@ function log_viewer_page_data(): array
         usort($logFiles, fn (array $a, array $b) => ($b['size_bytes'] ?? 0) <=> ($a['size_bytes'] ?? 0));
     }
 
+    // ── Scheduler cycle report (from loop_runner JSONL) ───────────────
+    // The Python orchestrator appends one line per cycle per lane to
+    // scheduler-report.jsonl.  We parse the tail of that file so the
+    // log viewer can render formatted timestamps and per-cycle stats
+    // instead of the raw JSON appearing in the generic file tail.
+    $schedulerReportPath = $logDir !== '' ? $logDir . '/scheduler-report.jsonl' : '';
+    $schedulerCycles = $schedulerReportPath !== ''
+        ? log_viewer_scheduler_report_cycles($schedulerReportPath, 50)
+        : [];
+
     // ── Backlog depth ────────────────────────────────────────────────────
     // Two execution paths feed the backlog and they use different tables:
     //
@@ -26325,6 +26335,7 @@ function log_viewer_page_data(): array
         'stuck_runs' => $stuckRuns,
         'never_ran' => $neverRan,
         'log_files' => $logFiles,
+        'scheduler_cycles' => $schedulerCycles,
         'kpi' => [
             'total_enabled' => $totalEnabled,
             'total_failed' => $totalFailed,
@@ -26375,6 +26386,120 @@ function log_viewer_tail_file(string $path, int $lines = 5): array
     fclose($fp);
 
     return $buffer;
+}
+
+/**
+ * Parse the most recent cycles from the orchestrator's scheduler-report.jsonl
+ * file written by `python/orchestrator/loop_runner.py:_append_scheduler_cycle_report`.
+ *
+ * Each line in that file is a JSON object describing one scheduler cycle for
+ * one lane (cycle counter, lane, started_at/finished_at, jobs_total/due/ran/
+ * succeeded/failed, slowest_job, failures[], memory_bytes, all_jobs[]).
+ *
+ * Returns the most recent ``$maxCycles`` parsed entries (newest first), each
+ * with normalised numeric fields and a synthesised ``has_failures`` flag.
+ * Lines that fail to decode are silently skipped so the page never throws.
+ */
+function log_viewer_scheduler_report_cycles(string $path, int $maxCycles = 50): array
+{
+    if (!is_file($path) || !is_readable($path)) {
+        return [];
+    }
+
+    // Read the tail of the file efficiently: seek to the end and walk
+    // backwards in 8 KiB chunks until we have enough lines or reach the
+    // start.  Avoids loading multi-megabyte JSONL files into memory.
+    $fp = fopen($path, 'rb');
+    if ($fp === false) {
+        return [];
+    }
+
+    $needLines = max(1, $maxCycles) * 2; // headroom for malformed lines
+    $chunkSize = 8192;
+    $buffer = '';
+    $lines = [];
+
+    fseek($fp, 0, SEEK_END);
+    $position = ftell($fp);
+    if ($position === false) {
+        fclose($fp);
+        return [];
+    }
+
+    while ($position > 0 && count($lines) < $needLines) {
+        $read = (int) min($chunkSize, $position);
+        $position -= $read;
+        fseek($fp, $position, SEEK_SET);
+        $chunk = (string) fread($fp, $read);
+        $buffer = $chunk . $buffer;
+
+        // Split off complete lines from the buffer; keep the leading
+        // partial fragment for the next iteration (it may be the tail
+        // end of an earlier line).
+        $parts = explode("\n", $buffer);
+        $buffer = array_shift($parts) ?? '';
+        foreach (array_reverse($parts) as $part) {
+            $part = rtrim($part, "\r");
+            if ($part !== '') {
+                $lines[] = $part;
+                if (count($lines) >= $needLines) {
+                    break;
+                }
+            }
+        }
+    }
+
+    // If we walked all the way to the start, the leftover buffer is the
+    // very first line of the file.
+    if ($position === 0 && $buffer !== '' && count($lines) < $needLines) {
+        $first = rtrim($buffer, "\r");
+        if ($first !== '') {
+            $lines[] = $first;
+        }
+    }
+
+    fclose($fp);
+
+    // ``$lines`` is currently newest-first.  Decode and normalise.
+    $cycles = [];
+    foreach ($lines as $line) {
+        $decoded = json_decode($line, true);
+        if (!is_array($decoded)) {
+            continue;
+        }
+        $failures = is_array($decoded['failures'] ?? null) ? $decoded['failures'] : [];
+        $cycles[] = [
+            'cycle' => (int) ($decoded['cycle'] ?? 0),
+            'lane' => (string) ($decoded['lane'] ?? 'unknown'),
+            'started_at' => isset($decoded['started_at']) ? (string) $decoded['started_at'] : null,
+            'finished_at' => isset($decoded['finished_at']) ? (string) $decoded['finished_at'] : null,
+            'duration_seconds' => (float) ($decoded['duration_seconds'] ?? 0),
+            'jobs_total' => (int) ($decoded['jobs_total'] ?? 0),
+            'jobs_due' => (int) ($decoded['jobs_due'] ?? 0),
+            'jobs_ran' => (int) ($decoded['jobs_ran'] ?? 0),
+            'jobs_succeeded' => (int) ($decoded['jobs_succeeded'] ?? 0),
+            'jobs_failed' => (int) ($decoded['jobs_failed'] ?? 0),
+            'jobs_skipped_not_due' => (int) ($decoded['jobs_skipped_not_due'] ?? 0),
+            'jobs_blocked_by_deps' => (int) ($decoded['jobs_blocked_by_deps'] ?? 0),
+            'slowest_job' => (string) ($decoded['slowest_job'] ?? ''),
+            'slowest_seconds' => (float) ($decoded['slowest_seconds'] ?? 0),
+            'failures' => $failures,
+            'memory_bytes' => (int) ($decoded['memory_bytes'] ?? 0),
+            'has_failures' => $failures !== [],
+        ];
+        if (count($cycles) >= $maxCycles) {
+            break;
+        }
+    }
+
+    // Sort by finished_at desc so multi-lane cycles interleave correctly.
+    usort($cycles, static function (array $a, array $b): int {
+        $aFinished = $a['finished_at'] !== null ? (int) strtotime($a['finished_at']) : 0;
+        $bFinished = $b['finished_at'] !== null ? (int) strtotime($b['finished_at']) : 0;
+        return $bFinished <=> $aFinished;
+    });
+
+    return array_slice($cycles, 0, $maxCycles);
 }
 
 function log_viewer_external_health(): array


### PR DESCRIPTION
## Summary
This PR adds a new "Scheduler Cycles" section to the log viewer that displays parsed scheduler cycle metrics from the orchestrator's `scheduler-report.jsonl` file, and fixes the tier timeout calculation to properly account for the executor's `max_parallel` setting.

## Key Changes

### Log Viewer Enhancement
- **New `log_viewer_scheduler_report_cycles()` function** in `src/functions.php`: Efficiently parses the tail of `scheduler-report.jsonl` (reads backwards in 8 KiB chunks to avoid loading large files) and returns the most recent cycles with normalized numeric fields and a synthesized `has_failures` flag
- **New "Scheduler Cycles" UI section** in `public/log-viewer/index.php`: Displays a formatted table showing per-cycle metrics including:
  - Lane and cycle number
  - Started time and duration
  - Job counts (ran/due/total, succeeded, failed, blocked by dependencies)
  - Slowest job and memory usage
  - Failure details (up to 4 shown inline, with overflow indicator)
  - Color-coded rows for failures (rose tint) and idle cycles (reduced opacity)

### Tier Timeout Calculation Fix
- **Updated `_tier_timeout_seconds()` function** in `python/orchestrator/loop_runner.py`:
  - Now accepts `max_parallel` parameter to account for actual parallelism constraints
  - Previous formula assumed unbounded parallelism (`max(units) + 120`), which silently starved deployments with `--max-parallel 1` where multiple heavy jobs share a tier
  - New formula correctly distributes work across available slots:
    - Fully serialized (`max_parallel <= 1`): `sum(units) + 120`
    - Fully parallel (`max_parallel >= len(units)`): `max(units) + 120`
    - Partial parallelism: `max(units) + ceil(remainder / max_parallel) + 120`
  - Updated all call sites in `run_tier()` and `_run_loop()` to pass `max_parallel`

## Implementation Details
- The scheduler cycles table is only rendered if cycles data is available, preventing empty sections
- Timestamps are displayed as relative times with full UTC timestamps in tooltips
- Memory is formatted in MB for readability
- Failures are truncated to 4 items with a "+N more" indicator to keep rows manageable
- The backwards file reading approach in `log_viewer_scheduler_report_cycles()` gracefully handles malformed JSON lines by silently skipping them

https://claude.ai/code/session_01RPhrMB7wy9ohtrTu45EqRt