### PR TITLE
Add global ESI error-limit tracking and blocking

### DIFF
--- a/python/orchestrator/esi_rate_limiter.py
+++ b/python/orchestrator/esi_rate_limiter.py
@@ -13,6 +13,9 @@ ESI rate limiting docs:
   - Token costs: 2xx=2, 3xx=1, 4xx=5, 5xx=0 (429 costs 0).
   - Headers: X-Ratelimit-Group, X-Ratelimit-Limit (e.g. "150/15m"),
     X-Ratelimit-Remaining, X-Ratelimit-Used, Retry-After (on 429).
+  - Global error limit: X-ESI-Error-Limit-Remain (errors left in this fixed
+    time frame) and X-ESI-Error-Limit-Reset (seconds until the frame resets).
+    Once remain hits 0, ESI discards all requests until the frame ends.
 """
 
 from __future__ import annotations
@@ -39,6 +42,9 @@ _SAFETY_MARGIN = 0.10
 
 # When remaining tokens are unknown and no Retry-After, use this delay.
 _FALLBACK_DELAY_SECONDS = 0.15
+
+# Log a warning when error-limit remain drops below this threshold.
+_ERROR_LIMIT_WARN_THRESHOLD = 10
 
 
 def token_cost_for_status(status_code: int) -> int:
@@ -85,6 +91,23 @@ class _GroupBucket:
     initialized: bool = False
 
 
+@dataclass
+class _ErrorLimitState:
+    """Tracks the global ESI error limit (X-ESI-Error-Limit-Remain/Reset).
+
+    Unlike the per-group bucket limit, the error limit is a fixed time frame
+    applied globally across all ESI requests from this application.  When
+    ``remain`` reaches 0, ESI discards every request until the frame ends.
+
+    ``reset_deadline`` is a ``time.monotonic()`` timestamp representing when
+    the current error-limit frame expires and the counter resets.
+    """
+
+    remain: int = 100
+    reset_deadline: float = 0.0  # monotonic timestamp when frame resets
+    initialized: bool = False
+
+
 class EsiRateLimiter:
     """Process-wide ESI rate limiter.
 
@@ -112,6 +135,8 @@ class EsiRateLimiter:
         self._redis: RedisClient | None = None
         # Optional DB handle for MariaDB fallback.
         self._db: Any = None
+        # Global ESI error limit state (X-ESI-Error-Limit-Remain/Reset).
+        self._error_limit = _ErrorLimitState()
 
     def set_redis(self, redis: RedisClient) -> None:
         """Inject a Redis client for cross-process rate-limit coordination.
@@ -154,6 +179,24 @@ class EsiRateLimiter:
                     time.sleep(wait)
                 finally:
                     self._lock.acquire()
+
+            # Enforce global ESI error limit.  When remain == 0, ESI discards
+            # all requests until the fixed time frame resets — block here so we
+            # don't accumulate wasted 420 responses.
+            self._merge_redis_error_limit()
+            if self._error_limit.initialized and self._error_limit.remain == 0:
+                now = time.monotonic()
+                wait = max(0.0, self._error_limit.reset_deadline - now)
+                if wait > 0:
+                    logger.warning(
+                        "ESI error limit exhausted: blocking for %.1fs until frame resets",
+                        wait,
+                    )
+                    self._lock.release()
+                    try:
+                        time.sleep(wait)
+                    finally:
+                        self._lock.acquire()
 
             resolved_group = group or self._last_group
             if resolved_group is None:
@@ -208,6 +251,8 @@ class EsiRateLimiter:
         limit = _get("X-Ratelimit-Limit")
         remaining = _get("X-Ratelimit-Remaining")
         retry_after = _get("Retry-After")
+        error_limit_remain = _get("X-ESI-Error-Limit-Remain")
+        error_limit_reset = _get("X-ESI-Error-Limit-Reset")
 
         with self._lock:
             # Handle 429 Retry-After.
@@ -219,6 +264,13 @@ class EsiRateLimiter:
                     logger.warning("ESI 429: Retry-After %s seconds", retry_after)
                 except ValueError:
                     pass
+
+            # Handle global error limit headers.  These are mutually exclusive
+            # with the bucket-limit headers — ESI sends one set or the other
+            # depending on which limit triggered.  We parse them whenever
+            # present so we always have the freshest picture.
+            if error_limit_remain is not None or error_limit_reset is not None:
+                self._update_error_limit(error_limit_remain, error_limit_reset)
 
             if group:
                 self._last_group = group
@@ -240,6 +292,91 @@ class EsiRateLimiter:
 
                 # Publish to Redis for cross-process coordination.
                 self._publish_redis_ratelimit(group, bucket, retry_after_seconds)
+
+    # -- Error limit helpers -----------------------------------------------
+
+    def _update_error_limit(
+        self,
+        remain_raw: str | None,
+        reset_raw: str | None,
+    ) -> None:
+        """Parse and store X-ESI-Error-Limit-Remain/Reset headers.
+
+        Must be called with ``self._lock`` held.
+        """
+        now = time.monotonic()
+        if remain_raw is not None:
+            try:
+                remain = int(remain_raw)
+                self._error_limit.remain = remain
+                self._error_limit.initialized = True
+                if remain == 0:
+                    logger.error(
+                        "ESI error limit exhausted (remain=0); all requests will be "
+                        "blocked until the frame resets."
+                    )
+                elif remain <= _ERROR_LIMIT_WARN_THRESHOLD:
+                    logger.warning(
+                        "ESI error limit running low: %d errors remaining in this frame",
+                        remain,
+                    )
+            except ValueError:
+                pass
+
+        if reset_raw is not None:
+            try:
+                reset_seconds = float(reset_raw)
+                self._error_limit.reset_deadline = now + reset_seconds
+                self._error_limit.initialized = True
+            except ValueError:
+                pass
+
+        # Publish updated state cross-process via Redis.
+        self._publish_redis_error_limit()
+
+    def _merge_redis_error_limit(self) -> None:
+        """Pull the most-conservative error-limit state from Redis.
+
+        Must be called with ``self._lock`` held.
+        """
+        if self._redis is None or not self._redis.available:
+            return
+        from .redis_keys import esi_error_limit_key
+        data = self._redis.get_json(esi_error_limit_key())
+        if not data or not isinstance(data, dict):
+            return
+        try:
+            redis_remain = int(data.get("remain", self._error_limit.remain))
+            redis_deadline = float(data.get("reset_deadline", self._error_limit.reset_deadline))
+            # Most-conservative-wins: take the lower remain.
+            if not self._error_limit.initialized or redis_remain < self._error_limit.remain:
+                self._error_limit.remain = redis_remain
+                self._error_limit.initialized = True
+            # Take the later deadline (more pessimistic reset time).
+            if redis_deadline > self._error_limit.reset_deadline:
+                self._error_limit.reset_deadline = redis_deadline
+        except (ValueError, TypeError):
+            pass
+
+    def _publish_redis_error_limit(self) -> None:
+        """Write current error-limit state to Redis.
+
+        Must be called with ``self._lock`` held.
+        """
+        if self._redis is None or not self._redis.available:
+            return
+        from .redis_keys import esi_error_limit_key
+        # TTL: however long until the frame resets, plus a small buffer.
+        now = time.monotonic()
+        ttl = max(60, int(self._error_limit.reset_deadline - now) + 10)
+        self._redis.set_json(
+            esi_error_limit_key(),
+            {
+                "remain": self._error_limit.remain,
+                "reset_deadline": self._error_limit.reset_deadline,
+            },
+            ex=ttl,
+        )
 
     # -- Redis coordination helpers ----------------------------------------
 
@@ -335,7 +472,7 @@ class EsiRateLimiter:
     def stats(self) -> dict[str, dict[str, object]]:
         """Return current rate-limit state for diagnostics."""
         with self._lock:
-            return {
+            groups = {
                 group: {
                     "max_tokens": b.max_tokens,
                     "remaining": b.remaining,
@@ -344,6 +481,13 @@ class EsiRateLimiter:
                 }
                 for group, b in self._groups.items()
             }
+            now = time.monotonic()
+            groups["_error_limit"] = {
+                "remain": self._error_limit.remain,
+                "reset_in_seconds": max(0.0, self._error_limit.reset_deadline - now),
+                "initialized": self._error_limit.initialized,
+            }
+            return groups
 
 
 # Process-wide singleton — import this from any module that makes ESI calls.

--- a/python/orchestrator/redis_keys.py
+++ b/python/orchestrator/redis_keys.py
@@ -56,6 +56,15 @@ def esi_suppress_key(endpoint_or_group: str) -> str:
     return f"esi:suppress:v1:{endpoint_or_group}"
 
 
+def esi_error_limit_key() -> str:
+    """Global ESI error-limit state (X-ESI-Error-Limit-Remain/Reset).
+
+    Unlike rate-limit buckets, the error limit is not per-group — it
+    applies to the entire application's ESI usage.
+    """
+    return "esi:error_limit:v1"
+
+
 # -- Distributed locks -------------------------------------------------
 
 def esi_fetch_lock_key(endpoint_key: str) -> str:

--- a/python/tests/test_esi_rate_limiter.py
+++ b/python/tests/test_esi_rate_limiter.py
@@ -113,14 +113,98 @@ class RateLimiterTests(unittest.TestCase):
             "X-Ratelimit-Remaining": "48",
         })
         stats = limiter.stats
-        self.assertEqual(len(stats), 2)
         self.assertIn("alpha", stats)
         self.assertIn("beta", stats)
+        # stats also always contains the synthetic _error_limit key.
+        self.assertIn("_error_limit", stats)
 
     def test_none_headers_handled_gracefully(self) -> None:
         limiter = EsiRateLimiter()
         limiter.update_from_response(200, None)
-        self.assertEqual(limiter.stats, {})
+        # Only the _error_limit synthetic key should be present.
+        self.assertIn("_error_limit", limiter.stats)
+        self.assertFalse(limiter.stats["_error_limit"]["initialized"])
+
+    def test_stats_includes_error_limit_key(self) -> None:
+        limiter = EsiRateLimiter()
+        limiter.update_from_response(200, {
+            "X-Ratelimit-Group": "market",
+            "X-Ratelimit-Limit": "150/15m",
+            "X-Ratelimit-Remaining": "148",
+        })
+        stats = limiter.stats
+        self.assertIn("_error_limit", stats)
+        self.assertIn("remain", stats["_error_limit"])
+        self.assertIn("reset_in_seconds", stats["_error_limit"])
+        self.assertIn("initialized", stats["_error_limit"])
+
+
+class ErrorLimitTests(unittest.TestCase):
+    def test_error_limit_headers_parsed(self) -> None:
+        limiter = EsiRateLimiter()
+        limiter.update_from_response(420, {
+            "X-ESI-Error-Limit-Remain": "50",
+            "X-ESI-Error-Limit-Reset": "30",
+        })
+        stats = limiter.stats["_error_limit"]
+        self.assertTrue(stats["initialized"])
+        self.assertEqual(stats["remain"], 50)
+        self.assertAlmostEqual(stats["reset_in_seconds"], 30.0, delta=1.0)
+
+    def test_error_limit_remain_only(self) -> None:
+        limiter = EsiRateLimiter()
+        limiter.update_from_response(200, {
+            "X-ESI-Error-Limit-Remain": "75",
+        })
+        stats = limiter.stats["_error_limit"]
+        self.assertTrue(stats["initialized"])
+        self.assertEqual(stats["remain"], 75)
+
+    def test_acquire_blocks_when_error_limit_exhausted(self) -> None:
+        limiter = EsiRateLimiter()
+        # Simulate error limit exhausted with a very short reset window.
+        limiter.update_from_response(420, {
+            "X-ESI-Error-Limit-Remain": "0",
+            "X-ESI-Error-Limit-Reset": "1",
+        })
+        start = time.monotonic()
+        limiter.acquire()
+        elapsed = time.monotonic() - start
+        self.assertGreaterEqual(elapsed, 0.8)
+        self.assertLess(elapsed, 4.0)
+
+    def test_acquire_does_not_block_when_error_limit_not_exhausted(self) -> None:
+        limiter = EsiRateLimiter()
+        limiter.update_from_response(200, {
+            "X-ESI-Error-Limit-Remain": "50",
+            "X-ESI-Error-Limit-Reset": "30",
+        })
+        start = time.monotonic()
+        limiter.acquire()
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, 0.1)
+
+    def test_error_limit_reset_deadline_expires(self) -> None:
+        limiter = EsiRateLimiter()
+        # Exhaust the limit but with a reset time already in the past.
+        limiter.update_from_response(420, {
+            "X-ESI-Error-Limit-Remain": "0",
+            "X-ESI-Error-Limit-Reset": "0",
+        })
+        start = time.monotonic()
+        limiter.acquire()
+        elapsed = time.monotonic() - start
+        # Deadline already passed — should not block.
+        self.assertLess(elapsed, 0.5)
+
+    def test_invalid_error_limit_headers_ignored(self) -> None:
+        limiter = EsiRateLimiter()
+        limiter.update_from_response(200, {
+            "X-ESI-Error-Limit-Remain": "not-a-number",
+            "X-ESI-Error-Limit-Reset": "also-bad",
+        })
+        # Graceful: no crash, uninitialized state.
+        self.assertFalse(limiter.stats["_error_limit"]["initialized"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Implements tracking and enforcement of ESI's global error limit (X-ESI-Error-Limit-Remain/Reset headers). When the error limit is exhausted, the rate limiter now blocks acquisition calls until the fixed time frame resets, preventing wasted 420 error responses.

## Key Changes
- **New `_ErrorLimitState` dataclass**: Tracks the global error limit state with `remain` counter and `reset_deadline` (monotonic timestamp)
- **Error limit parsing**: Added `_update_error_limit()` method to parse X-ESI-Error-Limit-Remain and X-ESI-Error-Limit-Reset headers from responses
- **Blocking on exhaustion**: Modified `acquire()` to block when error limit remain reaches 0, sleeping until the frame resets
- **Cross-process coordination**: Added `_merge_redis_error_limit()` and `_publish_redis_error_limit()` methods to share error-limit state across processes via Redis, using conservative merging (lowest remain, latest reset deadline)
- **Diagnostics**: Extended `stats()` to include `_error_limit` synthetic key with remain, reset_in_seconds, and initialized status
- **Logging**: Added warning logs when error limit drops below threshold (10) and error logs when exhausted
- **Redis key**: Added `esi_error_limit_key()` helper in redis_keys.py for consistent key naming

## Implementation Details
- Error limit headers are mutually exclusive with per-group bucket headers in ESI responses
- The error limit applies globally across all ESI requests from the application, unlike per-group rate limits
- TTL for Redis error-limit state is set to the reset deadline plus 10-second buffer (minimum 60 seconds)
- Graceful handling of invalid header values (non-numeric) with silent fallback
- All error-limit operations are protected by the existing `_lock` to ensure thread safety

https://claude.ai/code/session_01TfEjEYoSZRXivpFdK9BgFQ