### PR TITLE
fix(systemd): retune lane memory gates to match retuned job limits

### DIFF
--- a/ops/systemd/supplycore-lane-compute-battle.service
+++ b/ops/systemd/supplycore-lane-compute-battle.service
@@ -10,13 +10,13 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute-battle --max-parallel 1 --no-tier-barriers --fast-pause 15 --background-pause 30 --memory-max-gb 6.0
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute-battle --max-parallel 1 --no-tier-barriers --fast-pause 15 --background-pause 30 --memory-max-gb 8.0
 Nice=5
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=8G
+MemoryMax=10G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-compute-behavioral.service
+++ b/ops/systemd/supplycore-lane-compute-behavioral.service
@@ -10,7 +10,7 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute-behavioral --max-parallel 1 --no-tier-barriers --fast-pause 15 --background-pause 30 --memory-max-gb 8.0
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute-behavioral --max-parallel 1 --no-tier-barriers --fast-pause 15 --background-pause 30 --memory-max-gb 10.0
 Nice=5
 Restart=always
 RestartSec=5

--- a/ops/systemd/supplycore-lane-compute-misc.service
+++ b/ops/systemd/supplycore-lane-compute-misc.service
@@ -10,13 +10,13 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute-misc --max-parallel 1 --no-tier-barriers --fast-pause 15 --background-pause 30 --memory-max-gb 6.0
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane compute-misc --max-parallel 1 --no-tier-barriers --fast-pause 15 --background-pause 30 --memory-max-gb 16.0
 Nice=5
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=8G
+MemoryMax=20G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-ingestion.service
+++ b/ops/systemd/supplycore-lane-ingestion.service
@@ -10,7 +10,7 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane ingestion --max-parallel 3 --fast-pause 10 --background-pause 30
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane ingestion --max-parallel 3 --fast-pause 10 --background-pause 30 --memory-max-gb 4.0
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM

--- a/ops/systemd/supplycore-lane-maintenance.service
+++ b/ops/systemd/supplycore-lane-maintenance.service
@@ -10,13 +10,13 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane maintenance --max-parallel 1 --fast-pause 60 --background-pause 120
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane maintenance --max-parallel 1 --fast-pause 60 --background-pause 120 --memory-max-gb 1.5
 Nice=10
 Restart=always
 RestartSec=10
 KillSignal=SIGTERM
 TimeoutStopSec=90
-MemoryMax=512M
+MemoryMax=2G
 StandardOutput=journal
 StandardError=journal
 

--- a/ops/systemd/supplycore-lane-realtime.service
+++ b/ops/systemd/supplycore-lane-realtime.service
@@ -10,7 +10,7 @@ Group=www-data
 WorkingDirectory=/var/www/SupplyCore
 EnvironmentFile=-/etc/default/supplycore-worker
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane realtime --max-parallel 4 --fast-pause 5 --background-pause 15
+ExecStart=/var/www/SupplyCore/.venv-orchestrator/bin/python /var/www/SupplyCore/bin/python_orchestrator.py loop-runner --app-root /var/www/SupplyCore --lane realtime --max-parallel 4 --fast-pause 5 --background-pause 15 --memory-max-gb 6.0
 Restart=always
 RestartSec=3
 KillSignal=SIGTERM


### PR DESCRIPTION
## Summary

Follow-up to #1075. PR #1075 bumped `memory_limit_mb` for several heavy compute jobs, but the *lane-level* systemd services had not been retuned to match. This fills those gaps and adds missing `--memory-max-gb` safety gates on lanes that were running without one.

All changes are in `ops/systemd/*.service` — no Python / worker code touched.

| Lane | `MemoryMax` | `--memory-max-gb` | Reason |
|---|---|---|---|
| compute-misc | 8G → **20G** | 6.0 → **16.0** | `market_hub_local_history_sync` declares `memory_limit_mb=16384` (~11GB measured RSS). Prior cap would OOM-kill the runner on every run. |
| compute-battle | 8G → **10G** | 6.0 → **8.0** | `compute_battle_anomalies` and `compute_suspicion_scores_v2` now at 4096 MB each; old cap was tight once Python overhead and back-to-back runs counted. |
| compute-behavioral | 12G (keep) | 8.0 → **10.0** | `compute_behavioral_baselines` bumped to 5120 MB in #1075. |
| maintenance | 512M → **2G** | *(none)* → **1.5** | Maintenance jobs sit at 384–512 MB each; the 512M lane cap could not fit a single Python interpreter plus one of those jobs. |
| realtime | 12G (keep) | *(none)* → **6.0** | Lane was running with no graceful RSS abort threshold; a runaway job would be kernel-killed at `MemoryMax` instead of triggering a clean loop-runner restart. |
| ingestion | 8G (keep) | *(none)* → **4.0** | Same missing-gate issue. |

## Not in this PR

- `compute-graph` / `compute-spy` / `compute-cip` already had adequate caps and gates for their current `memory_limit_mb` values.
- **Lane reassignments** (e.g. moving `theater_graph_integration` off `compute-battle`): intentionally deferred. That job takes ~200 min and starves its lane, but changing its lane without also revisiting its dependency DAG could break ordering. Worth its own focused investigation.
- **Neo4j docker-compose config** (bump `db.memory.transaction.max` from `512m` → `2G`): still an open server-side action item, tracked in #1075.

## Test plan

- [ ] `sudo systemctl daemon-reload && sudo systemctl restart supplycore-lane-*.service`
- [ ] `systemctl status supplycore-lane-compute-misc.service` — confirm `MemoryMax=20G` picked up.
- [ ] Run `market_hub_local_history_sync` manually, confirm the lane doesn't OOM-abort.
- [ ] Watch `journalctl -u supplycore-lane-maintenance.service` for a full cycle; confirm no memory-gate aborts at baseline load.
- [ ] Confirm realtime and ingestion lanes now log `memory_gate_armed` (or equivalent) at startup.

https://claude.ai/code/session_01NzEcL2fNtd4LGDCfGtiAdb