### PR TITLE
feat(spy-detection): UI for ring cases + risk profiles, fix community sparsity

### DIFF
--- a/public/spy-detection/case.php
+++ b/public/spy-detection/case.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$caseId = isset($_GET['case_id']) ? (int) $_GET['case_id'] : 0;
+$title = $caseId > 0 ? "Spy Network Case #{$caseId}" : 'Spy Network Case';
+
+$tablesReadyError = null;
+$case = null;
+$members = [];
+$edges = [];
+$ciScores = [];
+
+if ($caseId > 0) {
+    try {
+        $case = db_spy_network_case_detail($caseId);
+        if ($case !== null) {
+            $members = db_spy_network_case_members($caseId, 500);
+            $edges = db_spy_network_case_edges($caseId, 500);
+
+            $memberIds = [];
+            foreach ($members as $m) {
+                $mid = (int) $m['character_id'];
+                if ($mid > 0) {
+                    $memberIds[] = $mid;
+                }
+            }
+            if ($memberIds !== []) {
+                try {
+                    $ciScores = db_counterintel_scores_for_characters($memberIds);
+                } catch (Throwable $e) {
+                    // Non-fatal — CI table may not be populated yet.
+                }
+            }
+        }
+    } catch (Throwable $e) {
+        $tablesReadyError = $e->getMessage();
+    }
+}
+
+$severityBadge = static function (string $tier): string {
+    return match ($tier) {
+        'critical' => 'bg-red-900/60 text-red-200 border-red-700/70',
+        'high' => 'bg-orange-900/50 text-orange-200 border-orange-700/60',
+        'medium' => 'bg-amber-900/40 text-amber-200 border-amber-700/50',
+        'monitor' => 'bg-sky-900/40 text-sky-200 border-sky-700/50',
+        default => 'bg-slate-800 text-slate-300 border-slate-700',
+    };
+};
+
+$statusBadge = static function (string $status): string {
+    return match ($status) {
+        'open' => 'bg-red-900/40 text-red-200 border-red-700/50',
+        'reviewing' => 'bg-amber-900/40 text-amber-200 border-amber-700/50',
+        'closed' => 'bg-slate-800 text-slate-400 border-slate-700',
+        'reopened' => 'bg-purple-900/40 text-purple-200 border-purple-700/50',
+        default => 'bg-slate-800 text-slate-300 border-slate-700',
+    };
+};
+
+$roleBadge = static function (string $role): string {
+    return match (strtolower($role)) {
+        'ringleader', 'leader' => 'bg-red-900/40 text-red-200 border-red-700/50',
+        'bridge' => 'bg-cyan-900/40 text-cyan-200 border-cyan-700/50',
+        'suspect' => 'bg-orange-900/40 text-orange-200 border-orange-700/50',
+        'peripheral' => 'bg-slate-800 text-slate-400 border-slate-700',
+        default => 'bg-slate-800 text-slate-300 border-slate-700',
+    };
+};
+
+$edgeTypeBadge = static function (string $edgeType): string {
+    return match ($edgeType) {
+        'identity' => 'bg-purple-900/40 text-purple-200 border-purple-700/50',
+        'copresence' => 'bg-sky-900/40 text-sky-200 border-sky-700/50',
+        'cross_side' => 'bg-red-900/40 text-red-200 border-red-700/50',
+        'temporal' => 'bg-amber-900/40 text-amber-200 border-amber-700/50',
+        default => 'bg-slate-800 text-slate-300 border-slate-700',
+    };
+};
+
+include __DIR__ . '/../../src/views/partials/header.php';
+?>
+
+<section class="surface-primary">
+    <div class="flex items-start justify-between gap-4">
+        <div>
+            <p class="text-xs uppercase tracking-[0.16em] text-muted">Counterintel &middot; Spy Detection</p>
+            <h1 class="mt-1 text-2xl font-semibold text-slate-50">
+                <?php if ($caseId > 0 && $case !== null): ?>
+                    Spy Network Case <span class="text-slate-400 font-mono">#<?= $caseId ?></span>
+                <?php else: ?>
+                    Spy Network Case
+                <?php endif; ?>
+            </h1>
+            <?php if ($case !== null): ?>
+                <p class="mt-2 text-xs text-muted">
+                    Community
+                    <span class="font-mono text-slate-300"><?= (int) ($case['community_id'] ?? 0) ?></span>
+                    &middot; Source <?= htmlspecialchars((string) ($case['community_source'] ?? '')) ?>
+                    &middot; Model <?= htmlspecialchars((string) ($case['model_version'] ?? '')) ?>
+                    &middot; Run <code class="text-xs"><?= htmlspecialchars((string) ($case['source_run_id'] ?? '')) ?></code>
+                </p>
+            <?php endif; ?>
+        </div>
+        <div class="flex items-center gap-2">
+            <a href="/spy-detection/" class="btn-secondary">&larr; All Cases</a>
+        </div>
+    </div>
+</section>
+
+<?php if ($tablesReadyError !== null): ?>
+<section class="surface-primary mt-4 border border-amber-500/30 bg-amber-500/10">
+    <p class="text-sm text-amber-200">
+        <strong>Spy detection tables not ready.</strong>
+        <?= htmlspecialchars($tablesReadyError, ENT_QUOTES) ?>
+    </p>
+</section>
+<?php endif; ?>
+
+<?php if ($caseId <= 0): ?>
+    <section class="surface-primary mt-4">
+        <p class="text-sm text-muted">No case selected. Return to the <a href="/spy-detection/" class="text-cyan-300">case list</a>.</p>
+    </section>
+<?php elseif ($case === null): ?>
+    <section class="surface-primary mt-4">
+        <p class="text-sm text-muted">Case #<?= $caseId ?> not found.</p>
+    </section>
+<?php else:
+    $sev = (string) ($case['severity_tier'] ?? 'monitor');
+    $st = (string) ($case['status'] ?? 'open');
+    $feature = $case['feature_breakdown_json'] ?? null;
+    if (is_string($feature)) {
+        $featureData = json_decode($feature, true);
+        $feature = is_array($featureData) ? $featureData : null;
+    }
+?>
+    <!-- Headline stats -->
+    <section class="mt-4 grid grid-cols-2 gap-4 md:grid-cols-5">
+        <div class="surface-primary">
+            <p class="text-xs uppercase tracking-wider text-muted">Severity</p>
+            <div class="mt-1">
+                <span class="inline-block rounded border px-2 py-0.5 text-xs uppercase <?= $severityBadge($sev) ?>">
+                    <?= htmlspecialchars(strtoupper($sev)) ?>
+                </span>
+            </div>
+            <p class="mt-2 text-xs text-muted">
+                Status
+                <span class="inline-block rounded border px-1.5 py-0.5 text-[10px] uppercase <?= $statusBadge($st) ?>">
+                    <?= htmlspecialchars(strtoupper($st)) ?>
+                </span>
+            </p>
+        </div>
+        <div class="surface-primary">
+            <p class="text-xs uppercase tracking-wider text-muted">Ring Score</p>
+            <p class="mt-1 text-2xl font-bold text-slate-100"><?= number_format((float) $case['ring_score'], 3) ?></p>
+            <p class="mt-1 text-xs text-muted">Confidence <?= number_format((float) $case['confidence_score'], 3) ?></p>
+        </div>
+        <div class="surface-primary">
+            <p class="text-xs uppercase tracking-wider text-muted">Members</p>
+            <p class="mt-1 text-2xl font-bold text-slate-100"><?= (int) $case['member_count'] ?></p>
+            <p class="mt-1 text-xs text-muted">Suspicious ratio <?= number_format((float) $case['suspicious_member_ratio'], 3) ?></p>
+        </div>
+        <div class="surface-primary">
+            <p class="text-xs uppercase tracking-wider text-muted">Bridge Concentration</p>
+            <p class="mt-1 text-2xl font-bold text-cyan-200"><?= number_format((float) $case['bridge_concentration'], 3) ?></p>
+            <p class="mt-1 text-xs text-muted">Hostile overlap <?= number_format((float) $case['hostile_overlap_density'], 3) ?></p>
+        </div>
+        <div class="surface-primary">
+            <p class="text-xs uppercase tracking-wider text-muted">Identity Density</p>
+            <p class="mt-1 text-2xl font-bold text-purple-200"><?= number_format((float) $case['identity_density'], 3) ?></p>
+            <p class="mt-1 text-xs text-muted">Recurrence <?= number_format((float) $case['recurrence_stability'], 3) ?></p>
+        </div>
+    </section>
+
+    <!-- Timing -->
+    <section class="surface-primary mt-4">
+        <div class="grid grid-cols-2 gap-4 md:grid-cols-4 text-xs">
+            <div>
+                <p class="uppercase tracking-wider text-muted">First Detected</p>
+                <p class="mt-1 text-slate-200"><?= htmlspecialchars((string) $case['first_detected_at']) ?></p>
+            </div>
+            <div>
+                <p class="uppercase tracking-wider text-muted">Last Reinforced</p>
+                <p class="mt-1 text-slate-200"><?= htmlspecialchars((string) $case['last_reinforced_at']) ?></p>
+            </div>
+            <div>
+                <p class="uppercase tracking-wider text-muted">Status Changed</p>
+                <p class="mt-1 text-slate-200"><?= htmlspecialchars((string) ($case['status_changed_at'] ?? '—')) ?></p>
+            </div>
+            <div>
+                <p class="uppercase tracking-wider text-muted">Computed</p>
+                <p class="mt-1 text-slate-200"><?= htmlspecialchars((string) $case['computed_at']) ?></p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Feature breakdown -->
+    <?php if (is_array($feature) && $feature !== []): ?>
+        <section class="surface-primary mt-4">
+            <h2 class="text-lg font-semibold text-slate-100 mb-3">Feature Breakdown</h2>
+            <div class="grid gap-3 md:grid-cols-2">
+                <?php foreach ($feature as $key => $value):
+                    if (is_array($value) || is_object($value)) {
+                        $display = json_encode($value, JSON_UNESCAPED_SLASHES);
+                    } else {
+                        $display = (string) $value;
+                    }
+                ?>
+                    <div class="flex items-start justify-between gap-3 rounded border border-border/40 bg-slate-800/30 px-3 py-2">
+                        <span class="text-xs text-muted uppercase tracking-wider"><?= htmlspecialchars((string) $key) ?></span>
+                        <span class="text-sm font-mono text-slate-200 text-right"><?= htmlspecialchars($display) ?></span>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </section>
+    <?php endif; ?>
+
+    <!-- Members -->
+    <section class="surface-primary mt-4">
+        <div class="flex items-center justify-between mb-3">
+            <h2 class="text-lg font-semibold text-slate-100">Members</h2>
+            <span class="text-xs text-muted"><?= count($members) ?> shown</span>
+        </div>
+
+        <?php if ($members): ?>
+            <div class="table-shell">
+                <table class="table-ui">
+                    <thead>
+                        <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                            <th class="px-3 py-2 text-left">Character</th>
+                            <th class="px-3 py-2 text-left">Role</th>
+                            <th class="px-3 py-2 text-right">Contribution</th>
+                            <th class="px-3 py-2 text-right">CI Priority</th>
+                            <th class="px-3 py-2 text-right">CI Percentile</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($members as $m):
+                            $cid = (int) $m['character_id'];
+                            $role = (string) ($m['role_label'] ?? 'member');
+                            $ci = $ciScores[$cid] ?? null;
+                        ?>
+                            <tr class="border-b border-border/30 hover:bg-slate-800/40 transition-colors">
+                                <td class="px-3 py-2 text-sm">
+                                    <a href="/killmail-intelligence/?character_id=<?= $cid ?>" class="text-cyan-300 hover:text-cyan-100">
+                                        <?= htmlspecialchars((string) $m['character_name']) ?>
+                                    </a>
+                                    <span class="ml-1 text-[10px] text-muted font-mono">#<?= $cid ?></span>
+                                </td>
+                                <td class="px-3 py-2">
+                                    <span class="inline-block rounded border px-1.5 py-0.5 text-[10px] uppercase <?= $roleBadge($role) ?>">
+                                        <?= htmlspecialchars(strtoupper($role)) ?>
+                                    </span>
+                                </td>
+                                <td class="px-3 py-2 text-right text-sm font-mono text-slate-100">
+                                    <?= number_format((float) $m['member_contribution_score'], 3) ?>
+                                </td>
+                                <td class="px-3 py-2 text-right text-sm font-mono">
+                                    <?= $ci !== null ? number_format((float) $ci['review_priority_score'], 3) : '<span class="text-muted">—</span>' ?>
+                                </td>
+                                <td class="px-3 py-2 text-right text-xs font-mono text-muted">
+                                    <?= $ci !== null ? number_format((float) $ci['percentile_rank'] * 100, 1) . '%' : '—' ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        <?php else: ?>
+            <p class="text-sm text-muted">No member rows.</p>
+        <?php endif; ?>
+    </section>
+
+    <!-- Edges -->
+    <section class="surface-primary mt-4">
+        <div class="flex items-center justify-between mb-3">
+            <h2 class="text-lg font-semibold text-slate-100">Relationship Edges</h2>
+            <span class="text-xs text-muted"><?= count($edges) ?> shown</span>
+        </div>
+
+        <?php if ($edges): ?>
+            <div class="table-shell">
+                <table class="table-ui">
+                    <thead>
+                        <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                            <th class="px-3 py-2 text-left">Character A</th>
+                            <th class="px-3 py-2 text-left">Character B</th>
+                            <th class="px-3 py-2 text-left">Type</th>
+                            <th class="px-3 py-2 text-right">Weight</th>
+                            <th class="px-3 py-2 text-left">Components</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($edges as $e):
+                            $aid = (int) $e['character_id_a'];
+                            $bid = (int) $e['character_id_b'];
+                            $etype = (string) $e['edge_type'];
+                            $components = $e['component_weights_json'] ?? null;
+                            if (is_string($components)) {
+                                $componentsData = json_decode($components, true);
+                                $components = is_array($componentsData) ? $componentsData : null;
+                            }
+                        ?>
+                            <tr class="border-b border-border/30 hover:bg-slate-800/40 transition-colors">
+                                <td class="px-3 py-2 text-sm font-mono">
+                                    <a href="/killmail-intelligence/?character_id=<?= $aid ?>" class="text-cyan-300 hover:text-cyan-100">#<?= $aid ?></a>
+                                </td>
+                                <td class="px-3 py-2 text-sm font-mono">
+                                    <a href="/killmail-intelligence/?character_id=<?= $bid ?>" class="text-cyan-300 hover:text-cyan-100">#<?= $bid ?></a>
+                                </td>
+                                <td class="px-3 py-2">
+                                    <span class="inline-block rounded border px-1.5 py-0.5 text-[10px] uppercase <?= $edgeTypeBadge($etype) ?>">
+                                        <?= htmlspecialchars($etype) ?>
+                                    </span>
+                                </td>
+                                <td class="px-3 py-2 text-right text-sm font-mono text-slate-100">
+                                    <?= number_format((float) $e['edge_weight'], 3) ?>
+                                </td>
+                                <td class="px-3 py-2 text-xs text-muted">
+                                    <?php if (is_array($components)): ?>
+                                        <?php
+                                        $parts = [];
+                                        foreach ($components as $ck => $cv) {
+                                            if (is_numeric($cv)) {
+                                                $parts[] = htmlspecialchars((string) $ck) . ': ' . number_format((float) $cv, 3);
+                                            }
+                                        }
+                                        echo implode(' · ', $parts);
+                                        ?>
+                                    <?php else: ?>
+                                        —
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        <?php else: ?>
+            <p class="text-sm text-muted">No edge rows.</p>
+        <?php endif; ?>
+    </section>
+<?php endif; ?>
+
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/public/spy-detection/index.php
+++ b/public/spy-detection/index.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/../../src/bootstrap.php';
+
+$title = 'Spy Detection — Ring Cases & Risk Profiles';
+
+$tablesReadyError = null;
+$summary = ['cases' => [], 'risk_profiles' => [], 'identity_links' => []];
+$cases = [];
+$topRisks = [];
+
+$severityFilter = isset($_GET['severity']) ? trim((string) $_GET['severity']) : '';
+$statusFilter = isset($_GET['status']) ? trim((string) $_GET['status']) : '';
+$severityParam = in_array($severityFilter, ['monitor', 'medium', 'high', 'critical'], true) ? $severityFilter : null;
+$statusParam = in_array($statusFilter, ['open', 'reviewing', 'closed', 'reopened'], true) ? $statusFilter : null;
+
+try {
+    $summary = db_spy_detection_summary();
+    $cases = db_spy_network_cases_recent(50, $severityParam, $statusParam);
+    $topRisks = db_character_spy_risk_top(25, $severityParam);
+} catch (Throwable $e) {
+    $tablesReadyError = $e->getMessage();
+}
+
+$severityBadge = static function (string $tier): string {
+    return match ($tier) {
+        'critical' => 'bg-red-900/60 text-red-200 border-red-700/70',
+        'high' => 'bg-orange-900/50 text-orange-200 border-orange-700/60',
+        'medium' => 'bg-amber-900/40 text-amber-200 border-amber-700/50',
+        'monitor' => 'bg-sky-900/40 text-sky-200 border-sky-700/50',
+        default => 'bg-slate-800 text-slate-300 border-slate-700',
+    };
+};
+
+$statusBadge = static function (string $status): string {
+    return match ($status) {
+        'open' => 'bg-red-900/40 text-red-200 border-red-700/50',
+        'reviewing' => 'bg-amber-900/40 text-amber-200 border-amber-700/50',
+        'closed' => 'bg-slate-800 text-slate-400 border-slate-700',
+        'reopened' => 'bg-purple-900/40 text-purple-200 border-purple-700/50',
+        default => 'bg-slate-800 text-slate-300 border-slate-700',
+    };
+};
+
+$confidenceBadge = static function (string $tier): string {
+    return match ($tier) {
+        'high' => 'bg-emerald-900/40 text-emerald-200 border-emerald-700/50',
+        'medium' => 'bg-sky-900/40 text-sky-200 border-sky-700/50',
+        'low' => 'bg-slate-800 text-slate-400 border-slate-700',
+        default => 'bg-slate-800 text-slate-300 border-slate-700',
+    };
+};
+
+include __DIR__ . '/../../src/views/partials/header.php';
+
+$caseStats = $summary['cases'] ?? [];
+$riskStats = $summary['risk_profiles'] ?? [];
+$linkStats = $summary['identity_links'] ?? [];
+?>
+
+<section class="surface-primary">
+    <div class="flex items-start justify-between gap-4">
+        <div>
+            <p class="text-xs uppercase tracking-[0.16em] text-muted">Counterintel</p>
+            <h1 class="mt-1 text-2xl font-semibold text-slate-50">Spy Detection</h1>
+            <p class="mt-2 text-sm text-muted">
+                Ring-scored network cases from Leiden community detection, per-character spy risk profiles,
+                and identity-resolution links. Built by the <code class="text-xs">graph_spy_ring_projection</code> &rarr;
+                <code class="text-xs">compute_spy_network_cases</code> &rarr; <code class="text-xs">compute_spy_risk_profiles</code>
+                pipeline.
+            </p>
+        </div>
+        <div class="flex items-center gap-2">
+            <a href="/battle-intelligence/" class="btn-secondary">Battle Intel</a>
+            <a href="/threat-corridors/" class="btn-secondary">Threat Corridors</a>
+        </div>
+    </div>
+</section>
+
+<?php if ($tablesReadyError !== null): ?>
+<section class="surface-primary mt-4 border border-amber-500/30 bg-amber-500/10">
+    <p class="text-sm text-amber-200">
+        <strong>Spy detection tables not ready.</strong>
+        Run the <code>20260411_spy_network_cases.sql</code>, <code>20260411_character_spy_risk_profiles.sql</code>
+        and <code>20260411_identity_resolution.sql</code> migrations, then execute the spy pipeline jobs
+        (<code>graph_spy_ring_projection</code>, <code>compute_spy_network_cases</code>,
+        <code>compute_spy_risk_profiles</code>, <code>compute_character_identity_links</code>).
+    </p>
+    <p class="mt-2 text-xs text-amber-200/70">Error: <?= htmlspecialchars($tablesReadyError, ENT_QUOTES) ?></p>
+</section>
+<?php endif; ?>
+
+<!-- KPI Summary Cards -->
+<section class="mt-4 grid grid-cols-2 gap-4 md:grid-cols-4">
+    <div class="surface-primary">
+        <p class="text-xs uppercase tracking-wider text-muted">Ring Cases</p>
+        <p class="mt-1 text-2xl font-bold text-slate-100"><?= number_format((int) ($caseStats['total'] ?? 0)) ?></p>
+        <p class="mt-1 text-xs text-muted">
+            <span class="text-red-300"><?= (int) ($caseStats['critical'] ?? 0) ?> crit</span> ·
+            <span class="text-orange-300"><?= (int) ($caseStats['high'] ?? 0) ?> high</span> ·
+            <span class="text-amber-300"><?= (int) ($caseStats['medium'] ?? 0) ?> med</span> ·
+            <span class="text-sky-300"><?= (int) ($caseStats['monitor'] ?? 0) ?> mon</span>
+        </p>
+    </div>
+    <div class="surface-primary">
+        <p class="text-xs uppercase tracking-wider text-muted">Open / Reviewing</p>
+        <p class="mt-1 text-2xl font-bold text-slate-100">
+            <?= (int) ($caseStats['open_cases'] ?? 0) ?>
+            <span class="text-sm text-muted">/ <?= (int) ($caseStats['reviewing_cases'] ?? 0) ?></span>
+        </p>
+        <p class="mt-1 text-xs text-muted">
+            Last reinforced:
+            <?= htmlspecialchars((string) ($caseStats['last_reinforced_at'] ?? '—')) ?>
+        </p>
+    </div>
+    <div class="surface-primary">
+        <p class="text-xs uppercase tracking-wider text-muted">Risk Profiles</p>
+        <p class="mt-1 text-2xl font-bold text-slate-100"><?= number_format((int) ($riskStats['total_profiles'] ?? 0)) ?></p>
+        <p class="mt-1 text-xs text-muted">
+            <span class="text-red-300"><?= (int) ($riskStats['critical_profiles'] ?? 0) ?> crit</span> ·
+            <span class="text-orange-300"><?= (int) ($riskStats['high_profiles'] ?? 0) ?> high</span> ·
+            <span class="text-emerald-300"><?= (int) ($riskStats['high_confidence'] ?? 0) ?> hi-conf</span>
+        </p>
+    </div>
+    <div class="surface-primary">
+        <p class="text-xs uppercase tracking-wider text-muted">Identity Links</p>
+        <p class="mt-1 text-2xl font-bold text-slate-100"><?= number_format((int) ($linkStats['total_links'] ?? 0)) ?></p>
+        <p class="mt-1 text-xs text-muted">
+            <span class="text-emerald-300"><?= (int) ($linkStats['high_confidence'] ?? 0) ?> high-confidence</span>
+        </p>
+    </div>
+</section>
+
+<!-- Filters -->
+<section class="surface-primary mt-4">
+    <form method="get" class="flex flex-wrap items-end gap-3">
+        <div>
+            <label class="block text-xs uppercase tracking-wider text-muted mb-1">Severity</label>
+            <select name="severity" class="bg-slate-800 border border-slate-700 text-slate-100 rounded px-2 py-1 text-sm">
+                <option value="" <?= $severityParam === null ? 'selected' : '' ?>>All</option>
+                <?php foreach (['critical', 'high', 'medium', 'monitor'] as $tier): ?>
+                    <option value="<?= $tier ?>" <?= $severityParam === $tier ? 'selected' : '' ?>><?= ucfirst($tier) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div>
+            <label class="block text-xs uppercase tracking-wider text-muted mb-1">Status</label>
+            <select name="status" class="bg-slate-800 border border-slate-700 text-slate-100 rounded px-2 py-1 text-sm">
+                <option value="" <?= $statusParam === null ? 'selected' : '' ?>>All</option>
+                <?php foreach (['open', 'reviewing', 'closed', 'reopened'] as $st): ?>
+                    <option value="<?= $st ?>" <?= $statusParam === $st ? 'selected' : '' ?>><?= ucfirst($st) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <button type="submit" class="btn-primary text-sm">Apply</button>
+        <?php if ($severityParam !== null || $statusParam !== null): ?>
+            <a href="/spy-detection/" class="text-xs text-muted hover:text-slate-200">Clear</a>
+        <?php endif; ?>
+    </form>
+</section>
+
+<!-- Spy Network Cases -->
+<section class="surface-primary mt-4">
+    <div class="flex items-center justify-between mb-3">
+        <h2 class="text-lg font-semibold text-slate-100">Spy Network Cases</h2>
+        <span class="text-xs text-muted">Top <?= count($cases) ?> by ring score</span>
+    </div>
+
+    <?php if ($cases): ?>
+        <div class="table-shell">
+            <table class="table-ui">
+                <thead>
+                    <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                        <th class="px-3 py-2 text-left">Case</th>
+                        <th class="px-3 py-2 text-left">Severity</th>
+                        <th class="px-3 py-2 text-left">Status</th>
+                        <th class="px-3 py-2 text-right">Ring</th>
+                        <th class="px-3 py-2 text-right">Confidence</th>
+                        <th class="px-3 py-2 text-right">Members</th>
+                        <th class="px-3 py-2 text-right">Bridges</th>
+                        <th class="px-3 py-2 text-right">Hostile</th>
+                        <th class="px-3 py-2 text-right">Identity</th>
+                        <th class="px-3 py-2 text-left">Last Reinforced</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($cases as $c):
+                        $caseId = (int) $c['case_id'];
+                        $sev = (string) ($c['severity_tier'] ?? 'monitor');
+                        $st = (string) ($c['status'] ?? 'open');
+                    ?>
+                        <tr class="border-b border-border/30 hover:bg-slate-800/40 transition-colors">
+                            <td class="px-3 py-2 text-sm">
+                                <a href="/spy-detection/case.php?case_id=<?= $caseId ?>" class="text-cyan-300 hover:text-cyan-100 font-mono">
+                                    #<?= $caseId ?>
+                                </a>
+                                <?php if (!empty($c['community_id'])): ?>
+                                    <span class="ml-1 text-[10px] text-muted">comm <?= (int) $c['community_id'] ?></span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="px-3 py-2">
+                                <span class="inline-block rounded border px-1.5 py-0.5 text-[10px] uppercase <?= $severityBadge($sev) ?>">
+                                    <?= htmlspecialchars(strtoupper($sev)) ?>
+                                </span>
+                            </td>
+                            <td class="px-3 py-2">
+                                <span class="inline-block rounded border px-1.5 py-0.5 text-[10px] uppercase <?= $statusBadge($st) ?>">
+                                    <?= htmlspecialchars(strtoupper($st)) ?>
+                                </span>
+                            </td>
+                            <td class="px-3 py-2 text-right text-sm font-mono text-slate-100"><?= number_format((float) $c['ring_score'], 3) ?></td>
+                            <td class="px-3 py-2 text-right text-sm font-mono text-slate-300"><?= number_format((float) $c['confidence_score'], 3) ?></td>
+                            <td class="px-3 py-2 text-right text-sm font-mono"><?= (int) $c['member_count'] ?></td>
+                            <td class="px-3 py-2 text-right text-sm font-mono text-muted"><?= number_format((float) $c['bridge_concentration'], 3) ?></td>
+                            <td class="px-3 py-2 text-right text-sm font-mono text-muted"><?= number_format((float) $c['hostile_overlap_density'], 3) ?></td>
+                            <td class="px-3 py-2 text-right text-sm font-mono text-muted"><?= number_format((float) $c['identity_density'], 3) ?></td>
+                            <td class="px-3 py-2 text-xs text-muted"><?= htmlspecialchars((string) $c['last_reinforced_at']) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php else: ?>
+        <p class="text-sm text-muted">No ring cases match the current filters.</p>
+    <?php endif; ?>
+</section>
+
+<!-- Top risk profiles -->
+<section class="surface-primary mt-4">
+    <div class="flex items-center justify-between mb-3">
+        <h2 class="text-lg font-semibold text-slate-100">Highest Individual Risk</h2>
+        <span class="text-xs text-muted">Top <?= count($topRisks) ?> by spy risk score</span>
+    </div>
+
+    <?php if ($topRisks): ?>
+        <div class="table-shell">
+            <table class="table-ui">
+                <thead>
+                    <tr class="border-b border-border/70 text-xs uppercase tracking-[0.15em] text-muted">
+                        <th class="px-3 py-2 text-left">Character</th>
+                        <th class="px-3 py-2 text-left">Severity</th>
+                        <th class="px-3 py-2 text-left">Confidence</th>
+                        <th class="px-3 py-2 text-right">Risk</th>
+                        <th class="px-3 py-2 text-right">Percentile</th>
+                        <th class="px-3 py-2 text-left">Top Case</th>
+                        <th class="px-3 py-2 text-left">Computed</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($topRisks as $r):
+                        $cid = (int) $r['character_id'];
+                        $sev = (string) ($r['severity_tier'] ?? 'monitor');
+                        $conf = (string) ($r['confidence_tier'] ?? 'low');
+                        $topCase = (int) ($r['top_case_id'] ?? 0);
+                    ?>
+                        <tr class="border-b border-border/30 hover:bg-slate-800/40 transition-colors">
+                            <td class="px-3 py-2 text-sm">
+                                <a href="/killmail-intelligence/?character_id=<?= $cid ?>" class="text-cyan-300 hover:text-cyan-100">
+                                    <?= htmlspecialchars((string) $r['character_name']) ?>
+                                </a>
+                                <span class="ml-1 text-[10px] text-muted font-mono">#<?= $cid ?></span>
+                            </td>
+                            <td class="px-3 py-2">
+                                <span class="inline-block rounded border px-1.5 py-0.5 text-[10px] uppercase <?= $severityBadge($sev) ?>">
+                                    <?= htmlspecialchars(strtoupper($sev)) ?>
+                                </span>
+                            </td>
+                            <td class="px-3 py-2">
+                                <span class="inline-block rounded border px-1.5 py-0.5 text-[10px] uppercase <?= $confidenceBadge($conf) ?>">
+                                    <?= htmlspecialchars(strtoupper($conf)) ?>
+                                </span>
+                            </td>
+                            <td class="px-3 py-2 text-right text-sm font-mono text-slate-100"><?= number_format((float) $r['spy_risk_score'], 3) ?></td>
+                            <td class="px-3 py-2 text-right text-sm font-mono text-muted"><?= number_format((float) $r['risk_percentile'] * 100, 1) ?>%</td>
+                            <td class="px-3 py-2 text-xs">
+                                <?php if ($topCase > 0): ?>
+                                    <a href="/spy-detection/case.php?case_id=<?= $topCase ?>" class="text-cyan-300 hover:text-cyan-100 font-mono">#<?= $topCase ?></a>
+                                <?php else: ?>
+                                    <span class="text-muted">—</span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="px-3 py-2 text-xs text-muted"><?= htmlspecialchars((string) $r['computed_at']) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php else: ?>
+        <p class="text-sm text-muted">No risk profiles available.</p>
+    <?php endif; ?>
+</section>
+
+<?php include __DIR__ . '/../../src/views/partials/footer.php'; ?>

--- a/python/orchestrator/jobs/graph_community_detection.py
+++ b/python/orchestrator/jobs/graph_community_detection.py
@@ -47,6 +47,12 @@ def _ensure_gds_projection(client: Neo4jClient) -> bool:
 
     Only includes relationship types that actually exist in the database to
     avoid GDS ``IllegalArgumentException`` when some types are absent.
+
+    Projects a ``weight`` property on every relationship (``defaultValue: 1.0``)
+    so downstream algorithms can run weighted — without the property,
+    Leiden/Louvain/PageRank silently treat every edge as equal, which
+    produces fragmented (overly-sparse) community assignments when some
+    edge types (e.g. CO_OCCURS_WITH) carry meaningful counts.
     """
     try:
         try:
@@ -68,8 +74,18 @@ def _ensure_gds_projection(client: Neo4jClient) -> bool:
             logger.warning("GDS projection skipped: no community relationship types exist")
             return False
 
+        # Native projection spec: each rel type declares its orientation
+        # and a weight property that defaults to 1.0 when the underlying
+        # edge has no numeric weight/count.  The default keeps the
+        # projection dense even for rel types that don't carry weights.
         rel_projection = ", ".join(
-            f"{rt}: {{orientation: 'UNDIRECTED'}}" for rt in present_types
+            (
+                f"{rt}: {{"
+                "orientation: 'UNDIRECTED', "
+                "properties: {weight: {property: 'weight', defaultValue: 1.0}}"
+                "}"
+            )
+            for rt in present_types
         )
         client.query(
             f"""
@@ -81,6 +97,28 @@ def _ensure_gds_projection(client: Neo4jClient) -> bool:
             """,
             timeout_seconds=120,
         )
+
+        # Diagnostics: surface the projection shape so operators can see
+        # whether sparsity is coming from a genuinely disconnected graph
+        # or from over-filtered edges.
+        try:
+            stats = client.query(
+                f"""
+                CALL gds.graph.list('{GDS_GRAPH_NAME}')
+                YIELD nodeCount, relationshipCount
+                RETURN nodeCount, relationshipCount
+                """
+            )
+            if stats:
+                logger.info(
+                    "GDS projection '%s' built: %s nodes, %s relationships (types=%s)",
+                    GDS_GRAPH_NAME,
+                    stats[0].get("nodeCount"),
+                    stats[0].get("relationshipCount"),
+                    ",".join(present_types),
+                )
+        except Exception:
+            pass
         return True
     except Exception as exc:
         logger.warning("GDS projection failed for community detection: %s", exc)
@@ -113,12 +151,15 @@ def _gds_community_detection(client: Neo4jClient) -> str:
 
     Returns the name of the algorithm that actually wrote the property.
     """
-    # Leiden — preferred when available
+    # Leiden — preferred when available.  ``relationshipWeightProperty``
+    # is what enables weighted modularity; without it the projection's
+    # ``weight`` values are ignored and singleton-heavy partitions result.
     try:
         client.query(
             f"""
             CALL gds.leiden.write('{GDS_GRAPH_NAME}', {{
                 writeProperty: 'community_label',
+                relationshipWeightProperty: 'weight',
                 maxLevels: 10,
                 gamma: 1.0,
                 theta: 0.01
@@ -135,7 +176,8 @@ def _gds_community_detection(client: Neo4jClient) -> str:
         client.query(
             f"""
             CALL gds.louvain.write('{GDS_GRAPH_NAME}', {{
-                writeProperty: 'community_label'
+                writeProperty: 'community_label',
+                relationshipWeightProperty: 'weight'
             }})
             """,
             timeout_seconds=180,
@@ -149,6 +191,7 @@ def _gds_community_detection(client: Neo4jClient) -> str:
         f"""
         CALL gds.labelPropagation.write('{GDS_GRAPH_NAME}', {{
             writeProperty: 'community_label',
+            relationshipWeightProperty: 'weight',
             maxIterations: {LABEL_PROPAGATION_ROUNDS}
         }})
         """,
@@ -169,6 +212,7 @@ def _gds_pagerank(client: Neo4jClient) -> None:
         f"""
         CALL gds.pageRank.write('{GDS_GRAPH_NAME}', {{
             writeProperty: 'pr',
+            relationshipWeightProperty: 'weight',
             maxIterations: {GDS_PAGERANK_MAX_ITERATIONS},
             tolerance: {GDS_PAGERANK_TOLERANCE},
             dampingFactor: 0.85
@@ -445,10 +489,31 @@ def run_graph_community_detection_sync(db: SupplyCoreDb, neo4j_raw: dict[str, An
         "SELECT COUNT(*) FROM graph_community_assignments WHERE is_bridge = 1"
     )
 
+    # Sparsity diagnostics: how many communities are effectively singletons
+    # (1 member) and how large is the biggest one.  When ``singleton_ratio``
+    # stays high after enabling weighted algorithms, the graph itself is
+    # disconnected rather than the detection being broken.
+    singleton_communities = db.fetch_scalar(
+        "SELECT COUNT(*) FROM ("
+        "  SELECT community_id FROM graph_community_assignments"
+        "  GROUP BY community_id HAVING COUNT(*) = 1"
+        ") s"
+    )
+    largest_community_size = db.fetch_scalar(
+        "SELECT MAX(community_size) FROM graph_community_assignments"
+    )
+
+    singletons = int(singleton_communities or 0)
+    distinct_comms = int(community_count_row or 0)
+    singleton_ratio = (singletons / distinct_comms) if distinct_comms > 0 else 0.0
+
     snapshot_payload = {
         "total_characters": rows_written,
-        "distinct_communities": int(community_count_row or 0),
+        "distinct_communities": distinct_comms,
         "bridge_characters": int(bridge_count or 0),
+        "singleton_communities": singletons,
+        "singleton_ratio": round(singleton_ratio, 4),
+        "largest_community_size": int(largest_community_size or 0),
         "label_propagation_rounds": LABEL_PROPAGATION_ROUNDS,
         "pagerank_iterations": (
             GDS_PAGERANK_MAX_ITERATIONS if analytics_path == "gds" else PAGERANK_ITERATIONS

--- a/src/db.php
+++ b/src/db.php
@@ -20629,3 +20629,215 @@ function db_cip_operational_health(): array
         'suppress_stats' => $suppressStats,
     ];
 }
+
+// ---------------------------------------------------------------------------
+// Spy detection — cases, risk profiles, identity links
+// ---------------------------------------------------------------------------
+
+function db_spy_network_cases_recent(int $limit = 50, ?string $severity = null, ?string $status = null): array
+{
+    $safeLimit = max(1, min(200, $limit));
+    $conditions = [];
+    $params = [];
+    if ($severity !== null && in_array($severity, ['monitor', 'medium', 'high', 'critical'], true)) {
+        $conditions[] = 'severity_tier = ?';
+        $params[] = $severity;
+    }
+    if ($status !== null && in_array($status, ['open', 'reviewing', 'closed', 'reopened'], true)) {
+        $conditions[] = 'status = ?';
+        $params[] = $status;
+    }
+    $where = $conditions === [] ? '' : ('WHERE ' . implode(' AND ', $conditions));
+    return db_select(
+        'SELECT case_id, community_id, community_source, ring_score, confidence_score,
+                severity_tier, member_count, suspicious_member_ratio, bridge_concentration,
+                hostile_overlap_density, recurrence_stability, identity_density,
+                status, first_detected_at, last_reinforced_at, computed_at
+         FROM spy_network_cases ' . $where . '
+         ORDER BY ring_score DESC, last_reinforced_at DESC
+         LIMIT ' . $safeLimit,
+        $params
+    );
+}
+
+function db_spy_network_case_detail(int $caseId): ?array
+{
+    if ($caseId <= 0) {
+        return null;
+    }
+    return db_select_one(
+        'SELECT case_id, community_id, community_source, identity_cluster_id,
+                ring_score, confidence_score, severity_tier, member_count,
+                suspicious_member_ratio, bridge_concentration, recent_growth_score,
+                hostile_overlap_density, recurrence_stability, identity_density,
+                feature_breakdown_json, status, status_changed_at,
+                first_detected_at, last_reinforced_at, model_version,
+                computed_at, source_run_id
+         FROM spy_network_cases
+         WHERE case_id = ?',
+        [$caseId]
+    );
+}
+
+function db_spy_network_case_members(int $caseId, int $limit = 200): array
+{
+    if ($caseId <= 0) {
+        return [];
+    }
+    $safeLimit = max(1, min(500, $limit));
+    return db_select(
+        'SELECT sncm.character_id, sncm.member_contribution_score, sncm.role_label,
+                sncm.evidence_json, sncm.computed_at,
+                COALESCE(emc.entity_name, CONCAT("Character #", sncm.character_id)) AS character_name
+         FROM spy_network_case_members sncm
+         LEFT JOIN entity_metadata_cache emc
+             ON emc.entity_type = "character" AND emc.entity_id = sncm.character_id
+         WHERE sncm.case_id = ?
+         ORDER BY sncm.member_contribution_score DESC
+         LIMIT ' . $safeLimit,
+        [$caseId]
+    );
+}
+
+function db_spy_network_case_edges(int $caseId, int $limit = 200): array
+{
+    if ($caseId <= 0) {
+        return [];
+    }
+    $safeLimit = max(1, min(500, $limit));
+    return db_select(
+        'SELECT character_id_a, character_id_b, edge_type, edge_weight,
+                component_weights_json, evidence_json, computed_at
+         FROM spy_network_case_edges
+         WHERE case_id = ?
+         ORDER BY edge_weight DESC
+         LIMIT ' . $safeLimit,
+        [$caseId]
+    );
+}
+
+function db_character_spy_risk_profile(int $characterId): ?array
+{
+    if ($characterId <= 0) {
+        return null;
+    }
+    return db_select_one(
+        'SELECT character_id, spy_risk_score, risk_percentile, confidence_score,
+                confidence_tier, severity_tier,
+                bridge_infiltration_score, pre_op_infiltration_score, hostile_overlap_score,
+                temporal_coordination_score, identity_association_score, ring_context_score,
+                behavioral_anomaly_score, org_movement_score, predicted_hostile_link_score,
+                top_case_id, explanation_json, component_weights_json,
+                model_version, computed_at, source_run_id
+         FROM character_spy_risk_profiles
+         WHERE character_id = ?',
+        [$characterId]
+    );
+}
+
+function db_character_spy_risk_evidence(int $characterId, int $limit = 50): array
+{
+    if ($characterId <= 0) {
+        return [];
+    }
+    $safeLimit = max(1, min(200, $limit));
+    return db_select(
+        'SELECT evidence_key, window_label, evidence_value, expected_value, deviation_value,
+                z_score, cohort_percentile, confidence_flag, contribution_to_score,
+                evidence_text, computed_at
+         FROM character_spy_risk_evidence
+         WHERE character_id = ?
+         ORDER BY contribution_to_score DESC, evidence_key ASC
+         LIMIT ' . $safeLimit,
+        [$characterId]
+    );
+}
+
+function db_character_spy_risk_top(int $limit = 50, ?string $severity = null): array
+{
+    $safeLimit = max(1, min(200, $limit));
+    $conditions = [];
+    $params = [];
+    if ($severity !== null && in_array($severity, ['monitor', 'medium', 'high', 'critical'], true)) {
+        $conditions[] = 'csrp.severity_tier = ?';
+        $params[] = $severity;
+    }
+    $where = $conditions === [] ? '' : ('WHERE ' . implode(' AND ', $conditions));
+    return db_select(
+        'SELECT csrp.character_id, csrp.spy_risk_score, csrp.risk_percentile,
+                csrp.confidence_score, csrp.confidence_tier, csrp.severity_tier,
+                csrp.top_case_id, csrp.computed_at,
+                COALESCE(emc.entity_name, CONCAT("Character #", csrp.character_id)) AS character_name
+         FROM character_spy_risk_profiles csrp
+         LEFT JOIN entity_metadata_cache emc
+             ON emc.entity_type = "character" AND emc.entity_id = csrp.character_id
+         ' . $where . '
+         ORDER BY csrp.spy_risk_score DESC
+         LIMIT ' . $safeLimit,
+        $params
+    );
+}
+
+function db_character_identity_links(int $characterId, int $limit = 25): array
+{
+    if ($characterId <= 0) {
+        return [];
+    }
+    $safeLimit = max(1, min(200, $limit));
+    return db_select(
+        'SELECT cil.link_id, cil.character_id_a, cil.character_id_b, cil.link_score,
+                cil.confidence_tier, cil.window_label,
+                cil.org_history_score, cil.copresence_score, cil.temporal_score,
+                cil.cross_side_score, cil.behavior_sim_score, cil.embedding_sim_score,
+                cil.computed_at,
+                CASE WHEN cil.character_id_a = ? THEN cil.character_id_b ELSE cil.character_id_a END AS other_character_id,
+                COALESCE(emc.entity_name,
+                    CONCAT("Character #", CASE WHEN cil.character_id_a = ? THEN cil.character_id_b ELSE cil.character_id_a END))
+                    AS other_character_name
+         FROM character_identity_links cil
+         LEFT JOIN entity_metadata_cache emc
+             ON emc.entity_type = "character"
+             AND emc.entity_id = CASE WHEN cil.character_id_a = ? THEN cil.character_id_b ELSE cil.character_id_a END
+         WHERE cil.character_id_a = ? OR cil.character_id_b = ?
+         ORDER BY cil.link_score DESC
+         LIMIT ' . $safeLimit,
+        [$characterId, $characterId, $characterId, $characterId, $characterId]
+    );
+}
+
+function db_spy_detection_summary(): array
+{
+    $caseCounts = db_select_one(
+        "SELECT COUNT(*) AS total,
+                SUM(CASE WHEN severity_tier = 'critical' THEN 1 ELSE 0 END) AS critical,
+                SUM(CASE WHEN severity_tier = 'high' THEN 1 ELSE 0 END) AS high,
+                SUM(CASE WHEN severity_tier = 'medium' THEN 1 ELSE 0 END) AS medium,
+                SUM(CASE WHEN severity_tier = 'monitor' THEN 1 ELSE 0 END) AS monitor,
+                SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) AS open_cases,
+                SUM(CASE WHEN status = 'reviewing' THEN 1 ELSE 0 END) AS reviewing_cases,
+                MAX(last_reinforced_at) AS last_reinforced_at
+         FROM spy_network_cases"
+    );
+
+    $riskCounts = db_select_one(
+        "SELECT COUNT(*) AS total_profiles,
+                SUM(CASE WHEN severity_tier = 'critical' THEN 1 ELSE 0 END) AS critical_profiles,
+                SUM(CASE WHEN severity_tier = 'high' THEN 1 ELSE 0 END) AS high_profiles,
+                SUM(CASE WHEN confidence_tier = 'high' THEN 1 ELSE 0 END) AS high_confidence,
+                MAX(computed_at) AS last_computed_at
+         FROM character_spy_risk_profiles"
+    );
+
+    $identityCounts = db_select_one(
+        "SELECT COUNT(*) AS total_links,
+                SUM(CASE WHEN confidence_tier = 'high' THEN 1 ELSE 0 END) AS high_confidence,
+                MAX(computed_at) AS last_computed_at
+         FROM character_identity_links"
+    );
+
+    return [
+        'cases' => $caseCounts ?: [],
+        'risk_profiles' => $riskCounts ?: [],
+        'identity_links' => $identityCounts ?: [],
+    ];
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -462,6 +462,12 @@ function nav_groups(): array
                         ['label' => 'CIP Admin', 'path' => '/intelligence-events/admin.php'],
                     ],
                 ],
+                [
+                    'label' => 'Spy Detection',
+                    'path' => '/spy-detection',
+                    'icon' => '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" class="h-4 w-4" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2a4 4 0 0 0-4 4v2H4l1 12h14l1-12h-4V6a4 4 0 0 0-4-4Z"/><circle cx="12" cy="14" r="2"/></svg>',
+                    'children' => [],
+                ],
             ],
         ],
         [


### PR DESCRIPTION
## Summary

- **New UI** at `/spy-detection/` — KPI cards, filterable ring-case list, highest-risk character leaderboard, and a per-case detail page showing feature breakdown, members (joined with counterintel priority), and relationship edges. Closes the gap where spy pipeline output was only visible in the DB.
- **Community sparsity fix** — `graph_community_detection.py` now projects an edge `weight` property (defaultValue 1.0) and passes `relationshipWeightProperty: 'weight'` to Leiden, Louvain, LPA and PageRank so weighted modularity actually kicks in. Previously unweighted detection was yielding one community per singleton (~483k singletons from 507k characters).
- **Diagnostics** — projection `nodeCount`/`relationshipCount` logged after creation; snapshot payload now includes `singleton_communities`, `singleton_ratio`, and `largest_community_size` so sparsity cause (disconnected graph vs detection config) is visible at a glance.
- **Nav** — new "Spy Detection" entry in the Counterintel group.

## Files changed

- `public/spy-detection/index.php` (new) — summary + filterable cases + top risk
- `public/spy-detection/case.php` (new) — case detail with members + edges
- `src/db.php` — helpers: `db_spy_network_cases_recent`, `db_spy_network_case_detail`, `db_spy_network_case_members`, `db_spy_network_case_edges`, `db_character_spy_risk_profile`, `db_character_spy_risk_evidence`, `db_character_spy_risk_top`, `db_character_identity_links`, `db_spy_detection_summary`
- `src/functions.php` — nav entry
- `python/orchestrator/jobs/graph_community_detection.py` — weighted projection + algorithm configs + diagnostics

## Test plan

- [ ] Visit `/spy-detection/` — verify KPI tiles render, severity/status filters work, and case rows link to `/spy-detection/case.php?case_id=...`
- [ ] Open a case detail page — verify feature breakdown, members table (with CI priority column), and edges table render
- [ ] Nav menu shows "Spy Detection" under Counterintel
- [ ] Run `python -m orchestrator run-job --job-key graph_community_detection_sync` — confirm log line reports projection `nodeCount`/`relationshipCount`, and the `graph_community_detection_state` snapshot JSON now includes `singleton_ratio` + `largest_community_size`
- [ ] Compare singleton ratio before vs. after the weighted config — expect a meaningful drop when dense neighborhoods (e.g. high-weight CO_OCCURS_WITH edges) now stay clustered

https://claude.ai/code/session_01DiLLoZ1Mr9NERgNo2rBiXf