### PR TITLE
diag(spy-pipeline): surface zero-output causes for IR + CIP

### DIFF
--- a/python/orchestrator/jobs/compute_identity_resolution.py
+++ b/python/orchestrator/jobs/compute_identity_resolution.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import math
 import time
 import uuid
@@ -25,6 +26,8 @@ from ..db import SupplyCoreDb
 from ..job_result import JobResult
 from ..job_utils import finish_job_run, start_job_run
 from ..json_utils import json_dumps_safe
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Tunables
@@ -326,6 +329,17 @@ def run_compute_identity_resolution(
 
         # ── 3. Score each pair ───────────────────────────────────────
         link_rows: list[tuple[Any, ...]] = []
+        # Diagnostics: track cache hit rates and per-component score sums so
+        # operators can see which cache is empty / which component is dragging
+        # the total score below the emit threshold.  Without these, a run that
+        # scores 50k pairs but emits 0 links looks identical to a run with
+        # genuinely low-similarity data.
+        all_scores: list[float] = []
+        component_sums = {"org_history": 0.0, "copresence": 0.0, "temporal": 0.0,
+                          "cross_side": 0.0, "behavior_sim": 0.0, "embedding_sim": 0.0}
+        component_nonzero = {k: 0 for k in component_sums}
+        near_miss_count = 0  # pairs scoring [threshold - 0.10, threshold)
+        zero_score_pairs = 0
         for (a, b), ctx in candidates.items():
             rows_processed += 1
             org = _score_org_history(a, b, org_cache)
@@ -335,6 +349,19 @@ def run_compute_identity_resolution(
             bsm = _score_behavior_sim(a, b, snapshot_cache)
             esm = _score_embedding_sim(ctx)
 
+            component_sums["org_history"] += org
+            component_sums["copresence"] += cop
+            component_sums["temporal"] += tmp
+            component_sums["cross_side"] += xsd
+            component_sums["behavior_sim"] += bsm
+            component_sums["embedding_sim"] += esm
+            if org > 0: component_nonzero["org_history"] += 1
+            if cop > 0: component_nonzero["copresence"] += 1
+            if tmp > 0: component_nonzero["temporal"] += 1
+            if xsd > 0: component_nonzero["cross_side"] += 1
+            if bsm > 0: component_nonzero["behavior_sim"] += 1
+            if esm > 0: component_nonzero["embedding_sim"] += 1
+
             link_score = (
                 WEIGHTS["org_history"] * org
                 + WEIGHTS["copresence"] * cop
@@ -343,6 +370,11 @@ def run_compute_identity_resolution(
                 + WEIGHTS["behavior_sim"] * bsm
                 + WEIGHTS["embedding_sim"] * esm
             )
+            all_scores.append(link_score)
+            if link_score == 0.0:
+                zero_score_pairs += 1
+            elif link_score >= LINK_EMIT_THRESHOLD - 0.10 and link_score < LINK_EMIT_THRESHOLD:
+                near_miss_count += 1
             if link_score < LINK_EMIT_THRESHOLD:
                 continue
 
@@ -459,17 +491,52 @@ def run_compute_identity_resolution(
             clusters_written += 1
 
         # ── 6. Finalize ──────────────────────────────────────────────
-        score_vals = [float(r[2]) for r in link_rows]
-        score_dist = {}
-        if score_vals:
-            s = sorted(score_vals)
+        # Score distribution over ALL candidate pairs (not just emitted
+        # links).  When no pair crosses the emit threshold, this is the
+        # only way to see whether scores were uniformly low or just below
+        # the cut.
+        score_dist: dict[str, Any] = {}
+        if all_scores:
+            s = sorted(all_scores)
             score_dist = {
+                "candidate_count": len(all_scores),
                 "p50": round(s[len(s) // 2], 4),
                 "p90": round(s[int(len(s) * 0.9)], 4),
                 "p99": round(s[int(len(s) * 0.99)], 4),
                 "min": round(s[0], 4),
                 "max": round(s[-1], 4),
+                "zero_score_pairs": zero_score_pairs,
+                "near_miss_count": near_miss_count,
+                "emit_threshold": LINK_EMIT_THRESHOLD,
             }
+
+        # Per-component diagnostics: mean contribution + how many pairs had
+        # a non-zero signal for each component.  A component with 0% non-zero
+        # almost certainly means its cache table is empty.
+        denom = max(1, len(all_scores))
+        component_means = {k: round(v / denom, 4) for k, v in component_sums.items()}
+        component_hit_rates = {k: round(component_nonzero[k] / denom, 4) for k in component_nonzero}
+
+        # Cache coverage over the deduplicated character list.  char_list is
+        # the set of character IDs that appear in at least one candidate pair.
+        char_count = max(1, len(char_list))
+        cache_coverage = {
+            "char_pool_size": len(char_list),
+            "org_history_hit_rate": round(len(org_cache) / char_count, 4),
+            "temporal_hit_rate": round(len(temporal_cache) / char_count, 4),
+            "snapshot_hit_rate": round(len(snapshot_cache) / char_count, 4),
+            "typed_pair_count": len(typed_cache),
+        }
+
+        logger.info(
+            "identity-resolution scoring: candidates=%d links=%d clusters=%d "
+            "score_p50=%s score_p99=%s zero_pairs=%d near_miss=%d "
+            "cache_hits=%s component_hit_rates=%s",
+            len(candidates), rows_written, clusters_written,
+            score_dist.get("p50"), score_dist.get("p99"),
+            zero_score_pairs, near_miss_count,
+            cache_coverage, component_hit_rates,
+        )
 
         _finish_run(db, run_id, "success", len(candidates), rows_written, clusters_written,
                      score_dist=score_dist)
@@ -482,7 +549,10 @@ def run_compute_identity_resolution(
             duration_ms=duration_ms,
             meta={"run_id": run_id, "candidate_pairs": len(candidates),
                   "links_written": rows_written, "clusters_written": clusters_written,
-                  "score_distribution": score_dist},
+                  "score_distribution": score_dist,
+                  "component_means": component_means,
+                  "component_hit_rates": component_hit_rates,
+                  "cache_coverage": cache_coverage},
         ).to_dict()
         finish_job_run(db, job, status="success", rows_processed=rows_processed,
                        rows_written=rows_written, meta=result)

--- a/python/orchestrator/jobs/counterintel_pipeline.py
+++ b/python/orchestrator/jobs/counterintel_pipeline.py
@@ -502,6 +502,41 @@ def run_compute_counterintel_pipeline(
         last_battle_id = cursor
         assignment_mismatch_count = 0
         assignment_mismatch_samples: list[dict[str, Any]] = []
+
+        # Eligibility diagnostics.  Without these, a successful run that
+        # processes 0 battles is indistinguishable from a healthy run that
+        # simply has nothing new since the last cursor.  The three counts
+        # answer three distinct ops questions: "how many battles would EVER
+        # be eligible?", "how many are new since my cursor?", and "how many
+        # have I already consumed?".
+        eligibility_diagnostics: dict[str, Any] = {
+            "min_participants": 20,
+            "cursor_position": cursor or None,
+        }
+        if not is_scoped:
+            try:
+                total_eligible = db.fetch_scalar(
+                    """
+                    SELECT COUNT(*) FROM battle_rollups
+                    WHERE eligible_for_suspicion = 1 AND participant_count >= 20
+                    """
+                )
+                new_eligible = db.fetch_scalar(
+                    """
+                    SELECT COUNT(*) FROM battle_rollups
+                    WHERE eligible_for_suspicion = 1 AND participant_count >= 20
+                      AND battle_id > %s
+                    """,
+                    (cursor,),
+                )
+                eligibility_diagnostics.update({
+                    "total_eligible_battles": int(total_eligible or 0),
+                    "new_eligible_since_cursor": int(new_eligible or 0),
+                    "already_consumed": max(0, int(total_eligible or 0) - int(new_eligible or 0)),
+                })
+            except Exception as exc:  # pragma: no cover — diagnostics must never fail the run
+                eligibility_diagnostics["diagnostics_error"] = str(exc)
+
         while batch_count < max_batches:
             if is_scoped:
                 # On-demand single-character path: only eligible battles this
@@ -1220,11 +1255,28 @@ def run_compute_counterintel_pipeline(
         has_more = (batch_count == max_batches) and not is_scoped
 
         duration_ms = int((time.perf_counter() - started) * 1000)
-        summary = (
-            f"Processed {processed_battles} eligible 100+ participant battles across {batch_count} batches."
-            if not is_scoped
-            else f"On-demand scoped run for character {scope_character_id}: {processed_battles} battles processed."
-        )
+        # Build a summary that reports both what ran THIS invocation and,
+        # for unscoped runs, how much is pending/consumed in total.  The
+        # old summary claimed "100+ participant" but the filter is ≥20 —
+        # correct that too.
+        if is_scoped:
+            summary = (
+                f"On-demand scoped run for character {scope_character_id}: "
+                f"{processed_battles} battles processed."
+            )
+        else:
+            total_eligible = eligibility_diagnostics.get("total_eligible_battles")
+            new_eligible = eligibility_diagnostics.get("new_eligible_since_cursor")
+            pending_note = ""
+            if total_eligible is not None and new_eligible is not None:
+                pending_note = (
+                    f" ({new_eligible} new of {total_eligible} eligible, "
+                    f"cursor has consumed {max(0, total_eligible - new_eligible)})"
+                )
+            summary = (
+                f"Processed {processed_battles} eligible battles (≥20 participants) "
+                f"across {batch_count} batches{pending_note}."
+            )
         result = JobResult.success(
             job_key=lock_key,
             summary=summary,
@@ -1244,6 +1296,7 @@ def run_compute_counterintel_pipeline(
                     "mismatch_count": assignment_mismatch_count,
                     "sample_rows": assignment_mismatch_samples,
                 },
+                "eligibility": eligibility_diagnostics,
             },
         ).to_dict()
         finish_job_run(db, job, status="success", rows_processed=rows_processed, rows_written=rows_written, meta=result)


### PR DESCRIPTION
## Summary

After running the full spy pipeline end-to-end, two jobs reported success but produced zero useful rows:

- `compute_identity_resolution`: "Scored 50000 pairs → 0 links, 0 clusters." with `score_distribution: {}`
- `compute_counterintel_pipeline`: "Processed 0 eligible 100+ participant battles"

Both were technically correct but indistinguishable from a healthy run. This PR adds the signals needed to tell _why_ each run was empty.

## Why — diagnosis

**Identity resolution**: the 50k pairs all fell below the 0.50 emit threshold. Component scorers return 0.0 when their cache tables are empty (`character_org_history_cache`, `character_temporal_metrics`, `character_feature_snapshots`, `character_typed_interactions`). A single empty cache can drag most pairs below threshold, but the job never surfaced which one. Previously the `score_distribution` field was `{}` when no pair crossed threshold — exactly when you most need it.

**CIP**: the summary said "100+ participant battles" but the actual SQL filter is `participant_count >= 20`. The misleading wording aside, "0 processed" could mean (a) no eligible battles exist at all, (b) the cursor has already consumed every eligible battle, or (c) all battles fall below the 20-participant threshold. You can't tell without querying the DB by hand.

## What changed

**`compute_identity_resolution.py`**
- Track per-component non-zero rates + mean contribution over all candidates
- Track per-cache hit-rate against the candidate character pool (`org_history_hit_rate`, `temporal_hit_rate`, `snapshot_hit_rate`, typed-pair count)
- `score_distribution` now covers ALL scored pairs (p50/p90/p99/min/max), plus `zero_score_pairs` and `near_miss_count` (pairs within 0.10 of the emit threshold)
- Log line at INFO summarizing everything

**`counterintel_pipeline.py`**
- Fix "100+" → "≥20" in the summary string
- Query total-eligible + new-since-cursor counts before the main loop
- Surface them in the summary and in `meta.eligibility`
- Distinguishes "cursor caught up" from "no eligible battles exist"

## Test plan

- [ ] Re-run `compute_identity_resolution` — confirm meta now contains `component_hit_rates`, `component_means`, `cache_coverage`, and a non-empty `score_distribution`. A cache_hit_rate near 0 will point directly at the missing upstream job.
- [ ] Re-run `compute_counterintel_pipeline` — summary should say "≥20 participants" and include `(N new of M eligible, cursor has consumed K)`; `meta.eligibility` should surface the same counts.
- [ ] `python3 -c "import ast; ast.parse(open(path).read())"` on both files (already done).

No behavioural changes — thresholds, queries, emit logic all unchanged.

https://claude.ai/code/session_01DiLLoZ1Mr9NERgNo2rBiXf