### PR TITLE
Implement keyset pagination for killmail overview list

### DIFF
--- a/public/api/killmail-intelligence/count.php
+++ b/public/api/killmail-intelligence/count.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+// AJAX endpoint for the /killmail-intelligence loss-list total count.
+//
+// Why this exists: db_killmail_overview_page() used to run a COUNT(*) across
+// 1.5M+ killmail_events rows on every page render. Even with the composite
+// idx_killmail_mailtype_effective_seq index that count adds measurable
+// latency to the initial paint. The main page now defers the count here so
+// the first paint lands as soon as the 25 rows come back; JS then fetches
+// this endpoint to fill in the "Total: N losses" label.
+//
+// Response shape:
+//   HTTP 200 { ok:true, total:N, filters:{...}, cached_at:ISO8601 }
+//
+// The response is cached alongside the main overview cache (same
+// `killmail_overview` dependency tag) so killmail ingestion busts both
+// entries at the same time.
+
+require_once __DIR__ . '/../../../src/bootstrap.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: private, max-age=30');
+
+try {
+    $allianceId = max(0, (int) ($_GET['alliance_id'] ?? 0));
+    $corporationId = max(0, (int) ($_GET['corporation_id'] ?? 0));
+    $trackedOnly = ((string) ($_GET['tracked_only'] ?? '0')) === '1';
+    $mailTypeRaw = (string) ($_GET['mail_type'] ?? 'loss');
+    $mailType = in_array($mailTypeRaw, ['kill', 'loss', ''], true) ? $mailTypeRaw : 'loss';
+    $startDate = '2024-01-01 00:00:00';
+
+    $filters = [
+        'alliance_id' => $allianceId,
+        'corporation_id' => $corporationId,
+        'tracked_only' => $trackedOnly,
+        'mail_type' => $mailType,
+        'start_date' => $startDate,
+    ];
+
+    // Cache the count for the full overview TTL. The cache is invalidated
+    // together with the main killmail_overview cache on ingestion, so the
+    // number stays in sync with the displayed list.
+    $cacheKey = [
+        'total_count',
+        'type', $mailType,
+        'alliance', $allianceId,
+        'corp', $corporationId,
+        'tracked', (int) $trackedOnly,
+    ];
+    $total = supplycore_cache_aside(
+        'killmail_overview',
+        $cacheKey,
+        supplycore_cache_ttl('killmail_summary'),
+        static fn (): int => db_killmail_overview_total_count($filters),
+        [
+            'dependencies' => ['killmail_overview'],
+            'lock_ttl' => 20,
+        ]
+    );
+
+    echo json_encode([
+        'ok' => true,
+        'total' => (int) $total,
+        'filters' => [
+            'alliance_id' => $allianceId,
+            'corporation_id' => $corporationId,
+            'tracked_only' => $trackedOnly,
+            'mail_type' => $mailType,
+        ],
+        'cached_at' => gmdate('c'),
+    ], JSON_UNESCAPED_SLASHES);
+} catch (Throwable $exception) {
+    http_response_code(500);
+    echo json_encode([
+        'ok' => false,
+        'error' => $exception->getMessage(),
+    ], JSON_UNESCAPED_SLASHES);
+}

--- a/public/killmail-intelligence/index.php
+++ b/public/killmail-intelligence/index.php
@@ -58,9 +58,27 @@ $queryParams = $_GET;
 $buildPageUrl = static function (int $targetPage) use ($queryParams): string {
     $params = $queryParams;
     $params['page'] = max(1, $targetPage);
+    // Page-number navigation is only used on the search path; keyset cursors
+    // are orthogonal so make sure they don't leak into a page-number URL.
+    unset($params['cursor'], $params['dir']);
 
     return current_path() . '?' . http_build_query($params);
 };
+$buildCursorUrl = static function (?string $cursor, string $dir) use ($queryParams): string {
+    $params = $queryParams;
+    if ($cursor === null || $cursor === '') {
+        // "First page" shortcut — drop cursor and dir entirely.
+        unset($params['cursor'], $params['dir'], $params['page']);
+    } else {
+        $params['cursor'] = $cursor;
+        $params['dir'] = $dir === 'prev' ? 'prev' : 'next';
+        unset($params['page']);
+    }
+
+    $query = http_build_query($params);
+    return current_path() . ($query !== '' ? '?' . $query : '');
+};
+$overviewHasSearch = trim((string) ($_GET['q'] ?? '')) !== '';
 
 include __DIR__ . '/../../src/views/partials/header.php';
 if (function_exists('ob_flush')) { @ob_flush(); }
@@ -305,11 +323,27 @@ if (function_exists('ob_flush')) { @ob_flush(); }
             </label>
         </div>
         <div class="mt-4 flex flex-wrap items-center justify-between gap-3">
-            <div class="text-sm text-muted">
-                Showing <?= (int) ($pagination['showing_from'] ?? 0) ?>-<?= (int) ($pagination['showing_to'] ?? 0) ?> of <?= number_format((int) ($pagination['total_items'] ?? 0)) ?> recorded losses
+            <?php
+                $totalItemsValue = $pagination['total_items'] ?? null;
+                $showingFrom = (int) ($pagination['showing_from'] ?? 0);
+                $showingTo = (int) ($pagination['showing_to'] ?? 0);
+            ?>
+            <div class="text-sm text-muted" data-loss-count-label>
+                <?php if ($totalItemsValue !== null): ?>
+                    Showing <?= $showingFrom ?>-<?= $showingTo ?> of <?= number_format((int) $totalItemsValue) ?> recorded losses
+                <?php else: ?>
+                    Showing <?= $showingFrom ?>-<?= $showingTo ?> recorded losses <span class="ml-1 text-xs text-slate-500" data-loss-count-suffix>· total counting…</span>
+                <?php endif; ?>
             </div>
-            <div class="flex flex-wrap gap-2">
-                <button type="submit" class="btn-primary">Apply filters</button>
+            <div class="flex flex-wrap items-center gap-2">
+                <span data-search-submit-spinner class="hidden items-center gap-2 text-xs text-muted" role="status" aria-live="polite">
+                    <svg class="h-4 w-4 animate-spin text-slate-300" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle>
+                        <path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round" class="opacity-75"></path>
+                    </svg>
+                    <span>Searching…</span>
+                </span>
+                <button type="submit" class="btn-primary" data-search-submit-btn>Apply filters</button>
                 <a href="<?= htmlspecialchars(current_path(), ENT_QUOTES) ?>" class="btn-secondary">Reset</a>
             </div>
         </div>
@@ -438,11 +472,48 @@ if (function_exists('ob_flush')) { @ob_flush(); }
         </table>
     </div>
 
+    <?php
+        $useKeyset = (bool) ($pagination['use_keyset'] ?? false);
+        $paginationNoSearch = !$overviewHasSearch;
+        $nextCursor = $pagination['next_cursor'] ?? null;
+        $prevCursor = $pagination['prev_cursor'] ?? null;
+        $pageNum = max(1, (int) ($pagination['page'] ?? 1));
+        $totalPagesValue = $pagination['total_pages'] ?? null;
+        $currentCursor = trim((string) ($_GET['cursor'] ?? ''));
+    ?>
     <div class="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm text-muted">
-        <p>Page <?= max(1, (int) ($pagination['page'] ?? 1)) ?> / <?= max(1, (int) ($pagination['total_pages'] ?? 1)) ?></p>
+        <?php if ($paginationNoSearch): ?>
+            <p data-loss-pagination-label>
+                <?php if ($useKeyset || $currentCursor !== ''): ?>
+                    Cursor view — newest first
+                <?php else: ?>
+                    Latest losses
+                <?php endif; ?>
+                <?php if ($totalPagesValue === null): ?>
+                    <span class="ml-2 text-xs text-slate-500" data-loss-pagination-total>· total pages: <span data-loss-pagination-total-value>counting…</span></span>
+                <?php else: ?>
+                    <span class="ml-2 text-xs text-slate-500">· <?= number_format((int) $totalPagesValue) ?> pages total</span>
+                <?php endif; ?>
+            </p>
+        <?php else: ?>
+            <p>Page <?= $pageNum ?> / <?= $totalPagesValue !== null ? max(1, (int) $totalPagesValue) : 1 ?></p>
+        <?php endif; ?>
         <div class="flex items-center gap-2">
-            <a href="<?= htmlspecialchars($buildPageUrl(((int) ($pagination['page'] ?? 1)) - 1), ENT_QUOTES) ?>" class="btn-secondary px-3 py-1.5 <?= ((int) ($pagination['page'] ?? 1)) <= 1 ? 'pointer-events-none opacity-40' : '' ?>">Previous</a>
-            <a href="<?= htmlspecialchars($buildPageUrl(((int) ($pagination['page'] ?? 1)) + 1), ENT_QUOTES) ?>" class="btn-secondary px-3 py-1.5 <?= ((int) ($pagination['page'] ?? 1)) >= ((int) ($pagination['total_pages'] ?? 1)) ? 'pointer-events-none opacity-40' : '' ?>">Next</a>
+            <?php if ($paginationNoSearch): ?>
+                <?php
+                    // Keyset navigation. "First" resets to the head view;
+                    // Previous/Next use the cursors returned by the DB layer.
+                    $isHead = $currentCursor === '';
+                    $prevDisabled = $prevCursor === null || $prevCursor === '';
+                    $nextDisabled = $nextCursor === null || $nextCursor === '';
+                ?>
+                <a href="<?= htmlspecialchars($buildCursorUrl(null, 'next'), ENT_QUOTES) ?>" class="btn-secondary px-3 py-1.5 <?= $isHead ? 'pointer-events-none opacity-40' : '' ?>">First</a>
+                <a href="<?= htmlspecialchars($buildCursorUrl($prevCursor, 'prev'), ENT_QUOTES) ?>" class="btn-secondary px-3 py-1.5 <?= $prevDisabled ? 'pointer-events-none opacity-40' : '' ?>">Previous</a>
+                <a href="<?= htmlspecialchars($buildCursorUrl($nextCursor, 'next'), ENT_QUOTES) ?>" class="btn-secondary px-3 py-1.5 <?= $nextDisabled ? 'pointer-events-none opacity-40' : '' ?>">Next</a>
+            <?php else: ?>
+                <a href="<?= htmlspecialchars($buildPageUrl($pageNum - 1), ENT_QUOTES) ?>" class="btn-secondary px-3 py-1.5 <?= $pageNum <= 1 ? 'pointer-events-none opacity-40' : '' ?>">Previous</a>
+                <a href="<?= htmlspecialchars($buildPageUrl($pageNum + 1), ENT_QUOTES) ?>" class="btn-secondary px-3 py-1.5 <?= ($totalPagesValue !== null && $pageNum >= (int) $totalPagesValue) ? 'pointer-events-none opacity-40' : '' ?>">Next</a>
+            <?php endif; ?>
         </div>
     </div>
 </section>
@@ -640,6 +711,100 @@ if (function_exists('ob_flush')) { @ob_flush(); }
         } else {
             loadCoverage(false);
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Deferred loss-count loader
+    //
+    // The overview page now skips the 1.5M-row COUNT(*) on the initial render
+    // and fetches it here instead. The label starts as "Showing N-M recorded
+    // losses · total counting…" and is rewritten once the fetch returns.
+    // -----------------------------------------------------------------------
+    const lossCountLabel = document.querySelector('[data-loss-count-label]');
+    const paginationTotalValueEl = document.querySelector('[data-loss-pagination-total-value]');
+
+    function formatCountNumber(n) {
+        const v = typeof n === 'number' ? n : parseInt(n, 10);
+        return Number.isFinite(v) ? v.toLocaleString() : '—';
+    }
+
+    function applyTotalToLabel(total, pageSize) {
+        if (!lossCountLabel) return;
+        // Re-derive the "Showing N-M" from the rendered row count so we don't
+        // rely on any intermediate text parsing.
+        const tableRows = document.querySelectorAll('[data-ui-section="killmail-overview-table"] tbody tr');
+        const rowCount = tableRows.length === 1 && tableRows[0].querySelector('[colspan]') ? 0 : tableRows.length;
+        // Only rewrite the "counting…" path — if the label already carries a
+        // concrete total (search path) leave it alone.
+        const suffix = lossCountLabel.querySelector('[data-loss-count-suffix]');
+        if (!suffix) return;
+        const totalFormatted = formatCountNumber(total);
+        lossCountLabel.textContent = 'Showing ' + (rowCount > 0 ? '1-' + rowCount : '0') + ' of ' + totalFormatted + ' recorded losses';
+    }
+
+    function applyTotalToPagination(total, pageSize) {
+        if (!paginationTotalValueEl) return;
+        const size = Math.max(1, parseInt(pageSize, 10) || 25);
+        const pages = Math.max(1, Math.ceil(total / size));
+        paginationTotalValueEl.textContent = pages.toLocaleString() + ' pages (' + formatCountNumber(total) + ' losses)';
+    }
+
+    async function loadLossCount() {
+        if (!lossCountLabel && !paginationTotalValueEl) return;
+        // Only the default list defers the count; search preserves the
+        // server-rendered total.
+        const urlParams = new URLSearchParams(window.location.search);
+        if ((urlParams.get('q') || '').trim() !== '') return;
+
+        const countParams = new URLSearchParams();
+        ['alliance_id', 'corporation_id', 'mail_type', 'tracked_only'].forEach(name => {
+            const v = urlParams.get(name);
+            if (v !== null && v !== '') countParams.set(name, v);
+        });
+        const pageSize = urlParams.get('page_size') || '25';
+
+        try {
+            const response = await fetch('/api/killmail-intelligence/count.php?' + countParams.toString(), {
+                headers: { 'Accept': 'application/json' },
+            });
+            const data = await response.json().catch(() => null);
+            if (!response.ok || !data || !data.ok) {
+                const suffix = lossCountLabel && lossCountLabel.querySelector('[data-loss-count-suffix]');
+                if (suffix) suffix.textContent = '· total unavailable';
+                if (paginationTotalValueEl) paginationTotalValueEl.textContent = 'unavailable';
+                return;
+            }
+            applyTotalToLabel(data.total, pageSize);
+            applyTotalToPagination(data.total, pageSize);
+        } catch (err) {
+            const suffix = lossCountLabel && lossCountLabel.querySelector('[data-loss-count-suffix]');
+            if (suffix) suffix.textContent = '· total unavailable';
+            if (paginationTotalValueEl) paginationTotalValueEl.textContent = 'unavailable';
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadLossCount);
+    } else {
+        loadLossCount();
+    }
+
+    // -----------------------------------------------------------------------
+    // Search-submit spinner
+    //
+    // Surfacing a visible "Searching…" status lets the user see that the
+    // request is in flight on slow search queries (multi-join + LIKE path).
+    // -----------------------------------------------------------------------
+    const overviewForm = document.querySelector('[data-ui-section="killmail-overview-table"] form');
+    const searchSubmitSpinner = document.querySelector('[data-search-submit-spinner]');
+    const searchSubmitBtn = document.querySelector('[data-search-submit-btn]');
+    if (overviewForm && searchSubmitSpinner && searchSubmitBtn) {
+        overviewForm.addEventListener('submit', () => {
+            searchSubmitSpinner.classList.remove('hidden');
+            searchSubmitSpinner.classList.add('inline-flex');
+            searchSubmitBtn.setAttribute('disabled', 'disabled');
+            searchSubmitBtn.classList.add('opacity-60', 'pointer-events-none');
+        });
     }
 })();
 </script>

--- a/python/orchestrator/jobs/killmail.py
+++ b/python/orchestrator/jobs/killmail.py
@@ -1,35 +1,58 @@
 from __future__ import annotations
 
+import subprocess
 import time
-import urllib.error
-import urllib.request
 from typing import Any
 
 from ..bridge import PhpBridge
 from ..esi_client import EsiClient
 from ..esi_rate_limiter import shared_limiter
-from ..http_client import ipv4_opener
 from ..job_result import JobResult
 from ..worker_runtime import payload_checksum, resident_memory_bytes, utc_now_iso
 
 
 def _http_json(url: str, user_agent: str, timeout_seconds: int = 25) -> tuple[int, Any]:
-    request = urllib.request.Request(
+    """HTTP GET via curl, matching ZKillAdapter's strategy.
+
+    Uses ``curl -4`` because:
+      1. r2z2.zkillboard.com resolves AAAA but the host has no IPv6 connectivity.
+      2. Cloudflare (which fronts zKB) blocks custom User-Agent strings with 403.
+         We let curl use its default UA and pass our identity via ``Maintainer``.
+    """
+    cmd = [
+        "curl", "-4", "-s",
+        "-o", "-",
+        "-w", "\n%{http_code}",
+        "--compressed",
+        "--connect-timeout", str(min(timeout_seconds, 10)),
+        "--max-time", str(timeout_seconds),
+        "-H", f"Maintainer: {user_agent}",
+        "-H", "Accept: application/json",
         url,
-        headers={
-            "Accept": "application/json",
-            "User-Agent": user_agent,
-        },
-    )
+    ]
+
     try:
-        with ipv4_opener.open(request, timeout=timeout_seconds) as response:
-            status = int(getattr(response, "status", response.getcode()))
-            payload = response.read().decode("utf-8", errors="replace")
-    except urllib.error.HTTPError as error:
-        status = int(error.code)
-        payload = error.read().decode("utf-8", errors="replace")
-    except urllib.error.URLError as error:
-        raise RuntimeError(f"R2Z2 request failed: {error.reason}") from error
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds + 5,
+        )
+    except (subprocess.TimeoutExpired, OSError) as error:
+        raise RuntimeError(f"R2Z2 request failed: {error}") from error
+
+    raw = result.stdout or ""
+    last_nl = raw.rfind("\n")
+    if last_nl == -1:
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"R2Z2 request failed: curl exit={result.returncode} stderr={result.stderr.strip()!r}"
+            )
+        return 0, {}
+
+    payload = raw[:last_nl]
+    status_str = raw[last_nl + 1:].strip()
+    status = int(status_str) if status_str.isdigit() else 0
 
     import json
 

--- a/src/db.php
+++ b/src/db.php
@@ -13375,6 +13375,32 @@ function db_killmail_overview_page(array $filters = []): array
     $search = trim((string) ($filters['search'] ?? ''));
     $startDate = trim((string) ($filters['start_date'] ?? '2024-01-01 00:00:00'));
 
+    // Keyset pagination support (no-search path only). Without a cursor this
+    // still runs as "keyset mode at the head" — LIMIT pageSize+1 with no extra
+    // WHERE clause — so the head view also gets a next-cursor for the Next
+    // button. When a cursor IS provided, pagination is driven by
+    // (effective_killmail_at, sequence_id) instead of LIMIT/OFFSET so deep-page
+    // navigation never scans skipped rows.
+    //   direction='next'  → rows strictly older than the cursor
+    //   direction='prev'  → rows strictly newer than the cursor (then reversed)
+    // $skipCount lets callers opt out of the 1.5M-row COUNT(*) when they plan
+    // to fetch the total asynchronously (see public/api/killmail-intelligence/count.php).
+    $cursor = trim((string) ($filters['cursor'] ?? ''));
+    $direction = (string) ($filters['direction'] ?? 'next');
+    if ($direction !== 'prev') {
+        $direction = 'next';
+    }
+    $skipCount = (bool) ($filters['skip_count'] ?? false);
+    $useKeyset = $search === '';
+    [$cursorAt, $cursorSeq] = db_killmail_overview_parse_cursor($cursor);
+    $hasCursor = $cursorAt !== null && $cursorSeq > 0;
+    if (!$hasCursor) {
+        // Keyset still active for fetch-limit and cursor generation, but the
+        // WHERE clause below only fires when $hasCursor is true.
+        $cursorAt = null;
+        $cursorSeq = 0;
+    }
+
     // --- Base predicates (apply to both COUNT and row fetch) ---
     //
     // This function used to wrap killmail_events in a GROUP BY derived table
@@ -13478,24 +13504,32 @@ function db_killmail_overview_page(array $filters = []): array
     // idx_killmail_mailtype_effective_seq this is a pure range scan with no
     // joins, no temp tables and no filesort. This is the change that fixes
     // the killmail-intelligence page timing out during backload.
-    if ($searchConditions === []) {
-        $countWhereSql = ' WHERE ' . implode(' AND ', $baseConditions);
-        $countRow = db_select_one(
-            'SELECT COUNT(*) AS total_items FROM killmail_events e' . $countWhereSql,
-            $baseParams
-        );
-    } else {
-        $countConditions = array_merge($baseConditions, $searchConditions);
-        $countWhereSql = ' WHERE ' . implode(' AND ', $countConditions);
-        $countRow = db_select_one(
-            'SELECT COUNT(*) AS total_items FROM killmail_events e' . $displayJoinsSql . $countWhereSql,
-            array_merge($baseParams, $searchParams)
-        );
+    //
+    // When $skipCount is true we return $totalItems=null and the caller fills
+    // it in later via an async AJAX fetch. The keyset path always sets
+    // $skipCount=true because "page N of M" is meaningless with cursor paging.
+    $totalItems = null;
+    $totalPages = null;
+    if (!$skipCount && !$useKeyset) {
+        if ($searchConditions === []) {
+            $countWhereSql = ' WHERE ' . implode(' AND ', $baseConditions);
+            $countRow = db_select_one(
+                'SELECT COUNT(*) AS total_items FROM killmail_events e' . $countWhereSql,
+                $baseParams
+            );
+        } else {
+            $countConditions = array_merge($baseConditions, $searchConditions);
+            $countWhereSql = ' WHERE ' . implode(' AND ', $countConditions);
+            $countRow = db_select_one(
+                'SELECT COUNT(*) AS total_items FROM killmail_events e' . $displayJoinsSql . $countWhereSql,
+                array_merge($baseParams, $searchParams)
+            );
+        }
+        $totalItems = (int) ($countRow['total_items'] ?? 0);
+        $totalPages = max(1, (int) ceil($totalItems / $pageSize));
+        $page = min($page, $totalPages);
+        $offset = ($page - 1) * $pageSize;
     }
-    $totalItems = (int) ($countRow['total_items'] ?? 0);
-    $totalPages = max(1, (int) ceil($totalItems / $pageSize));
-    $page = min($page, $totalPages);
-    $offset = ($page - 1) * $pageSize;
 
     // --- Row fetch ---
     // Needs the display joins (the SELECT references their columns) but the
@@ -13505,8 +13539,30 @@ function db_killmail_overview_page(array $filters = []): array
     // this view: the old UNION-derived tracked table declared them but never
     // populated them (it only covered the victim side).
     $rowConditions = array_merge($baseConditions, $searchConditions);
-    $rowWhereSql = ' WHERE ' . implode(' AND ', $rowConditions);
     $rowParams = array_merge($baseParams, $searchParams);
+
+    // Keyset predicate on (effective_killmail_at, sequence_id). "Next" walks
+    // older rows; "prev" walks newer ones (then we reverse the result set in
+    // PHP so output stays newest-first). Both branches use the existing
+    // idx_killmail_mailtype_effective_seq index for a pure range scan.
+    $orderSql = 'ORDER BY e.effective_killmail_at DESC, e.sequence_id DESC, e.killmail_id DESC';
+    if ($useKeyset && $hasCursor) {
+        if ($direction === 'prev') {
+            $rowConditions[] = '(e.effective_killmail_at > ? OR (e.effective_killmail_at = ? AND e.sequence_id > ?))';
+            $orderSql = 'ORDER BY e.effective_killmail_at ASC, e.sequence_id ASC, e.killmail_id ASC';
+        } else {
+            $rowConditions[] = '(e.effective_killmail_at < ? OR (e.effective_killmail_at = ? AND e.sequence_id < ?))';
+        }
+        $rowParams[] = $cursorAt;
+        $rowParams[] = $cursorAt;
+        $rowParams[] = $cursorSeq;
+    }
+    $rowWhereSql = ' WHERE ' . implode(' AND ', $rowConditions);
+    // Fetch one extra row to detect has_next (or has_prev when going backward).
+    $fetchLimit = $useKeyset ? $pageSize + 1 : $pageSize;
+    $limitSql = $useKeyset
+        ? "LIMIT {$fetchLimit}"
+        : "LIMIT {$pageSize} OFFSET {$offset}";
 
     $rows = db_select(
         "SELECT
@@ -13517,6 +13573,7 @@ function db_killmail_overview_page(array $filters = []): array
             e.killmail_time,
             e.uploaded_at,
             e.created_at,
+            e.effective_killmail_at,
             e.victim_character_id,
             e.victim_corporation_id,
             e.victim_alliance_id,
@@ -13563,20 +13620,184 @@ function db_killmail_overview_page(array $filters = []): array
          FROM killmail_events e
          {$displayJoinsSql}
          {$rowWhereSql}
-         ORDER BY e.effective_killmail_at DESC, e.sequence_id DESC, e.killmail_id DESC
-         LIMIT {$pageSize} OFFSET {$offset}",
+         {$orderSql}
+         {$limitSql}",
         $rowParams
     );
 
-    return [
+    // Keyset post-processing: drop the "+1" probe row, detect has_more, flip
+    // the "prev" direction back to newest-first, and compute the cursors the
+    // UI needs for the next round of navigation.
+    //
+    // Semantics:
+    //   hasMore=true means "extra row was returned, more data exists in the
+    //   direction we were walking". For direction='next' that means more
+    //   OLDER rows; for direction='prev' that means more NEWER rows.
+    //   hasCursor=false means we're at the head (newest rows) — so Previous
+    //   is hidden and Next is shown whenever there are more older rows.
+    $hasMore = false;
+    $nextCursor = null;
+    $prevCursor = null;
+    $showNext = false;
+    $showPrev = false;
+    if ($useKeyset) {
+        if (count($rows) > $pageSize) {
+            $hasMore = true;
+            $rows = array_slice($rows, 0, $pageSize);
+        }
+        if ($direction === 'prev') {
+            $rows = array_reverse($rows);
+        }
+        if ($rows !== []) {
+            $firstRow = $rows[0];
+            $lastRow = $rows[count($rows) - 1];
+            $prevCursor = db_killmail_overview_build_cursor($firstRow);
+            $nextCursor = db_killmail_overview_build_cursor($lastRow);
+        }
+        if (!$hasCursor) {
+            // Head view: no Previous, Next only if more older rows exist.
+            $showPrev = false;
+            $showNext = $hasMore;
+        } elseif ($direction === 'next') {
+            // Walking older: Previous always (we came from newer). Next only
+            // if more older rows remain.
+            $showPrev = true;
+            $showNext = $hasMore;
+        } else {
+            // Walking newer: Next always (we came from older). Previous only
+            // if more newer rows remain.
+            $showPrev = $hasMore;
+            $showNext = true;
+        }
+    }
+
+    $result = [
         'rows' => $rows,
         'page' => $page,
         'page_size' => $pageSize,
         'total_items' => $totalItems,
         'total_pages' => $totalPages,
-        'showing_from' => $totalItems > 0 ? $offset + 1 : 0,
-        'showing_to' => min($offset + $pageSize, $totalItems),
+        'use_keyset' => $useKeyset,
+        'direction' => $direction,
+        'next_cursor' => $showNext ? $nextCursor : null,
+        'prev_cursor' => $showPrev ? $prevCursor : null,
     ];
+    if ($totalItems !== null) {
+        $result['showing_from'] = $totalItems > 0 ? $offset + 1 : 0;
+        $result['showing_to'] = min($offset + $pageSize, $totalItems);
+    } else {
+        $result['showing_from'] = $rows === [] ? 0 : 1;
+        $result['showing_to'] = count($rows);
+    }
+
+    return $result;
+}
+
+/**
+ * Parse the opaque cursor used by the killmail overview keyset pagination.
+ *
+ * Format: "{Y-m-d H:i:s}|{sequence_id}" URL-safe-base64 encoded. Returning
+ * [null, 0] means "no valid cursor" and the caller falls back to page 1.
+ */
+function db_killmail_overview_parse_cursor(string $cursor): array
+{
+    $cursor = trim($cursor);
+    if ($cursor === '') {
+        return [null, 0];
+    }
+    // Opaque URL-safe base64 so stray characters don't slip into the SQL
+    // parameters. The structure inside is still a plain "at|seq" pair.
+    $decoded = base64_decode(strtr($cursor, '-_', '+/'), true);
+    if ($decoded === false) {
+        return [null, 0];
+    }
+    $parts = explode('|', $decoded, 2);
+    if (count($parts) !== 2) {
+        return [null, 0];
+    }
+    $at = trim($parts[0]);
+    $seq = (int) $parts[1];
+    if ($at === '' || $seq <= 0) {
+        return [null, 0];
+    }
+    // Reject obviously malformed datetimes so we don't pass garbage to MySQL.
+    $ts = strtotime($at . ' UTC');
+    if ($ts === false) {
+        return [null, 0];
+    }
+    return [$at, $seq];
+}
+
+/**
+ * Build the opaque cursor string for a killmail row. Pairs with
+ * db_killmail_overview_parse_cursor().
+ */
+function db_killmail_overview_build_cursor(array $row): ?string
+{
+    $at = isset($row['effective_killmail_at']) ? trim((string) $row['effective_killmail_at']) : '';
+    // effective_killmail_at is a generated column; fall back to killmail_time
+    // then created_at for rows where the cursor column was not selected.
+    if ($at === '') {
+        $at = isset($row['killmail_time']) ? trim((string) $row['killmail_time']) : '';
+    }
+    if ($at === '') {
+        $at = isset($row['created_at']) ? trim((string) $row['created_at']) : '';
+    }
+    $seq = isset($row['sequence_id']) ? (int) $row['sequence_id'] : 0;
+    if ($at === '' || $seq <= 0) {
+        return null;
+    }
+    return rtrim(strtr(base64_encode($at . '|' . $seq), '+/', '-_'), '=');
+}
+
+/**
+ * Count-only variant used by the async count endpoint. Shares filter logic
+ * with db_killmail_overview_page() but skips the row SELECT entirely.
+ */
+function db_killmail_overview_total_count(array $filters = []): int
+{
+    db_killmail_overview_schema_ensure();
+
+    $allianceId = max(0, (int) ($filters['alliance_id'] ?? 0));
+    $corporationId = max(0, (int) ($filters['corporation_id'] ?? 0));
+    $trackedOnly = (bool) ($filters['tracked_only'] ?? false);
+    $mailType = in_array((string) ($filters['mail_type'] ?? 'loss'), ['kill', 'loss', ''], true) ? (string) ($filters['mail_type'] ?? 'loss') : 'loss';
+    $startDate = trim((string) ($filters['start_date'] ?? '2024-01-01 00:00:00'));
+
+    $conditions = [];
+    $params = [];
+    if ($allianceId > 0) {
+        $conditions[] = 'e.victim_alliance_id = ?';
+        $params[] = $allianceId;
+    }
+    if ($corporationId > 0) {
+        $conditions[] = 'e.victim_corporation_id = ?';
+        $params[] = $corporationId;
+    }
+    if ($mailType !== '') {
+        $conditions[] = 'e.mail_type = ?';
+        $params[] = $mailType;
+    }
+    $conditions[] = 'e.effective_killmail_at >= ?';
+    $params[] = $startDate;
+    if ($trackedOnly) {
+        $conditions[] = '(
+            e.victim_alliance_id IN (
+                SELECT contact_id FROM corp_contacts
+                WHERE contact_type = \'alliance\' AND standing > 0
+            )
+            OR e.victim_corporation_id IN (
+                SELECT contact_id FROM corp_contacts
+                WHERE contact_type = \'corporation\' AND standing > 0
+            )
+        )';
+    }
+
+    $row = db_select_one(
+        'SELECT COUNT(*) AS total_items FROM killmail_events e WHERE ' . implode(' AND ', $conditions),
+        $params
+    );
+    return (int) ($row['total_items'] ?? 0);
 }
 
 function db_killmail_overview_duplicate_identity_check(array $filters = []): array

--- a/src/functions.php
+++ b/src/functions.php
@@ -11875,7 +11875,15 @@ function killmail_overview_data(): array
         'mail_type' => in_array($_GET['mail_type'] ?? 'loss', ['kill', 'loss', ''], true) ? ($_GET['mail_type'] ?? 'loss') : 'loss',
         'page' => max(1, (int) ($_GET['page'] ?? 1)),
         'page_size' => $pageSize,
+        'cursor' => trim((string) ($_GET['cursor'] ?? '')),
+        'direction' => ($_GET['dir'] ?? 'next') === 'prev' ? 'prev' : 'next',
     ];
+    // Fast path for the default list (no free-text search): use keyset
+    // pagination driven by (effective_killmail_at, sequence_id) and skip the
+    // COUNT(*) on initial render. The total gets filled in asynchronously via
+    // /api/killmail-intelligence/count.php so the 1.5M-row COUNT no longer
+    // blocks the page.
+    $filters['skip_count'] = $filters['search'] === '';
     // Cache all views that don't have a free-text search query. Free-text search has
     // too many possible combinations to cache usefully; everything else (pagination,
     // alliance/corp/type filters) is keyed explicitly so each combination gets its
@@ -11926,6 +11934,10 @@ function killmail_overview_data(): array
                     'total_items' => 0,
                     'showing_from' => 0,
                     'showing_to' => 0,
+                    'use_keyset' => false,
+                    'direction' => 'next',
+                    'next_cursor' => null,
+                    'prev_cursor' => null,
                 ],
                 'coverage' => [
                     'start_date' => $overviewStartDate,
@@ -12314,16 +12326,26 @@ function killmail_overview_data(): array
                 'page' => (int) ($listing['page'] ?? 1),
                 'page_size' => (int) ($listing['page_size'] ?? $pageSize),
                 'page_size_options' => $allowedPageSizes,
-                'total_pages' => (int) ($listing['total_pages'] ?? 1),
-                'total_items' => (int) ($listing['total_items'] ?? 0),
+                // total_pages / total_items are null on the keyset fast path —
+                // the UI should render them as "counting…" until the async
+                // count endpoint returns.
+                'total_pages' => $listing['total_pages'] ?? null,
+                'total_items' => $listing['total_items'] ?? null,
                 'showing_from' => (int) ($listing['showing_from'] ?? 0),
                 'showing_to' => (int) ($listing['showing_to'] ?? 0),
+                'use_keyset' => (bool) ($listing['use_keyset'] ?? false),
+                'direction' => (string) ($listing['direction'] ?? 'next'),
+                'next_cursor' => isset($listing['next_cursor']) ? (string) $listing['next_cursor'] : null,
+                'prev_cursor' => isset($listing['prev_cursor']) ? (string) $listing['prev_cursor'] : null,
             ],
             'empty_message' => $emptyMessage,
         ];
     };
 
     if ($useCache) {
+        // Keyset cursor + direction are part of the cache key so Next/Previous
+        // navigation each get their own entry. When there's no cursor we fall
+        // back to the old page-number key for the default (head) view.
         $cacheKey = [
             'page', $filters['page'],
             'size', $filters['page_size'],
@@ -12331,6 +12353,8 @@ function killmail_overview_data(): array
             'alliance', $filters['alliance_id'],
             'corp', $filters['corporation_id'],
             'tracked', (int) $filters['tracked_only'],
+            'cursor', $filters['cursor'],
+            'dir', $filters['direction'],
         ];
         return supplycore_cache_aside('killmail_overview', $cacheKey, supplycore_cache_ttl('killmail_summary'), $resolver, [
             'dependencies' => ['killmail_overview'],


### PR DESCRIPTION
## Summary

Replaces offset-based pagination with keyset (cursor-based) pagination for the killmail overview list when no search query is present. This eliminates the expensive 1.5M-row COUNT(*) query from the initial page render and defers it to an async AJAX endpoint, significantly improving page load performance.

## Key Changes

- **Keyset pagination implementation**: Added `db_killmail_overview_parse_cursor()` and `db_killmail_overview_build_cursor()` functions to handle opaque base64-encoded cursors containing `(effective_killmail_at, sequence_id)` tuples for stable row ordering.

- **Deferred COUNT query**: Introduced `db_killmail_overview_total_count()` function and new `/api/killmail-intelligence/count.php` endpoint to fetch the total loss count asynchronously. The main page now skips the COUNT on initial render when using keyset pagination.

- **Bidirectional cursor navigation**: Keyset pagination supports both forward ("next", older rows) and backward ("prev", newer rows) navigation. The "prev" direction reverses the sort order in SQL and flips results back in PHP to maintain newest-first display.

- **Hybrid pagination strategy**: 
  - Search queries continue using traditional offset-based pagination with full COUNT
  - Default list (no search) uses keyset pagination with deferred count
  - UI conditionally renders page numbers vs. cursor buttons based on active mode

- **UI enhancements**:
  - Added "First/Previous/Next" cursor navigation buttons for the default list
  - Added "Searching…" spinner during search form submission
  - Loss count label shows "counting…" until async endpoint returns
  - Pagination label displays cursor view status and deferred total page count

- **HTTP client refactor**: Replaced Python's `urllib` with `curl -4` subprocess calls in `killmail.py` to match zKillboard's IPv4-only connectivity and avoid User-Agent blocking by Cloudflare.

## Implementation Details

- Cursors are URL-safe base64-encoded to prevent SQL injection and maintain opacity
- The keyset query uses the existing `idx_killmail_mailtype_effective_seq` index for pure range scans with no filesort
- Fetches `pageSize + 1` rows to detect whether more data exists in the current direction
- Cursor values are extracted from `effective_killmail_at` (generated column) with fallbacks to `killmail_time` and `created_at`
- Count endpoint response is cached with the same TTL and invalidation tags as the main overview cache

https://claude.ai/code/session_017Mi6SqEwbjJtfKsKuaoBTD