### PR TITLE
Add structured log file viewer with JSONL parsing and filtering

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -25,5 +25,6 @@ RewriteRule ^killmail-intelligence/?$ killmail-intelligence/index.php [L,QSA]
 RewriteRule ^killmail-intelligence/view/?$ killmail-intelligence/view.php [L,QSA]
 
 RewriteRule ^log-viewer/?$ log-viewer/index.php [L,QSA]
+RewriteRule ^log-viewer/file/?$ log-viewer/file.php [L,QSA]
 
 RewriteRule ^$ index.php [L,QSA]

--- a/public/log-viewer/file.php
+++ b/public/log-viewer/file.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+// ── Input parsing ────────────────────────────────────────────────────────────
+$requestedName = isset($_GET['name']) ? (string) $_GET['name'] : '';
+$requestedLevel = isset($_GET['level']) ? strtolower(trim((string) $_GET['level'])) : '';
+$requestedQuery = isset($_GET['q']) ? trim((string) $_GET['q']) : '';
+$requestedLines = isset($_GET['lines']) ? (int) $_GET['lines'] : 300;
+
+$allowedLevels = ['', 'debug', 'info', 'warning', 'error'];
+if (!in_array($requestedLevel, $allowedLevels, true)) {
+    $requestedLevel = '';
+}
+
+$allowedLineCounts = [100, 300, 1000, 3000];
+if (!in_array($requestedLines, $allowedLineCounts, true)) {
+    $requestedLines = 300;
+}
+
+// ── Data ─────────────────────────────────────────────────────────────────────
+$availableFiles = log_viewer_available_files();
+$detail = log_viewer_file_detail($requestedName, [
+    'max_lines' => $requestedLines,
+    'level' => $requestedLevel,
+    'q' => $requestedQuery,
+]);
+
+$title = 'Log Viewer · ' . ($detail['filename'] ?? $requestedName);
+$pageHeaderBadge = 'Structured scheduler logs';
+$pageHeaderSummary = 'Pretty-printed lane-aware log viewer. JSONL files are parsed and grouped by level; legacy text logs fall through to a raw tail.';
+
+// Build a relative freshness caption from the file's modified time.
+$pageFreshness = [];
+if (($detail['error'] ?? null) === null && ($detail['modified_at'] ?? null) !== null) {
+    $pageFreshness = [
+        'label' => 'Log file',
+        'computed_relative' => $detail['modified_relative'] ?? 'Unknown',
+        'computed_at' => $detail['modified_at'] ?? 'Unavailable',
+        'tone' => 'border-emerald-400/20 bg-emerald-500/10 text-emerald-100',
+    ];
+}
+
+// Preserve the current filter in querystrings for the control buttons.
+$baseQuery = [
+    'name' => $requestedName,
+    'lines' => $requestedLines,
+];
+if ($requestedQuery !== '') {
+    $baseQuery['q'] = $requestedQuery;
+}
+$levelBase = $baseQuery;
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+
+<div class="mb-4 flex flex-wrap items-center gap-3">
+    <a href="/log-viewer" class="text-sm text-sky-300 hover:text-sky-200">← Back to log viewer</a>
+    <?php if (($detail['error'] ?? null) === null): ?>
+        <span class="text-xs text-slate-400">
+            <?= htmlspecialchars((string) ($detail['filename'] ?? $requestedName), ENT_QUOTES) ?>
+            · <?= htmlspecialchars((string) ($detail['size_human'] ?? ''), ENT_QUOTES) ?>
+            · modified <?= htmlspecialchars((string) ($detail['modified_relative'] ?? 'unknown'), ENT_QUOTES) ?>
+        </span>
+    <?php endif; ?>
+</div>
+
+<?php if (($detail['error'] ?? null) !== null): ?>
+    <section class="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+        <p class="font-semibold">Could not load log file.</p>
+        <p class="mt-1"><?= htmlspecialchars((string) $detail['error'], ENT_QUOTES) ?></p>
+        <?php if ($requestedName !== ''): ?>
+            <p class="mt-1 text-xs text-rose-200/80">Requested: <?= htmlspecialchars($requestedName, ENT_QUOTES) ?></p>
+        <?php endif; ?>
+    </section>
+
+    <?php if ($availableFiles !== []): ?>
+    <section class="mt-6">
+        <h2 class="section-title mb-4">Available log files</h2>
+        <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            <?php foreach ($availableFiles as $lf): ?>
+                <?php
+                $href = '/log-viewer/file?' . http_build_query(['name' => $lf['filename']]);
+                ?>
+                <a href="<?= htmlspecialchars($href, ENT_QUOTES) ?>"
+                   class="block rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm hover:bg-white/[0.06]">
+                    <p class="font-medium text-white"><?= htmlspecialchars($lf['filename'], ENT_QUOTES) ?></p>
+                    <p class="mt-1 text-xs text-slate-400">
+                        <?= htmlspecialchars($lf['size_human'], ENT_QUOTES) ?> · modified <?= htmlspecialchars($lf['modified_relative'], ENT_QUOTES) ?>
+                    </p>
+                </a>
+            <?php endforeach; ?>
+        </div>
+    </section>
+    <?php endif; ?>
+<?php else: ?>
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         Controls — file picker, level filter, tail length, search
+         ═══════════════════════════════════════════════════════════════════ -->
+    <section class="mb-4 rounded-2xl border border-white/8 bg-white/[0.02] p-4">
+        <form method="get" action="/log-viewer/file" class="flex flex-wrap items-end gap-3">
+            <label class="flex min-w-[16rem] flex-1 flex-col gap-1 text-xs uppercase tracking-wider text-slate-400">
+                Log file
+                <select name="name" class="rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white">
+                    <?php foreach ($availableFiles as $lf): ?>
+                        <option value="<?= htmlspecialchars($lf['filename'], ENT_QUOTES) ?>"
+                            <?= $lf['filename'] === $detail['filename'] ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($lf['filename'], ENT_QUOTES) ?>
+                            (<?= htmlspecialchars($lf['size_human'], ENT_QUOTES) ?> · <?= htmlspecialchars($lf['modified_relative'], ENT_QUOTES) ?>)
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+
+            <label class="flex flex-col gap-1 text-xs uppercase tracking-wider text-slate-400">
+                Tail lines
+                <select name="lines" class="rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white">
+                    <?php foreach ($allowedLineCounts as $lc): ?>
+                        <option value="<?= $lc ?>" <?= $requestedLines === $lc ? 'selected' : '' ?>><?= $lc ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+
+            <label class="flex flex-col gap-1 text-xs uppercase tracking-wider text-slate-400">
+                Minimum level
+                <select name="level" class="rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white">
+                    <option value="" <?= $requestedLevel === '' ? 'selected' : '' ?>>All</option>
+                    <option value="debug" <?= $requestedLevel === 'debug' ? 'selected' : '' ?>>Debug+</option>
+                    <option value="info" <?= $requestedLevel === 'info' ? 'selected' : '' ?>>Info+</option>
+                    <option value="warning" <?= $requestedLevel === 'warning' ? 'selected' : '' ?>>Warning+</option>
+                    <option value="error" <?= $requestedLevel === 'error' ? 'selected' : '' ?>>Error only</option>
+                </select>
+            </label>
+
+            <label class="flex flex-1 min-w-[12rem] flex-col gap-1 text-xs uppercase tracking-wider text-slate-400">
+                Search (substring)
+                <input type="text" name="q" value="<?= htmlspecialchars($requestedQuery, ENT_QUOTES) ?>"
+                    placeholder="e.g. job_key, error snippet, event name"
+                    class="rounded-lg border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white placeholder-slate-500">
+            </label>
+
+            <div class="flex gap-2">
+                <button type="submit" class="rounded-lg border border-sky-400/40 bg-sky-500/15 px-4 py-2 text-sm font-medium text-sky-100 hover:bg-sky-500/25">
+                    Apply
+                </button>
+                <a href="/log-viewer/file?<?= htmlspecialchars(http_build_query(['name' => $detail['filename']]), ENT_QUOTES) ?>"
+                   class="rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm text-slate-300 hover:bg-white/10">
+                    Reset
+                </a>
+            </div>
+        </form>
+
+        <div class="mt-3 flex flex-wrap items-center gap-4 text-xs text-slate-400">
+            <span>
+                <span class="text-slate-300"><?= number_format($detail['lines_returned']) ?></span> of
+                <span class="text-slate-300"><?= number_format($detail['lines_scanned']) ?></span>
+                lines match (reading tail of <?= htmlspecialchars($detail['size_human'], ENT_QUOTES) ?>).
+            </span>
+            <?php if ($detail['is_jsonl']): ?>
+                <span class="inline-flex items-center gap-1 rounded-full border border-sky-400/25 bg-sky-500/10 px-2 py-0.5 text-[0.7rem] text-sky-200">
+                    JSONL parsed
+                </span>
+            <?php endif; ?>
+            <span class="text-rose-300">error: <?= $detail['level_counts']['error'] ?></span>
+            <span class="text-amber-300">warn: <?= $detail['level_counts']['warning'] ?></span>
+            <span class="text-slate-300">info: <?= $detail['level_counts']['info'] ?></span>
+            <?php if ($detail['level_counts']['debug'] > 0): ?>
+                <span class="text-slate-500">debug: <?= $detail['level_counts']['debug'] ?></span>
+            <?php endif; ?>
+        </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         Log entries
+         ═══════════════════════════════════════════════════════════════════ -->
+    <section>
+        <?php if ($detail['entries'] === []): ?>
+            <div class="rounded-2xl border border-white/8 bg-white/[0.02] p-8 text-center text-slate-400">
+                No entries match the current filters.
+            </div>
+        <?php else: ?>
+            <ul class="space-y-1.5">
+                <?php foreach ($detail['entries'] as $entry):
+                    $levelTone = match ($entry['level']) {
+                        'error', 'critical' => 'border-rose-400/30 bg-rose-500/10 text-rose-100',
+                        'warning', 'warn'   => 'border-amber-400/30 bg-amber-500/10 text-amber-100',
+                        'info', 'notice'    => 'border-sky-400/25 bg-sky-500/8 text-sky-100',
+                        'debug'             => 'border-slate-400/20 bg-slate-500/8 text-slate-300',
+                        default             => 'border-white/10 bg-white/[0.03] text-slate-200',
+                    };
+                    $rowTone = match ($entry['level']) {
+                        'error', 'critical' => 'border-l-2 border-l-rose-400/60',
+                        'warning', 'warn'   => 'border-l-2 border-l-amber-400/60',
+                        default             => 'border-l border-l-white/5',
+                    };
+                ?>
+                    <li class="rounded-lg bg-white/[0.02] <?= $rowTone ?> px-3 py-2">
+                        <?php if ($entry['is_json']): ?>
+                            <div class="flex flex-wrap items-baseline gap-2">
+                                <span class="inline-flex items-center rounded-md border px-1.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wider <?= $levelTone ?>">
+                                    <?= htmlspecialchars($entry['level'], ENT_QUOTES) ?>
+                                </span>
+                                <?php if ($entry['ts_display'] !== null): ?>
+                                    <span class="font-mono text-[0.7rem] text-slate-500"><?= htmlspecialchars((string) $entry['ts_display'], ENT_QUOTES) ?></span>
+                                <?php endif; ?>
+                                <?php if ($entry['event'] !== null): ?>
+                                    <span class="rounded-md bg-slate-800/80 px-1.5 py-0.5 font-mono text-[0.7rem] text-slate-300"><?= htmlspecialchars($entry['event'], ENT_QUOTES) ?></span>
+                                <?php endif; ?>
+                                <?php if ($entry['job_key'] !== null): ?>
+                                    <span class="rounded-md border border-indigo-400/25 bg-indigo-500/10 px-1.5 py-0.5 font-mono text-[0.7rem] text-indigo-100"><?= htmlspecialchars($entry['job_key'], ENT_QUOTES) ?></span>
+                                <?php endif; ?>
+                                <?php if ($entry['logger'] !== null): ?>
+                                    <span class="ml-auto text-[0.7rem] text-slate-500"><?= htmlspecialchars($entry['logger'], ENT_QUOTES) ?></span>
+                                <?php endif; ?>
+                            </div>
+                            <p class="mt-1 text-sm text-slate-100"><?= htmlspecialchars($entry['message'], ENT_QUOTES) ?></p>
+                            <?php if ($entry['payload'] !== null || $entry['exception'] !== null): ?>
+                                <details class="mt-1">
+                                    <summary class="cursor-pointer text-[0.7rem] text-slate-400 hover:text-slate-200">
+                                        payload<?= $entry['exception'] !== null ? ' / exception' : '' ?>
+                                    </summary>
+                                    <?php if ($entry['payload'] !== null): ?>
+                                        <pre class="mt-2 max-h-64 overflow-auto rounded-lg bg-black/40 p-3 text-[0.7rem] leading-relaxed text-slate-300"><?= htmlspecialchars(json_encode($entry['payload'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE) ?: '{}', ENT_QUOTES) ?></pre>
+                                    <?php endif; ?>
+                                    <?php if ($entry['exception'] !== null): ?>
+                                        <pre class="mt-2 max-h-64 overflow-auto rounded-lg bg-rose-950/40 p-3 text-[0.7rem] leading-relaxed text-rose-200"><?= htmlspecialchars($entry['exception'], ENT_QUOTES) ?></pre>
+                                    <?php endif; ?>
+                                </details>
+                            <?php endif; ?>
+                        <?php else: ?>
+                            <pre class="whitespace-pre-wrap font-mono text-[0.75rem] leading-relaxed text-slate-300"><?= htmlspecialchars($entry['raw'], ENT_QUOTES) ?></pre>
+                        <?php endif; ?>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+
+            <?php if ($detail['truncated']): ?>
+                <p class="mt-3 text-xs text-slate-500">
+                    Showing the most recent <?= number_format($detail['lines_returned']) ?> entries.
+                    Older content is not loaded — raise <em>Tail lines</em> to see more.
+                </p>
+            <?php endif; ?>
+        <?php endif; ?>
+    </section>
+
+<?php endif; ?>
+
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/log-viewer/index.php
+++ b/public/log-viewer/index.php
@@ -516,20 +516,34 @@ $attentionCount = $kpi['total_failed'] + $kpi['total_timeout'] + $kpi['total_ove
 <?php endif; ?>
 
 <!-- ═══════════════════════════════════════════════════════════════════════════
-     Log Files on Disk — collapsible, cleaner
+     Log Files on Disk — collapsible; each file also links to the structured
+     viewer (/log-viewer/file) which pretty-prints JSONL lane-*.log output.
      ══════════════════════════════════════════════════════════════════════════ -->
 <?php if ($logFiles !== []): ?>
 <section class="mt-8">
     <h2 class="section-title mb-4">Log Files</h2>
+    <p class="mb-3 text-xs text-slate-400">
+        Click <span class="text-sky-300">Open</span> on any lane-*.log or *.jsonl file
+        to load it in the structured viewer (filterable by level, search, tail length).
+    </p>
     <div class="space-y-2">
-        <?php foreach ($logFiles as $lf): ?>
+        <?php foreach ($logFiles as $lf):
+            $viewerHref = '/log-viewer/file?' . http_build_query(['name' => $lf['filename']]);
+        ?>
             <details class="group rounded-2xl border border-white/8 bg-white/[0.02]">
                 <summary class="flex cursor-pointer items-center justify-between gap-3 px-5 py-3 text-sm">
                     <div class="flex items-center gap-3">
                         <span class="font-medium text-white"><?= htmlspecialchars($lf['filename'], ENT_QUOTES) ?></span>
                         <span class="text-xs text-slate-400"><?= htmlspecialchars($lf['size_human'], ENT_QUOTES) ?></span>
                     </div>
-                    <span class="text-xs text-slate-500">modified <?= htmlspecialchars($lf['modified_relative'], ENT_QUOTES) ?></span>
+                    <div class="flex items-center gap-3">
+                        <span class="text-xs text-slate-500">modified <?= htmlspecialchars($lf['modified_relative'], ENT_QUOTES) ?></span>
+                        <a href="<?= htmlspecialchars($viewerHref, ENT_QUOTES) ?>"
+                           class="rounded-md border border-sky-400/30 bg-sky-500/15 px-2.5 py-1 text-[0.7rem] font-medium text-sky-100 hover:bg-sky-500/25"
+                           onclick="event.stopPropagation();">
+                            Open
+                        </a>
+                    </div>
                 </summary>
                 <?php if ($lf['tail_lines'] !== []): ?>
                     <div class="border-t border-white/8 px-5 py-3">

--- a/src/functions.php
+++ b/src/functions.php
@@ -26227,6 +26227,309 @@ function log_viewer_scheduler_report_cycles(string $path, int $maxCycles = 50): 
     return array_slice($cycles, 0, $maxCycles);
 }
 
+/**
+ * Resolve a user-supplied log filename to an absolute path inside storage/logs.
+ *
+ * Returns null if the filename is empty, contains path separators, escapes the
+ * log directory, or doesn't point at a regular readable file.  Used by the
+ * per-file log viewer to guard against traversal attempts.
+ */
+function log_viewer_resolve_log_path(string $filename): ?string
+{
+    $filename = trim($filename);
+    if ($filename === '' || $filename === '.' || $filename === '..') {
+        return null;
+    }
+    // Reject any attempt at traversal or absolute paths.
+    if (strpbrk($filename, "/\\\0") !== false) {
+        return null;
+    }
+
+    $logDir = realpath(__DIR__ . '/../storage/logs');
+    if ($logDir === false || !is_dir($logDir)) {
+        return null;
+    }
+
+    $fullPath = realpath($logDir . '/' . $filename);
+    if ($fullPath === false) {
+        return null;
+    }
+    // Ensure the resolved path is still inside the log directory.
+    if (strncmp($fullPath, $logDir . DIRECTORY_SEPARATOR, strlen($logDir) + 1) !== 0) {
+        return null;
+    }
+    if (!is_file($fullPath) || !is_readable($fullPath)) {
+        return null;
+    }
+    return $fullPath;
+}
+
+/**
+ * Read the tail of a log file and return parsed entries suitable for display.
+ *
+ * Lane-*.log and scheduler-report.jsonl files are emitted as one JSON object
+ * per line by the Python loop runner's ``JsonFormatter``; other logs (cron.log,
+ * worker.log, legacy compute.log) are free-form text.  This helper tries to
+ * decode each line as JSON; if decoding fails the raw text is preserved, so
+ * the same renderer can handle both.
+ *
+ * The read is a reverse tail: we seek to the end of the file and walk
+ * backwards in chunks until we have ``$maxLines`` (or reach the start).  That
+ * keeps memory bounded for multi-gigabyte logs.
+ *
+ * Options:
+ *   - ``max_lines`` (int, default 500): how many raw lines to read.
+ *   - ``level``    (string, default ''): filter JSON entries whose ``level``
+ *                   is below this minimum (debug/info/warning/error).
+ *   - ``q``        (string, default ''): case-insensitive substring filter
+ *                   applied to the raw line before parsing.
+ */
+function log_viewer_file_detail(string $filename, array $opts = []): array
+{
+    $path = log_viewer_resolve_log_path($filename);
+    if ($path === null) {
+        return [
+            'error' => 'Log file not found or not readable.',
+            'filename' => $filename,
+        ];
+    }
+
+    $maxLines = max(1, min(5000, (int) ($opts['max_lines'] ?? 500)));
+    $minLevel = strtolower(trim((string) ($opts['level'] ?? '')));
+    $query = trim((string) ($opts['q'] ?? ''));
+    $queryLower = $query !== '' ? strtolower($query) : '';
+
+    $levelOrder = [
+        'debug'    => 0,
+        'info'     => 1,
+        'notice'   => 1,
+        'warning'  => 2,
+        'warn'     => 2,
+        'error'    => 3,
+        'critical' => 4,
+    ];
+    $minLevelRank = $minLevel !== '' && isset($levelOrder[$minLevel]) ? $levelOrder[$minLevel] : null;
+
+    $sizeBytes = @filesize($path);
+    $modifiedAt = @filemtime($path);
+
+    // Reverse-tail read: walk backwards in 32 KiB chunks and split on newlines.
+    $fp = @fopen($path, 'rb');
+    if ($fp === false) {
+        return [
+            'error' => 'Unable to open log file.',
+            'filename' => basename($path),
+        ];
+    }
+
+    // Oversample a bit so that filtering by level/query can still return
+    // roughly $maxLines results without an extra read pass.
+    $needLines = $queryLower !== '' || $minLevelRank !== null
+        ? $maxLines * 4
+        : $maxLines + 32;
+
+    $chunkSize = 32768;
+    $buffer = '';
+    $rawLines = [];
+
+    fseek($fp, 0, SEEK_END);
+    $position = ftell($fp);
+    if ($position === false) {
+        fclose($fp);
+        return [
+            'error' => 'Unable to read log file position.',
+            'filename' => basename($path),
+        ];
+    }
+    $fileSize = $position;
+
+    while ($position > 0 && count($rawLines) < $needLines) {
+        $read = (int) min($chunkSize, $position);
+        $position -= $read;
+        fseek($fp, $position, SEEK_SET);
+        $chunk = (string) fread($fp, $read);
+        $buffer = $chunk . $buffer;
+
+        $parts = explode("\n", $buffer);
+        $buffer = array_shift($parts) ?? '';
+        foreach (array_reverse($parts) as $part) {
+            $part = rtrim($part, "\r");
+            if ($part === '') {
+                continue;
+            }
+            $rawLines[] = $part;
+            if (count($rawLines) >= $needLines) {
+                break;
+            }
+        }
+    }
+
+    if ($position === 0 && $buffer !== '' && count($rawLines) < $needLines) {
+        $first = rtrim($buffer, "\r");
+        if ($first !== '') {
+            $rawLines[] = $first;
+        }
+    }
+    fclose($fp);
+
+    // ``$rawLines`` is newest-first.  Parse/filter.
+    $entries = [];
+    $levelCounts = ['error' => 0, 'warning' => 0, 'info' => 0, 'debug' => 0, 'other' => 0];
+    $jsonParsed = 0;
+    $jsonFailed = 0;
+    $totalScanned = 0;
+
+    foreach ($rawLines as $line) {
+        $totalScanned++;
+        if ($queryLower !== '' && stripos($line, $query) === false) {
+            continue;
+        }
+
+        $entry = [
+            'raw' => $line,
+            'is_json' => false,
+            'ts' => null,
+            'ts_display' => null,
+            'level' => 'other',
+            'level_rank' => 0,
+            'logger' => null,
+            'message' => $line,
+            'event' => null,
+            'job_key' => null,
+            'payload' => null,
+            'exception' => null,
+        ];
+
+        // Try JSON-first so structured log files render cleanly, falling
+        // through to raw text for legacy plain-text logs.
+        $firstChar = $line[0] ?? '';
+        if ($firstChar === '{' || $firstChar === '[') {
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                $entry['is_json'] = true;
+                $jsonParsed++;
+                $entry['ts'] = isset($decoded['ts']) ? (string) $decoded['ts'] : null;
+                $entry['ts_display'] = $entry['ts'] !== null
+                    ? log_viewer_format_iso_timestamp($entry['ts'])
+                    : null;
+                $entry['logger'] = isset($decoded['logger']) ? (string) $decoded['logger'] : null;
+                $entry['message'] = isset($decoded['message']) ? (string) $decoded['message'] : $line;
+                $rawLevel = strtolower((string) ($decoded['level'] ?? 'info'));
+                $entry['level'] = $rawLevel;
+                $entry['level_rank'] = $levelOrder[$rawLevel] ?? 1;
+                if (isset($decoded['exception'])) {
+                    $entry['exception'] = (string) $decoded['exception'];
+                }
+                // Everything else is treated as payload metadata; surface
+                // the two most common fields (event / job_key) for quick
+                // scanning and leave the rest in the expandable payload.
+                $payload = $decoded;
+                unset($payload['ts'], $payload['level'], $payload['logger'], $payload['message'], $payload['exception']);
+                if (isset($payload['event'])) {
+                    $entry['event'] = (string) $payload['event'];
+                }
+                if (isset($payload['job_key'])) {
+                    $entry['job_key'] = (string) $payload['job_key'];
+                }
+                $entry['payload'] = $payload !== [] ? $payload : null;
+            } else {
+                $jsonFailed++;
+            }
+        }
+
+        if ($minLevelRank !== null && $entry['level_rank'] < $minLevelRank) {
+            continue;
+        }
+
+        $bucket = match ($entry['level']) {
+            'error', 'critical' => 'error',
+            'warning', 'warn'   => 'warning',
+            'info', 'notice'    => 'info',
+            'debug'             => 'debug',
+            default             => 'other',
+        };
+        $levelCounts[$bucket]++;
+
+        $entries[] = $entry;
+        if (count($entries) >= $maxLines) {
+            break;
+        }
+    }
+
+    return [
+        'error' => null,
+        'filename' => basename($path),
+        'path' => $path,
+        'size_bytes' => $sizeBytes !== false ? (int) $sizeBytes : 0,
+        'size_human' => $sizeBytes !== false ? log_viewer_format_bytes((int) $sizeBytes) : '0 B',
+        'modified_at' => $modifiedAt !== false ? gmdate('Y-m-d H:i:s', $modifiedAt) : null,
+        'modified_relative' => $modifiedAt !== false ? human_duration_ago(max(0, time() - $modifiedAt)) . ' ago' : 'Unknown',
+        'is_jsonl' => $jsonParsed > 0 && $jsonFailed === 0,
+        'lines_returned' => count($entries),
+        'lines_scanned' => $totalScanned,
+        'entries' => $entries,
+        'level_counts' => $levelCounts,
+        'max_lines' => $maxLines,
+        'truncated' => $fileSize > 0 && $position > 0,
+        'file_size_bytes' => $fileSize,
+    ];
+}
+
+/**
+ * Format an ISO-8601 timestamp into a compact "HH:MM:SS (Y-m-d)" string for
+ * the log viewer.  Returns the input unchanged if it cannot be parsed.
+ */
+function log_viewer_format_iso_timestamp(string $iso): string
+{
+    if ($iso === '') {
+        return '';
+    }
+    $ts = strtotime($iso);
+    if ($ts === false) {
+        return $iso;
+    }
+    return gmdate('H:i:s', $ts) . ' UTC · ' . gmdate('Y-m-d', $ts);
+}
+
+/**
+ * List log files suitable for the "Log Files" picker in the viewer.  Returns
+ * an array of [filename, size_bytes, size_human, modified_at, modified_relative,
+ * is_jsonl] sorted by most-recently-modified first (so the file the operator
+ * is most likely to care about comes first).
+ */
+function log_viewer_available_files(): array
+{
+    $logDir = realpath(__DIR__ . '/../storage/logs');
+    if ($logDir === false || !is_dir($logDir)) {
+        return [];
+    }
+    $files = [];
+    foreach (scandir($logDir) as $entry) {
+        if ($entry === '.' || $entry === '..' || $entry === '.gitkeep') {
+            continue;
+        }
+        $fullPath = $logDir . '/' . $entry;
+        if (!is_file($fullPath)) {
+            continue;
+        }
+        $sizeBytes = @filesize($fullPath);
+        $modifiedAt = @filemtime($fullPath);
+        $files[] = [
+            'filename' => $entry,
+            'size_bytes' => $sizeBytes !== false ? (int) $sizeBytes : 0,
+            'size_human' => $sizeBytes !== false ? log_viewer_format_bytes((int) $sizeBytes) : '0 B',
+            'modified_at' => $modifiedAt !== false ? gmdate('Y-m-d H:i:s', $modifiedAt) : null,
+            'modified_relative' => $modifiedAt !== false ? human_duration_ago(max(0, time() - $modifiedAt)) . ' ago' : 'Unknown',
+            'modified_ts' => $modifiedAt !== false ? (int) $modifiedAt : 0,
+            'is_jsonl' => str_ends_with($entry, '.jsonl')
+                || str_starts_with($entry, 'lane-')
+                || $entry === 'worker.log',
+        ];
+    }
+    usort($files, fn (array $a, array $b) => ($b['modified_ts'] ?? 0) <=> ($a['modified_ts'] ?? 0));
+    return $files;
+}
+
 function log_viewer_external_health(): array
 {
     $results = [];


### PR DESCRIPTION
## Summary
Adds a new per-file log viewer at `/log-viewer/file` that provides a structured interface for viewing and filtering log files. The viewer includes support for JSONL parsing, level-based filtering, substring search, and configurable tail length.

## Key Changes

- **New helper functions in `src/functions.php`:**
  - `log_viewer_resolve_log_path()`: Safely resolves user-supplied filenames to absolute paths within `storage/logs`, preventing directory traversal attacks
  - `log_viewer_file_detail()`: Reads log files in reverse (memory-efficient for large files), parses JSONL entries, and applies filtering by log level and search query
  - `log_viewer_format_iso_timestamp()`: Formats ISO-8601 timestamps into compact "HH:MM:SS UTC · Y-m-d" display format
  - `log_viewer_available_files()`: Lists available log files sorted by modification time, with metadata for the file picker

- **New viewer page at `public/log-viewer/file.php`:**
  - Displays detailed view of a single log file with controls for filtering and navigation
  - Supports filtering by minimum log level (debug/info/warning/error)
  - Supports substring search across raw log lines
  - Configurable tail length (100, 300, 1000, or 3000 lines)
  - Renders JSONL entries with structured display (timestamp, level badge, event, job_key, logger, message, expandable payload/exception)
  - Falls back to raw text display for non-JSON logs
  - Shows file metadata (size, modification time, line counts, level distribution)

- **Updated `public/log-viewer/index.php`:**
  - Added "Open" button on each log file to link to the structured viewer
  - Added explanatory text directing users to the new structured viewer for JSONL files

- **Updated `public/.htaccess`:**
  - Added rewrite rule for `/log-viewer/file` route

## Implementation Details

- **Reverse-tail reading**: Efficiently reads large log files by seeking to the end and walking backwards in 32 KiB chunks, keeping memory bounded
- **Dual-format parsing**: Attempts JSON decoding first (for structured logs), falls back to raw text for legacy plain-text logs
- **Oversampling for filters**: When filtering by level or search query, reads 4x the requested lines to ensure sufficient results after filtering
- **Security**: Path resolution validates against directory traversal, symlink escapes, and ensures files are readable
- **Level hierarchy**: Implements log level ranking (debug < info < warning < error < critical) for filtering
- **Metadata extraction**: Surfaces common fields (event, job_key) prominently while keeping other payload data in expandable details

https://claude.ai/code/session_012ABZAMjspWERgWijv4NpKA