### PR TITLE
feat: theater_clustering lookback window and batch processing

### DIFF
--- a/database/migrations/20260512_unlock_recent_theaters.sql
+++ b/database/migrations/20260512_unlock_recent_theaters.sql
@@ -1,0 +1,9 @@
+-- One-time fix: unlock theaters within the lookback window so that
+-- theater_clustering can re-process them.  theater_analysis previously
+-- auto-locked everything >1 hour old; now it respects the clustering
+-- lookback window (default 48h).
+
+UPDATE theaters
+SET locked_at = NULL
+WHERE locked_at IS NOT NULL
+  AND end_time >= NOW() - INTERVAL 48 HOUR;

--- a/python/orchestrator/jobs/theater_analysis.py
+++ b/python/orchestrator/jobs/theater_analysis.py
@@ -1717,12 +1717,21 @@ def run_theater_analysis(
                 "third_party_count": side_resolution.get("total_third_party", 0),
             })
 
-        # Auto-lock theaters whose last battle ended > 1 hour ago.
-        # Locked theaters won't be re-analyzed on subsequent runs, saving
-        # resources.  The view snapshot is generated on first page load.
-        auto_lock_threshold = datetime.now(UTC) - timedelta(hours=1)
+        # Auto-lock theaters whose end_time is before the clustering lookback
+        # window.  Theaters inside the window must remain unlocked so that
+        # theater_clustering can re-cluster them as new battles arrive.
+        # Falls back to 48 hours if the setting is missing.
         auto_locked = 0
         if not dry_run:
+            lookback_row = db.fetch_all(
+                "SELECT setting_value FROM app_settings WHERE setting_key = 'theater_clustering_lookback_hours' LIMIT 1"
+            )
+            lookback_hours = int(lookback_row[0]["setting_value"]) if lookback_row else 48
+            if lookback_hours > 0:
+                auto_lock_threshold = datetime.now(UTC) - timedelta(hours=lookback_hours)
+            else:
+                # lookback disabled — fall back to conservative 1-hour threshold
+                auto_lock_threshold = datetime.now(UTC) - timedelta(hours=1)
             auto_lock_candidates = db.fetch_all(
                 """
                 SELECT theater_id, end_time


### PR DESCRIPTION
## Summary

- **Lookback window for theater_clustering**: Only loads battles from the last N hours (default 48h) instead of scanning the entire `battle_rollups` table (13M+ killmails). Configurable via `app_settings` key `theater_clustering_lookback_hours`. Set to `0` to restore legacy full-table behaviour.
- **Scoped flush**: `_flush_theaters` now only deletes/replaces unlocked theaters within the lookback window. Older theaters and locked theaters are never touched.
- **Auto-locking**: Theaters whose `end_time` falls before the lookback cutoff are automatically locked after each clustering run, so they are never recalculated unless manually unlocked (`UPDATE theaters SET locked_at = NULL WHERE theater_id = '...'`).
- **Fix theater_analysis conflict**: `theater_analysis` was auto-locking every theater >1 hour old, which starved clustering of battles on subsequent runs. Now reads the same `theater_clustering_lookback_hours` setting and only auto-locks theaters outside that window.
- **One-time migration**: Unlocks theaters from the last 48 hours that were previously locked by the old 1-hour threshold.

## Files changed

| File | Change |
|------|--------|
| `python/orchestrator/jobs/theater_clustering.py` | Lookback window, scoped flush, auto-lock |
| `python/orchestrator/jobs/theater_analysis.py` | Align auto-lock threshold with clustering lookback |
| `database/migrations/20260512_theater_clustering_lookback.sql` | Seed `theater_clustering_lookback_hours` app_setting |
| `database/migrations/20260512_unlock_recent_theaters.sql` | One-time unlock of recent theaters |

## Test plan

- [ ] Run both migrations on the database
- [ ] Run `theater_clustering` — confirm it loads only battles from the last 48h (check `theater_clustering.lookback_window` and `theater_clustering.battles_loaded` log events)
- [ ] Verify theaters older than 48h are auto-locked after the run
- [ ] Run `theater_analysis` — confirm it only auto-locks theaters outside the 48h window
- [ ] Change `theater_clustering_lookback_hours` to `0` in `app_settings` — verify legacy full-table behaviour is restored
- [ ] Manually unlock a theater (`UPDATE theaters SET locked_at = NULL WHERE theater_id = '...'`) — verify it gets re-clustered on the next run

https://claude.ai/code/session_01AMy2Uu8kCDZA2WcZWPPDti