### PR TITLE
fix: spy ring projection query — wrong property names and self-loop rel

### DIFF
--- a/python/orchestrator/jobs/graph_spy_ring_projection.py
+++ b/python/orchestrator/jobs/graph_spy_ring_projection.py
@@ -96,11 +96,12 @@ def run_graph_spy_ring_projection(
         cypher_node = "MATCH (n:Character) RETURN id(n) AS id"
         cypher_rel = f"""
         MATCH (a:Character)-[r:CO_OCCURS_WITH]->(b:Character)
-        WHERE r.count >= {COPRESENCE_MIN_COUNT}
-        RETURN id(a) AS source, id(b) AS target, r.count AS weight, 'copresence' AS type
+        WHERE r.occurrence_count >= {COPRESENCE_MIN_COUNT}
+        RETURN id(a) AS source, id(b) AS target, r.weight AS weight, 'copresence' AS type
         UNION ALL
-        MATCH (a:Character)-[r:CROSSED_SIDES]->(b:Character)
-        RETURN id(a) AS source, id(b) AS target, r.count AS weight, 'cross_side' AS type
+        MATCH (a:Character)-[r:DIRECT_COMBAT]->(b:Character)
+        WHERE r.count >= {CROSS_SIDE_MIN_COUNT}
+        RETURN id(a) AS source, id(b) AS target, toFloat(r.count) AS weight, 'cross_side' AS type
         """
 
         # Try GDS cypher projection


### PR DESCRIPTION
Two issues caused 0 edges in the GDS projection:

1. CO_OCCURS_WITH: queried r.count but graph_pipeline.py writes r.occurrence_count and r.weight. Fixed to use correct properties.

2. CROSSED_SIDES: is a self-loop (c)-[r:CROSSED_SIDES]->(c) on single characters, not an inter-character edge. Useless for community detection. Replaced with DIRECT_COMBAT which represents actual cross-side combat between character pairs (written by graph_typed_interactions.py).

https://claude.ai/code/session_01369Vyz3wVVTfb7w7G7M5WH